### PR TITLE
LPS-149279 Include createStrategy and updateStrategy parameters to allow selecting between modes for Import functionality

### DIFF
--- a/modules/apps/batch-planner/batch-planner-service/src/main/java/com/liferay/batch/planner/internal/batch/engine/broker/BatchEngineBrokerImpl.java
+++ b/modules/apps/batch-planner/batch-planner-service/src/main/java/com/liferay/batch/planner/internal/batch/engine/broker/BatchEngineBrokerImpl.java
@@ -218,7 +218,7 @@ public class BatchEngineBrokerImpl implements BatchEngineBroker {
 							"allowUpdate")))) {
 
 				_importTaskResource.postImportTask(
-					batchPlannerPlan.getInternalClassName(), null,
+					batchPlannerPlan.getInternalClassName(), null, null,
 					String.valueOf(batchPlannerPlan.getBatchPlannerPlanId()),
 					_getFieldNameMapping(
 						_batchPlannerMappingLocalService.
@@ -243,7 +243,7 @@ public class BatchEngineBrokerImpl implements BatchEngineBroker {
 				batchPlannerPlan.getInternalClassName(), null,
 				String.valueOf(batchPlannerPlan.getBatchPlannerPlanId()),
 				_getImportStrategy(batchPlannerPlan),
-				batchPlannerPlan.getTaskItemDelegateName(),
+				batchPlannerPlan.getTaskItemDelegateName(), null,
 				MultipartBody.of(
 					Collections.singletonMap(
 						"file",

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountAddressResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountAddressResourceImpl.java
@@ -55,6 +55,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -770,11 +771,42 @@ public abstract class BaseAccountAddressResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		for (AccountAddress accountAddress : accountAddresses) {
-			putAccountAddress(
+		UnsafeConsumer<AccountAddress, Exception> accountAddressUnsafeConsumer =
+			null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			accountAddressUnsafeConsumer =
+				accountAddress -> patchAccountAddress(
+					accountAddress.getId() != null ? accountAddress.getId() :
+						Long.parseLong(
+							(String)parameters.get("accountAddressId")),
+					accountAddress);
+		}
+
+		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
+			accountAddressUnsafeConsumer = accountAddress -> putAccountAddress(
 				accountAddress.getId() != null ? accountAddress.getId() :
 					Long.parseLong((String)parameters.get("accountAddressId")),
 				accountAddress);
+		}
+
+		if (accountAddressUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for AccountAddress");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				accountAddresses, accountAddressUnsafeConsumer);
+		}
+		else {
+			for (AccountAddress accountAddress : accountAddresses) {
+				accountAddressUnsafeConsumer.accept(accountAddress);
+			}
 		}
 	}
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountGroupResourceImpl.java
@@ -55,6 +55,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -508,7 +509,21 @@ public abstract class BaseAccountGroupResourceImpl
 		throws Exception {
 
 		UnsafeConsumer<AccountGroup, Exception> accountGroupUnsafeConsumer =
-			accountGroup -> postAccountGroup(accountGroup);
+			null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
+			accountGroupUnsafeConsumer = accountGroup -> postAccountGroup(
+				accountGroup);
+		}
+
+		if (accountGroupUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for AccountGroup");
+		}
 
 		if (contextBatchUnsafeConsumer != null) {
 			contextBatchUnsafeConsumer.accept(
@@ -587,6 +602,35 @@ public abstract class BaseAccountGroupResourceImpl
 			java.util.Collection<AccountGroup> accountGroups,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		UnsafeConsumer<AccountGroup, Exception> accountGroupUnsafeConsumer =
+			null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			accountGroupUnsafeConsumer = accountGroup -> patchAccountGroup(
+				accountGroup.getId() != null ? accountGroup.getId() :
+					Long.parseLong((String)parameters.get("accountGroupId")),
+				accountGroup);
+		}
+
+		if (accountGroupUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for AccountGroup");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				accountGroups, accountGroupUnsafeConsumer);
+		}
+		else {
+			for (AccountGroup accountGroup : accountGroups) {
+				accountGroupUnsafeConsumer.accept(accountGroup);
+			}
+		}
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountResourceImpl.java
@@ -56,6 +56,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -580,8 +581,20 @@ public abstract class BaseAccountResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		UnsafeConsumer<Account, Exception> accountUnsafeConsumer =
-			account -> postAccount(account);
+		UnsafeConsumer<Account, Exception> accountUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
+			accountUnsafeConsumer = account -> postAccount(account);
+		}
+
+		if (accountUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for Account");
+		}
 
 		if (contextBatchUnsafeConsumer != null) {
 			contextBatchUnsafeConsumer.accept(accounts, accountUnsafeConsumer);
@@ -659,6 +672,33 @@ public abstract class BaseAccountResourceImpl
 			java.util.Collection<Account> accounts,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		UnsafeConsumer<Account, Exception> accountUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			accountUnsafeConsumer = account -> patchAccount(
+				account.getId() != null ? account.getId() :
+					Long.parseLong((String)parameters.get("accountId")),
+				account);
+		}
+
+		if (accountUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for Account");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(accounts, accountUnsafeConsumer);
+		}
+		else {
+			for (Account account : accounts) {
+				accountUnsafeConsumer.accept(account);
+			}
+		}
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseCatalogResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseCatalogResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -510,8 +511,20 @@ public abstract class BaseCatalogResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		UnsafeConsumer<Catalog, Exception> catalogUnsafeConsumer =
-			catalog -> postCatalog(catalog);
+		UnsafeConsumer<Catalog, Exception> catalogUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
+			catalogUnsafeConsumer = catalog -> postCatalog(catalog);
+		}
+
+		if (catalogUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for Catalog");
+		}
 
 		if (contextBatchUnsafeConsumer != null) {
 			contextBatchUnsafeConsumer.accept(catalogs, catalogUnsafeConsumer);
@@ -589,6 +602,33 @@ public abstract class BaseCatalogResourceImpl
 			java.util.Collection<Catalog> catalogs,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		UnsafeConsumer<Catalog, Exception> catalogUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			catalogUnsafeConsumer = catalog -> patchCatalog(
+				catalog.getId() != null ? catalog.getId() :
+					Long.parseLong((String)parameters.get("catalogId")),
+				catalog);
+		}
+
+		if (catalogUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for Catalog");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(catalogs, catalogUnsafeConsumer);
+		}
+		else {
+			for (Catalog catalog : catalogs) {
+				catalogUnsafeConsumer.accept(catalog);
+			}
+		}
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseDiagramResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseDiagramResourceImpl.java
@@ -53,6 +53,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.UriInfo;
@@ -297,6 +298,33 @@ public abstract class BaseDiagramResourceImpl
 			java.util.Collection<Diagram> diagrams,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		UnsafeConsumer<Diagram, Exception> diagramUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			diagramUnsafeConsumer = diagram -> patchDiagram(
+				diagram.getId() != null ? diagram.getId() :
+					Long.parseLong((String)parameters.get("diagramId")),
+				diagram);
+		}
+
+		if (diagramUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for Diagram");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(diagrams, diagramUnsafeConsumer);
+		}
+		else {
+			for (Diagram diagram : diagrams) {
+				diagramUnsafeConsumer.accept(diagram);
+			}
+		}
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseMappedProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseMappedProductResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -517,6 +518,35 @@ public abstract class BaseMappedProductResourceImpl
 			java.util.Collection<MappedProduct> mappedProducts,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		UnsafeConsumer<MappedProduct, Exception> mappedProductUnsafeConsumer =
+			null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			mappedProductUnsafeConsumer = mappedProduct -> patchMappedProduct(
+				mappedProduct.getId() != null ? mappedProduct.getId() :
+					Long.parseLong((String)parameters.get("mappedProductId")),
+				mappedProduct);
+		}
+
+		if (mappedProductUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for MappedProduct");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				mappedProducts, mappedProductUnsafeConsumer);
+		}
+		else {
+			for (MappedProduct mappedProduct : mappedProducts) {
+				mappedProductUnsafeConsumer.accept(mappedProduct);
+			}
+		}
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseOptionCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseOptionCategoryResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -339,7 +340,21 @@ public abstract class BaseOptionCategoryResourceImpl
 		throws Exception {
 
 		UnsafeConsumer<OptionCategory, Exception> optionCategoryUnsafeConsumer =
-			optionCategory -> postOptionCategory(optionCategory);
+			null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
+			optionCategoryUnsafeConsumer = optionCategory -> postOptionCategory(
+				optionCategory);
+		}
+
+		if (optionCategoryUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for OptionCategory");
+		}
 
 		if (contextBatchUnsafeConsumer != null) {
 			contextBatchUnsafeConsumer.accept(
@@ -418,6 +433,37 @@ public abstract class BaseOptionCategoryResourceImpl
 			java.util.Collection<OptionCategory> optionCategories,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		UnsafeConsumer<OptionCategory, Exception> optionCategoryUnsafeConsumer =
+			null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			optionCategoryUnsafeConsumer =
+				optionCategory -> patchOptionCategory(
+					optionCategory.getId() != null ? optionCategory.getId() :
+						Long.parseLong(
+							(String)parameters.get("optionCategoryId")),
+					optionCategory);
+		}
+
+		if (optionCategoryUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for OptionCategory");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				optionCategories, optionCategoryUnsafeConsumer);
+		}
+		else {
+			for (OptionCategory optionCategory : optionCategories) {
+				optionCategoryUnsafeConsumer.accept(optionCategory);
+			}
+		}
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseOptionResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseOptionResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -431,8 +432,20 @@ public abstract class BaseOptionResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		UnsafeConsumer<Option, Exception> optionUnsafeConsumer =
-			option -> postOption(option);
+		UnsafeConsumer<Option, Exception> optionUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
+			optionUnsafeConsumer = option -> postOption(option);
+		}
+
+		if (optionUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for Option");
+		}
 
 		if (contextBatchUnsafeConsumer != null) {
 			contextBatchUnsafeConsumer.accept(options, optionUnsafeConsumer);
@@ -510,6 +523,33 @@ public abstract class BaseOptionResourceImpl
 			java.util.Collection<Option> options,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		UnsafeConsumer<Option, Exception> optionUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			optionUnsafeConsumer = option -> patchOption(
+				option.getId() != null ? option.getId() :
+					Long.parseLong((String)parameters.get("optionId")),
+				option);
+		}
+
+		if (optionUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for Option");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(options, optionUnsafeConsumer);
+		}
+		else {
+			for (Option option : options) {
+				optionUnsafeConsumer.accept(option);
+			}
+		}
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseOptionValueResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseOptionValueResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -608,6 +609,34 @@ public abstract class BaseOptionValueResourceImpl
 			java.util.Collection<OptionValue> optionValues,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		UnsafeConsumer<OptionValue, Exception> optionValueUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			optionValueUnsafeConsumer = optionValue -> patchOptionValue(
+				optionValue.getId() != null ? optionValue.getId() :
+					Long.parseLong((String)parameters.get("optionValueId")),
+				optionValue);
+		}
+
+		if (optionValueUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for OptionValue");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				optionValues, optionValueUnsafeConsumer);
+		}
+		else {
+			for (OptionValue optionValue : optionValues) {
+				optionValueUnsafeConsumer.accept(optionValue);
+			}
+		}
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BasePinResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BasePinResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -417,6 +418,33 @@ public abstract class BasePinResourceImpl
 			java.util.Collection<Pin> pins,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		UnsafeConsumer<Pin, Exception> pinUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			pinUnsafeConsumer = pin -> patchPin(
+				pin.getId() != null ? pin.getId() :
+					Long.parseLong((String)parameters.get("pinId")),
+				pin);
+		}
+
+		if (pinUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for Pin");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(pins, pinUnsafeConsumer);
+		}
+		else {
+			for (Pin pin : pins) {
+				pinUnsafeConsumer.accept(pin);
+			}
+		}
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductGroupResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -426,7 +427,21 @@ public abstract class BaseProductGroupResourceImpl
 		throws Exception {
 
 		UnsafeConsumer<ProductGroup, Exception> productGroupUnsafeConsumer =
-			productGroup -> postProductGroup(productGroup);
+			null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
+			productGroupUnsafeConsumer = productGroup -> postProductGroup(
+				productGroup);
+		}
+
+		if (productGroupUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for ProductGroup");
+		}
 
 		if (contextBatchUnsafeConsumer != null) {
 			contextBatchUnsafeConsumer.accept(
@@ -505,6 +520,35 @@ public abstract class BaseProductGroupResourceImpl
 			java.util.Collection<ProductGroup> productGroups,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		UnsafeConsumer<ProductGroup, Exception> productGroupUnsafeConsumer =
+			null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			productGroupUnsafeConsumer = productGroup -> patchProductGroup(
+				productGroup.getId() != null ? productGroup.getId() :
+					Long.parseLong((String)parameters.get("productGroupId")),
+				productGroup);
+		}
+
+		if (productGroupUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for ProductGroup");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				productGroups, productGroupUnsafeConsumer);
+		}
+		else {
+			for (ProductGroup productGroup : productGroups) {
+				productGroupUnsafeConsumer.accept(productGroup);
+			}
+		}
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductOptionResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductOptionResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -473,6 +474,35 @@ public abstract class BaseProductOptionResourceImpl
 			java.util.Collection<ProductOption> productOptions,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		UnsafeConsumer<ProductOption, Exception> productOptionUnsafeConsumer =
+			null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			productOptionUnsafeConsumer = productOption -> patchProductOption(
+				productOption.getId() != null ? productOption.getId() :
+					Long.parseLong((String)parameters.get("productOptionId")),
+				productOption);
+		}
+
+		if (productOptionUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for ProductOption");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				productOptions, productOptionUnsafeConsumer);
+		}
+		else {
+			for (ProductOption productOption : productOptions) {
+				productOptionUnsafeConsumer.accept(productOption);
+			}
+		}
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -507,8 +508,20 @@ public abstract class BaseProductResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		UnsafeConsumer<Product, Exception> productUnsafeConsumer =
-			product -> postProduct(product);
+		UnsafeConsumer<Product, Exception> productUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
+			productUnsafeConsumer = product -> postProduct(product);
+		}
+
+		if (productUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for Product");
+		}
 
 		if (contextBatchUnsafeConsumer != null) {
 			contextBatchUnsafeConsumer.accept(products, productUnsafeConsumer);
@@ -586,6 +599,33 @@ public abstract class BaseProductResourceImpl
 			java.util.Collection<Product> products,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		UnsafeConsumer<Product, Exception> productUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			productUnsafeConsumer = product -> patchProduct(
+				product.getId() != null ? product.getId() :
+					Long.parseLong((String)parameters.get("productId")),
+				product);
+		}
+
+		if (productUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for Product");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(products, productUnsafeConsumer);
+		}
+		else {
+			for (Product product : products) {
+				productUnsafeConsumer.accept(product);
+			}
+		}
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseSkuResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseSkuResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -626,6 +627,33 @@ public abstract class BaseSkuResourceImpl
 			java.util.Collection<Sku> skus,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		UnsafeConsumer<Sku, Exception> skuUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			skuUnsafeConsumer = sku -> patchSku(
+				sku.getId() != null ? sku.getId() :
+					Long.parseLong((String)parameters.get("skuId")),
+				sku);
+		}
+
+		if (skuUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for Sku");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(skus, skuUnsafeConsumer);
+		}
+		else {
+			for (Sku sku : skus) {
+				skuUnsafeConsumer.accept(sku);
+			}
+		}
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseSpecificationResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseSpecificationResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -346,7 +347,21 @@ public abstract class BaseSpecificationResourceImpl
 		throws Exception {
 
 		UnsafeConsumer<Specification, Exception> specificationUnsafeConsumer =
-			specification -> postSpecification(specification);
+			null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
+			specificationUnsafeConsumer = specification -> postSpecification(
+				specification);
+		}
+
+		if (specificationUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for Specification");
+		}
 
 		if (contextBatchUnsafeConsumer != null) {
 			contextBatchUnsafeConsumer.accept(
@@ -425,6 +440,35 @@ public abstract class BaseSpecificationResourceImpl
 			java.util.Collection<Specification> specifications,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		UnsafeConsumer<Specification, Exception> specificationUnsafeConsumer =
+			null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			specificationUnsafeConsumer = specification -> patchSpecification(
+				specification.getId() != null ? specification.getId() :
+					Long.parseLong((String)parameters.get("specificationId")),
+				specification);
+		}
+
+		if (specificationUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for Specification");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				specifications, specificationUnsafeConsumer);
+		}
+		else {
+			for (Specification specification : specifications) {
+				specificationUnsafeConsumer.accept(specification);
+			}
+		}
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseChannelResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -586,8 +587,26 @@ public abstract class BaseChannelResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		UnsafeConsumer<Channel, Exception> channelUnsafeConsumer =
-			channel -> postChannel(channel);
+		UnsafeConsumer<Channel, Exception> channelUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
+			channelUnsafeConsumer = channel -> postChannel(channel);
+		}
+
+		if ("UPSERT".equalsIgnoreCase(createStrategy)) {
+			channelUnsafeConsumer =
+				channel -> putChannelByExternalReferenceCode(
+					channel.getExternalReferenceCode(), channel);
+		}
+
+		if (channelUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for Channel");
+		}
 
 		if (contextBatchUnsafeConsumer != null) {
 			contextBatchUnsafeConsumer.accept(channels, channelUnsafeConsumer);
@@ -666,11 +685,38 @@ public abstract class BaseChannelResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		for (Channel channel : channels) {
-			putChannel(
+		UnsafeConsumer<Channel, Exception> channelUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			channelUnsafeConsumer = channel -> patchChannel(
 				channel.getId() != null ? channel.getId() :
 					Long.parseLong((String)parameters.get("channelId")),
 				channel);
+		}
+
+		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
+			channelUnsafeConsumer = channel -> putChannel(
+				channel.getId() != null ? channel.getId() :
+					Long.parseLong((String)parameters.get("channelId")),
+				channel);
+		}
+
+		if (channelUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for Channel");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(channels, channelUnsafeConsumer);
+		}
+		else {
+			for (Channel channel : channels) {
+				channelUnsafeConsumer.accept(channel);
+			}
 		}
 	}
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/BaseWarehouseItemResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/BaseWarehouseItemResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -640,6 +641,35 @@ public abstract class BaseWarehouseItemResourceImpl
 			java.util.Collection<WarehouseItem> warehouseItems,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		UnsafeConsumer<WarehouseItem, Exception> warehouseItemUnsafeConsumer =
