### PR TITLE
LPS-147943

### DIFF
--- a/modules/apps/calendar/calendar-web-test/src/testFunctional/tests/CalendarPermissions.testcase
+++ b/modules/apps/calendar/calendar-web-test/src/testFunctional/tests/CalendarPermissions.testcase
@@ -76,7 +76,7 @@ definition {
 
 		CalendarPermissions.searchRoleName(searchTerm = "Guest");
 
-		CalendarPermissions.viewSearchResult(searchResults = "1 Results for &quot;Guest&quot;");
+		CalendarPermissions.viewSearchResult(searchResults = "1 Result for &quot;Guest&quot;");
 
 		CalendarPermissions.cleanSearchResult();
 
@@ -90,7 +90,7 @@ definition {
 
 		CalendarPermissions.searchRoleName(searchTerm = "Guest");
 
-		CalendarPermissions.viewSearchResult(searchResults = "1 Results for &quot;Guest&quot;");
+		CalendarPermissions.viewSearchResult(searchResults = "1 Result for &quot;Guest&quot;");
 
 		CalendarPermissions.viewPermissionsRoleName(roleName = "Guest");
 

--- a/modules/apps/calendar/calendar-web-test/src/testFunctional/tests/ResourcesListView.testcase
+++ b/modules/apps/calendar/calendar-web-test/src/testFunctional/tests/ResourcesListView.testcase
@@ -86,7 +86,7 @@ definition {
 
 		CalendarResource.search(searchTerm = "Resource1");
 
-		CalendarResource.viewSearchSummaryResults(searchResults = '''1 Results for "Resource1"''');
+		CalendarResource.viewSearchSummaryResults(searchResults = '''1 Result for "Resource1"''');
 
 		CalendarResource.viewResourceName(calendarResourceName = "New Resource1");
 
@@ -206,7 +206,7 @@ definition {
 
 		CalendarResource.search(searchTerm = "Description");
 
-		CalendarResource.viewSearchSummaryResults(searchResults = "1 Results for &quot;Description&quot;");
+		CalendarResource.viewSearchSummaryResults(searchResults = "1 Result for &quot;Description&quot;");
 
 		CalendarResource.viewResourceName(calendarResourceName = "Resource Name");
 

--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/macros/AppBuilderAdmin.macro
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/macros/AppBuilderAdmin.macro
@@ -506,7 +506,7 @@ definition {
 	macro validateIfSearchItemIsFound {
 		AssertTextEquals(
 			locator1 = "AppBuilder#VALIDATE_SEARCH_RESULTS_BAR",
-			value1 = "1 Results for ${itemName}");
+			value1 = "1 Result for ${itemName}");
 	}
 
 	macro validateIfSearchItemIsNotFound {

--- a/modules/apps/depot/depot-test/src/testFunctional/tests/DepotPermission.testcase
+++ b/modules/apps/depot/depot-test/src/testFunctional/tests/DepotPermission.testcase
@@ -1168,7 +1168,7 @@ definition {
 
 		AssertTextEquals.assertPartialText(
 			locator1 = "ManagementBar#SEARCH_RESULT_SUMMARY",
-			value1 = "1 Results for &quot;Depot&quot;");
+			value1 = "1 Result for &quot;Depot&quot;");
 
 		Search.searchCP(searchTerm = "No View Permissions");
 

--- a/modules/apps/digital-signature/digital-signature-web/src/main/resources/META-INF/resources/js/components/management-toolbar/ManagementToolbarResultsBar.js
+++ b/modules/apps/digital-signature/digital-signature-web/src/main/resources/META-INF/resources/js/components/management-toolbar/ManagementToolbarResultsBar.js
@@ -86,7 +86,11 @@ export default function ManagementToolbarResultsBar({
 						<span className="component-text text-truncate-inline">
 							<span className="text-truncate">
 								{Liferay.Util.sub(
-									Liferay.Language.get('x-results-for-x'),
+									totalCount === 1
+										? Liferay.Language.get('x-result-for-x')
+										: Liferay.Language.get(
+												'x-results-for-x'
+										  ),
 									totalCount,
 									keywords
 								)}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ManagementToolbarTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ManagementToolbarTag.java
@@ -1239,7 +1239,8 @@ public class ManagementToolbarTag extends BaseContainerTag {
 			jspWriter.write(" class=\"text-truncate\">");
 			jspWriter.write(
 				LanguageUtil.format(
-					resourceBundle, "x-results-for",
+					resourceBundle,
+					(getItemsTotal() == 1) ? "x-result-for" : "x-results-for",
 					new Object[] {getItemsTotal()}));
 
 			if (searchValue != null) {

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ResultsBar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ResultsBar.js
@@ -33,7 +33,9 @@ const ResultsBar = ({
 					<span className="component-text text-truncate-inline">
 						<span className="text-truncate">
 							{Liferay.Util.sub(
-								Liferay.Language.get('x-results-for'),
+								itemsTotal === 1
+									? Liferay.Language.get('x-result-for')
+									: Liferay.Language.get('x-results-for'),
 								itemsTotal
 							)}
 

--- a/modules/apps/portal-language/portal-language-override-test/src/testFunctional/tests/LanguageOverride.testcase
+++ b/modules/apps/portal-language/portal-language-override-test/src/testFunctional/tests/LanguageOverride.testcase
@@ -89,7 +89,7 @@ definition {
 		task ("Then user can only view Overridden keys") {
 			AssertTextEquals(
 				locator1 = "Search#SEARCH_INFO",
-				value1 = "1 Results for");
+				value1 = "1 Result for");
 
 			AssertElementPresent(locator1 = "LanguageOverride#FILTER_BY_ANY_LANGUAGE_FILTER_LABEL");
 
@@ -182,7 +182,7 @@ definition {
 		task ("Then the language key can be viewed in the View page and there is results message") {
 			AssertTextEquals(
 				locator1 = "Search#SEARCH_INFO",
-				value1 = "1 Results for &quot;2-synced-contact-data&quot;");
+				value1 = "1 Result for &quot;2-synced-contact-data&quot;");
 
 			AssertTextEquals(
 				key_languageKey = "2-synced-contact-data",
@@ -219,7 +219,7 @@ definition {
 		task ("Then the language key can be viewed in the View page and there is results message and search for translations") {
 			AssertTextEquals(
 				locator1 = "Search#SEARCH_INFO",
-				value1 = "1 Results for &quot;O texto contÃƒÂ©m erro&quot;");
+				value1 = "1 Result for &quot;O texto contÃƒÂ©m erro&quot;");
 
 			AssertTextEquals(
 				key_languageKey = "text-contains-error",
@@ -239,7 +239,7 @@ definition {
 
 			AssertTextEquals(
 				locator1 = "Search#SEARCH_INFO",
-				value1 = "1 Results for &quot;Le texte contient une erreur&quot;");
+				value1 = "1 Result for &quot;Le texte contient une erreur&quot;");
 
 			AssertTextEquals(
 				key_languageKey = "text-contains-error",

--- a/modules/apps/portal-workflow/portal-workflow-test/src/testFunctional/tests/MyWorkflowTasks.testcase
+++ b/modules/apps/portal-workflow/portal-workflow-test/src/testFunctional/tests/MyWorkflowTasks.testcase
@@ -861,7 +861,7 @@ definition {
 		MyWorkflowTasks.searchMyWorkflowTasks(searchTerm = "Blogs Entry Title");
 
 		AssertElementPresent(
-			key_resultBarMessage = "1 Results for &quot;Blogs Entry Title&quot;",
+			key_resultBarMessage = "1 Result for &quot;Blogs Entry Title&quot;",
 			locator1 = "MyWorkflowTasks#MY_WORKFLOW_TASKS_SEARCH_RESULT_BAR");
 	}
 
@@ -879,7 +879,7 @@ definition {
 		MyWorkflowTasks.searchMyWorkflowTasks(searchTerm = "Blogs Entry");
 
 		AssertElementPresent(
-			key_resultBarMessage = "1 Results for &quot;Blogs Entry&quot;",
+			key_resultBarMessage = "1 Result for &quot;Blogs Entry&quot;",
 			locator1 = "MyWorkflowTasks#MY_WORKFLOW_TASKS_SEARCH_RESULT_BAR");
 	}
 
@@ -897,7 +897,7 @@ definition {
 		MyWorkflowTasks.searchMyWorkflowTasks(searchTerm = "Review");
 
 		AssertElementPresent(
-			key_resultBarMessage = "1 Results for &quot;Review&quot;",
+			key_resultBarMessage = "1 Result for &quot;Review&quot;",
 			locator1 = "MyWorkflowTasks#MY_WORKFLOW_TASKS_SEARCH_RESULT_BAR");
 	}
 
@@ -918,7 +918,7 @@ definition {
 		MyWorkflowTasks.searchMyWorkflowTasks(searchTerm = "Review");
 
 		AssertElementPresent(
-			key_resultBarMessage = "1 Results for &quot;Review&quot;",
+			key_resultBarMessage = "1 Result for &quot;Review&quot;",
 			locator1 = "MyWorkflowTasks#MY_WORKFLOW_TASKS_SEARCH_RESULT_BAR");
 	}
 
@@ -936,7 +936,7 @@ definition {
 		MyWorkflowTasks.searchMyWorkflowTasks(searchTerm = "New Blog Title");
 
 		AssertElementPresent(
-			key_resultBarMessage = "1 Results for &quot;New Blog Title&quot;",
+			key_resultBarMessage = "1 Result for &quot;New Blog Title&quot;",
 			locator1 = "MyWorkflowTasks#MY_WORKFLOW_TASKS_SEARCH_RESULT_BAR");
 	}
 
@@ -957,7 +957,7 @@ definition {
 		MyWorkflowTasks.searchMyWorkflowTasks(searchTerm = "Blogs Entry");
 
 		AssertElementPresent(
-			key_resultBarMessage = "1 Results for &quot;Blogs Entry&quot;",
+			key_resultBarMessage = "1 Result for &quot;Blogs Entry&quot;",
 			locator1 = "MyWorkflowTasks#MY_WORKFLOW_TASKS_SEARCH_RESULT_BAR");
 	}
 

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/ResultsMessage.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/ResultsMessage.es.js
@@ -46,7 +46,11 @@ export default function ResultsMessage({
 						<span
 							dangerouslySetInnerHTML={{
 								__html: lang.sub(
-									Liferay.Language.get('x-results-for-x'),
+									totalCount === 1
+										? Liferay.Language.get('x-result-for-x')
+										: Liferay.Language.get(
+												'x-results-for-x'
+										  ),
 									[
 										totalCount,
 										`<strong>"${slugToText(

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/list/FilterDisplay.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/list/FilterDisplay.es.js
@@ -33,10 +33,12 @@ class FilterDisplay extends Component {
 				<ManagementToolbar.ResultsBarItem expand>
 					<span className="component-text text-truncate-inline">
 						<span className="text-truncate">
-							{sub(Liferay.Language.get('x-results-for-x'), [
-								totalResultsCount,
-								searchBarTerm,
-							])}
+							{sub(
+								totalResultsCount === 1
+									? Liferay.Language.get('x-result-for-x')
+									: Liferay.Language.get('x-results-for-x'),
+								[totalResultsCount, searchBarTerm]
+							)}
 						</span>
 					</span>
 				</ManagementToolbar.ResultsBarItem>

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/clause_contributors_sidebar/ManagementToolbar.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/clause_contributors_sidebar/ManagementToolbar.js
@@ -239,10 +239,14 @@ function ManagementToolbar({
 					<FrontendManagementToolbar.ResultsBarItem>
 						<span className="component-text text-truncate-inline">
 							<span className="text-truncate">
-								{sub(Liferay.Language.get('x-results-for-x'), [
-									allItems.length,
-									keyword,
-								])}
+								{sub(
+									allItems.length === 1
+										? Liferay.Language.get('x-result-for-x')
+										: Liferay.Language.get(
+												'x-results-for-x'
+										  ),
+									[allItems.length, keyword]
+								)}
 							</span>
 						</span>
 					</FrontendManagementToolbar.ResultsBarItem>

--- a/portal-web/test/functional/com/liferay/portalweb/macros/ItemSelector.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/ItemSelector.macro
@@ -395,7 +395,7 @@ definition {
 
 		AssertTextEquals(
 			locator1 = "Search#SEARCH_INFO",
-			value1 = "1 Results for &quot;${imageFileName}&quot;");
+			value1 = "1 Result for &quot;${imageFileName}&quot;");
 
 		AssertElementPresent(locator1 = "ItemSelector#SELECT_FILE_IMAGE_CARD");
 
@@ -432,7 +432,7 @@ definition {
 
 		AssertTextEquals(
 			locator1 = "Search#SEARCH_INFO",
-			value1 = "1 Results for &quot;${imageFileName}&quot;");
+			value1 = "1 Result for &quot;${imageFileName}&quot;");
 
 		LexiconCard.viewCardPresent(card = "${imageFileName}");
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/layout/displaypagetemplate/DisplayPageTemplate.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/layout/displaypagetemplate/DisplayPageTemplate.macro
@@ -111,7 +111,7 @@ definition {
 
 						AssertTextEquals(
 							locator1 = "Search#SEARCH_INFO",
-							value1 = "1 Results for &quot;${searchTerm}&quot;");
+							value1 = "1 Result for &quot;${searchTerm}&quot;");
 					}
 
 					Click(

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/elasticsearch/Elasticsearch7.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/elasticsearch/Elasticsearch7.testcase
@@ -605,7 +605,7 @@ definition {
 
 		AssertTextEquals.assertPartialText(
 			locator1 = "SearchResults#RESULTS_PORTLET_SEARCH_QUERY",
-			value1 = "1 results for bicycle");
+			value1 = "1 result for bicycle");
 	}
 
 	@priority = "4"

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/questions/QuestionsEntry.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/questions/QuestionsEntry.testcase
@@ -780,7 +780,7 @@ definition {
 			topicName = "questions-test-category");
 
 		Questions.search(
-			resultsInfo = '''1 Results for "questions title 5"''',
+			resultsInfo = '''1 Result for "questions title 5"''',
 			searchKey = "Questions Title 5");
 
 		Questions.viewSearchResults(questionsList = "Questions Title 5");
@@ -794,7 +794,7 @@ definition {
 		Questions.viewSearchResults(questionsList = "Question1,Question2,Question3,Question4");
 
 		Questions.search(
-			resultsInfo = '''1 Results for "question4"''',
+			resultsInfo = '''1 Result for "question4"''',
 			searchKey = "Question4");
 
 		Questions.viewSearchResults(questionsList = "Question4");
@@ -802,7 +802,7 @@ definition {
 		Questions.viewNoSearchResults(questionsList = "Question1,Question2,Question3");
 
 		Questions.search(
-			resultsInfo = '''1 Results for "content2"''',
+			resultsInfo = '''1 Result for "content2"''',
 			searchKey = "Content2");
 
 		Questions.viewSearchResults(questionsList = "Question2");
@@ -810,7 +810,7 @@ definition {
 		Questions.viewNoSearchResults(questionsList = "Question1,Question3,Question4");
 
 		Questions.search(
-			resultsInfo = '''1 Results for "new"''',
+			resultsInfo = '''1 Result for "new"''',
 			searchKey = "New");
 
 		Questions.viewSearchResults(questionsList = "Question1");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/trash/RecycleBin.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/trash/RecycleBin.testcase
@@ -764,7 +764,7 @@ definition {
 
 			AssertTextEquals(
 				locator1 = "Search#SEARCH_INFO",
-				value1 = "1 Results for &quot;Comment&quot;");
+				value1 = "1 Result for &quot;Comment&quot;");
 
 			Blogs.viewEntryTitle(entryTitle = "Blogs Entry Title 2");
 


### PR DESCRIPTION
Manually forwarded because `ci:test:relevant` and forward attempts failed for unrelated reasons in [here](https://github.com/liferay-frontend/liferay-portal/pull/2162#issuecomment-1125271037) and [here](https://github.com/john-co/liferay-portal/pull/460#issuecomment-1126418604). cc/ @holatuwol @diegonvs

----

https://issues.liferay.com/browse/LPS-147943

/cc @hongvo2308 @sontruongces

Resend of https://github.com/liferay-frontend/liferay-portal/pull/2156 after running source formatter.

### Steps to reproduce

1. Go to Control Panel - Configuration - Language Override
1. Add a new language key
1. Search it or filter by Any Language

![](https://issues.liferay.com/secure/attachment/442534/reproduce-LPS-147943.png)

### Solution overview

Identified uses of "x-results-for" and replaced it, as needed, with a ternary statement that's still compatible with the pattern used by [Language.process](https://github.com/liferay/liferay-portal/blob/7.4.1-ga2/portal-impl/src/com/liferay/portal/language/LanguageImpl.java#L2028-L2031), used by LanguageFilter.
