### PR TITLE
LPS-147637 Immediately show next tab panel if reduced motion

### DIFF
--- a/modules/apps/frontend-js/frontend-js-tabs-support-web/src/main/resources/META-INF/resources/TabsProvider.tsx
+++ b/modules/apps/frontend-js/frontend-js-tabs-support-web/src/main/resources/META-INF/resources/TabsProvider.tsx
@@ -74,17 +74,16 @@ class TabsProvider {
 
 		this._transitioning = true;
 
-		panel.addEventListener(
-			this._transitionEndEvent,
-			() => {
-				panel.classList.remove(CssClass.ACTIVE);
-
-				this._transitioning = false;
-
-				Liferay.fire(this.EVENT_HIDDEN, {panel, trigger});
-			},
-			{once: true}
-		);
+		if (this._prefersReducedMotion()) {
+			this._onFadeEnd(panel, trigger);
+		}
+		else {
+			panel.addEventListener(
+				this._transitionEndEvent,
+				() => this._onFadeEnd(panel, trigger),
+				{once: true}
+			);
+		}
 	};
 
 	show = ({panel, trigger}: {panel?: any; trigger?: any}) => {
@@ -138,6 +137,14 @@ class TabsProvider {
 		return document.querySelector(`[href="#${panel.getAttribute('id')}"]`);
 	}
 
+	_onFadeEnd = (panel: any, trigger: any) => {
+		panel.classList.remove(CssClass.ACTIVE);
+
+		this._transitioning = false;
+
+		Liferay.fire(this.EVENT_HIDDEN, {panel, trigger});
+	};
+
 	_onTriggerClick = (event: any) => {
 		const trigger = event.delegateTarget;
 
@@ -151,6 +158,10 @@ class TabsProvider {
 			this.show({panel, trigger});
 		}
 	};
+
+	_prefersReducedMotion() {
+		return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+	}
 
 	_setTransitionEndEvent() {
 		const sampleElement = document.body;

--- a/modules/apps/frontend-js/frontend-js-tabs-support-web/types/src/main/resources/META-INF/resources/TabsProvider.d.ts
+++ b/modules/apps/frontend-js/frontend-js-tabs-support-web/types/src/main/resources/META-INF/resources/TabsProvider.d.ts
@@ -24,7 +24,9 @@ declare class TabsProvider {
 	show: ({panel, trigger}: {panel?: any; trigger?: any}) => void;
 	_getPanel(trigger: any): any;
 	_getTrigger(panel: any): Element | null;
+	_onFadeEnd: (panel: any, trigger: any) => void;
 	_onTriggerClick: (event: any) => void;
+	_prefersReducedMotion(): boolean;
 	_setTransitionEndEvent(): void;
 }
 export default TabsProvider;


### PR DESCRIPTION
Manually forwarded from https://github.com/liferay-frontend/liferay-portal/pull/2245.

[Unrelated CI errors checked by QA](https://github.com/liferay-frontend/liferay-portal/pull/2245#issuecomment-1137179756).

---

### References

- [LPS-147637](https://issues.liferay.com/browse/LPS-147637)

### What is the goal?

* Fix bug where tabs wouldn't switch properly when `prefers-reduced-motion` is active

### What does it look like?
#### Before fix

https://user-images.githubusercontent.com/6642927/168849622-177b8cfd-6913-4913-bd38-6bf87f37f095.mov



#### After fix
https://user-images.githubusercontent.com/6642927/168848981-3d297df5-960f-4ea2-839a-99b7b37d6430.mov



### How to replicate
- Access DXP from CentOS or enable Reduced motion in your OS ([instructions here](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion#user_preferences))
- Navigate to System Settings / OAuth 2 / Bundle PrefixHandlerFactory
- Delete the configuration named "Default"
- Navigate to OAuth 2 Administration.
- Edit Analytics Cloud.
- Open its Scopes tab
- Navigate to Global scopes tab.
- See that the tab content isn't empty anymore