+			null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			warehouseItemUnsafeConsumer = warehouseItem -> patchWarehouseItem(
+				warehouseItem.getId() != null ? warehouseItem.getId() :
+					Long.parseLong((String)parameters.get("warehouseItemId")),
+				warehouseItem);
+		}
+
+		if (warehouseItemUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for WarehouseItem");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				warehouseItems, warehouseItemUnsafeConsumer);
+		}
+		else {
+			for (WarehouseItem warehouseItem : warehouseItems) {
+				warehouseItemUnsafeConsumer.accept(warehouseItem);
+			}
+		}
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderItemResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderItemResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -584,6 +585,34 @@ public abstract class BaseOrderItemResourceImpl
 			java.util.Collection<OrderItem> orderItems,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		UnsafeConsumer<OrderItem, Exception> orderItemUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			orderItemUnsafeConsumer = orderItem -> patchOrderItem(
+				orderItem.getId() != null ? orderItem.getId() :
+					Long.parseLong((String)parameters.get("orderItemId")),
+				orderItem);
+		}
+
+		if (orderItemUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for OrderItem");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				orderItems, orderItemUnsafeConsumer);
+		}
+		else {
+			for (OrderItem orderItem : orderItems) {
+				orderItemUnsafeConsumer.accept(orderItem);
+			}
+		}
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderNoteResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderNoteResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -584,6 +585,34 @@ public abstract class BaseOrderNoteResourceImpl
 			java.util.Collection<OrderNote> orderNotes,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		UnsafeConsumer<OrderNote, Exception> orderNoteUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			orderNoteUnsafeConsumer = orderNote -> patchOrderNote(
+				orderNote.getId() != null ? orderNote.getId() :
+					Long.parseLong((String)parameters.get("orderNoteId")),
+				orderNote);
+		}
+
+		if (orderNoteUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for OrderNote");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				orderNotes, orderNoteUnsafeConsumer);
+		}
+		else {
+			for (OrderNote orderNote : orderNotes) {
+				orderNoteUnsafeConsumer.accept(orderNote);
+			}
+		}
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -431,8 +432,20 @@ public abstract class BaseOrderResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		UnsafeConsumer<Order, Exception> orderUnsafeConsumer =
-			order -> postOrder(order);
+		UnsafeConsumer<Order, Exception> orderUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
+			orderUnsafeConsumer = order -> postOrder(order);
+		}
+
+		if (orderUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for Order");
+		}
 
 		if (contextBatchUnsafeConsumer != null) {
 			contextBatchUnsafeConsumer.accept(orders, orderUnsafeConsumer);
@@ -510,6 +523,33 @@ public abstract class BaseOrderResourceImpl
 			java.util.Collection<Order> orders,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		UnsafeConsumer<Order, Exception> orderUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			orderUnsafeConsumer = order -> patchOrder(
+				order.getId() != null ? order.getId() :
+					Long.parseLong((String)parameters.get("orderId")),
+				order);
+		}
+
+		if (orderUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for Order");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(orders, orderUnsafeConsumer);
+		}
+		else {
+			for (Order order : orders) {
+				orderUnsafeConsumer.accept(order);
+			}
+		}
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -419,8 +420,20 @@ public abstract class BaseOrderRuleResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		UnsafeConsumer<OrderRule, Exception> orderRuleUnsafeConsumer =
-			orderRule -> postOrderRule(orderRule);
+		UnsafeConsumer<OrderRule, Exception> orderRuleUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
+			orderRuleUnsafeConsumer = orderRule -> postOrderRule(orderRule);
+		}
+
+		if (orderRuleUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for OrderRule");
+		}
 
 		if (contextBatchUnsafeConsumer != null) {
 			contextBatchUnsafeConsumer.accept(
@@ -499,6 +512,34 @@ public abstract class BaseOrderRuleResourceImpl
 			java.util.Collection<OrderRule> orderRules,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		UnsafeConsumer<OrderRule, Exception> orderRuleUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			orderRuleUnsafeConsumer = orderRule -> patchOrderRule(
+				orderRule.getId() != null ? orderRule.getId() :
+					Long.parseLong((String)parameters.get("orderRuleId")),
+				orderRule);
+		}
+
+		if (orderRuleUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for OrderRule");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				orderRules, orderRuleUnsafeConsumer);
+		}
+		else {
+			for (OrderRule orderRule : orderRules) {
+				orderRuleUnsafeConsumer.accept(orderRule);
+			}
+		}
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderTypeResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -481,8 +482,20 @@ public abstract class BaseOrderTypeResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		UnsafeConsumer<OrderType, Exception> orderTypeUnsafeConsumer =
-			orderType -> postOrderType(orderType);
+		UnsafeConsumer<OrderType, Exception> orderTypeUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
+			orderTypeUnsafeConsumer = orderType -> postOrderType(orderType);
+		}
+
+		if (orderTypeUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for OrderType");
+		}
 
 		if (contextBatchUnsafeConsumer != null) {
 			contextBatchUnsafeConsumer.accept(
@@ -561,6 +574,34 @@ public abstract class BaseOrderTypeResourceImpl
 			java.util.Collection<OrderType> orderTypes,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		UnsafeConsumer<OrderType, Exception> orderTypeUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			orderTypeUnsafeConsumer = orderType -> patchOrderType(
+				orderType.getId() != null ? orderType.getId() :
+					Long.parseLong((String)parameters.get("orderTypeId")),
+				orderType);
+		}
+
+		if (orderTypeUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for OrderType");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				orderTypes, orderTypeUnsafeConsumer);
+		}
+		else {
+			for (OrderType orderType : orderTypes) {
+				orderTypeUnsafeConsumer.accept(orderType);
+			}
+		}
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseTermResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseTermResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -413,8 +414,20 @@ public abstract class BaseTermResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		UnsafeConsumer<Term, Exception> termUnsafeConsumer = term -> postTerm(
-			term);
+		UnsafeConsumer<Term, Exception> termUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
+			termUnsafeConsumer = term -> postTerm(term);
+		}
+
+		if (termUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for Term");
+		}
 
 		if (contextBatchUnsafeConsumer != null) {
 			contextBatchUnsafeConsumer.accept(terms, termUnsafeConsumer);
@@ -492,6 +505,33 @@ public abstract class BaseTermResourceImpl
 			java.util.Collection<Term> terms,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		UnsafeConsumer<Term, Exception> termUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			termUnsafeConsumer = term -> patchTerm(
+				term.getId() != null ? term.getId() :
+					Long.parseLong((String)parameters.get("termId")),
+				term);
+		}
+
+		if (termUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for Term");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(terms, termUnsafeConsumer);
+		}
+		else {
+			for (Term term : terms) {
+				termUnsafeConsumer.accept(term);
+			}
+		}
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -414,8 +415,20 @@ public abstract class BaseDiscountResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		UnsafeConsumer<Discount, Exception> discountUnsafeConsumer =
-			discount -> postDiscount(discount);
+		UnsafeConsumer<Discount, Exception> discountUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
+			discountUnsafeConsumer = discount -> postDiscount(discount);
+		}
+
+		if (discountUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for Discount");
+		}
 
 		if (contextBatchUnsafeConsumer != null) {
 			contextBatchUnsafeConsumer.accept(
@@ -494,6 +507,34 @@ public abstract class BaseDiscountResourceImpl
 			java.util.Collection<Discount> discounts,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		UnsafeConsumer<Discount, Exception> discountUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			discountUnsafeConsumer = discount -> patchDiscount(
+				discount.getId() != null ? discount.getId() :
+					Long.parseLong((String)parameters.get("discountId")),
+				discount);
+		}
+
+		if (discountUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for Discount");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				discounts, discountUnsafeConsumer);
+		}
+		else {
+			for (Discount discount : discounts) {
+				discountUnsafeConsumer.accept(discount);
+			}
+		}
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountRuleResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountRuleResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -483,6 +484,35 @@ public abstract class BaseDiscountRuleResourceImpl
 			java.util.Collection<DiscountRule> discountRules,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		UnsafeConsumer<DiscountRule, Exception> discountRuleUnsafeConsumer =
+			null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			discountRuleUnsafeConsumer = discountRule -> patchDiscountRule(
+				discountRule.getId() != null ? discountRule.getId() :
+					Long.parseLong((String)parameters.get("discountRuleId")),
+				discountRule);
+		}
+
+		if (discountRuleUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for DiscountRule");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				discountRules, discountRuleUnsafeConsumer);
+		}
+		else {
+			for (DiscountRule discountRule : discountRules) {
+				discountRuleUnsafeConsumer.accept(discountRule);
+			}
+		}
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BasePriceEntryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BasePriceEntryResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -584,6 +585,34 @@ public abstract class BasePriceEntryResourceImpl
 			java.util.Collection<PriceEntry> priceEntries,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		UnsafeConsumer<PriceEntry, Exception> priceEntryUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			priceEntryUnsafeConsumer = priceEntry -> patchPriceEntry(
+				priceEntry.getId() != null ? priceEntry.getId() :
+					Long.parseLong((String)parameters.get("priceEntryId")),
+				priceEntry);
+		}
+
+		if (priceEntryUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for PriceEntry");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				priceEntries, priceEntryUnsafeConsumer);
+		}
+		else {
+			for (PriceEntry priceEntry : priceEntries) {
+				priceEntryUnsafeConsumer.accept(priceEntry);
+			}
+		}
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BasePriceListResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BasePriceListResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -424,8 +425,20 @@ public abstract class BasePriceListResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		UnsafeConsumer<PriceList, Exception> priceListUnsafeConsumer =
-			priceList -> postPriceList(priceList);
+		UnsafeConsumer<PriceList, Exception> priceListUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
+			priceListUnsafeConsumer = priceList -> postPriceList(priceList);
+		}
+
+		if (priceListUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for PriceList");
+		}
 
 		if (contextBatchUnsafeConsumer != null) {
 			contextBatchUnsafeConsumer.accept(
@@ -504,6 +517,34 @@ public abstract class BasePriceListResourceImpl
 			java.util.Collection<PriceList> priceLists,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		UnsafeConsumer<PriceList, Exception> priceListUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			priceListUnsafeConsumer = priceList -> patchPriceList(
+				priceList.getId() != null ? priceList.getId() :
+					Long.parseLong((String)parameters.get("priceListId")),
+				priceList);
+		}
+
+		if (priceListUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for PriceList");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				priceLists, priceListUnsafeConsumer);
+		}
+		else {
+			for (PriceList priceList : priceLists) {
+				priceListUnsafeConsumer.accept(priceList);
+			}
+		}
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseTierPriceResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseTierPriceResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -584,6 +585,34 @@ public abstract class BaseTierPriceResourceImpl
 			java.util.Collection<TierPrice> tierPrices,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		UnsafeConsumer<TierPrice, Exception> tierPriceUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			tierPriceUnsafeConsumer = tierPrice -> patchTierPrice(
+				tierPrice.getId() != null ? tierPrice.getId() :
+					Long.parseLong((String)parameters.get("tierPriceId")),
+				tierPrice);
+		}
+
+		if (tierPriceUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for TierPrice");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				tierPrices, tierPriceUnsafeConsumer);
+		}
+		else {
+			for (TierPrice tierPrice : tierPrices) {
+				tierPriceUnsafeConsumer.accept(tierPrice);
+			}
+		}
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -419,8 +420,20 @@ public abstract class BaseDiscountResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		UnsafeConsumer<Discount, Exception> discountUnsafeConsumer =
-			discount -> postDiscount(discount);
+		UnsafeConsumer<Discount, Exception> discountUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
+			discountUnsafeConsumer = discount -> postDiscount(discount);
+		}
+
+		if (discountUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for Discount");
+		}
 
 		if (contextBatchUnsafeConsumer != null) {
 			contextBatchUnsafeConsumer.accept(
@@ -499,6 +512,34 @@ public abstract class BaseDiscountResourceImpl
 			java.util.Collection<Discount> discounts,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		UnsafeConsumer<Discount, Exception> discountUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			discountUnsafeConsumer = discount -> patchDiscount(
+				discount.getId() != null ? discount.getId() :
+					Long.parseLong((String)parameters.get("discountId")),
+				discount);
+		}
+
+		if (discountUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for Discount");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				discounts, discountUnsafeConsumer);
+		}
+		else {
+			for (Discount discount : discounts) {
+				discountUnsafeConsumer.accept(discount);
+			}
+		}
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountRuleResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountRuleResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -494,6 +495,35 @@ public abstract class BaseDiscountRuleResourceImpl
 			java.util.Collection<DiscountRule> discountRules,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		UnsafeConsumer<DiscountRule, Exception> discountRuleUnsafeConsumer =
+			null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			discountRuleUnsafeConsumer = discountRule -> patchDiscountRule(
+				discountRule.getId() != null ? discountRule.getId() :
+					Long.parseLong((String)parameters.get("discountRuleId")),
+				discountRule);
+		}
+
+		if (discountRuleUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for DiscountRule");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				discountRules, discountRuleUnsafeConsumer);
+		}
+		else {
+			for (DiscountRule discountRule : discountRules) {
+				discountRuleUnsafeConsumer.accept(discountRule);
+			}
+		}
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceEntryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceEntryResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -585,6 +586,35 @@ public abstract class BasePriceEntryResourceImpl
 			java.util.Collection<PriceEntry> priceEntries,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		UnsafeConsumer<PriceEntry, Exception> priceEntryUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			priceEntryUnsafeConsumer = priceEntry -> patchPriceEntry(
+				(priceEntry.getPriceEntryId() != null) ?
+					priceEntry.getPriceEntryId() :
+						Long.parseLong((String)parameters.get("priceEntryId")),
+				priceEntry);
+		}
+
+		if (priceEntryUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for PriceEntry");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				priceEntries, priceEntryUnsafeConsumer);
+		}
+		else {
+			for (PriceEntry priceEntry : priceEntries) {
+				priceEntryUnsafeConsumer.accept(priceEntry);
+			}
+		}
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -419,8 +420,20 @@ public abstract class BasePriceListResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		UnsafeConsumer<PriceList, Exception> priceListUnsafeConsumer =
-			priceList -> postPriceList(priceList);
+		UnsafeConsumer<PriceList, Exception> priceListUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
+			priceListUnsafeConsumer = priceList -> postPriceList(priceList);
+		}
+
+		if (priceListUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for PriceList");
+		}
 
 		if (contextBatchUnsafeConsumer != null) {
 			contextBatchUnsafeConsumer.accept(
@@ -499,6 +512,34 @@ public abstract class BasePriceListResourceImpl
 			java.util.Collection<PriceList> priceLists,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		UnsafeConsumer<PriceList, Exception> priceListUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			priceListUnsafeConsumer = priceList -> patchPriceList(
+				priceList.getId() != null ? priceList.getId() :
+					Long.parseLong((String)parameters.get("priceListId")),
+				priceList);
+		}
+
+		if (priceListUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for PriceList");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				priceLists, priceListUnsafeConsumer);
+		}
+		else {
+			for (PriceList priceList : priceLists) {
+				priceListUnsafeConsumer.accept(priceList);
+			}
+		}
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceModifierResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceModifierResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -618,6 +619,35 @@ public abstract class BasePriceModifierResourceImpl
 			java.util.Collection<PriceModifier> priceModifiers,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		UnsafeConsumer<PriceModifier, Exception> priceModifierUnsafeConsumer =
+			null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			priceModifierUnsafeConsumer = priceModifier -> patchPriceModifier(
+				priceModifier.getId() != null ? priceModifier.getId() :
+					Long.parseLong((String)parameters.get("priceModifierId")),
+				priceModifier);
+		}
+
+		if (priceModifierUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for PriceModifier");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				priceModifiers, priceModifierUnsafeConsumer);
+		}
+		else {
+			for (PriceModifier priceModifier : priceModifiers) {
+				priceModifierUnsafeConsumer.accept(priceModifier);
+			}
+		}
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseTierPriceResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseTierPriceResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -579,6 +580,34 @@ public abstract class BaseTierPriceResourceImpl
 			java.util.Collection<TierPrice> tierPrices,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		UnsafeConsumer<TierPrice, Exception> tierPriceUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			tierPriceUnsafeConsumer = tierPrice -> patchTierPrice(
+				tierPrice.getId() != null ? tierPrice.getId() :
+					Long.parseLong((String)parameters.get("tierPriceId")),
+				tierPrice);
+		}
+
+		if (tierPriceUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for TierPrice");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				tierPrices, tierPriceUnsafeConsumer);
+		}
+		else {
+			for (TierPrice tierPrice : tierPrices) {
+				tierPriceUnsafeConsumer.accept(tierPrice);
+			}
+		}
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/BaseShipmentItemResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/BaseShipmentItemResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -519,6 +520,35 @@ public abstract class BaseShipmentItemResourceImpl
 			java.util.Collection<ShipmentItem> shipmentItems,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		UnsafeConsumer<ShipmentItem, Exception> shipmentItemUnsafeConsumer =
+			null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			shipmentItemUnsafeConsumer = shipmentItem -> patchShipmentItem(
+				shipmentItem.getId() != null ? shipmentItem.getId() :
+					Long.parseLong((String)parameters.get("shipmentItemId")),
+				shipmentItem);
+		}
+
+		if (shipmentItemUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for ShipmentItem");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				shipmentItems, shipmentItemUnsafeConsumer);
+		}
+		else {
+			for (ShipmentItem shipmentItem : shipmentItems) {
+				shipmentItemUnsafeConsumer.accept(shipmentItem);
+			}
+		}
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/BaseShipmentResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/BaseShipmentResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -704,8 +705,26 @@ public abstract class BaseShipmentResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		UnsafeConsumer<Shipment, Exception> shipmentUnsafeConsumer =
-			shipment -> postShipment(shipment);
+		UnsafeConsumer<Shipment, Exception> shipmentUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
+			shipmentUnsafeConsumer = shipment -> postShipment(shipment);
+		}
+
+		if ("UPSERT".equalsIgnoreCase(createStrategy)) {
+			shipmentUnsafeConsumer =
+				shipment -> putShipmentByExternalReferenceCode(
+					shipment.getExternalReferenceCode(), shipment);
+		}
+
+		if (shipmentUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for Shipment");
+		}
 
 		if (contextBatchUnsafeConsumer != null) {
 			contextBatchUnsafeConsumer.accept(
@@ -784,6 +803,34 @@ public abstract class BaseShipmentResourceImpl
 			java.util.Collection<Shipment> shipments,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		UnsafeConsumer<Shipment, Exception> shipmentUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			shipmentUnsafeConsumer = shipment -> patchShipment(
+				shipment.getId() != null ? shipment.getId() :
+					Long.parseLong((String)parameters.get("shipmentId")),
+				shipment);
+		}
+
+		if (shipmentUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for Shipment");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				shipments, shipmentUnsafeConsumer);
+		}
+		else {
+			for (Shipment shipment : shipments) {
+				shipmentUnsafeConsumer.accept(shipment);
+			}
+		}
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseAvailabilityEstimateResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseAvailabilityEstimateResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -446,15 +447,39 @@ public abstract class BaseAvailabilityEstimateResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		for (AvailabilityEstimate availabilityEstimate :
-				availabilityEstimates) {
+		UnsafeConsumer<AvailabilityEstimate, Exception>
+			availabilityEstimateUnsafeConsumer = null;
 
-			putAvailabilityEstimate(
-				availabilityEstimate.getId() != null ?
-					availabilityEstimate.getId() :
-						Long.parseLong(
-							(String)parameters.get("availabilityEstimateId")),
-				availabilityEstimate);
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
+			availabilityEstimateUnsafeConsumer =
+				availabilityEstimate -> putAvailabilityEstimate(
+					availabilityEstimate.getId() != null ?
+						availabilityEstimate.getId() :
+							Long.parseLong(
+								(String)parameters.get(
+									"availabilityEstimateId")),
+					availabilityEstimate);
+		}
+
+		if (availabilityEstimateUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for AvailabilityEstimate");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				availabilityEstimates, availabilityEstimateUnsafeConsumer);
+		}
+		else {
+			for (AvailabilityEstimate availabilityEstimate :
+					availabilityEstimates) {
+
+				availabilityEstimateUnsafeConsumer.accept(availabilityEstimate);
+			}
 		}
 	}
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseMeasurementUnitResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseMeasurementUnitResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -432,11 +433,35 @@ public abstract class BaseMeasurementUnitResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		for (MeasurementUnit measurementUnit : measurementUnits) {
-			putMeasurementUnit(
-				measurementUnit.getId() != null ? measurementUnit.getId() :
-					Long.parseLong((String)parameters.get("measurementUnitId")),
-				measurementUnit);
+		UnsafeConsumer<MeasurementUnit, Exception>
+			measurementUnitUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
+			measurementUnitUnsafeConsumer =
+				measurementUnit -> putMeasurementUnit(
+					measurementUnit.getId() != null ? measurementUnit.getId() :
+						Long.parseLong(
+							(String)parameters.get("measurementUnitId")),
+					measurementUnit);
+		}
+
+		if (measurementUnitUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for MeasurementUnit");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				measurementUnits, measurementUnitUnsafeConsumer);
+		}
+		else {
+			for (MeasurementUnit measurementUnit : measurementUnits) {
+				measurementUnitUnsafeConsumer.accept(measurementUnit);
+			}
 		}
 	}
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseTaxCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseTaxCategoryResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -410,11 +411,32 @@ public abstract class BaseTaxCategoryResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		for (TaxCategory taxCategory : taxCategories) {
-			putTaxCategory(
+		UnsafeConsumer<TaxCategory, Exception> taxCategoryUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
+			taxCategoryUnsafeConsumer = taxCategory -> putTaxCategory(
 				taxCategory.getId() != null ? taxCategory.getId() :
 					Long.parseLong((String)parameters.get("taxCategoryId")),
 				taxCategory);
+		}
+
+		if (taxCategoryUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for TaxCategory");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				taxCategories, taxCategoryUnsafeConsumer);
+		}
+		else {
+			for (TaxCategory taxCategory : taxCategories) {
+				taxCategoryUnsafeConsumer.accept(taxCategory);
+			}
 		}
 	}
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseWarehouseResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseWarehouseResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -417,11 +418,32 @@ public abstract class BaseWarehouseResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		for (Warehouse warehouse : warehouses) {
-			putWarehouse(
+		UnsafeConsumer<Warehouse, Exception> warehouseUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
+			warehouseUnsafeConsumer = warehouse -> putWarehouse(
 				warehouse.getId() != null ? warehouse.getId() :
 					Long.parseLong((String)parameters.get("warehouseId")),
 				warehouse);
+		}
+
+		if (warehouseUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for Warehouse");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				warehouses, warehouseUnsafeConsumer);
+		}
+		else {
+			for (Warehouse warehouse : warehouses) {
+				warehouseUnsafeConsumer.accept(warehouse);
+			}
 		}
 	}
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartCommentResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartCommentResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -449,11 +450,39 @@ public abstract class BaseCartCommentResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		for (CartComment cartComment : cartComments) {
-			putCartComment(
+		UnsafeConsumer<CartComment, Exception> cartCommentUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			cartCommentUnsafeConsumer = cartComment -> patchCartComment(
 				cartComment.getId() != null ? cartComment.getId() :
 					Long.parseLong((String)parameters.get("cartCommentId")),
 				cartComment);
+		}
+
+		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
+			cartCommentUnsafeConsumer = cartComment -> putCartComment(
+				cartComment.getId() != null ? cartComment.getId() :
+					Long.parseLong((String)parameters.get("cartCommentId")),
+				cartComment);
+		}
+
+		if (cartCommentUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for CartComment");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				cartComments, cartCommentUnsafeConsumer);
+		}
+		else {
+			for (CartComment cartComment : cartComments) {
+				cartCommentUnsafeConsumer.accept(cartComment);
+			}
 		}
 	}
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartItemResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartItemResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -516,11 +517,39 @@ public abstract class BaseCartItemResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		for (CartItem cartItem : cartItems) {
-			putCartItem(
+		UnsafeConsumer<CartItem, Exception> cartItemUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			cartItemUnsafeConsumer = cartItem -> patchCartItem(
 				cartItem.getId() != null ? cartItem.getId() :
 					Long.parseLong((String)parameters.get("cartItemId")),
 				cartItem);
+		}
+
+		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
+			cartItemUnsafeConsumer = cartItem -> putCartItem(
+				cartItem.getId() != null ? cartItem.getId() :
+					Long.parseLong((String)parameters.get("cartItemId")),
+				cartItem);
+		}
+
+		if (cartItemUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for CartItem");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				cartItems, cartItemUnsafeConsumer);
+		}
+		else {
+			for (CartItem cartItem : cartItems) {
+				cartItemUnsafeConsumer.accept(cartItem);
+			}
 		}
 	}
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartResourceImpl.java
@@ -56,6 +56,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -660,11 +661,38 @@ public abstract class BaseCartResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		for (Cart cart : carts) {
-			putCart(
+		UnsafeConsumer<Cart, Exception> cartUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			cartUnsafeConsumer = cart -> patchCart(
 				cart.getId() != null ? cart.getId() :
 					Long.parseLong((String)parameters.get("cartId")),
 				cart);
+		}
+
+		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
+			cartUnsafeConsumer = cart -> putCart(
+				cart.getId() != null ? cart.getId() :
+					Long.parseLong((String)parameters.get("cartId")),
+				cart);
+		}
+
+		if (cartUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for Cart");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(carts, cartUnsafeConsumer);
+		}
+		else {
+			for (Cart cart : carts) {
+				cartUnsafeConsumer.accept(cart);
+			}
 		}
 	}
 

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataDefinitionResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataDefinitionResourceImpl.java
@@ -63,6 +63,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -820,11 +821,42 @@ public abstract class BaseDataDefinitionResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		for (DataDefinition dataDefinition : dataDefinitions) {
-			putDataDefinition(
+		UnsafeConsumer<DataDefinition, Exception> dataDefinitionUnsafeConsumer =
+			null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			dataDefinitionUnsafeConsumer =
+				dataDefinition -> patchDataDefinition(
+					dataDefinition.getId() != null ? dataDefinition.getId() :
+						Long.parseLong(
+							(String)parameters.get("dataDefinitionId")),
+					dataDefinition);
+		}
+
+		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
+			dataDefinitionUnsafeConsumer = dataDefinition -> putDataDefinition(
 				dataDefinition.getId() != null ? dataDefinition.getId() :
 					Long.parseLong((String)parameters.get("dataDefinitionId")),
 				dataDefinition);
+		}
+
+		if (dataDefinitionUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for DataDefinition");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				dataDefinitions, dataDefinitionUnsafeConsumer);
+		}
+		else {
+			for (DataDefinition dataDefinition : dataDefinitions) {
+				dataDefinitionUnsafeConsumer.accept(dataDefinition);
+			}
 		}
 	}
 

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataLayoutResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataLayoutResourceImpl.java
@@ -55,6 +55,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -500,10 +501,23 @@ public abstract class BaseDataLayoutResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		UnsafeConsumer<DataLayout, Exception> dataLayoutUnsafeConsumer =
-			dataLayout -> postDataDefinitionDataLayout(
-				Long.parseLong((String)parameters.get("dataDefinitionId")),
-				dataLayout);
+		UnsafeConsumer<DataLayout, Exception> dataLayoutUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
+			dataLayoutUnsafeConsumer =
+				dataLayout -> postDataDefinitionDataLayout(
+					Long.parseLong((String)parameters.get("dataDefinitionId")),
+					dataLayout);
+		}
+
+		if (dataLayoutUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for DataLayout");
+		}
 
 		if (contextBatchUnsafeConsumer != null) {
 			contextBatchUnsafeConsumer.accept(
@@ -585,11 +599,32 @@ public abstract class BaseDataLayoutResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		for (DataLayout dataLayout : dataLayouts) {
-			putDataLayout(
+		UnsafeConsumer<DataLayout, Exception> dataLayoutUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
+			dataLayoutUnsafeConsumer = dataLayout -> putDataLayout(
 				dataLayout.getId() != null ? dataLayout.getId() :
 					Long.parseLong((String)parameters.get("dataLayoutId")),
 				dataLayout);
+		}
+
+		if (dataLayoutUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for DataLayout");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				dataLayouts, dataLayoutUnsafeConsumer);
+		}
+		else {
+			for (DataLayout dataLayout : dataLayouts) {
+				dataLayoutUnsafeConsumer.accept(dataLayout);
+			}
 		}
 	}
 

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataListViewResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataListViewResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -420,9 +421,23 @@ public abstract class BaseDataListViewResourceImpl
 		throws Exception {
 
 		UnsafeConsumer<DataListView, Exception> dataListViewUnsafeConsumer =
-			dataListView -> postDataDefinitionDataListView(
-				Long.parseLong((String)parameters.get("dataDefinitionId")),
-				dataListView);
+			null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
+			dataListViewUnsafeConsumer =
+				dataListView -> postDataDefinitionDataListView(
+					Long.parseLong((String)parameters.get("dataDefinitionId")),
+					dataListView);
+		}
+
+		if (dataListViewUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for DataListView");
+		}
 
 		if (contextBatchUnsafeConsumer != null) {
 			contextBatchUnsafeConsumer.accept(
@@ -504,11 +519,33 @@ public abstract class BaseDataListViewResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		for (DataListView dataListView : dataListViews) {
-			putDataListView(
+		UnsafeConsumer<DataListView, Exception> dataListViewUnsafeConsumer =
+			null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
+			dataListViewUnsafeConsumer = dataListView -> putDataListView(
 				dataListView.getId() != null ? dataListView.getId() :
 					Long.parseLong((String)parameters.get("dataListViewId")),
 				dataListView);
+		}
+
+		if (dataListViewUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for DataListView");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				dataListViews, dataListViewUnsafeConsumer);
+		}
+		else {
+			for (DataListView dataListView : dataListViews) {
+				dataListViewUnsafeConsumer.accept(dataListView);
+			}
 		}
 	}
 

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataRecordCollectionResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataRecordCollectionResourceImpl.java
@@ -63,6 +63,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -687,10 +688,23 @@ public abstract class BaseDataRecordCollectionResourceImpl
 		throws Exception {
 
 		UnsafeConsumer<DataRecordCollection, Exception>
+			dataRecordCollectionUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
 			dataRecordCollectionUnsafeConsumer =
 				dataRecordCollection -> postDataDefinitionDataRecordCollection(
 					Long.parseLong((String)parameters.get("dataDefinitionId")),
 					dataRecordCollection);
+		}
+
+		if (dataRecordCollectionUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for DataRecordCollection");
+		}
 
 		if (contextBatchUnsafeConsumer != null) {
 			contextBatchUnsafeConsumer.accept(
@@ -776,15 +790,39 @@ public abstract class BaseDataRecordCollectionResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		for (DataRecordCollection dataRecordCollection :
-				dataRecordCollections) {
+		UnsafeConsumer<DataRecordCollection, Exception>
+			dataRecordCollectionUnsafeConsumer = null;
 
-			putDataRecordCollection(
-				dataRecordCollection.getId() != null ?
-					dataRecordCollection.getId() :
-						Long.parseLong(
-							(String)parameters.get("dataRecordCollectionId")),
-				dataRecordCollection);
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
+			dataRecordCollectionUnsafeConsumer =
+				dataRecordCollection -> putDataRecordCollection(
+					dataRecordCollection.getId() != null ?
+						dataRecordCollection.getId() :
+							Long.parseLong(
+								(String)parameters.get(
+									"dataRecordCollectionId")),
+					dataRecordCollection);
+		}
+
+		if (dataRecordCollectionUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for DataRecordCollection");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				dataRecordCollections, dataRecordCollectionUnsafeConsumer);
+		}
+		else {
+			for (DataRecordCollection dataRecordCollection :
+					dataRecordCollections) {
+
+				dataRecordCollectionUnsafeConsumer.accept(dataRecordCollection);
+			}
 		}
 	}
 

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataRecordResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataRecordResourceImpl.java
@@ -55,6 +55,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -636,10 +637,23 @@ public abstract class BaseDataRecordResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		UnsafeConsumer<DataRecord, Exception> dataRecordUnsafeConsumer =
-			dataRecord -> postDataDefinitionDataRecord(
-				Long.parseLong((String)parameters.get("dataDefinitionId")),
-				dataRecord);
+		UnsafeConsumer<DataRecord, Exception> dataRecordUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
+			dataRecordUnsafeConsumer =
+				dataRecord -> postDataDefinitionDataRecord(
+					Long.parseLong((String)parameters.get("dataDefinitionId")),
+					dataRecord);
+		}
+
+		if (dataRecordUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for DataRecord");
+		}
 
 		if (contextBatchUnsafeConsumer != null) {
 			contextBatchUnsafeConsumer.accept(
@@ -722,11 +736,39 @@ public abstract class BaseDataRecordResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		for (DataRecord dataRecord : dataRecords) {
-			putDataRecord(
+		UnsafeConsumer<DataRecord, Exception> dataRecordUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			dataRecordUnsafeConsumer = dataRecord -> patchDataRecord(
 				dataRecord.getId() != null ? dataRecord.getId() :
 					Long.parseLong((String)parameters.get("dataRecordId")),
 				dataRecord);
+		}
+
+		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
+			dataRecordUnsafeConsumer = dataRecord -> putDataRecord(
+				dataRecord.getId() != null ? dataRecord.getId() :
+					Long.parseLong((String)parameters.get("dataRecordId")),
+				dataRecord);
+		}
+
+		if (dataRecordUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for DataRecord");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				dataRecords, dataRecordUnsafeConsumer);
+		}
+		else {
+			for (DataRecord dataRecord : dataRecords) {
+				dataRecordUnsafeConsumer.accept(dataRecord);
+			}
 		}
 	}
 

--- a/modules/apps/digital-signature/digital-signature-rest-impl/src/main/java/com/liferay/digital/signature/rest/internal/resource/v1_0/BaseDSEnvelopeResourceImpl.java
+++ b/modules/apps/digital-signature/digital-signature-rest-impl/src/main/java/com/liferay/digital/signature/rest/internal/resource/v1_0/BaseDSEnvelopeResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -238,13 +239,25 @@ public abstract class BaseDSEnvelopeResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		UnsafeConsumer<DSEnvelope, Exception> dsEnvelopeUnsafeConsumer =
-			dsEnvelope -> {
+		UnsafeConsumer<DSEnvelope, Exception> dsEnvelopeUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
+			dsEnvelopeUnsafeConsumer = dsEnvelope -> {
 			};
 
-		if (parameters.containsKey("siteId")) {
-			dsEnvelopeUnsafeConsumer = dsEnvelope -> postSiteDSEnvelope(
-				(Long)parameters.get("siteId"), dsEnvelope);
+			if (parameters.containsKey("siteId")) {
+				dsEnvelopeUnsafeConsumer = dsEnvelope -> postSiteDSEnvelope(
+					(Long)parameters.get("siteId"), dsEnvelope);
+			}
+		}
+
+		if (dsEnvelopeUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for DsEnvelope");
 		}
 
 		if (contextBatchUnsafeConsumer != null) {

--- a/modules/apps/headless/headless-admin-address/headless-admin-address-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-address/headless-admin-address-impl/rest-openapi.yaml
@@ -85,7 +85,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.admin.address.client', and version '1.0.2'."
+        'com.liferay.headless.admin.address.client', and version '1.0.3'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/java/com/liferay/headless/admin/address/internal/resource/v1_0/BaseCountryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/java/com/liferay/headless/admin/address/internal/resource/v1_0/BaseCountryResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -406,8 +407,20 @@ public abstract class BaseCountryResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		UnsafeConsumer<Country, Exception> countryUnsafeConsumer =
-			country -> postCountry(country);
+		UnsafeConsumer<Country, Exception> countryUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
+			countryUnsafeConsumer = country -> postCountry(country);
+		}
+
+		if (countryUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for Country");
+		}
 
 		if (contextBatchUnsafeConsumer != null) {
 			contextBatchUnsafeConsumer.accept(countries, countryUnsafeConsumer);

--- a/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/java/com/liferay/headless/admin/address/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/java/com/liferay/headless/admin/address/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -47,7 +47,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.address.client', and version '1.0.2'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin Address", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.address.client', and version '1.0.3'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin Address", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-impl/rest-openapi.yaml
@@ -186,7 +186,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.admin.content.client', and version '2.0.14'."
+        'com.liferay.headless.admin.content.client', and version '2.0.15'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -47,7 +47,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.content.client', and version '2.0.14'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin Content", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.content.client', and version '2.0.15'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin Content", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/resource/v1_0/BaseListTypeDefinitionResourceImpl.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/resource/v1_0/BaseListTypeDefinitionResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -449,9 +450,22 @@ public abstract class BaseListTypeDefinitionResourceImpl
 		throws Exception {
 
 		UnsafeConsumer<ListTypeDefinition, Exception>
+			listTypeDefinitionUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
 			listTypeDefinitionUnsafeConsumer =
 				listTypeDefinition -> postListTypeDefinition(
 					listTypeDefinition);
+		}
+
+		if (listTypeDefinitionUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for ListTypeDefinition");
+		}
 
 		if (contextBatchUnsafeConsumer != null) {
 			contextBatchUnsafeConsumer.accept(
@@ -532,13 +546,46 @@ public abstract class BaseListTypeDefinitionResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		for (ListTypeDefinition listTypeDefinition : listTypeDefinitions) {
-			putListTypeDefinition(
-				listTypeDefinition.getId() != null ?
-					listTypeDefinition.getId() :
-						Long.parseLong(
-							(String)parameters.get("listTypeDefinitionId")),
-				listTypeDefinition);
+		UnsafeConsumer<ListTypeDefinition, Exception>
+			listTypeDefinitionUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			listTypeDefinitionUnsafeConsumer =
+				listTypeDefinition -> patchListTypeDefinition(
+					listTypeDefinition.getId() != null ?
+						listTypeDefinition.getId() :
+							Long.parseLong(
+								(String)parameters.get("listTypeDefinitionId")),
+					listTypeDefinition);
+		}
+
+		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
+			listTypeDefinitionUnsafeConsumer =
+				listTypeDefinition -> putListTypeDefinition(
+					listTypeDefinition.getId() != null ?
+						listTypeDefinition.getId() :
+							Long.parseLong(
+								(String)parameters.get("listTypeDefinitionId")),
+					listTypeDefinition);
+		}
+
+		if (listTypeDefinitionUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for ListTypeDefinition");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				listTypeDefinitions, listTypeDefinitionUnsafeConsumer);
+		}
+		else {
+			for (ListTypeDefinition listTypeDefinition : listTypeDefinitions) {
+				listTypeDefinitionUnsafeConsumer.accept(listTypeDefinition);
+			}
 		}
 	}
 

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/resource/v1_0/BaseListTypeEntryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/resource/v1_0/BaseListTypeEntryResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -419,9 +420,24 @@ public abstract class BaseListTypeEntryResourceImpl
 		throws Exception {
 
 		UnsafeConsumer<ListTypeEntry, Exception> listTypeEntryUnsafeConsumer =
-			listTypeEntry -> postListTypeDefinitionListTypeEntry(
-				Long.parseLong((String)parameters.get("listTypeDefinitionId")),
-				listTypeEntry);
+			null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
+			listTypeEntryUnsafeConsumer =
+				listTypeEntry -> postListTypeDefinitionListTypeEntry(
+					Long.parseLong(
+						(String)parameters.get("listTypeDefinitionId")),
+					listTypeEntry);
+		}
+
+		if (listTypeEntryUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for ListTypeEntry");
+		}
 
 		if (contextBatchUnsafeConsumer != null) {
 			contextBatchUnsafeConsumer.accept(
@@ -501,11 +517,33 @@ public abstract class BaseListTypeEntryResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		for (ListTypeEntry listTypeEntry : listTypeEntries) {
-			putListTypeEntry(
+		UnsafeConsumer<ListTypeEntry, Exception> listTypeEntryUnsafeConsumer =
+			null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
+			listTypeEntryUnsafeConsumer = listTypeEntry -> putListTypeEntry(
 				listTypeEntry.getId() != null ? listTypeEntry.getId() :
 					Long.parseLong((String)parameters.get("listTypeEntryId")),
 				listTypeEntry);
+		}
+
+		if (listTypeEntryUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for ListTypeEntry");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				listTypeEntries, listTypeEntryUnsafeConsumer);
+		}
+		else {
+			for (ListTypeEntry listTypeEntry : listTypeEntries) {
+				listTypeEntryUnsafeConsumer.accept(listTypeEntry);
+			}
 		}
 	}
 

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseKeywordResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseKeywordResourceImpl.java
@@ -62,6 +62,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -890,16 +891,29 @@ public abstract class BaseKeywordResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		UnsafeConsumer<Keyword, Exception> keywordUnsafeConsumer = keyword -> {
-		};
+		UnsafeConsumer<Keyword, Exception> keywordUnsafeConsumer = null;
 
-		if (parameters.containsKey("assetLibraryId")) {
-			keywordUnsafeConsumer = keyword -> postAssetLibraryKeyword(
-				(Long)parameters.get("assetLibraryId"), keyword);
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
+			keywordUnsafeConsumer = keyword -> {
+			};
+
+			if (parameters.containsKey("assetLibraryId")) {
+				keywordUnsafeConsumer = keyword -> postAssetLibraryKeyword(
+					(Long)parameters.get("assetLibraryId"), keyword);
+			}
+			else if (parameters.containsKey("siteId")) {
+				keywordUnsafeConsumer = keyword -> postSiteKeyword(
+					(Long)parameters.get("siteId"), keyword);
+			}
 		}
-		else if (parameters.containsKey("siteId")) {
-			keywordUnsafeConsumer = keyword -> postSiteKeyword(
-				(Long)parameters.get("siteId"), keyword);
+
+		if (keywordUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for Keyword");
 		}
 
 		if (contextBatchUnsafeConsumer != null) {
@@ -991,11 +1005,31 @@ public abstract class BaseKeywordResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		for (Keyword keyword : keywords) {
-			putKeyword(
+		UnsafeConsumer<Keyword, Exception> keywordUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
+			keywordUnsafeConsumer = keyword -> putKeyword(
 				keyword.getId() != null ? keyword.getId() :
 					Long.parseLong((String)parameters.get("keywordId")),
 				keyword);
+		}
+
+		if (keywordUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for Keyword");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(keywords, keywordUnsafeConsumer);
+		}
+		else {
+			for (Keyword keyword : keywords) {
+				keywordUnsafeConsumer.accept(keyword);
+			}
 		}
 	}
 

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyCategoryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyCategoryResourceImpl.java
@@ -62,6 +62,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -956,11 +957,35 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 		throws Exception {
 
 		UnsafeConsumer<TaxonomyCategory, Exception>
+			taxonomyCategoryUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
 			taxonomyCategoryUnsafeConsumer =
 				taxonomyCategory -> postTaxonomyVocabularyTaxonomyCategory(
 					Long.parseLong(
 						(String)parameters.get("taxonomyVocabularyId")),
 					taxonomyCategory);
+		}
+
+		if ("UPSERT".equalsIgnoreCase(createStrategy)) {
+			taxonomyCategoryUnsafeConsumer = taxonomyCategory ->
+				putTaxonomyVocabularyTaxonomyCategoryByExternalReferenceCode(
+					taxonomyCategory.getTaxonomyVocabularyId() != null ?
+						taxonomyCategory.getTaxonomyVocabularyId() :
+							Long.parseLong(
+								(String)parameters.get("taxonomyVocabularyId")),
+					taxonomyCategory.getExternalReferenceCode(),
+					taxonomyCategory);
+		}
+
+		if (taxonomyCategoryUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for TaxonomyCategory");
+		}
 
 		if (contextBatchUnsafeConsumer != null) {
 			contextBatchUnsafeConsumer.accept(
@@ -1040,11 +1065,44 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		for (TaxonomyCategory taxonomyCategory : taxonomyCategories) {
-			putTaxonomyCategory(
-				taxonomyCategory.getId() != null ? taxonomyCategory.getId() :
-					(String)parameters.get("taxonomyCategoryId"),
-				taxonomyCategory);
+		UnsafeConsumer<TaxonomyCategory, Exception>
+			taxonomyCategoryUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			taxonomyCategoryUnsafeConsumer =
+				taxonomyCategory -> patchTaxonomyCategory(
+					taxonomyCategory.getId() != null ?
+						taxonomyCategory.getId() :
+							(String)parameters.get("taxonomyCategoryId"),
+					taxonomyCategory);
+		}
+
+		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
+			taxonomyCategoryUnsafeConsumer =
+				taxonomyCategory -> putTaxonomyCategory(
+					taxonomyCategory.getId() != null ?
+						taxonomyCategory.getId() :
+							(String)parameters.get("taxonomyCategoryId"),
+					taxonomyCategory);
+		}
+
+		if (taxonomyCategoryUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for TaxonomyCategory");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				taxonomyCategories, taxonomyCategoryUnsafeConsumer);
+		}
+		else {
+			for (TaxonomyCategory taxonomyCategory : taxonomyCategories) {
+				taxonomyCategoryUnsafeConsumer.accept(taxonomyCategory);
+			}
 		}
 	}
 

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyVocabularyResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyVocabularyResourceImpl.java
@@ -62,6 +62,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -1203,18 +1204,42 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 		throws Exception {
 
 		UnsafeConsumer<TaxonomyVocabulary, Exception>
+			taxonomyVocabularyUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
 			taxonomyVocabularyUnsafeConsumer = taxonomyVocabulary -> {
 			};
 
-		if (parameters.containsKey("assetLibraryId")) {
-			taxonomyVocabularyUnsafeConsumer =
-				taxonomyVocabulary -> postAssetLibraryTaxonomyVocabulary(
-					(Long)parameters.get("assetLibraryId"), taxonomyVocabulary);
+			if (parameters.containsKey("assetLibraryId")) {
+				taxonomyVocabularyUnsafeConsumer =
+					taxonomyVocabulary -> postAssetLibraryTaxonomyVocabulary(
+						(Long)parameters.get("assetLibraryId"),
+						taxonomyVocabulary);
+			}
+			else if (parameters.containsKey("siteId")) {
+				taxonomyVocabularyUnsafeConsumer =
+					taxonomyVocabulary -> postSiteTaxonomyVocabulary(
+						(Long)parameters.get("siteId"), taxonomyVocabulary);
+			}
 		}
-		else if (parameters.containsKey("siteId")) {
-			taxonomyVocabularyUnsafeConsumer =
-				taxonomyVocabulary -> postSiteTaxonomyVocabulary(
-					(Long)parameters.get("siteId"), taxonomyVocabulary);
+
+		if ("UPSERT".equalsIgnoreCase(createStrategy)) {
+			taxonomyVocabularyUnsafeConsumer = taxonomyVocabulary ->
+				putSiteTaxonomyVocabularyByExternalReferenceCode(
+					taxonomyVocabulary.getSiteId() != null ?
+						taxonomyVocabulary.getSiteId() :
+							(Long)parameters.get("siteId"),
+					taxonomyVocabulary.getExternalReferenceCode(),
+					taxonomyVocabulary);
+		}
+
+		if (taxonomyVocabularyUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for TaxonomyVocabulary");
 		}
 
 		if (contextBatchUnsafeConsumer != null) {
@@ -1295,13 +1320,46 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		for (TaxonomyVocabulary taxonomyVocabulary : taxonomyVocabularies) {
-			putTaxonomyVocabulary(
-				taxonomyVocabulary.getId() != null ?
-					taxonomyVocabulary.getId() :
-						Long.parseLong(
-							(String)parameters.get("taxonomyVocabularyId")),
-				taxonomyVocabulary);
+		UnsafeConsumer<TaxonomyVocabulary, Exception>
+			taxonomyVocabularyUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			taxonomyVocabularyUnsafeConsumer =
+				taxonomyVocabulary -> patchTaxonomyVocabulary(
+					taxonomyVocabulary.getId() != null ?
+						taxonomyVocabulary.getId() :
+							Long.parseLong(
+								(String)parameters.get("taxonomyVocabularyId")),
+					taxonomyVocabulary);
+		}
+
+		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
+			taxonomyVocabularyUnsafeConsumer =
+				taxonomyVocabulary -> putTaxonomyVocabulary(
+					taxonomyVocabulary.getId() != null ?
+						taxonomyVocabulary.getId() :
+							Long.parseLong(
+								(String)parameters.get("taxonomyVocabularyId")),
+					taxonomyVocabulary);
+		}
+
+		if (taxonomyVocabularyUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for TaxonomyVocabulary");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				taxonomyVocabularies, taxonomyVocabularyUnsafeConsumer);
+		}
+		else {
+			for (TaxonomyVocabulary taxonomyVocabulary : taxonomyVocabularies) {
+				taxonomyVocabularyUnsafeConsumer.accept(taxonomyVocabulary);
+			}
 		}
 	}
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseAccountResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseAccountResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -904,8 +905,26 @@ public abstract class BaseAccountResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		UnsafeConsumer<Account, Exception> accountUnsafeConsumer =
-			account -> postAccount(account);
+		UnsafeConsumer<Account, Exception> accountUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
+			accountUnsafeConsumer = account -> postAccount(account);
+		}
+
+		if ("UPSERT".equalsIgnoreCase(createStrategy)) {
+			accountUnsafeConsumer =
+				account -> putAccountByExternalReferenceCode(
+					account.getExternalReferenceCode(), account);
+		}
+
+		if (accountUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for Account");
+		}
 
 		if (contextBatchUnsafeConsumer != null) {
 			contextBatchUnsafeConsumer.accept(accounts, accountUnsafeConsumer);
@@ -984,11 +1003,38 @@ public abstract class BaseAccountResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		for (Account account : accounts) {
-			putAccount(
+		UnsafeConsumer<Account, Exception> accountUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			accountUnsafeConsumer = account -> patchAccount(
 				account.getId() != null ? account.getId() :
 					Long.parseLong((String)parameters.get("accountId")),
 				account);
+		}
+
+		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
+			accountUnsafeConsumer = account -> putAccount(
+				account.getId() != null ? account.getId() :
+					Long.parseLong((String)parameters.get("accountId")),
+				account);
+		}
+
+		if (accountUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for Account");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(accounts, accountUnsafeConsumer);
+		}
+		else {
+			for (Account account : accounts) {
+				accountUnsafeConsumer.accept(account);
+			}
 		}
 	}
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseAccountRoleResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseAccountRoleResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -706,10 +707,22 @@ public abstract class BaseAccountRoleResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		UnsafeConsumer<AccountRole, Exception> accountRoleUnsafeConsumer =
-			accountRole -> postAccountAccountRole(
+		UnsafeConsumer<AccountRole, Exception> accountRoleUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
+			accountRoleUnsafeConsumer = accountRole -> postAccountAccountRole(
 				Long.parseLong((String)parameters.get("accountId")),
 				accountRole);
+		}
+
+		if (accountRoleUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for AccountRole");
+		}
 
 		if (contextBatchUnsafeConsumer != null) {
 			contextBatchUnsafeConsumer.accept(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseOrganizationResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseOrganizationResourceImpl.java
@@ -55,6 +55,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -1235,7 +1236,27 @@ public abstract class BaseOrganizationResourceImpl
 		throws Exception {
 
 		UnsafeConsumer<Organization, Exception> organizationUnsafeConsumer =
-			organization -> postOrganization(organization);
+			null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
+			organizationUnsafeConsumer = organization -> postOrganization(
+				organization);
+		}
+
+		if ("UPSERT".equalsIgnoreCase(createStrategy)) {
+			organizationUnsafeConsumer =
+				organization -> putOrganizationByExternalReferenceCode(
+					organization.getExternalReferenceCode(), organization);
+		}
+
+		if (organizationUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for Organization");
+		}
 
 		if (contextBatchUnsafeConsumer != null) {
 			contextBatchUnsafeConsumer.accept(
@@ -1317,11 +1338,40 @@ public abstract class BaseOrganizationResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		for (Organization organization : organizations) {
-			putOrganization(
+		UnsafeConsumer<Organization, Exception> organizationUnsafeConsumer =
+			null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			organizationUnsafeConsumer = organization -> patchOrganization(
 				organization.getId() != null ? organization.getId() :
 					(String)parameters.get("organizationId"),
 				organization);
+		}
+
+		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
+			organizationUnsafeConsumer = organization -> putOrganization(
+				organization.getId() != null ? organization.getId() :
+					(String)parameters.get("organizationId"),
+				organization);
+		}
+
+		if (organizationUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for Organization");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				organizations, organizationUnsafeConsumer);
+		}
+		else {
+			for (Organization organization : organizations) {
+				organizationUnsafeConsumer.accept(organization);
+			}
 		}
 	}
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseUserAccountResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseUserAccountResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -1377,10 +1378,28 @@ public abstract class BaseUserAccountResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		UnsafeConsumer<UserAccount, Exception> userAccountUnsafeConsumer =
-			userAccount -> postAccountUserAccount(
+		UnsafeConsumer<UserAccount, Exception> userAccountUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
+			userAccountUnsafeConsumer = userAccount -> postAccountUserAccount(
 				Long.parseLong((String)parameters.get("accountId")),
 				userAccount);
+		}
+
+		if ("UPSERT".equalsIgnoreCase(createStrategy)) {
+			userAccountUnsafeConsumer =
+				userAccount -> putUserAccountByExternalReferenceCode(
+					userAccount.getExternalReferenceCode(), userAccount);
+		}
+
+		if (userAccountUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for UserAccount");
+		}
 
 		if (contextBatchUnsafeConsumer != null) {
 			contextBatchUnsafeConsumer.accept(
@@ -1469,11 +1488,39 @@ public abstract class BaseUserAccountResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		for (UserAccount userAccount : userAccounts) {
-			putUserAccount(
+		UnsafeConsumer<UserAccount, Exception> userAccountUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			userAccountUnsafeConsumer = userAccount -> patchUserAccount(
 				userAccount.getId() != null ? userAccount.getId() :
 					Long.parseLong((String)parameters.get("userAccountId")),
 				userAccount);
+		}
+
+		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
+			userAccountUnsafeConsumer = userAccount -> putUserAccount(
+				userAccount.getId() != null ? userAccount.getId() :
+					Long.parseLong((String)parameters.get("userAccountId")),
+				userAccount);
+		}
+
+		if (userAccountUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for UserAccount");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				userAccounts, userAccountUnsafeConsumer);
+		}
+		else {
+			for (UserAccount userAccount : userAccounts) {
+				userAccountUnsafeConsumer.accept(userAccount);
+			}
 		}
 	}
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseUserGroupResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseUserGroupResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -637,8 +638,26 @@ public abstract class BaseUserGroupResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		UnsafeConsumer<UserGroup, Exception> userGroupUnsafeConsumer =
-			userGroup -> postUserGroup(userGroup);
+		UnsafeConsumer<UserGroup, Exception> userGroupUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
+			userGroupUnsafeConsumer = userGroup -> postUserGroup(userGroup);
+		}
+
+		if ("UPSERT".equalsIgnoreCase(createStrategy)) {
+			userGroupUnsafeConsumer =
+				userGroup -> putUserGroupByExternalReferenceCode(
+					userGroup.getExternalReferenceCode(), userGroup);
+		}
+
+		if (userGroupUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for UserGroup");
+		}
 
 		if (contextBatchUnsafeConsumer != null) {
 			contextBatchUnsafeConsumer.accept(
@@ -718,11 +737,39 @@ public abstract class BaseUserGroupResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		for (UserGroup userGroup : userGroups) {
-			putUserGroup(
+		UnsafeConsumer<UserGroup, Exception> userGroupUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			userGroupUnsafeConsumer = userGroup -> patchUserGroup(
 				userGroup.getId() != null ? userGroup.getId() :
 					Long.parseLong((String)parameters.get("userGroupId")),
 				userGroup);
+		}
+
+		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
+			userGroupUnsafeConsumer = userGroup -> putUserGroup(
+				userGroup.getId() != null ? userGroup.getId() :
+					Long.parseLong((String)parameters.get("userGroupId")),
+				userGroup);
+		}
+
+		if (userGroupUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for UserGroup");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				userGroups, userGroupUnsafeConsumer);
+		}
+		else {
+			for (UserGroup userGroup : userGroups) {
+				userGroupUnsafeConsumer.accept(userGroup);
+			}
 		}
 	}
 

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-api/bnd.bnd
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Batch Engine API
 Bundle-SymbolicName: com.liferay.headless.batch.engine.api
-Bundle-Version: 15.1.1
+Bundle-Version: 16.0.0
 Export-Package:\
 	com.liferay.headless.batch.engine.dto.v1_0,\
 	com.liferay.headless.batch.engine.resource.v1_0

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-api/src/main/java/com/liferay/headless/batch/engine/resource/v1_0/ImportTaskResource.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-api/src/main/java/com/liferay/headless/batch/engine/resource/v1_0/ImportTaskResource.java
@@ -80,26 +80,28 @@ public interface ImportTaskResource {
 		throws Exception;
 
 	public ImportTask postImportTask(
-			String className, String callbackURL, String externalReferenceCode,
-			String fieldNameMapping, String importStrategy,
-			String taskItemDelegateName, Object object)
+			String className, String callbackURL, String createStrategy,
+			String externalReferenceCode, String fieldNameMapping,
+			String importStrategy, String taskItemDelegateName, Object object)
 		throws Exception;
 
 	public ImportTask postImportTask(
-			String className, String callbackURL, String externalReferenceCode,
-			String fieldNameMapping, String importStrategy,
-			String taskItemDelegateName, MultipartBody multipartBody)
-		throws Exception;
-
-	public ImportTask putImportTask(
-			String className, String callbackURL, String externalReferenceCode,
-			String importStrategy, String taskItemDelegateName, Object object)
+			String className, String callbackURL, String createStrategy,
+			String externalReferenceCode, String fieldNameMapping,
+			String importStrategy, String taskItemDelegateName,
+			MultipartBody multipartBody)
 		throws Exception;
 
 	public ImportTask putImportTask(
 			String className, String callbackURL, String externalReferenceCode,
 			String importStrategy, String taskItemDelegateName,
-			MultipartBody multipartBody)
+			String updateStrategy, Object object)
+		throws Exception;
+
+	public ImportTask putImportTask(
+			String className, String callbackURL, String externalReferenceCode,
+			String importStrategy, String taskItemDelegateName,
+			String updateStrategy, MultipartBody multipartBody)
 		throws Exception;
 
 	public ImportTask getImportTask(Long importTaskId) throws Exception;

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-api/src/main/resources/com/liferay/headless/batch/engine/resource/v1_0/packageinfo
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-api/src/main/resources/com/liferay/headless/batch/engine/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 5.1.0
+version 6.0.0

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-client/src/main/java/com/liferay/headless/batch/engine/client/resource/v1_0/ImportTaskResource.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-client/src/main/java/com/liferay/headless/batch/engine/client/resource/v1_0/ImportTaskResource.java
@@ -90,51 +90,55 @@ public interface ImportTaskResource {
 		throws Exception;
 
 	public ImportTask postImportTask(
-			String className, String callbackURL, String externalReferenceCode,
-			String fieldNameMapping, String importStrategy,
-			String taskItemDelegateName, Object object)
+			String className, String callbackURL, String createStrategy,
+			String externalReferenceCode, String fieldNameMapping,
+			String importStrategy, String taskItemDelegateName, Object object)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse postImportTaskHttpResponse(
-			String className, String callbackURL, String externalReferenceCode,
-			String fieldNameMapping, String importStrategy,
-			String taskItemDelegateName, Object object)
+			String className, String callbackURL, String createStrategy,
+			String externalReferenceCode, String fieldNameMapping,
+			String importStrategy, String taskItemDelegateName, Object object)
 		throws Exception;
 
 	public ImportTask postFormDataImportTask(
-			String className, String callbackURL, String externalReferenceCode,
-			String fieldNameMapping, String importStrategy,
-			String taskItemDelegateName, ImportTask importTask,
-			Map<String, File> multipartFiles)
+			String className, String callbackURL, String createStrategy,
+			String externalReferenceCode, String fieldNameMapping,
+			String importStrategy, String taskItemDelegateName,
+			ImportTask importTask, Map<String, File> multipartFiles)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse postFormDataImportTaskHttpResponse(
-			String className, String callbackURL, String externalReferenceCode,
-			String fieldNameMapping, String importStrategy,
-			String taskItemDelegateName, ImportTask importTask,
-			Map<String, File> multipartFiles)
+			String className, String callbackURL, String createStrategy,
+			String externalReferenceCode, String fieldNameMapping,
+			String importStrategy, String taskItemDelegateName,
+			ImportTask importTask, Map<String, File> multipartFiles)
 		throws Exception;
 
 	public ImportTask putImportTask(
 			String className, String callbackURL, String externalReferenceCode,
-			String importStrategy, String taskItemDelegateName, Object object)
+			String importStrategy, String taskItemDelegateName,
+			String updateStrategy, Object object)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse putImportTaskHttpResponse(
 			String className, String callbackURL, String externalReferenceCode,
-			String importStrategy, String taskItemDelegateName, Object object)
+			String importStrategy, String taskItemDelegateName,
+			String updateStrategy, Object object)
 		throws Exception;
 
 	public ImportTask putFormDataImportTask(
 			String className, String callbackURL, String externalReferenceCode,
 			String importStrategy, String taskItemDelegateName,
-			ImportTask importTask, Map<String, File> multipartFiles)
+			String updateStrategy, ImportTask importTask,
+			Map<String, File> multipartFiles)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse putFormDataImportTaskHttpResponse(
 			String className, String callbackURL, String externalReferenceCode,
 			String importStrategy, String taskItemDelegateName,
-			ImportTask importTask, Map<String, File> multipartFiles)
+			String updateStrategy, ImportTask importTask,
+			Map<String, File> multipartFiles)
 		throws Exception;
 
 	public ImportTask getImportTask(Long importTaskId) throws Exception;
@@ -690,15 +694,15 @@ public interface ImportTaskResource {
 		}
 
 		public ImportTask postImportTask(
-				String className, String callbackURL,
+				String className, String callbackURL, String createStrategy,
 				String externalReferenceCode, String fieldNameMapping,
 				String importStrategy, String taskItemDelegateName,
 				Object object)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse = postImportTaskHttpResponse(
-				className, callbackURL, externalReferenceCode, fieldNameMapping,
-				importStrategy, taskItemDelegateName, object);
+				className, callbackURL, createStrategy, externalReferenceCode,
+				fieldNameMapping, importStrategy, taskItemDelegateName, object);
 
 			String content = httpResponse.getContent();
 
@@ -738,7 +742,7 @@ public interface ImportTaskResource {
 		}
 
 		public HttpInvoker.HttpResponse postImportTaskHttpResponse(
-				String className, String callbackURL,
+				String className, String callbackURL, String createStrategy,
 				String externalReferenceCode, String fieldNameMapping,
 				String importStrategy, String taskItemDelegateName,
 				Object object)
@@ -770,6 +774,11 @@ public interface ImportTaskResource {
 			if (callbackURL != null) {
 				httpInvoker.parameter(
 					"callbackURL", String.valueOf(callbackURL));
+			}
+
+			if (createStrategy != null) {
+				httpInvoker.parameter(
+					"createStrategy", String.valueOf(createStrategy));
 			}
 
 			if (externalReferenceCode != null) {
@@ -808,7 +817,7 @@ public interface ImportTaskResource {
 		}
 
 		public ImportTask postFormDataImportTask(
-				String className, String callbackURL,
+				String className, String callbackURL, String createStrategy,
 				String externalReferenceCode, String fieldNameMapping,
 				String importStrategy, String taskItemDelegateName,
 				ImportTask importTask, Map<String, File> multipartFiles)
@@ -816,9 +825,9 @@ public interface ImportTaskResource {
 
 			HttpInvoker.HttpResponse httpResponse =
 				postFormDataImportTaskHttpResponse(
-					className, callbackURL, externalReferenceCode,
-					fieldNameMapping, importStrategy, taskItemDelegateName,
-					importTask, multipartFiles);
+					className, callbackURL, createStrategy,
+					externalReferenceCode, fieldNameMapping, importStrategy,
+					taskItemDelegateName, importTask, multipartFiles);
 
 			String content = httpResponse.getContent();
 
@@ -858,7 +867,7 @@ public interface ImportTaskResource {
 		}
 
 		public HttpInvoker.HttpResponse postFormDataImportTaskHttpResponse(
-				String className, String callbackURL,
+				String className, String callbackURL, String createStrategy,
 				String externalReferenceCode, String fieldNameMapping,
 				String importStrategy, String taskItemDelegateName,
 				ImportTask importTask, Map<String, File> multipartFiles)
@@ -896,6 +905,11 @@ public interface ImportTaskResource {
 			if (callbackURL != null) {
 				httpInvoker.parameter(
 					"callbackURL", String.valueOf(callbackURL));
+			}
+
+			if (createStrategy != null) {
+				httpInvoker.parameter(
+					"createStrategy", String.valueOf(createStrategy));
 			}
 
 			if (externalReferenceCode != null) {
@@ -936,12 +950,13 @@ public interface ImportTaskResource {
 		public ImportTask putImportTask(
 				String className, String callbackURL,
 				String externalReferenceCode, String importStrategy,
-				String taskItemDelegateName, Object object)
+				String taskItemDelegateName, String updateStrategy,
+				Object object)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse = putImportTaskHttpResponse(
 				className, callbackURL, externalReferenceCode, importStrategy,
-				taskItemDelegateName, object);
+				taskItemDelegateName, updateStrategy, object);
 
 			String content = httpResponse.getContent();
 
@@ -983,7 +998,8 @@ public interface ImportTaskResource {
 		public HttpInvoker.HttpResponse putImportTaskHttpResponse(
 				String className, String callbackURL,
 				String externalReferenceCode, String importStrategy,
-				String taskItemDelegateName, Object object)
+				String taskItemDelegateName, String updateStrategy,
+				Object object)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -1031,6 +1047,11 @@ public interface ImportTaskResource {
 					String.valueOf(taskItemDelegateName));
 			}
 
+			if (updateStrategy != null) {
+				httpInvoker.parameter(
+					"updateStrategy", String.valueOf(updateStrategy));
+			}
+
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port +
@@ -1047,15 +1068,15 @@ public interface ImportTaskResource {
 		public ImportTask putFormDataImportTask(
 				String className, String callbackURL,
 				String externalReferenceCode, String importStrategy,
-				String taskItemDelegateName, ImportTask importTask,
-				Map<String, File> multipartFiles)
+				String taskItemDelegateName, String updateStrategy,
+				ImportTask importTask, Map<String, File> multipartFiles)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
 				putFormDataImportTaskHttpResponse(
 					className, callbackURL, externalReferenceCode,
-					importStrategy, taskItemDelegateName, importTask,
-					multipartFiles);
+					importStrategy, taskItemDelegateName, updateStrategy,
+					importTask, multipartFiles);
 
 			String content = httpResponse.getContent();
 
@@ -1097,8 +1118,8 @@ public interface ImportTaskResource {
 		public HttpInvoker.HttpResponse putFormDataImportTaskHttpResponse(
 				String className, String callbackURL,
 				String externalReferenceCode, String importStrategy,
-				String taskItemDelegateName, ImportTask importTask,
-				Map<String, File> multipartFiles)
+				String taskItemDelegateName, String updateStrategy,
+				ImportTask importTask, Map<String, File> multipartFiles)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -1150,6 +1171,11 @@ public interface ImportTaskResource {
 				httpInvoker.parameter(
 					"taskItemDelegateName",
 					String.valueOf(taskItemDelegateName));
+			}
+
+			if (updateStrategy != null) {
+				httpInvoker.parameter(
+					"updateStrategy", String.valueOf(updateStrategy));
 			}
 
 			httpInvoker.path(

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/rest-openapi.yaml
@@ -425,6 +425,11 @@ paths:
                   schema:
                       type: string
                 - in: query
+                  name: createStrategy
+                  schema:
+                      enum: [INSERT, UPSERT]
+                      type: string
+                - in: query
                   name: externalReferenceCode
                   schema:
                       type: string
@@ -500,6 +505,11 @@ paths:
                 - in: query
                   name: taskItemDelegateName
                   schema:
+                      type: string
+                - in: query
+                  name: updateStrategy
+                  schema:
+                      enum: [PARTIAL_UPDATE, UPDATE]
                       type: string
             requestBody:
                 content:

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/src/main/java/com/liferay/headless/batch/engine/internal/resource/v1_0/BaseImportTaskResourceImpl.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/src/main/java/com/liferay/headless/batch/engine/internal/resource/v1_0/BaseImportTaskResourceImpl.java
@@ -308,6 +308,10 @@ public abstract class BaseImportTaskResourceImpl implements ImportTaskResource {
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "createStrategy"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "externalReferenceCode"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
@@ -346,6 +350,9 @@ public abstract class BaseImportTaskResourceImpl implements ImportTaskResource {
 			@javax.ws.rs.QueryParam("callbackURL")
 			String callbackURL,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("createStrategy")
+			String createStrategy,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@javax.ws.rs.QueryParam("externalReferenceCode")
 			String externalReferenceCode,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
@@ -383,6 +390,10 @@ public abstract class BaseImportTaskResourceImpl implements ImportTaskResource {
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "createStrategy"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "externalReferenceCode"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
@@ -415,6 +426,9 @@ public abstract class BaseImportTaskResourceImpl implements ImportTaskResource {
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@javax.ws.rs.QueryParam("callbackURL")
 			String callbackURL,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("createStrategy")
+			String createStrategy,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@javax.ws.rs.QueryParam("externalReferenceCode")
 			String externalReferenceCode,
@@ -462,6 +476,10 @@ public abstract class BaseImportTaskResourceImpl implements ImportTaskResource {
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "taskItemDelegateName"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "updateStrategy"
 			)
 		}
 	)
@@ -495,6 +513,9 @@ public abstract class BaseImportTaskResourceImpl implements ImportTaskResource {
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@javax.ws.rs.QueryParam("taskItemDelegateName")
 			String taskItemDelegateName,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("updateStrategy")
+			String updateStrategy,
 			Object object)
 		throws Exception {
 
@@ -530,6 +551,10 @@ public abstract class BaseImportTaskResourceImpl implements ImportTaskResource {
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "taskItemDelegateName"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "updateStrategy"
 			)
 		}
 	)
@@ -558,6 +583,9 @@ public abstract class BaseImportTaskResourceImpl implements ImportTaskResource {
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@javax.ws.rs.QueryParam("taskItemDelegateName")
 			String taskItemDelegateName,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("updateStrategy")
+			String updateStrategy,
 			MultipartBody multipartBody)
 		throws Exception {
 

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/src/main/java/com/liferay/headless/batch/engine/internal/resource/v1_0/ImportTaskResourceImpl.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/src/main/java/com/liferay/headless/batch/engine/internal/resource/v1_0/ImportTaskResourceImpl.java
@@ -95,8 +95,8 @@ public class ImportTaskResourceImpl extends BaseImportTaskResourceImpl {
 
 		return _importFile(
 			BatchEngineTaskOperation.DELETE,
-			multipartBody.getBinaryFile("file"), callbackURL, className, null,
-			externalReferenceCode, importStrategy, taskItemDelegateName);
+			multipartBody.getBinaryFile("file"), callbackURL, className,
+			externalReferenceCode, null, importStrategy, taskItemDelegateName);
 	}
 
 	@Override
@@ -110,9 +110,8 @@ public class ImportTaskResourceImpl extends BaseImportTaskResourceImpl {
 
 		return _importFile(
 			BatchEngineTaskOperation.DELETE, _getBytes(object, contentType),
-			callbackURL, className, externalReferenceCode,
-			_getBatchEngineTaskContentType(contentType), taskItemDelegateName,
-			importStrategy, null);
+			callbackURL, className, _getBatchEngineTaskContentType(contentType),
+			externalReferenceCode, taskItemDelegateName, importStrategy, null);
 	}
 
 	@Override
@@ -212,8 +211,8 @@ public class ImportTaskResourceImpl extends BaseImportTaskResourceImpl {
 
 		return _importFile(
 			BatchEngineTaskOperation.UPDATE,
-			multipartBody.getBinaryFile("file"), callbackURL, className, null,
-			externalReferenceCode, importStrategy, taskItemDelegateName);
+			multipartBody.getBinaryFile("file"), callbackURL, className,
+			externalReferenceCode, null, importStrategy, taskItemDelegateName);
 	}
 
 	@Override
@@ -228,7 +227,7 @@ public class ImportTaskResourceImpl extends BaseImportTaskResourceImpl {
 		return _importFile(
 			BatchEngineTaskOperation.UPDATE, _getBytes(object, contentType),
 			callbackURL, className, _getBatchEngineTaskContentType(contentType),
-			null, externalReferenceCode, importStrategy, taskItemDelegateName);
+			externalReferenceCode, null, importStrategy, taskItemDelegateName);
 	}
 
 	@Activate

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -5042,7 +5042,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.delivery.client', and version '4.0.26'."
+        'com.liferay.headless.delivery.client', and version '4.0.27'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingImageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingImageResourceImpl.java
@@ -55,6 +55,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -347,14 +348,27 @@ public abstract class BaseBlogPostingImageResourceImpl
 		throws Exception {
 
 		UnsafeConsumer<BlogPostingImage, Exception>
+			blogPostingImageUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
 			blogPostingImageUnsafeConsumer = blogPostingImage -> {
 			};
 
-		if (parameters.containsKey("siteId")) {
-			blogPostingImageUnsafeConsumer =
-				blogPostingImage -> postSiteBlogPostingImage(
-					(Long)parameters.get("siteId"),
-					(MultipartBody)parameters.get("multipartBody"));
+			if (parameters.containsKey("siteId")) {
+				blogPostingImageUnsafeConsumer =
+					blogPostingImage -> postSiteBlogPostingImage(
+						(Long)parameters.get("siteId"),
+						(MultipartBody)parameters.get("multipartBody"));
+			}
+		}
+
+		if (blogPostingImageUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for BlogPostingImage");
 		}
 
 		if (contextBatchUnsafeConsumer != null) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingResourceImpl.java
@@ -64,6 +64,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -1124,13 +1125,33 @@ public abstract class BaseBlogPostingResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		UnsafeConsumer<BlogPosting, Exception> blogPostingUnsafeConsumer =
-			blogPosting -> {
+		UnsafeConsumer<BlogPosting, Exception> blogPostingUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
+			blogPostingUnsafeConsumer = blogPosting -> {
 			};
 
-		if (parameters.containsKey("siteId")) {
-			blogPostingUnsafeConsumer = blogPosting -> postSiteBlogPosting(
-				(Long)parameters.get("siteId"), blogPosting);
+			if (parameters.containsKey("siteId")) {
+				blogPostingUnsafeConsumer = blogPosting -> postSiteBlogPosting(
+					(Long)parameters.get("siteId"), blogPosting);
+			}
+		}
+
+		if ("UPSERT".equalsIgnoreCase(createStrategy)) {
+			blogPostingUnsafeConsumer =
+				blogPosting -> putSiteBlogPostingByExternalReferenceCode(
+					blogPosting.getSiteId() != null ? blogPosting.getSiteId() :
+						(Long)parameters.get("siteId"),
+					blogPosting.getExternalReferenceCode(), blogPosting);
+		}
+
+		if (blogPostingUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for BlogPosting");
 		}
 
 		if (contextBatchUnsafeConsumer != null) {
@@ -1218,11 +1239,39 @@ public abstract class BaseBlogPostingResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		for (BlogPosting blogPosting : blogPostings) {
-			putBlogPosting(
+		UnsafeConsumer<BlogPosting, Exception> blogPostingUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			blogPostingUnsafeConsumer = blogPosting -> patchBlogPosting(
 				blogPosting.getId() != null ? blogPosting.getId() :
 					Long.parseLong((String)parameters.get("blogPostingId")),
 				blogPosting);
+		}
+
+		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
+			blogPostingUnsafeConsumer = blogPosting -> putBlogPosting(
+				blogPosting.getId() != null ? blogPosting.getId() :
+					Long.parseLong((String)parameters.get("blogPostingId")),
+				blogPosting);
+		}
+
+		if (blogPostingUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for BlogPosting");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				blogPostings, blogPostingUnsafeConsumer);
+		}
+		else {
+			for (BlogPosting blogPosting : blogPostings) {
+				blogPostingUnsafeConsumer.accept(blogPosting);
+			}
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseCommentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseCommentResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -1429,10 +1430,22 @@ public abstract class BaseCommentResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		UnsafeConsumer<Comment, Exception> commentUnsafeConsumer =
-			comment -> postBlogPostingComment(
+		UnsafeConsumer<Comment, Exception> commentUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
+			commentUnsafeConsumer = comment -> postBlogPostingComment(
 				Long.parseLong((String)parameters.get("blogPostingId")),
 				comment);
+		}
+
+		if (commentUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for Comment");
+		}
 
 		if (contextBatchUnsafeConsumer != null) {
 			contextBatchUnsafeConsumer.accept(comments, commentUnsafeConsumer);
@@ -1513,11 +1526,31 @@ public abstract class BaseCommentResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		for (Comment comment : comments) {
-			putComment(
+		UnsafeConsumer<Comment, Exception> commentUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
+			commentUnsafeConsumer = comment -> putComment(
 				comment.getId() != null ? comment.getId() :
 					Long.parseLong((String)parameters.get("commentId")),
 				comment);
+		}
+
+		if (commentUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for Comment");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(comments, commentUnsafeConsumer);
+		}
+		else {
+			for (Comment comment : comments) {
+				commentUnsafeConsumer.accept(comment);
+			}
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentFolderResourceImpl.java
@@ -62,6 +62,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -1237,18 +1238,31 @@ public abstract class BaseDocumentFolderResourceImpl
 		throws Exception {
 
 		UnsafeConsumer<DocumentFolder, Exception> documentFolderUnsafeConsumer =
-			documentFolder -> {
+			null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
+			documentFolderUnsafeConsumer = documentFolder -> {
 			};
 
-		if (parameters.containsKey("assetLibraryId")) {
-			documentFolderUnsafeConsumer =
-				documentFolder -> postAssetLibraryDocumentFolder(
-					(Long)parameters.get("assetLibraryId"), documentFolder);
+			if (parameters.containsKey("assetLibraryId")) {
+				documentFolderUnsafeConsumer =
+					documentFolder -> postAssetLibraryDocumentFolder(
+						(Long)parameters.get("assetLibraryId"), documentFolder);
+			}
+			else if (parameters.containsKey("siteId")) {
+				documentFolderUnsafeConsumer =
+					documentFolder -> postSiteDocumentFolder(
+						(Long)parameters.get("siteId"), documentFolder);
+			}
 		}
-		else if (parameters.containsKey("siteId")) {
-			documentFolderUnsafeConsumer =
-				documentFolder -> postSiteDocumentFolder(
-					(Long)parameters.get("siteId"), documentFolder);
+
+		if (documentFolderUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for DocumentFolder");
 		}
 
 		if (contextBatchUnsafeConsumer != null) {
@@ -1343,11 +1357,42 @@ public abstract class BaseDocumentFolderResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		for (DocumentFolder documentFolder : documentFolders) {
-			putDocumentFolder(
+		UnsafeConsumer<DocumentFolder, Exception> documentFolderUnsafeConsumer =
+			null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			documentFolderUnsafeConsumer =
+				documentFolder -> patchDocumentFolder(
+					documentFolder.getId() != null ? documentFolder.getId() :
+						Long.parseLong(
+							(String)parameters.get("documentFolderId")),
+					documentFolder);
+		}
+
+		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
+			documentFolderUnsafeConsumer = documentFolder -> putDocumentFolder(
 				documentFolder.getId() != null ? documentFolder.getId() :
 					Long.parseLong((String)parameters.get("documentFolderId")),
 				documentFolder);
+		}
+
+		if (documentFolderUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for DocumentFolder");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				documentFolders, documentFolderUnsafeConsumer);
+		}
+		else {
+			for (DocumentFolder documentFolder : documentFolders) {
+				documentFolderUnsafeConsumer.accept(documentFolder);
+			}
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentResourceImpl.java
@@ -65,6 +65,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -1427,20 +1428,40 @@ public abstract class BaseDocumentResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		UnsafeConsumer<Document, Exception> documentUnsafeConsumer =
-			document -> postDocumentFolderDocument(
+		UnsafeConsumer<Document, Exception> documentUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
+			documentUnsafeConsumer = document -> postDocumentFolderDocument(
 				Long.parseLong((String)parameters.get("documentFolderId")),
 				(MultipartBody)parameters.get("multipartBody"));
 
-		if (parameters.containsKey("assetLibraryId")) {
-			documentUnsafeConsumer = document -> postAssetLibraryDocument(
-				(Long)parameters.get("assetLibraryId"),
-				(MultipartBody)parameters.get("multipartBody"));
+			if (parameters.containsKey("assetLibraryId")) {
+				documentUnsafeConsumer = document -> postAssetLibraryDocument(
+					(Long)parameters.get("assetLibraryId"),
+					(MultipartBody)parameters.get("multipartBody"));
+			}
+			else if (parameters.containsKey("siteId")) {
+				documentUnsafeConsumer = document -> postSiteDocument(
+					(Long)parameters.get("siteId"),
+					(MultipartBody)parameters.get("multipartBody"));
+			}
 		}
-		else if (parameters.containsKey("siteId")) {
-			documentUnsafeConsumer = document -> postSiteDocument(
-				(Long)parameters.get("siteId"),
-				(MultipartBody)parameters.get("multipartBody"));
+
+		if ("UPSERT".equalsIgnoreCase(createStrategy)) {
+			documentUnsafeConsumer =
+				document -> putSiteDocumentByExternalReferenceCode(
+					document.getSiteId() != null ? document.getSiteId() :
+						(Long)parameters.get("siteId"),
+					document.getExternalReferenceCode(), null);
+		}
+
+		if (documentUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for Document");
 		}
 
 		if (contextBatchUnsafeConsumer != null) {
@@ -1538,11 +1559,39 @@ public abstract class BaseDocumentResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		for (Document document : documents) {
-			putDocument(
+		UnsafeConsumer<Document, Exception> documentUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			documentUnsafeConsumer = document -> patchDocument(
 				document.getId() != null ? document.getId() :
 					Long.parseLong((String)parameters.get("documentId")),
 				null);
+		}
+
+		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
+			documentUnsafeConsumer = document -> putDocument(
+				document.getId() != null ? document.getId() :
+					Long.parseLong((String)parameters.get("documentId")),
+				null);
+		}
+
+		if (documentUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for Document");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				documents, documentUnsafeConsumer);
+		}
+		else {
+			for (Document document : documents) {
+				documentUnsafeConsumer.accept(document);
+			}
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseArticleResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseArticleResourceImpl.java
@@ -63,6 +63,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -1583,6 +1584,12 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 		throws Exception {
 
 		UnsafeConsumer<KnowledgeBaseArticle, Exception>
+			knowledgeBaseArticleUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
 			knowledgeBaseArticleUnsafeConsumer =
 				knowledgeBaseArticle ->
 					postKnowledgeBaseFolderKnowledgeBaseArticle(
@@ -1590,10 +1597,27 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 							(String)parameters.get("knowledgeBaseFolderId")),
 						knowledgeBaseArticle);
 
-		if (parameters.containsKey("siteId")) {
-			knowledgeBaseArticleUnsafeConsumer =
-				knowledgeBaseArticle -> postSiteKnowledgeBaseArticle(
-					(Long)parameters.get("siteId"), knowledgeBaseArticle);
+			if (parameters.containsKey("siteId")) {
+				knowledgeBaseArticleUnsafeConsumer =
+					knowledgeBaseArticle -> postSiteKnowledgeBaseArticle(
+						(Long)parameters.get("siteId"), knowledgeBaseArticle);
+			}
+		}
+
+		if ("UPSERT".equalsIgnoreCase(createStrategy)) {
+			knowledgeBaseArticleUnsafeConsumer = knowledgeBaseArticle ->
+				putSiteKnowledgeBaseArticleByExternalReferenceCode(
+					knowledgeBaseArticle.getSiteId() != null ?
+						knowledgeBaseArticle.getSiteId() :
+							(Long)parameters.get("siteId"),
+					knowledgeBaseArticle.getExternalReferenceCode(),
+					knowledgeBaseArticle);
+		}
+
+		if (knowledgeBaseArticleUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for KnowledgeBaseArticle");
 		}
 
 		if (contextBatchUnsafeConsumer != null) {
@@ -1689,15 +1713,50 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		for (KnowledgeBaseArticle knowledgeBaseArticle :
-				knowledgeBaseArticles) {
+		UnsafeConsumer<KnowledgeBaseArticle, Exception>
+			knowledgeBaseArticleUnsafeConsumer = null;
 
-			putKnowledgeBaseArticle(
-				knowledgeBaseArticle.getId() != null ?
-					knowledgeBaseArticle.getId() :
-						Long.parseLong(
-							(String)parameters.get("knowledgeBaseArticleId")),
-				knowledgeBaseArticle);
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			knowledgeBaseArticleUnsafeConsumer =
+				knowledgeBaseArticle -> patchKnowledgeBaseArticle(
+					knowledgeBaseArticle.getId() != null ?
+						knowledgeBaseArticle.getId() :
+							Long.parseLong(
+								(String)parameters.get(
+									"knowledgeBaseArticleId")),
+					knowledgeBaseArticle);
+		}
+
+		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
+			knowledgeBaseArticleUnsafeConsumer =
+				knowledgeBaseArticle -> putKnowledgeBaseArticle(
+					knowledgeBaseArticle.getId() != null ?
+						knowledgeBaseArticle.getId() :
+							Long.parseLong(
+								(String)parameters.get(
+									"knowledgeBaseArticleId")),
+					knowledgeBaseArticle);
+		}
+
+		if (knowledgeBaseArticleUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for KnowledgeBaseArticle");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				knowledgeBaseArticles, knowledgeBaseArticleUnsafeConsumer);
+		}
+		else {
+			for (KnowledgeBaseArticle knowledgeBaseArticle :
+					knowledgeBaseArticles) {
+
+				knowledgeBaseArticleUnsafeConsumer.accept(knowledgeBaseArticle);
+			}
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseAttachmentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseAttachmentResourceImpl.java
@@ -55,6 +55,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -341,11 +342,24 @@ public abstract class BaseKnowledgeBaseAttachmentResourceImpl
 		throws Exception {
 
 		UnsafeConsumer<KnowledgeBaseAttachment, Exception>
+			knowledgeBaseAttachmentUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
 			knowledgeBaseAttachmentUnsafeConsumer = knowledgeBaseAttachment ->
 				postKnowledgeBaseArticleKnowledgeBaseAttachment(
 					Long.parseLong(
 						(String)parameters.get("knowledgeBaseArticleId")),
 					(MultipartBody)parameters.get("multipartBody"));
+		}
+
+		if (knowledgeBaseAttachmentUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for KnowledgeBaseAttachment");
+		}
 
 		if (contextBatchUnsafeConsumer != null) {
 			contextBatchUnsafeConsumer.accept(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseFolderResourceImpl.java
@@ -62,6 +62,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -1026,13 +1027,36 @@ public abstract class BaseKnowledgeBaseFolderResourceImpl
 		throws Exception {
 
 		UnsafeConsumer<KnowledgeBaseFolder, Exception>
+			knowledgeBaseFolderUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
 			knowledgeBaseFolderUnsafeConsumer = knowledgeBaseFolder -> {
 			};
 
-		if (parameters.containsKey("siteId")) {
-			knowledgeBaseFolderUnsafeConsumer =
-				knowledgeBaseFolder -> postSiteKnowledgeBaseFolder(
-					(Long)parameters.get("siteId"), knowledgeBaseFolder);
+			if (parameters.containsKey("siteId")) {
+				knowledgeBaseFolderUnsafeConsumer =
+					knowledgeBaseFolder -> postSiteKnowledgeBaseFolder(
+						(Long)parameters.get("siteId"), knowledgeBaseFolder);
+			}
+		}
+
+		if ("UPSERT".equalsIgnoreCase(createStrategy)) {
+			knowledgeBaseFolderUnsafeConsumer = knowledgeBaseFolder ->
+				putSiteKnowledgeBaseFolderByExternalReferenceCode(
+					knowledgeBaseFolder.getSiteId() != null ?
+						knowledgeBaseFolder.getSiteId() :
+							(Long)parameters.get("siteId"),
+					knowledgeBaseFolder.getExternalReferenceCode(),
+					knowledgeBaseFolder);
+		}
+
+		if (knowledgeBaseFolderUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for KnowledgeBaseFolder");
 		}
 
 		if (contextBatchUnsafeConsumer != null) {
@@ -1121,13 +1145,50 @@ public abstract class BaseKnowledgeBaseFolderResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		for (KnowledgeBaseFolder knowledgeBaseFolder : knowledgeBaseFolders) {
-			putKnowledgeBaseFolder(
-				knowledgeBaseFolder.getId() != null ?
-					knowledgeBaseFolder.getId() :
-						Long.parseLong(
-							(String)parameters.get("knowledgeBaseFolderId")),
-				knowledgeBaseFolder);
+		UnsafeConsumer<KnowledgeBaseFolder, Exception>
+			knowledgeBaseFolderUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			knowledgeBaseFolderUnsafeConsumer =
+				knowledgeBaseFolder -> patchKnowledgeBaseFolder(
+					knowledgeBaseFolder.getId() != null ?
+						knowledgeBaseFolder.getId() :
+							Long.parseLong(
+								(String)parameters.get(
+									"knowledgeBaseFolderId")),
+					knowledgeBaseFolder);
+		}
+
+		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
+			knowledgeBaseFolderUnsafeConsumer =
+				knowledgeBaseFolder -> putKnowledgeBaseFolder(
+					knowledgeBaseFolder.getId() != null ?
+						knowledgeBaseFolder.getId() :
+							Long.parseLong(
+								(String)parameters.get(
+									"knowledgeBaseFolderId")),
+					knowledgeBaseFolder);
+		}
+
+		if (knowledgeBaseFolderUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for KnowledgeBaseFolder");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				knowledgeBaseFolders, knowledgeBaseFolderUnsafeConsumer);
+		}
+		else {
+			for (KnowledgeBaseFolder knowledgeBaseFolder :
+					knowledgeBaseFolders) {
+
+				knowledgeBaseFolderUnsafeConsumer.accept(knowledgeBaseFolder);
+			}
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardAttachmentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardAttachmentResourceImpl.java
@@ -55,6 +55,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -481,11 +482,24 @@ public abstract class BaseMessageBoardAttachmentResourceImpl
 		throws Exception {
 
 		UnsafeConsumer<MessageBoardAttachment, Exception>
+			messageBoardAttachmentUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
 			messageBoardAttachmentUnsafeConsumer = messageBoardAttachment ->
 				postMessageBoardMessageMessageBoardAttachment(
 					Long.parseLong(
 						(String)parameters.get("messageBoardMessageId")),
 					(MultipartBody)parameters.get("multipartBody"));
+		}
+
+		if (messageBoardAttachmentUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for MessageBoardAttachment");
+		}
 
 		if (contextBatchUnsafeConsumer != null) {
 			contextBatchUnsafeConsumer.accept(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardMessageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardMessageResourceImpl.java
@@ -63,6 +63,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -1469,12 +1470,35 @@ public abstract class BaseMessageBoardMessageResourceImpl
 		throws Exception {
 
 		UnsafeConsumer<MessageBoardMessage, Exception>
+			messageBoardMessageUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
 			messageBoardMessageUnsafeConsumer =
 				messageBoardMessage ->
 					postMessageBoardThreadMessageBoardMessage(
 						Long.parseLong(
 							(String)parameters.get("messageBoardThreadId")),
 						messageBoardMessage);
+		}
+
+		if ("UPSERT".equalsIgnoreCase(createStrategy)) {
+			messageBoardMessageUnsafeConsumer = messageBoardMessage ->
+				putSiteMessageBoardMessageByExternalReferenceCode(
+					messageBoardMessage.getSiteId() != null ?
+						messageBoardMessage.getSiteId() :
+							(Long)parameters.get("siteId"),
+					messageBoardMessage.getExternalReferenceCode(),
+					messageBoardMessage);
+		}
+
+		if (messageBoardMessageUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for MessageBoardMessage");
+		}
 
 		if (contextBatchUnsafeConsumer != null) {
 			contextBatchUnsafeConsumer.accept(
@@ -1566,13 +1590,50 @@ public abstract class BaseMessageBoardMessageResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		for (MessageBoardMessage messageBoardMessage : messageBoardMessages) {
-			putMessageBoardMessage(
-				messageBoardMessage.getId() != null ?
-					messageBoardMessage.getId() :
-						Long.parseLong(
-							(String)parameters.get("messageBoardMessageId")),
-				messageBoardMessage);
+		UnsafeConsumer<MessageBoardMessage, Exception>
+			messageBoardMessageUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			messageBoardMessageUnsafeConsumer =
+				messageBoardMessage -> patchMessageBoardMessage(
+					messageBoardMessage.getId() != null ?
+						messageBoardMessage.getId() :
+							Long.parseLong(
+								(String)parameters.get(
+									"messageBoardMessageId")),
+					messageBoardMessage);
+		}
+
+		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
+			messageBoardMessageUnsafeConsumer =
+				messageBoardMessage -> putMessageBoardMessage(
+					messageBoardMessage.getId() != null ?
+						messageBoardMessage.getId() :
+							Long.parseLong(
+								(String)parameters.get(
+									"messageBoardMessageId")),
+					messageBoardMessage);
+		}
+
+		if (messageBoardMessageUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for MessageBoardMessage");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				messageBoardMessages, messageBoardMessageUnsafeConsumer);
+		}
+		else {
+			for (MessageBoardMessage messageBoardMessage :
+					messageBoardMessages) {
+
+				messageBoardMessageUnsafeConsumer.accept(messageBoardMessage);
+			}
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardSectionResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardSectionResourceImpl.java
@@ -62,6 +62,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -998,13 +999,26 @@ public abstract class BaseMessageBoardSectionResourceImpl
 		throws Exception {
 
 		UnsafeConsumer<MessageBoardSection, Exception>
+			messageBoardSectionUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
 			messageBoardSectionUnsafeConsumer = messageBoardSection -> {
 			};
 
-		if (parameters.containsKey("siteId")) {
-			messageBoardSectionUnsafeConsumer =
-				messageBoardSection -> postSiteMessageBoardSection(
-					(Long)parameters.get("siteId"), messageBoardSection);
+			if (parameters.containsKey("siteId")) {
+				messageBoardSectionUnsafeConsumer =
+					messageBoardSection -> postSiteMessageBoardSection(
+						(Long)parameters.get("siteId"), messageBoardSection);
+			}
+		}
+
+		if (messageBoardSectionUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for MessageBoardSection");
 		}
 
 		if (contextBatchUnsafeConsumer != null) {
@@ -1095,13 +1109,50 @@ public abstract class BaseMessageBoardSectionResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		for (MessageBoardSection messageBoardSection : messageBoardSections) {
-			putMessageBoardSection(
-				messageBoardSection.getId() != null ?
-					messageBoardSection.getId() :
-						Long.parseLong(
-							(String)parameters.get("messageBoardSectionId")),
-				messageBoardSection);
+		UnsafeConsumer<MessageBoardSection, Exception>
+			messageBoardSectionUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			messageBoardSectionUnsafeConsumer =
+				messageBoardSection -> patchMessageBoardSection(
+					messageBoardSection.getId() != null ?
+						messageBoardSection.getId() :
+							Long.parseLong(
+								(String)parameters.get(
+									"messageBoardSectionId")),
+					messageBoardSection);
+		}
+
+		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
+			messageBoardSectionUnsafeConsumer =
+				messageBoardSection -> putMessageBoardSection(
+					messageBoardSection.getId() != null ?
+						messageBoardSection.getId() :
+							Long.parseLong(
+								(String)parameters.get(
+									"messageBoardSectionId")),
+					messageBoardSection);
+		}
+
+		if (messageBoardSectionUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for MessageBoardSection");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				messageBoardSections, messageBoardSectionUnsafeConsumer);
+		}
+		else {
+			for (MessageBoardSection messageBoardSection :
+					messageBoardSections) {
+
+				messageBoardSectionUnsafeConsumer.accept(messageBoardSection);
+			}
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardThreadResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardThreadResourceImpl.java
@@ -63,6 +63,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -1316,16 +1317,29 @@ public abstract class BaseMessageBoardThreadResourceImpl
 		throws Exception {
 
 		UnsafeConsumer<MessageBoardThread, Exception>
+			messageBoardThreadUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
 			messageBoardThreadUnsafeConsumer =
 				messageBoardThread -> postMessageBoardSectionMessageBoardThread(
 					Long.parseLong(
 						(String)parameters.get("messageBoardSectionId")),
 					messageBoardThread);
 
-		if (parameters.containsKey("siteId")) {
-			messageBoardThreadUnsafeConsumer =
-				messageBoardThread -> postSiteMessageBoardThread(
-					(Long)parameters.get("siteId"), messageBoardThread);
+			if (parameters.containsKey("siteId")) {
+				messageBoardThreadUnsafeConsumer =
+					messageBoardThread -> postSiteMessageBoardThread(
+						(Long)parameters.get("siteId"), messageBoardThread);
+			}
+		}
+
+		if (messageBoardThreadUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for MessageBoardThread");
 		}
 
 		if (contextBatchUnsafeConsumer != null) {
@@ -1416,13 +1430,46 @@ public abstract class BaseMessageBoardThreadResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		for (MessageBoardThread messageBoardThread : messageBoardThreads) {
-			putMessageBoardThread(
-				messageBoardThread.getId() != null ?
-					messageBoardThread.getId() :
-						Long.parseLong(
-							(String)parameters.get("messageBoardThreadId")),
-				messageBoardThread);
+		UnsafeConsumer<MessageBoardThread, Exception>
+			messageBoardThreadUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			messageBoardThreadUnsafeConsumer =
+				messageBoardThread -> patchMessageBoardThread(
+					messageBoardThread.getId() != null ?
+						messageBoardThread.getId() :
+							Long.parseLong(
+								(String)parameters.get("messageBoardThreadId")),
+					messageBoardThread);
+		}
+
+		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
+			messageBoardThreadUnsafeConsumer =
+				messageBoardThread -> putMessageBoardThread(
+					messageBoardThread.getId() != null ?
+						messageBoardThread.getId() :
+							Long.parseLong(
+								(String)parameters.get("messageBoardThreadId")),
+					messageBoardThread);
+		}
+
+		if (messageBoardThreadUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for MessageBoardThread");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				messageBoardThreads, messageBoardThreadUnsafeConsumer);
+		}
+		else {
+			for (MessageBoardThread messageBoardThread : messageBoardThreads) {
+				messageBoardThreadUnsafeConsumer.accept(messageBoardThread);
+			}
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseNavigationMenuResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseNavigationMenuResourceImpl.java
@@ -62,6 +62,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -652,13 +653,26 @@ public abstract class BaseNavigationMenuResourceImpl
 		throws Exception {
 
 		UnsafeConsumer<NavigationMenu, Exception> navigationMenuUnsafeConsumer =
-			navigationMenu -> {
+			null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
+			navigationMenuUnsafeConsumer = navigationMenu -> {
 			};
 
-		if (parameters.containsKey("siteId")) {
-			navigationMenuUnsafeConsumer =
-				navigationMenu -> postSiteNavigationMenu(
-					(Long)parameters.get("siteId"), navigationMenu);
+			if (parameters.containsKey("siteId")) {
+				navigationMenuUnsafeConsumer =
+					navigationMenu -> postSiteNavigationMenu(
+						(Long)parameters.get("siteId"), navigationMenu);
+			}
+		}
+
+		if (navigationMenuUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for NavigationMenu");
 		}
 
 		if (contextBatchUnsafeConsumer != null) {
@@ -745,11 +759,33 @@ public abstract class BaseNavigationMenuResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		for (NavigationMenu navigationMenu : navigationMenus) {
-			putNavigationMenu(
+		UnsafeConsumer<NavigationMenu, Exception> navigationMenuUnsafeConsumer =
+			null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
+			navigationMenuUnsafeConsumer = navigationMenu -> putNavigationMenu(
 				navigationMenu.getId() != null ? navigationMenu.getId() :
 					Long.parseLong((String)parameters.get("navigationMenuId")),
 				navigationMenu);
+		}
+
+		if (navigationMenuUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for NavigationMenu");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				navigationMenus, navigationMenuUnsafeConsumer);
+		}
+		else {
+			for (NavigationMenu navigationMenu : navigationMenus) {
+				navigationMenuUnsafeConsumer.accept(navigationMenu);
+			}
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentFolderResourceImpl.java
@@ -62,6 +62,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -1312,20 +1313,34 @@ public abstract class BaseStructuredContentFolderResourceImpl
 		throws Exception {
 
 		UnsafeConsumer<StructuredContentFolder, Exception>
+			structuredContentFolderUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
 			structuredContentFolderUnsafeConsumer = structuredContentFolder -> {
 			};
 
-		if (parameters.containsKey("assetLibraryId")) {
-			structuredContentFolderUnsafeConsumer =
-				structuredContentFolder ->
-					postAssetLibraryStructuredContentFolder(
-						(Long)parameters.get("assetLibraryId"),
+			if (parameters.containsKey("assetLibraryId")) {
+				structuredContentFolderUnsafeConsumer =
+					structuredContentFolder ->
+						postAssetLibraryStructuredContentFolder(
+							(Long)parameters.get("assetLibraryId"),
+							structuredContentFolder);
+			}
+			else if (parameters.containsKey("siteId")) {
+				structuredContentFolderUnsafeConsumer =
+					structuredContentFolder -> postSiteStructuredContentFolder(
+						(Long)parameters.get("siteId"),
 						structuredContentFolder);
+			}
 		}
-		else if (parameters.containsKey("siteId")) {
-			structuredContentFolderUnsafeConsumer =
-				structuredContentFolder -> postSiteStructuredContentFolder(
-					(Long)parameters.get("siteId"), structuredContentFolder);
+
+		if (structuredContentFolderUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for StructuredContentFolder");
 		}
 
 		if (contextBatchUnsafeConsumer != null) {
@@ -1428,16 +1443,52 @@ public abstract class BaseStructuredContentFolderResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		for (StructuredContentFolder structuredContentFolder :
-				structuredContentFolders) {
+		UnsafeConsumer<StructuredContentFolder, Exception>
+			structuredContentFolderUnsafeConsumer = null;
 
-			putStructuredContentFolder(
-				structuredContentFolder.getId() != null ?
-					structuredContentFolder.getId() :
-						Long.parseLong(
-							(String)parameters.get(
-								"structuredContentFolderId")),
-				structuredContentFolder);
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			structuredContentFolderUnsafeConsumer =
+				structuredContentFolder -> patchStructuredContentFolder(
+					structuredContentFolder.getId() != null ?
+						structuredContentFolder.getId() :
+							Long.parseLong(
+								(String)parameters.get(
+									"structuredContentFolderId")),
+					structuredContentFolder);
+		}
+
+		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
+			structuredContentFolderUnsafeConsumer =
+				structuredContentFolder -> putStructuredContentFolder(
+					structuredContentFolder.getId() != null ?
+						structuredContentFolder.getId() :
+							Long.parseLong(
+								(String)parameters.get(
+									"structuredContentFolderId")),
+					structuredContentFolder);
+		}
+
+		if (structuredContentFolderUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for StructuredContentFolder");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				structuredContentFolders,
+				structuredContentFolderUnsafeConsumer);
+		}
+		else {
+			for (StructuredContentFolder structuredContentFolder :
+					structuredContentFolders) {
+
+				structuredContentFolderUnsafeConsumer.accept(
+					structuredContentFolder);
+			}
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentResourceImpl.java
@@ -64,6 +64,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -1877,6 +1878,12 @@ public abstract class BaseStructuredContentResourceImpl
 		throws Exception {
 
 		UnsafeConsumer<StructuredContent, Exception>
+			structuredContentUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
 			structuredContentUnsafeConsumer =
 				structuredContent ->
 					postStructuredContentFolderStructuredContent(
@@ -1885,15 +1892,33 @@ public abstract class BaseStructuredContentResourceImpl
 								"structuredContentFolderId")),
 						structuredContent);
 
-		if (parameters.containsKey("assetLibraryId")) {
-			structuredContentUnsafeConsumer =
-				structuredContent -> postAssetLibraryStructuredContent(
-					(Long)parameters.get("assetLibraryId"), structuredContent);
+			if (parameters.containsKey("assetLibraryId")) {
+				structuredContentUnsafeConsumer =
+					structuredContent -> postAssetLibraryStructuredContent(
+						(Long)parameters.get("assetLibraryId"),
+						structuredContent);
+			}
+			else if (parameters.containsKey("siteId")) {
+				structuredContentUnsafeConsumer =
+					structuredContent -> postSiteStructuredContent(
+						(Long)parameters.get("siteId"), structuredContent);
+			}
 		}
-		else if (parameters.containsKey("siteId")) {
-			structuredContentUnsafeConsumer =
-				structuredContent -> postSiteStructuredContent(
-					(Long)parameters.get("siteId"), structuredContent);
+
+		if ("UPSERT".equalsIgnoreCase(createStrategy)) {
+			structuredContentUnsafeConsumer = structuredContent ->
+				putSiteStructuredContentByExternalReferenceCode(
+					structuredContent.getSiteId() != null ?
+						structuredContent.getSiteId() :
+							(Long)parameters.get("siteId"),
+					structuredContent.getExternalReferenceCode(),
+					structuredContent);
+		}
+
+		if (structuredContentUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for StructuredContent");
 		}
 
 		if (contextBatchUnsafeConsumer != null) {
@@ -1990,12 +2015,46 @@ public abstract class BaseStructuredContentResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		for (StructuredContent structuredContent : structuredContents) {
-			putStructuredContent(
-				structuredContent.getId() != null ? structuredContent.getId() :
-					Long.parseLong(
-						(String)parameters.get("structuredContentId")),
-				structuredContent);
+		UnsafeConsumer<StructuredContent, Exception>
+			structuredContentUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			structuredContentUnsafeConsumer =
+				structuredContent -> patchStructuredContent(
+					structuredContent.getId() != null ?
+						structuredContent.getId() :
+							Long.parseLong(
+								(String)parameters.get("structuredContentId")),
+					structuredContent);
+		}
+
+		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
+			structuredContentUnsafeConsumer =
+				structuredContent -> putStructuredContent(
+					structuredContent.getId() != null ?
+						structuredContent.getId() :
+							Long.parseLong(
+								(String)parameters.get("structuredContentId")),
+					structuredContent);
+		}
+
+		if (structuredContentUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for StructuredContent");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				structuredContents, structuredContentUnsafeConsumer);
+		}
+		else {
+			for (StructuredContent structuredContent : structuredContents) {
+				structuredContentUnsafeConsumer.accept(structuredContent);
+			}
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiNodeResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiNodeResourceImpl.java
@@ -62,6 +62,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -835,13 +836,33 @@ public abstract class BaseWikiNodeResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		UnsafeConsumer<WikiNode, Exception> wikiNodeUnsafeConsumer =
-			wikiNode -> {
+		UnsafeConsumer<WikiNode, Exception> wikiNodeUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
+			wikiNodeUnsafeConsumer = wikiNode -> {
 			};
 
-		if (parameters.containsKey("siteId")) {
-			wikiNodeUnsafeConsumer = wikiNode -> postSiteWikiNode(
-				(Long)parameters.get("siteId"), wikiNode);
+			if (parameters.containsKey("siteId")) {
+				wikiNodeUnsafeConsumer = wikiNode -> postSiteWikiNode(
+					(Long)parameters.get("siteId"), wikiNode);
+			}
+		}
+
+		if ("UPSERT".equalsIgnoreCase(createStrategy)) {
+			wikiNodeUnsafeConsumer =
+				wikiNode -> putSiteWikiNodeByExternalReferenceCode(
+					wikiNode.getSiteId() != null ? wikiNode.getSiteId() :
+						(Long)parameters.get("siteId"),
+					wikiNode.getExternalReferenceCode(), wikiNode);
+		}
+
+		if (wikiNodeUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for WikiNode");
 		}
 
 		if (contextBatchUnsafeConsumer != null) {
@@ -929,11 +950,32 @@ public abstract class BaseWikiNodeResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		for (WikiNode wikiNode : wikiNodes) {
-			putWikiNode(
+		UnsafeConsumer<WikiNode, Exception> wikiNodeUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
+			wikiNodeUnsafeConsumer = wikiNode -> putWikiNode(
 				wikiNode.getId() != null ? wikiNode.getId() :
 					Long.parseLong((String)parameters.get("wikiNodeId")),
 				wikiNode);
+		}
+
+		if (wikiNodeUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for WikiNode");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				wikiNodes, wikiNodeUnsafeConsumer);
+		}
+		else {
+			for (WikiNode wikiNode : wikiNodes) {
+				wikiNodeUnsafeConsumer.accept(wikiNode);
+			}
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiPageAttachmentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiPageAttachmentResourceImpl.java
@@ -55,6 +55,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -320,10 +321,23 @@ public abstract class BaseWikiPageAttachmentResourceImpl
 		throws Exception {
 
 		UnsafeConsumer<WikiPageAttachment, Exception>
+			wikiPageAttachmentUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
 			wikiPageAttachmentUnsafeConsumer =
 				wikiPageAttachment -> postWikiPageWikiPageAttachment(
 					Long.parseLong((String)parameters.get("wikiPageId")),
 					(MultipartBody)parameters.get("multipartBody"));
+		}
+
+		if (wikiPageAttachmentUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for WikiPageAttachment");
+		}
 
 		if (contextBatchUnsafeConsumer != null) {
 			contextBatchUnsafeConsumer.accept(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiPageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiPageResourceImpl.java
@@ -62,6 +62,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -789,9 +790,29 @@ public abstract class BaseWikiPageResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		UnsafeConsumer<WikiPage, Exception> wikiPageUnsafeConsumer =
-			wikiPage -> postWikiNodeWikiPage(
+		UnsafeConsumer<WikiPage, Exception> wikiPageUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
+			wikiPageUnsafeConsumer = wikiPage -> postWikiNodeWikiPage(
 				Long.parseLong((String)parameters.get("wikiNodeId")), wikiPage);
+		}
+
+		if ("UPSERT".equalsIgnoreCase(createStrategy)) {
+			wikiPageUnsafeConsumer =
+				wikiPage -> putSiteWikiPageByExternalReferenceCode(
+					wikiPage.getSiteId() != null ? wikiPage.getSiteId() :
+						(Long)parameters.get("siteId"),
+					wikiPage.getExternalReferenceCode(), wikiPage);
+		}
+
+		if (wikiPageUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for WikiPage");
+		}
 
 		if (contextBatchUnsafeConsumer != null) {
 			contextBatchUnsafeConsumer.accept(
@@ -873,11 +894,32 @@ public abstract class BaseWikiPageResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		for (WikiPage wikiPage : wikiPages) {
-			putWikiPage(
+		UnsafeConsumer<WikiPage, Exception> wikiPageUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
+			wikiPageUnsafeConsumer = wikiPage -> putWikiPage(
 				wikiPage.getId() != null ? wikiPage.getId() :
 					Long.parseLong((String)parameters.get("wikiPageId")),
 				wikiPage);
+		}
+
+		if (wikiPageUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for WikiPage");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				wikiPages, wikiPageUnsafeConsumer);
+		}
+		else {
+			for (WikiPage wikiPage : wikiPages) {
+				wikiPageUnsafeConsumer.accept(wikiPage);
+			}
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -47,7 +47,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.delivery.client', and version '4.0.26'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Delivery", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.delivery.client', and version '4.0.27'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Delivery", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormRecordResourceImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormRecordResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -345,9 +346,21 @@ public abstract class BaseFormRecordResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		UnsafeConsumer<FormRecord, Exception> formRecordUnsafeConsumer =
-			formRecord -> postFormFormRecord(
+		UnsafeConsumer<FormRecord, Exception> formRecordUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
+			formRecordUnsafeConsumer = formRecord -> postFormFormRecord(
 				Long.parseLong((String)parameters.get("formId")), formRecord);
+		}
+
+		if (formRecordUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for FormRecord");
+		}
 
 		if (contextBatchUnsafeConsumer != null) {
 			contextBatchUnsafeConsumer.accept(
@@ -424,11 +437,32 @@ public abstract class BaseFormRecordResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		for (FormRecord formRecord : formRecords) {
-			putFormRecord(
+		UnsafeConsumer<FormRecord, Exception> formRecordUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
+			formRecordUnsafeConsumer = formRecord -> putFormRecord(
 				formRecord.getId() != null ? formRecord.getId() :
 					Long.parseLong((String)parameters.get("formRecordId")),
 				formRecord);
+		}
+
+		if (formRecordUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for FormRecord");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				formRecords, formRecordUnsafeConsumer);
+		}
+		else {
+			for (FormRecord formRecord : formRecords) {
+				formRecordUnsafeConsumer.accept(formRecord);
+			}
 		}
 	}
 

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectActionResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectActionResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -462,9 +463,24 @@ public abstract class BaseObjectActionResourceImpl
 		throws Exception {
 
 		UnsafeConsumer<ObjectAction, Exception> objectActionUnsafeConsumer =
-			objectAction -> postObjectDefinitionObjectAction(
-				Long.parseLong((String)parameters.get("objectDefinitionId")),
-				objectAction);
+			null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
+			objectActionUnsafeConsumer =
+				objectAction -> postObjectDefinitionObjectAction(
+					Long.parseLong(
+						(String)parameters.get("objectDefinitionId")),
+					objectAction);
+		}
+
+		if (objectActionUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for ObjectAction");
+		}
 
 		if (contextBatchUnsafeConsumer != null) {
 			contextBatchUnsafeConsumer.accept(
@@ -546,11 +562,40 @@ public abstract class BaseObjectActionResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		for (ObjectAction objectAction : objectActions) {
-			putObjectAction(
+		UnsafeConsumer<ObjectAction, Exception> objectActionUnsafeConsumer =
+			null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			objectActionUnsafeConsumer = objectAction -> patchObjectAction(
 				objectAction.getId() != null ? objectAction.getId() :
 					Long.parseLong((String)parameters.get("objectActionId")),
 				objectAction);
+		}
+
+		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
+			objectActionUnsafeConsumer = objectAction -> putObjectAction(
+				objectAction.getId() != null ? objectAction.getId() :
+					Long.parseLong((String)parameters.get("objectActionId")),
+				objectAction);
+		}
+
+		if (objectActionUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for ObjectAction");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				objectActions, objectActionUnsafeConsumer);
+		}
+		else {
+			for (ObjectAction objectAction : objectActions) {
+				objectActionUnsafeConsumer.accept(objectAction);
+			}
 		}
 	}
 

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectDefinitionResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectDefinitionResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -513,8 +514,21 @@ public abstract class BaseObjectDefinitionResourceImpl
 		throws Exception {
 
 		UnsafeConsumer<ObjectDefinition, Exception>
+			objectDefinitionUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
 			objectDefinitionUnsafeConsumer =
 				objectDefinition -> postObjectDefinition(objectDefinition);
+		}
+
+		if (objectDefinitionUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for ObjectDefinition");
+		}
 
 		if (contextBatchUnsafeConsumer != null) {
 			contextBatchUnsafeConsumer.accept(
@@ -595,12 +609,46 @@ public abstract class BaseObjectDefinitionResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		for (ObjectDefinition objectDefinition : objectDefinitions) {
-			putObjectDefinition(
-				objectDefinition.getId() != null ? objectDefinition.getId() :
-					Long.parseLong(
-						(String)parameters.get("objectDefinitionId")),
-				objectDefinition);
+		UnsafeConsumer<ObjectDefinition, Exception>
+			objectDefinitionUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			objectDefinitionUnsafeConsumer =
+				objectDefinition -> patchObjectDefinition(
+					objectDefinition.getId() != null ?
+						objectDefinition.getId() :
+							Long.parseLong(
+								(String)parameters.get("objectDefinitionId")),
+					objectDefinition);
+		}
+
+		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
+			objectDefinitionUnsafeConsumer =
+				objectDefinition -> putObjectDefinition(
+					objectDefinition.getId() != null ?
+						objectDefinition.getId() :
+							Long.parseLong(
+								(String)parameters.get("objectDefinitionId")),
+					objectDefinition);
+		}
+
+		if (objectDefinitionUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for ObjectDefinition");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				objectDefinitions, objectDefinitionUnsafeConsumer);
+		}
+		else {
+			for (ObjectDefinition objectDefinition : objectDefinitions) {
+				objectDefinitionUnsafeConsumer.accept(objectDefinition);
+			}
 		}
 	}
 

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectFieldResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectFieldResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -474,10 +475,24 @@ public abstract class BaseObjectFieldResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		UnsafeConsumer<ObjectField, Exception> objectFieldUnsafeConsumer =
-			objectField -> postObjectDefinitionObjectField(
-				Long.parseLong((String)parameters.get("objectDefinitionId")),
-				objectField);
+		UnsafeConsumer<ObjectField, Exception> objectFieldUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
+			objectFieldUnsafeConsumer =
+				objectField -> postObjectDefinitionObjectField(
+					Long.parseLong(
+						(String)parameters.get("objectDefinitionId")),
+					objectField);
+		}
+
+		if (objectFieldUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for ObjectField");
+		}
 
 		if (contextBatchUnsafeConsumer != null) {
 			contextBatchUnsafeConsumer.accept(
@@ -559,11 +574,39 @@ public abstract class BaseObjectFieldResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		for (ObjectField objectField : objectFields) {
-			putObjectField(
+		UnsafeConsumer<ObjectField, Exception> objectFieldUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			objectFieldUnsafeConsumer = objectField -> patchObjectField(
 				objectField.getId() != null ? objectField.getId() :
 					Long.parseLong((String)parameters.get("objectFieldId")),
 				objectField);
+		}
+
+		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
+			objectFieldUnsafeConsumer = objectField -> putObjectField(
+				objectField.getId() != null ? objectField.getId() :
+					Long.parseLong((String)parameters.get("objectFieldId")),
+				objectField);
+		}
+
+		if (objectFieldUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for ObjectField");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				objectFields, objectFieldUnsafeConsumer);
+		}
+		else {
+			for (ObjectField objectField : objectFields) {
+				objectFieldUnsafeConsumer.accept(objectField);
+			}
 		}
 	}
 

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectLayoutResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectLayoutResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -387,9 +388,24 @@ public abstract class BaseObjectLayoutResourceImpl
 		throws Exception {
 
 		UnsafeConsumer<ObjectLayout, Exception> objectLayoutUnsafeConsumer =
-			objectLayout -> postObjectDefinitionObjectLayout(
-				Long.parseLong((String)parameters.get("objectDefinitionId")),
-				objectLayout);
+			null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
+			objectLayoutUnsafeConsumer =
+				objectLayout -> postObjectDefinitionObjectLayout(
+					Long.parseLong(
+						(String)parameters.get("objectDefinitionId")),
+					objectLayout);
+		}
+
+		if (objectLayoutUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for ObjectLayout");
+		}
 
 		if (contextBatchUnsafeConsumer != null) {
 			contextBatchUnsafeConsumer.accept(
@@ -471,11 +487,33 @@ public abstract class BaseObjectLayoutResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		for (ObjectLayout objectLayout : objectLayouts) {
-			putObjectLayout(
+		UnsafeConsumer<ObjectLayout, Exception> objectLayoutUnsafeConsumer =
+			null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
+			objectLayoutUnsafeConsumer = objectLayout -> putObjectLayout(
 				objectLayout.getId() != null ? objectLayout.getId() :
 					Long.parseLong((String)parameters.get("objectLayoutId")),
 				objectLayout);
+		}
+
+		if (objectLayoutUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for ObjectLayout");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				objectLayouts, objectLayoutUnsafeConsumer);
+		}
+		else {
+			for (ObjectLayout objectLayout : objectLayouts) {
+				objectLayoutUnsafeConsumer.accept(objectLayout);
+			}
 		}
 	}
 

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectRelationshipResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectRelationshipResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -412,11 +413,24 @@ public abstract class BaseObjectRelationshipResourceImpl
 		throws Exception {
 
 		UnsafeConsumer<ObjectRelationship, Exception>
+			objectRelationshipUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
 			objectRelationshipUnsafeConsumer =
 				objectRelationship -> postObjectDefinitionObjectRelationship(
 					Long.parseLong(
 						(String)parameters.get("objectDefinitionId")),
 					objectRelationship);
+		}
+
+		if (objectRelationshipUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for ObjectRelationship");
+		}
 
 		if (contextBatchUnsafeConsumer != null) {
 			contextBatchUnsafeConsumer.accept(
@@ -498,13 +512,36 @@ public abstract class BaseObjectRelationshipResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		for (ObjectRelationship objectRelationship : objectRelationships) {
-			putObjectRelationship(
-				objectRelationship.getId() != null ?
-					objectRelationship.getId() :
-						Long.parseLong(
-							(String)parameters.get("objectRelationshipId")),
-				objectRelationship);
+		UnsafeConsumer<ObjectRelationship, Exception>
+			objectRelationshipUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
+			objectRelationshipUnsafeConsumer =
+				objectRelationship -> putObjectRelationship(
+					objectRelationship.getId() != null ?
+						objectRelationship.getId() :
+							Long.parseLong(
+								(String)parameters.get("objectRelationshipId")),
+					objectRelationship);
+		}
+
+		if (objectRelationshipUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for ObjectRelationship");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				objectRelationships, objectRelationshipUnsafeConsumer);
+		}
+		else {
+			for (ObjectRelationship objectRelationship : objectRelationships) {
+				objectRelationshipUnsafeConsumer.accept(objectRelationship);
+			}
 		}
 	}
 

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectValidationRuleResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectValidationRuleResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -516,12 +517,25 @@ public abstract class BaseObjectValidationRuleResourceImpl
 		throws Exception {
 
 		UnsafeConsumer<ObjectValidationRule, Exception>
+			objectValidationRuleUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
 			objectValidationRuleUnsafeConsumer =
 				objectValidationRule ->
 					postObjectDefinitionObjectValidationRule(
 						Long.parseLong(
 							(String)parameters.get("objectDefinitionId")),
 						objectValidationRule);
+		}
+
+		if (objectValidationRuleUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for ObjectValidationRule");
+		}
 
 		if (contextBatchUnsafeConsumer != null) {
 			contextBatchUnsafeConsumer.accept(
@@ -607,15 +621,50 @@ public abstract class BaseObjectValidationRuleResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		for (ObjectValidationRule objectValidationRule :
-				objectValidationRules) {
+		UnsafeConsumer<ObjectValidationRule, Exception>
+			objectValidationRuleUnsafeConsumer = null;
 
-			putObjectValidationRule(
-				objectValidationRule.getId() != null ?
-					objectValidationRule.getId() :
-						Long.parseLong(
-							(String)parameters.get("objectValidationRuleId")),
-				objectValidationRule);
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			objectValidationRuleUnsafeConsumer =
+				objectValidationRule -> patchObjectValidationRule(
+					objectValidationRule.getId() != null ?
+						objectValidationRule.getId() :
+							Long.parseLong(
+								(String)parameters.get(
+									"objectValidationRuleId")),
+					objectValidationRule);
+		}
+
+		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
+			objectValidationRuleUnsafeConsumer =
+				objectValidationRule -> putObjectValidationRule(
+					objectValidationRule.getId() != null ?
+						objectValidationRule.getId() :
+							Long.parseLong(
+								(String)parameters.get(
+									"objectValidationRuleId")),
+					objectValidationRule);
+		}
+
+		if (objectValidationRuleUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for ObjectValidationRule");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				objectValidationRules, objectValidationRuleUnsafeConsumer);
+		}
+		else {
+			for (ObjectValidationRule objectValidationRule :
+					objectValidationRules) {
+
+				objectValidationRuleUnsafeConsumer.accept(objectValidationRule);
+			}
 		}
 	}
 

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectViewResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectViewResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -416,10 +417,24 @@ public abstract class BaseObjectViewResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		UnsafeConsumer<ObjectView, Exception> objectViewUnsafeConsumer =
-			objectView -> postObjectDefinitionObjectView(
-				Long.parseLong((String)parameters.get("objectDefinitionId")),
-				objectView);
+		UnsafeConsumer<ObjectView, Exception> objectViewUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
+			objectViewUnsafeConsumer =
+				objectView -> postObjectDefinitionObjectView(
+					Long.parseLong(
+						(String)parameters.get("objectDefinitionId")),
+					objectView);
+		}
+
+		if (objectViewUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for ObjectView");
+		}
 
 		if (contextBatchUnsafeConsumer != null) {
 			contextBatchUnsafeConsumer.accept(
@@ -501,11 +516,32 @@ public abstract class BaseObjectViewResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		for (ObjectView objectView : objectViews) {
-			putObjectView(
+		UnsafeConsumer<ObjectView, Exception> objectViewUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
+			objectViewUnsafeConsumer = objectView -> putObjectView(
 				objectView.getId() != null ? objectView.getId() :
 					Long.parseLong((String)parameters.get("objectViewId")),
 				objectView);
+		}
+
+		if (objectViewUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for ObjectView");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				objectViews, objectViewUnsafeConsumer);
+		}
+		else {
+			for (ObjectView objectView : objectViews) {
+				objectViewUnsafeConsumer.accept(objectView);
+			}
 		}
 	}
 

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseObjectEntryResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -654,8 +655,21 @@ public abstract class BaseObjectEntryResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		UnsafeConsumer<ObjectEntry, Exception> objectEntryUnsafeConsumer =
-			objectEntry -> postObjectEntry(objectEntry);
+		UnsafeConsumer<ObjectEntry, Exception> objectEntryUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
+			objectEntryUnsafeConsumer = objectEntry -> postObjectEntry(
+				objectEntry);
+		}
+
+		if (objectEntryUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for ObjectEntry");
+		}
 
 		if (contextBatchUnsafeConsumer != null) {
 			contextBatchUnsafeConsumer.accept(
@@ -735,11 +749,39 @@ public abstract class BaseObjectEntryResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		for (ObjectEntry objectEntry : objectEntries) {
-			putObjectEntry(
+		UnsafeConsumer<ObjectEntry, Exception> objectEntryUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			objectEntryUnsafeConsumer = objectEntry -> patchObjectEntry(
 				objectEntry.getId() != null ? objectEntry.getId() :
 					Long.parseLong((String)parameters.get("objectEntryId")),
 				objectEntry);
+		}
+
+		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
+			objectEntryUnsafeConsumer = objectEntry -> putObjectEntry(
+				objectEntry.getId() != null ? objectEntry.getId() :
+					Long.parseLong((String)parameters.get("objectEntryId")),
+				objectEntry);
+		}
+
+		if (objectEntryUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for ObjectEntry");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				objectEntries, objectEntryUnsafeConsumer);
+		}
+		else {
+			for (ObjectEntry objectEntry : objectEntries) {
+				objectEntryUnsafeConsumer.accept(objectEntry);
+			}
 		}
 	}
 

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/batch/engine/resource/VulcanBatchEngineImportTaskResourceImpl.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/batch/engine/resource/VulcanBatchEngineImportTaskResourceImpl.java
@@ -59,8 +59,9 @@ public class VulcanBatchEngineImportTaskResourceImpl
 		_initializeContext();
 
 		return _importTaskResource.postImportTask(
-			name, callbackURL, _getExternalReferenceCode(), fields,
-			_getImportStrategy(), _getTaskItemDelegateName(), object);
+			name, callbackURL, _getQueryParameterValue("createStrategy"),
+			_getExternalReferenceCode(), fields, _getImportStrategy(),
+			_getTaskItemDelegateName(), object);
 	}
 
 	@Override
@@ -71,7 +72,8 @@ public class VulcanBatchEngineImportTaskResourceImpl
 
 		return _importTaskResource.putImportTask(
 			name, callbackURL, _getExternalReferenceCode(),
-			_getImportStrategy(), _getTaskItemDelegateName(), object);
+			_getImportStrategy(), _getTaskItemDelegateName(),
+			_getQueryParameterValue("updateStrategy"), object);
 	}
 
 	@Override

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseInstanceResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseInstanceResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -403,9 +404,21 @@ public abstract class BaseInstanceResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		UnsafeConsumer<Instance, Exception> instanceUnsafeConsumer =
-			instance -> postProcessInstance(
+		UnsafeConsumer<Instance, Exception> instanceUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
+			instanceUnsafeConsumer = instance -> postProcessInstance(
 				Long.parseLong((String)parameters.get("processId")), instance);
+		}
+
+		if (instanceUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for Instance");
+		}
 
 		if (contextBatchUnsafeConsumer != null) {
 			contextBatchUnsafeConsumer.accept(

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseNodeResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseNodeResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -226,9 +227,21 @@ public abstract class BaseNodeResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		UnsafeConsumer<Node, Exception> nodeUnsafeConsumer =
-			node -> postProcessNode(
+		UnsafeConsumer<Node, Exception> nodeUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
+			nodeUnsafeConsumer = node -> postProcessNode(
 				Long.parseLong((String)parameters.get("processId")), node);
+		}
+
+		if (nodeUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for Node");
+		}
 
 		if (contextBatchUnsafeConsumer != null) {
 			contextBatchUnsafeConsumer.accept(nodes, nodeUnsafeConsumer);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseProcessResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseProcessResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -343,8 +344,20 @@ public abstract class BaseProcessResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		UnsafeConsumer<Process, Exception> processUnsafeConsumer =
-			process -> postProcess(process);
+		UnsafeConsumer<Process, Exception> processUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
+			processUnsafeConsumer = process -> postProcess(process);
+		}
+
+		if (processUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for Process");
+		}
 
 		if (contextBatchUnsafeConsumer != null) {
 			contextBatchUnsafeConsumer.accept(processes, processUnsafeConsumer);
@@ -423,11 +436,31 @@ public abstract class BaseProcessResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		for (Process process : processes) {
-			putProcess(
+		UnsafeConsumer<Process, Exception> processUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
+			processUnsafeConsumer = process -> putProcess(
 				process.getId() != null ? process.getId() :
 					Long.parseLong((String)parameters.get("processId")),
 				process);
+		}
+
+		if (processUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for Process");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(processes, processUnsafeConsumer);
+		}
+		else {
+			for (Process process : processes) {
+				processUnsafeConsumer.accept(process);
+			}
 		}
 	}
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseSLAResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseSLAResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -402,9 +403,21 @@ public abstract class BaseSLAResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		UnsafeConsumer<SLA, Exception> slaUnsafeConsumer =
-			sla -> postProcessSLA(
+		UnsafeConsumer<SLA, Exception> slaUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
+			slaUnsafeConsumer = sla -> postProcessSLA(
 				Long.parseLong((String)parameters.get("processId")), sla);
+		}
+
+		if (slaUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for Sla");
+		}
 
 		if (contextBatchUnsafeConsumer != null) {
 			contextBatchUnsafeConsumer.accept(slas, slaUnsafeConsumer);
@@ -485,11 +498,31 @@ public abstract class BaseSLAResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		for (SLA sla : slas) {
-			putSLA(
+		UnsafeConsumer<SLA, Exception> slaUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
+			slaUnsafeConsumer = sla -> putSLA(
 				sla.getId() != null ? sla.getId() :
 					Long.parseLong((String)parameters.get("slaId")),
 				sla);
+		}
+
+		if (slaUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for Sla");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(slas, slaUnsafeConsumer);
+		}
+		else {
+			for (SLA sla : slas) {
+				slaUnsafeConsumer.accept(sla);
+			}
 		}
 	}
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseTaskResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseTaskResourceImpl.java
@@ -55,6 +55,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -374,9 +375,21 @@ public abstract class BaseTaskResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		UnsafeConsumer<Task, Exception> taskUnsafeConsumer =
-			task -> postProcessTask(
+		UnsafeConsumer<Task, Exception> taskUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
+			taskUnsafeConsumer = task -> postProcessTask(
 				Long.parseLong((String)parameters.get("processId")), task);
+		}
+
+		if (taskUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for Task");
+		}
 
 		if (contextBatchUnsafeConsumer != null) {
 			contextBatchUnsafeConsumer.accept(tasks, taskUnsafeConsumer);

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSXPBlueprintResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSXPBlueprintResourceImpl.java
@@ -55,6 +55,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -413,7 +414,21 @@ public abstract class BaseSXPBlueprintResourceImpl
 		throws Exception {
 
 		UnsafeConsumer<SXPBlueprint, Exception> sxpBlueprintUnsafeConsumer =
-			sxpBlueprint -> postSXPBlueprint(sxpBlueprint);
+			null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
+			sxpBlueprintUnsafeConsumer = sxpBlueprint -> postSXPBlueprint(
+				sxpBlueprint);
+		}
+
+		if (sxpBlueprintUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for SxpBlueprint");
+		}
 
 		if (contextBatchUnsafeConsumer != null) {
 			contextBatchUnsafeConsumer.accept(
@@ -492,6 +507,35 @@ public abstract class BaseSXPBlueprintResourceImpl
 			java.util.Collection<SXPBlueprint> sxpBlueprints,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		UnsafeConsumer<SXPBlueprint, Exception> sxpBlueprintUnsafeConsumer =
+			null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			sxpBlueprintUnsafeConsumer = sxpBlueprint -> patchSXPBlueprint(
+				sxpBlueprint.getId() != null ? sxpBlueprint.getId() :
+					Long.parseLong((String)parameters.get("sxpBlueprintId")),
+				sxpBlueprint);
+		}
+
+		if (sxpBlueprintUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for SxpBlueprint");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				sxpBlueprints, sxpBlueprintUnsafeConsumer);
+		}
+		else {
+			for (SXPBlueprint sxpBlueprint : sxpBlueprints) {
+				sxpBlueprintUnsafeConsumer.accept(sxpBlueprint);
+			}
+		}
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSXPElementResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSXPElementResourceImpl.java
@@ -55,6 +55,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -408,8 +409,20 @@ public abstract class BaseSXPElementResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		UnsafeConsumer<SXPElement, Exception> sxpElementUnsafeConsumer =
-			sxpElement -> postSXPElement(sxpElement);
+		UnsafeConsumer<SXPElement, Exception> sxpElementUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
+			sxpElementUnsafeConsumer = sxpElement -> postSXPElement(sxpElement);
+		}
+
+		if (sxpElementUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for SxpElement");
+		}
 
 		if (contextBatchUnsafeConsumer != null) {
 			contextBatchUnsafeConsumer.accept(
@@ -488,6 +501,34 @@ public abstract class BaseSXPElementResourceImpl
 			java.util.Collection<SXPElement> sxpElements,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		UnsafeConsumer<SXPElement, Exception> sxpElementUnsafeConsumer = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+			sxpElementUnsafeConsumer = sxpElement -> patchSXPElement(
+				sxpElement.getId() != null ? sxpElement.getId() :
+					Long.parseLong((String)parameters.get("sxpElementId")),
+				sxpElement);
+		}
+
+		if (sxpElementUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" not supported for SxpElement");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				sxpElements, sxpElementUnsafeConsumer);
+		}
+		else {
+			for (SXPElement sxpElement : sxpElements) {
+				sxpElementUnsafeConsumer.accept(sxpElement);
+			}
+		}
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/BaseStatusResourceImpl.java
+++ b/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/BaseStatusResourceImpl.java
@@ -54,6 +54,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -160,9 +161,21 @@ public abstract class BaseStatusResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		UnsafeConsumer<Status, Exception> statusUnsafeConsumer =
-			status -> postExperimentStatus(
+		UnsafeConsumer<Status, Exception> statusUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
+			statusUnsafeConsumer = status -> postExperimentStatus(
 				Long.parseLong((String)parameters.get("experimentId")), status);
+		}
+
+		if (statusUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" not supported for Status");
+		}
 
 		if (contextBatchUnsafeConsumer != null) {
 			contextBatchUnsafeConsumer.accept(statuses, statusUnsafeConsumer);

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/ResourceOpenAPIParser.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/ResourceOpenAPIParser.java
@@ -882,13 +882,22 @@ public class ResourceOpenAPIParser {
 	private static String _getParentSchema(
 		String path, Map<String, PathItem> pathItems, String schemaName) {
 
-		int lastIndexOfSlash = path.lastIndexOf("/");
+		String basePath = path;
+
+		if (basePath.endsWith(
+				"/by-external-reference-code/{externalReferenceCode}")) {
+
+			basePath = StringUtil.removeLast(
+				path, "/by-external-reference-code/{externalReferenceCode}");
+		}
+
+		int lastIndexOfSlash = basePath.lastIndexOf("/");
 
 		if (lastIndexOfSlash < 1) {
 			return null;
 		}
 
-		String basePath = path.substring(0, lastIndexOfSlash);
+		basePath = basePath.substring(0, lastIndexOfSlash);
 
 		if (basePath.equals("/asset-libraries/{assetLibraryId}")) {
 			return "AssetLibrary";

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
@@ -57,6 +57,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -116,6 +117,10 @@ public abstract class Base${schemaName}ResourceImpl
 			</#if>
 		<#elseif stringUtil.equals(javaMethodSignature.methodName, "put" + schemaName)>
 			<#assign putBatchJavaMethodSignature = javaMethodSignature />
+		<#elseif stringUtil.equals(javaMethodSignature.methodName, "patch" + schemaName)>
+			<#assign patchBatchJavaMethodSignature = javaMethodSignature />
+		<#elseif stringUtil.equals(javaMethodSignature.methodName, "put" + parentSchemaName + schemaName + "ByExternalReferenceCode")>
+			<#assign putByERCBatchJavaMethodSignature = javaMethodSignature />
 		</#if>
 
 		<#if configYAML.application??>
@@ -330,43 +335,100 @@ public abstract class Base${schemaName}ResourceImpl
 		@Override
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		public void create(java.util.Collection<${javaDataType}> ${schemaVarNames}, Map<String, Serializable> parameters) throws Exception {
-			<#if postAssetLibraryBatchJavaMethodSignature?? || postSiteBatchJavaMethodSignature?? || postBatchJavaMethodSignature??>
-				UnsafeConsumer<${javaDataType}, Exception> ${schemaVarName}UnsafeConsumer =
-				<#if postBatchJavaMethodSignature??>
-					${schemaVarName} -> ${postBatchJavaMethodSignature.methodName}(
-						<@getPOSTBatchJavaMethodParameters
-							javaMethodParameters=postBatchJavaMethodSignature.javaMethodParameters
-							schemaVarName=schemaVarName
-						/>
-					);
-				<#else>
-					${schemaVarName} -> {};
-				</#if>
 
-				<#if postAssetLibraryBatchJavaMethodSignature??>
-					if (parameters.containsKey("assetLibraryId")) {
-						${schemaVarName}UnsafeConsumer = ${schemaVarName} -> ${postAssetLibraryBatchJavaMethodSignature.methodName}(
+			<#assign
+				properties = freeMarkerTool.getDTOProperties(configYAML, openAPIYAML, schema)
+
+				generateInsertStrategy = postAssetLibraryBatchJavaMethodSignature?? || postSiteBatchJavaMethodSignature?? || postBatchJavaMethodSignature??
+				generateUpsertStrategy = putByERCBatchJavaMethodSignature?? && properties?keys?seq_contains("externalReferenceCode")
+			/>
+
+			<#if generateInsertStrategy || generateUpsertStrategy>
+				UnsafeConsumer<${javaDataType}, Exception> ${schemaVarName}UnsafeConsumer = null;
+
+				String createStrategy = (String) parameters.getOrDefault("createStrategy", "INSERT");
+			</#if>
+
+			<#if generateInsertStrategy>
+
+				if ("INSERT".equalsIgnoreCase(createStrategy)) {
+
+					${schemaVarName}UnsafeConsumer =
+					<#if postBatchJavaMethodSignature??>
+						${schemaVarName} -> ${postBatchJavaMethodSignature.methodName}(
 							<@getPOSTBatchJavaMethodParameters
-								javaMethodParameters=postAssetLibraryBatchJavaMethodSignature.javaMethodParameters
+								javaMethodParameters=postBatchJavaMethodSignature.javaMethodParameters
 								schemaVarName=schemaVarName
 							/>
 						);
-					}
-				</#if>
-
-				<#if postSiteBatchJavaMethodSignature??>
-					<#if postAssetLibraryBatchJavaMethodSignature??>
-						else
+					<#else>
+						${schemaVarName} -> {};
 					</#if>
-					if (parameters.containsKey("siteId")) {
-						${schemaVarName}UnsafeConsumer = ${schemaVarName} -> ${postSiteBatchJavaMethodSignature.methodName}(
-							<@getPOSTBatchJavaMethodParameters
-								javaMethodParameters=postSiteBatchJavaMethodSignature.javaMethodParameters
-								schemaVarName=schemaVarName
-							/>
-						);
-					}
-				</#if>
+
+					<#if postAssetLibraryBatchJavaMethodSignature??>
+						if (parameters.containsKey("assetLibraryId")) {
+							${schemaVarName}UnsafeConsumer = ${schemaVarName} -> ${postAssetLibraryBatchJavaMethodSignature.methodName}(
+								<@getPOSTBatchJavaMethodParameters
+									javaMethodParameters=postAssetLibraryBatchJavaMethodSignature.javaMethodParameters
+									schemaVarName=schemaVarName
+								/>
+							);
+						}
+					</#if>
+
+					<#if postSiteBatchJavaMethodSignature??>
+						<#if postAssetLibraryBatchJavaMethodSignature??>
+							else
+						</#if>
+						if (parameters.containsKey("siteId")) {
+							${schemaVarName}UnsafeConsumer = ${schemaVarName} -> ${postSiteBatchJavaMethodSignature.methodName}(
+								<@getPOSTBatchJavaMethodParameters
+									javaMethodParameters=postSiteBatchJavaMethodSignature.javaMethodParameters
+									schemaVarName=schemaVarName
+								/>
+							);
+						}
+					</#if>
+				}
+			</#if>
+
+			<#if generateUpsertStrategy>
+
+				if ("UPSERT".equalsIgnoreCase(createStrategy)) {
+
+					${schemaVarName}UnsafeConsumer =
+						${schemaVarName} -> ${putByERCBatchJavaMethodSignature.methodName}(
+						<#list putByERCBatchJavaMethodSignature.javaMethodParameters as javaMethodParameter>
+							<#if stringUtil.equals(javaMethodParameter.parameterName, "externalReferenceCode")>
+								${schemaVarName}.get${javaMethodParameter.parameterName?cap_first}()
+							<#elseif putByERCBatchJavaMethodSignature.parentSchemaName?? && stringUtil.equals(javaMethodParameter.parameterName, putByERCBatchJavaMethodSignature.parentSchemaName!?uncap_first + "Id")>
+
+								<#if properties?keys?seq_contains(javaMethodParameter.parameterName)>
+									${schemaVarName}.get${javaMethodParameter.parameterName?cap_first}() != null ?
+									${schemaVarName}.get${javaMethodParameter.parameterName?cap_first}() :
+								</#if>
+
+								<@castParameters
+									type=javaMethodParameter.parameterType
+									value="${javaMethodParameter.parameterName}"
+								/>
+							<#elseif stringUtil.equals(javaMethodParameter.parameterName, schemaVarName)>
+								${schemaVarName}
+							<#else>
+								null
+							</#if>
+
+							<#sep>, </#sep>
+						</#list>
+					);
+				}
+			</#if>
+
+			<#if generateInsertStrategy || generateUpsertStrategy>
+
+				if (${schemaVarName}UnsafeConsumer == null) {
+					throw new NotSupportedException("Create strategy \"" + createStrategy + "\" not supported for ${schemaVarName?cap_first}");
+				}
 
 				if (contextBatchUnsafeConsumer != null) {
 					contextBatchUnsafeConsumer.accept(${schemaVarNames}, ${schemaVarName}UnsafeConsumer);
@@ -475,16 +537,64 @@ public abstract class Base${schemaName}ResourceImpl
 
 		@Override
 		public void update(java.util.Collection<${javaDataType}> ${schemaVarNames}, Map<String, Serializable> parameters) throws Exception {
-			<#if putBatchJavaMethodSignature??>
-				for (${javaDataType} ${schemaVarName} : ${schemaVarNames}) {
-					put${schemaName}(
+			<#assign
+				properties = freeMarkerTool.getDTOProperties(configYAML, openAPIYAML, schema)
+
+				generatePartialUpdateStrategy = patchBatchJavaMethodSignature??
+				generateUpdateStrategy = putBatchJavaMethodSignature??
+			/>
+
+			<#if generatePartialUpdateStrategy || generateUpdateStrategy>
+				UnsafeConsumer<${javaDataType}, Exception> ${schemaVarName}UnsafeConsumer = null;
+
+				String updateStrategy = (String) parameters.getOrDefault("updateStrategy", "UPDATE");
+			</#if>
+
+			<#if generatePartialUpdateStrategy>
+
+				if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
+
+					${schemaVarName}UnsafeConsumer =
+						${schemaVarName} -> patch${schemaName}(
+						<#list patchBatchJavaMethodSignature.javaMethodParameters as javaMethodParameter>
+							<#if stringUtil.equals(javaMethodParameter.parameterName, schemaVarName)>
+								${schemaVarName}
+							<#elseif stringUtil.equals(javaMethodParameter.parameterName, schemaVarName + "Id") || stringUtil.equals(javaMethodParameter.parameterName, "id")>
+
+								<#if properties?keys?seq_contains("id")>
+									${schemaVarName}.getId() != null ? ${schemaVarName}.getId() :
+								<#elseif properties?keys?seq_contains(schemaVarName + "Id")>
+									(${schemaVarName}.get${schemaName}Id() != null) ? ${schemaVarName}.get${schemaName}Id() :
+								</#if>
+
+								<@castParameters
+									type=javaMethodParameter.parameterType
+									value="${schemaVarName}Id"
+								/>
+							<#elseif stringUtil.equals(javaMethodParameter.parameterName, "multipartBody")>
+								null
+							<#else>
+								${javaMethodParameter.parameterName}
+							</#if>
+
+							<#sep>, </#sep>
+						</#list>
+						);
+				}
+			</#if>
+
+			<#if generateUpdateStrategy>
+
+				if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
+
+					${schemaVarName}UnsafeConsumer =
+						${schemaVarName} -> put${schemaName}(
 						<#list putBatchJavaMethodSignature.javaMethodParameters as javaMethodParameter>
 							<#if stringUtil.equals(javaMethodParameter.parameterName, "flatten")>
 								(Boolean)parameters.get("flatten")
 							<#elseif stringUtil.equals(javaMethodParameter.parameterName, schemaVarName)>
 								${schemaVarName}
 							<#elseif stringUtil.equals(javaMethodParameter.parameterName, schemaVarName + "Id") || stringUtil.equals(javaMethodParameter.parameterName, "id")>
-								<#assign properties = freeMarkerTool.getDTOProperties(configYAML, openAPIYAML, schema) />
 
 								<#if properties?keys?seq_contains("id")>
 									${schemaVarName}.getId() != null ? ${schemaVarName}.getId() :
@@ -509,7 +619,23 @@ public abstract class Base${schemaName}ResourceImpl
 
 							<#sep>, </#sep>
 						</#list>
-					);
+						);
+				}
+			</#if>
+
+			<#if generatePartialUpdateStrategy || generateUpdateStrategy>
+
+				if (${schemaVarName}UnsafeConsumer == null) {
+					throw new NotSupportedException("Update strategy \"" + updateStrategy + "\" not supported for ${schemaVarName?cap_first}");
+				}
+
+				if (contextBatchUnsafeConsumer != null) {
+					contextBatchUnsafeConsumer.accept(${schemaVarNames}, ${schemaVarName}UnsafeConsumer);
+				}
+				else {
+					for (${javaDataType} ${schemaVarName} : ${schemaVarNames}) {
+						${schemaVarName}UnsafeConsumer.accept(${schemaVarName});
+					}
 				}
 			</#if>
 		}


### PR DESCRIPTION
Forwarded manually from [this PR](https://github.com/liferay-frontend/liferay-portal/pull/2200) as `ci:forward` command was failing one the tests were successfully passed

---

This PR contains the code to allow selecting the update mode between:

- INSERT and UPSERT for BatchEngineTaskOperation.CREATE operation
- UPDATE and PARTIAL_UPDATE  for BatchEngineTaskOperation.UPDATE operation

In the ImportTask endpoint in the Headless Batch Engine API are added the following parameters:

**createStrategy**

![image](https://user-images.githubusercontent.com/32699538/167678504-f39fb733-44c7-457e-a8ef-00bb293fbcd3.png)


**updateStrategy**

![image](https://user-images.githubusercontent.com/32699538/167102558-e412199c-acb9-4422-a0f2-af0eebf1d5ef.png)

This new parameters are optional. If any of the parameters is set in the request, it is stored in the _parameters_ field of the _BatchEngineImportTask_ database table.

To manage the possible values of the parameters, the REST Builder template for Base[Schema]ResourceImpl has been modified, specifically the _create_ and _update_ methods, with the following structure, given a [SchemaName]:


```

@Override
public void create(
		java.util.Collection<[SchemaName]> [schemaName]s,
		Map<String, Serializable> parameters)
	throws Exception {

	UnsafeConsumer<[SchemaName], Exception>
		[schemaName]UnsafeConsumer = null;

	String createStrategy = (String)parameters.getOrDefault(
		"createStrategy", "INSERT");

	[NOTE: This "INSERT" code block is generated if the post method by Id, by siteId or by assetLibraryId exists]
	if ("INSERT".equalsIgnoreCase(createStrategy)) {
		[schemaName]UnsafeConsumer = [CONSUMER WITH THE POST METHOD BY ID, SITE ID OR ASSET LIBRARY ID]
	}

	[NOTE: This "UPSERT" code block is only generated if the put method by external reference code exists]
	if ("UPSERT".equalsIgnoreCase(createStrategy)) {
		[schemaName]UnsafeConsumer = [CONSUMER WITH THE PUT METHOD BY EXTERNAL REFERENCE CODE]
	}

	if ([schemaName]UnsafeConsumer == null) {
		throw new NotSupportedException(
			"Create strategy \"" + createStrategy +
				"\" not supported for [SchemaName]");
	}

	if (contextBatchUnsafeConsumer != null) {
		contextBatchUnsafeConsumer.accept(
			[schemaName]s, [schemaName]UnsafeConsumer);
	}
	else {
		for ([SchemaName] [schemaName] : [schemaName]s) {
			[schemaName]UnsafeConsumer.accept([schemaName]);
		}
	}
}
```

```
@Override
public void update(
		java.util.Collection<[SchemaName]> [schemaName]s,
		Map<String, Serializable> parameters)
	throws Exception {

	UnsafeConsumer<[SchemaName], Exception>
		[schemaName]UnsafeConsumer = null;

	String updateStrategy = (String)parameters.getOrDefault(
		"updateStrategy", "UPDATE");

	[NOTE: This "PARTIAL_UPDATE" code block is only generated if the patch method by Id exists]
	if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
		[schemaName]UnsafeConsumer = [CONSUMER WITH THE PATCH METHOD BY ID]
	}

	[NOTE: This "UPDATE" code block is only generated if the put method by Id exists]
	if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
		[schemaName]UnsafeConsumer = [CONSUMER WITH THE PUT METHOD BY ID]
	}

	if ([schemaName]UnsafeConsumer == null) {
		throw new NotSupportedException(
			"Update strategy \"" + updateStrategy +
				"\" not supported for [SchemaName]");
	}

	if (contextBatchUnsafeConsumer != null) {
		contextBatchUnsafeConsumer.accept(
			[schemaName]s, [schemaName]UnsafeConsumer);
	}
	else {
		for ([SchemaName] [schemaName] : [schemaName]s) {
			[schemaName]UnsafeConsumer.accept([schemaName]);
		}
	}
}
```

