### PR TITLE
LPS-152690 Modernize AUI checkbox utilities

### DIFF
--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/js/AccountEntriesManagementToolbarPropsTransformer.js
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/js/AccountEntriesManagementToolbarPropsTransformer.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {postForm} from 'frontend-js-web';
+import {getCheckedCheckboxes, postForm} from 'frontend-js-web';
 
 const updateAccountEntries = (portletNamespace, url) => {
 	const form = document.getElementById(`${portletNamespace}fm`);
@@ -20,7 +20,7 @@ const updateAccountEntries = (portletNamespace, url) => {
 	if (form) {
 		postForm(form, {
 			data: {
-				accountEntryIds: Liferay.Util.getCheckedCheckboxes(
+				accountEntryIds: getCheckedCheckboxes(
 					form,
 					`${portletNamespace}allRowIds`
 				),

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/js/AccountEntriesManagementToolbarPropsTransformer.js
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/js/AccountEntriesManagementToolbarPropsTransformer.js
@@ -20,7 +20,7 @@ const updateAccountEntries = (portletNamespace, url) => {
 	if (form) {
 		postForm(form, {
 			data: {
-				accountEntryIds: Liferay.Util.listCheckedExcept(
+				accountEntryIds: Liferay.Util.getCheckedCheckboxes(
 					form,
 					`${portletNamespace}allRowIds`
 				),

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/js/AccountEntryAddressesManagementToolbarPropsTransformer.js
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/js/AccountEntryAddressesManagementToolbarPropsTransformer.js
@@ -37,7 +37,7 @@ export default function propsTransformer({portletNamespace, ...otherProps}) {
 					if (form) {
 						postForm(form, {
 							data: {
-								accountEntryAddressIds: Liferay.Util.listCheckedExcept(
+								accountEntryAddressIds: Liferay.Util.getCheckedCheckboxes(
 									form,
 									`${portletNamespace}allRowIds`
 								),

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/js/AccountEntryAddressesManagementToolbarPropsTransformer.js
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/js/AccountEntryAddressesManagementToolbarPropsTransformer.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {postForm} from 'frontend-js-web';
+import {getCheckedCheckboxes, postForm} from 'frontend-js-web';
 
 export default function propsTransformer({portletNamespace, ...otherProps}) {
 	return {
@@ -37,7 +37,7 @@ export default function propsTransformer({portletNamespace, ...otherProps}) {
 					if (form) {
 						postForm(form, {
 							data: {
-								accountEntryAddressIds: Liferay.Util.getCheckedCheckboxes(
+								accountEntryAddressIds: getCheckedCheckboxes(
 									form,
 									`${portletNamespace}allRowIds`
 								),

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/js/AccountOrganizationsManagementToolbarPropsTransformer.js
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/js/AccountOrganizationsManagementToolbarPropsTransformer.js
@@ -37,7 +37,7 @@ export default function propsTransformer({portletNamespace, ...otherProps}) {
 					if (form) {
 						postForm(form, {
 							data: {
-								accountOrganizationIds: Liferay.Util.listCheckedExcept(
+								accountOrganizationIds: Liferay.Util.getCheckedCheckboxes(
 									form,
 									`${portletNamespace}allRowIds`
 								),

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/js/AccountOrganizationsManagementToolbarPropsTransformer.js
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/js/AccountOrganizationsManagementToolbarPropsTransformer.js
@@ -12,7 +12,11 @@
  * details.
  */
 
-import {openSelectionModal, postForm} from 'frontend-js-web';
+import {
+	getCheckedCheckboxes,
+	openSelectionModal,
+	postForm,
+} from 'frontend-js-web';
 
 export default function propsTransformer({portletNamespace, ...otherProps}) {
 	return {
@@ -37,7 +41,7 @@ export default function propsTransformer({portletNamespace, ...otherProps}) {
 					if (form) {
 						postForm(form, {
 							data: {
-								accountOrganizationIds: Liferay.Util.getCheckedCheckboxes(
+								accountOrganizationIds: getCheckedCheckboxes(
 									form,
 									`${portletNamespace}allRowIds`
 								),

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/js/AccountRolesManagementToolbarPropsTransformer.js
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/js/AccountRolesManagementToolbarPropsTransformer.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {postForm} from 'frontend-js-web';
+import {getCheckedCheckboxes, postForm} from 'frontend-js-web';
 
 export default function propsTransformer({portletNamespace, ...otherProps}) {
 	return {
@@ -37,7 +37,7 @@ export default function propsTransformer({portletNamespace, ...otherProps}) {
 					if (form) {
 						postForm(form, {
 							data: {
-								accountRoleIds: Liferay.Util.getCheckedCheckboxes(
+								accountRoleIds: getCheckedCheckboxes(
 									form,
 									`${portletNamespace}allRowIds`
 								),

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/js/AccountRolesManagementToolbarPropsTransformer.js
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/js/AccountRolesManagementToolbarPropsTransformer.js
@@ -37,7 +37,7 @@ export default function propsTransformer({portletNamespace, ...otherProps}) {
 					if (form) {
 						postForm(form, {
 							data: {
-								accountRoleIds: Liferay.Util.listCheckedExcept(
+								accountRoleIds: Liferay.Util.getCheckedCheckboxes(
 									form,
 									`${portletNamespace}allRowIds`
 								),

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/js/AccountUsersManagementToolbarPropsTransformer.js
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/js/AccountUsersManagementToolbarPropsTransformer.js
@@ -12,7 +12,11 @@
  * details.
  */
 
-import {openSelectionModal, postForm} from 'frontend-js-web';
+import {
+	getCheckedCheckboxes,
+	openSelectionModal,
+	postForm,
+} from 'frontend-js-web';
 
 export default function propsTransformer({
 	additionalProps: {
@@ -45,7 +49,7 @@ export default function propsTransformer({
 					if (form) {
 						postForm(form, {
 							data: {
-								accountUserIds: Liferay.Util.getCheckedCheckboxes(
+								accountUserIds: getCheckedCheckboxes(
 									form,
 									`${portletNamespace}allRowIds`
 								),

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/js/AccountUsersManagementToolbarPropsTransformer.js
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/js/AccountUsersManagementToolbarPropsTransformer.js
@@ -45,7 +45,7 @@ export default function propsTransformer({
 					if (form) {
 						postForm(form, {
 							data: {
-								accountUserIds: Liferay.Util.listCheckedExcept(
+								accountUserIds: Liferay.Util.getCheckedCheckboxes(
 									form,
 									`${portletNamespace}allRowIds`
 								),

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_groups_admin/js/AccountGroupAccountEntriesManagementToolbarPropsTransformer.js
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_groups_admin/js/AccountGroupAccountEntriesManagementToolbarPropsTransformer.js
@@ -12,7 +12,11 @@
  * details.
  */
 
-import {openSelectionModal, postForm} from 'frontend-js-web';
+import {
+	getCheckedCheckboxes,
+	openSelectionModal,
+	postForm,
+} from 'frontend-js-web';
 
 export default function propsTransformer({
 	additionalProps: {
@@ -44,7 +48,7 @@ export default function propsTransformer({
 					if (form) {
 						postForm(form, {
 							data: {
-								accountEntryIds: Liferay.Util.getCheckedCheckboxes(
+								accountEntryIds: getCheckedCheckboxes(
 									form,
 									`${portletNamespace}allRowIds`
 								),

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_groups_admin/js/AccountGroupAccountEntriesManagementToolbarPropsTransformer.js
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_groups_admin/js/AccountGroupAccountEntriesManagementToolbarPropsTransformer.js
@@ -44,7 +44,7 @@ export default function propsTransformer({
 					if (form) {
 						postForm(form, {
 							data: {
-								accountEntryIds: Liferay.Util.listCheckedExcept(
+								accountEntryIds: Liferay.Util.getCheckedCheckboxes(
 									form,
 									`${portletNamespace}allRowIds`
 								),

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_groups_admin/js/AccountGroupsManagementToolbarPropsTransformer.js
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_groups_admin/js/AccountGroupsManagementToolbarPropsTransformer.js
@@ -37,7 +37,7 @@ export default function propsTransformer({portletNamespace, ...otherProps}) {
 					if (form) {
 						postForm(form, {
 							data: {
-								accountGroupIds: Liferay.Util.listCheckedExcept(
+								accountGroupIds: Liferay.Util.getCheckedCheckboxes(
 									form,
 									`${portletNamespace}allRowIds`
 								),

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_groups_admin/js/AccountGroupsManagementToolbarPropsTransformer.js
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_groups_admin/js/AccountGroupsManagementToolbarPropsTransformer.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {postForm} from 'frontend-js-web';
+import {getCheckedCheckboxes, postForm} from 'frontend-js-web';
 
 export default function propsTransformer({portletNamespace, ...otherProps}) {
 	return {
@@ -37,7 +37,7 @@ export default function propsTransformer({portletNamespace, ...otherProps}) {
 					if (form) {
 						postForm(form, {
 							data: {
-								accountGroupIds: Liferay.Util.getCheckedCheckboxes(
+								accountGroupIds: getCheckedCheckboxes(
 									form,
 									`${portletNamespace}allRowIds`
 								),

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_users_admin/js/AccountUsersAdminManagementToolbarPropsTransformer.js
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_users_admin/js/AccountUsersAdminManagementToolbarPropsTransformer.js
@@ -14,6 +14,7 @@
 
 import {
 	createPortletURL,
+	getCheckedCheckboxes,
 	navigate,
 	openSelectionModal,
 	postForm,
@@ -25,7 +26,7 @@ const updateAccountUsers = (portletNamespace, url) => {
 	if (form) {
 		postForm(form, {
 			data: {
-				accountUserIds: Liferay.Util.getCheckedCheckboxes(
+				accountUserIds: getCheckedCheckboxes(
 					form,
 					`${portletNamespace}allRowIds`
 				),

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_users_admin/js/AccountUsersAdminManagementToolbarPropsTransformer.js
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_users_admin/js/AccountUsersAdminManagementToolbarPropsTransformer.js
@@ -25,7 +25,7 @@ const updateAccountUsers = (portletNamespace, url) => {
 	if (form) {
 		postForm(form, {
 			data: {
-				accountUserIds: Liferay.Util.listCheckedExcept(
+				accountUserIds: Liferay.Util.getCheckedCheckboxes(
 					form,
 					`${portletNamespace}allRowIds`
 				),

--- a/modules/apps/asset/asset-tags-admin-web/src/main/resources/META-INF/resources/js/ManagementToolbarPropsTransformer.js
+++ b/modules/apps/asset/asset-tags-admin-web/src/main/resources/META-INF/resources/js/ManagementToolbarPropsTransformer.js
@@ -34,7 +34,7 @@ export default function propsTransformer({portletNamespace, ...otherProps}) {
 		if (form) {
 			location.href = itemData?.mergeTagsURL.replace(
 				escape('[$MERGE_TAGS_IDS$]'),
-				Liferay.Util.listCheckedExcept(
+				Liferay.Util.getCheckedCheckboxes(
 					form,
 					`${portletNamespace}allRowIds`
 				)

--- a/modules/apps/asset/asset-tags-admin-web/src/main/resources/META-INF/resources/js/ManagementToolbarPropsTransformer.js
+++ b/modules/apps/asset/asset-tags-admin-web/src/main/resources/META-INF/resources/js/ManagementToolbarPropsTransformer.js
@@ -12,6 +12,8 @@
  * details.
  */
 
+import {getCheckedCheckboxes} from 'frontend-js-web';
+
 import openDeleteTagModal from './openDeleteTagModal';
 
 export default function propsTransformer({portletNamespace, ...otherProps}) {
@@ -34,10 +36,7 @@ export default function propsTransformer({portletNamespace, ...otherProps}) {
 		if (form) {
 			location.href = itemData?.mergeTagsURL.replace(
 				escape('[$MERGE_TAGS_IDS$]'),
-				Liferay.Util.getCheckedCheckboxes(
-					form,
-					`${portletNamespace}allRowIds`
-				)
+				getCheckedCheckboxes(form, `${portletNamespace}allRowIds`)
 			);
 		}
 	};

--- a/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/js/BatchPlannerPlanTemplateManagementToolbarPropsTransformer.js
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/js/BatchPlannerPlanTemplateManagementToolbarPropsTransformer.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {postForm} from 'frontend-js-web';
+import {getCheckedCheckboxes, postForm} from 'frontend-js-web';
 
 export default function propsTransformer({portletNamespace, ...otherProps}) {
 	const deleteBatchPlannerPlanTemplates = (itemData) => {
@@ -32,7 +32,7 @@ export default function propsTransformer({portletNamespace, ...otherProps}) {
 			if (form && searchContainer) {
 				postForm(form, {
 					data: {
-						batchPlannerPlanIds: Liferay.Util.getCheckedCheckboxes(
+						batchPlannerPlanIds: getCheckedCheckboxes(
 							searchContainer,
 							`${portletNamespace}allRowIds`
 						),

--- a/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/js/BatchPlannerPlanTemplateManagementToolbarPropsTransformer.js
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/js/BatchPlannerPlanTemplateManagementToolbarPropsTransformer.js
@@ -32,7 +32,7 @@ export default function propsTransformer({portletNamespace, ...otherProps}) {
 			if (form && searchContainer) {
 				postForm(form, {
 					data: {
-						batchPlannerPlanIds: Liferay.Util.listCheckedExcept(
+						batchPlannerPlanIds: Liferay.Util.getCheckedCheckboxes(
 							searchContainer,
 							`${portletNamespace}allRowIds`
 						),

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/js/BlogEntriesManagementToolbarPropsTransformer.js
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/js/BlogEntriesManagementToolbarPropsTransformer.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {postForm} from 'frontend-js-web';
+import {getCheckedCheckboxes, postForm} from 'frontend-js-web';
 
 export default function propsTransformer({
 	additionalProps: {deleteEntriesCmd, deleteEntriesURL, trashEnabled},
@@ -46,7 +46,7 @@ export default function propsTransformer({
 					postForm(form, {
 						data: {
 							cmd: deleteEntriesCmd,
-							deleteEntryIds: Liferay.Util.getCheckedCheckboxes(
+							deleteEntryIds: getCheckedCheckboxes(
 								form,
 								`${portletNamespace}allRowIds`
 							),

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/js/BlogEntriesManagementToolbarPropsTransformer.js
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/js/BlogEntriesManagementToolbarPropsTransformer.js
@@ -46,7 +46,7 @@ export default function propsTransformer({
 					postForm(form, {
 						data: {
 							cmd: deleteEntriesCmd,
-							deleteEntryIds: Liferay.Util.listCheckedExcept(
+							deleteEntryIds: Liferay.Util.getCheckedCheckboxes(
 								form,
 								`${portletNamespace}allRowIds`
 							),

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/js/BlogImagesManagementToolbarPropsTransformer.js
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/js/BlogImagesManagementToolbarPropsTransformer.js
@@ -45,7 +45,7 @@ export default function propsTransformer({portletNamespace, ...otherProps}) {
 					if (deleteFileEntryIds) {
 						deleteFileEntryIds.setAttribute(
 							'value',
-							Liferay.Util.listCheckedExcept(
+							Liferay.Util.getCheckedCheckboxes(
 								form,
 								`${portletNamespace}allRowIds`
 							)

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/js/BlogImagesManagementToolbarPropsTransformer.js
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/js/BlogImagesManagementToolbarPropsTransformer.js
@@ -12,6 +12,8 @@
  * details.
  */
 
+import {getCheckedCheckboxes} from 'frontend-js-web';
+
 export default function propsTransformer({portletNamespace, ...otherProps}) {
 	return {
 		...otherProps,
@@ -45,7 +47,7 @@ export default function propsTransformer({portletNamespace, ...otherProps}) {
 					if (deleteFileEntryIds) {
 						deleteFileEntryIds.setAttribute(
 							'value',
-							Liferay.Util.getCheckedCheckboxes(
+							getCheckedCheckboxes(
 								form,
 								`${portletNamespace}allRowIds`
 							)

--- a/modules/apps/commerce/commerce-address-web/src/main/resources/META-INF/resources/commerce_country/channels.jsp
+++ b/modules/apps/commerce/commerce-address-web/src/main/resources/META-INF/resources/commerce_country/channels.jsp
@@ -72,7 +72,7 @@ long[] commerceChannelIds = commerceCountriesDisplayContext.getCommerceChannelRe
 <aui:script>
 	function <portlet:namespace />fulfillCommerceChannelIds(e) {
 		var form = window.document['<portlet:namespace />fm'];
-		var values = Liferay.Util.listCheckedExcept(
+		var values = Liferay.Util.getCheckedCheckboxes(
 			form,
 			'<portlet:namespace />allRowIds'
 		);

--- a/modules/apps/commerce/commerce-address-web/src/main/resources/META-INF/resources/commerce_country/commerce_regions.jsp
+++ b/modules/apps/commerce/commerce-address-web/src/main/resources/META-INF/resources/commerce_country/commerce_regions.jsp
@@ -163,7 +163,7 @@ CommerceRegionsDisplayContext commerceRegionsDisplayContext = (CommerceRegionsDi
 
 				form[
 					'<portlet:namespace />deleteRegionIds'
-				].value = Liferay.Util.listCheckedExcept(
+				].value = Liferay.Util.getCheckedCheckboxes(
 					form,
 					'<portlet:namespace />allRowIds'
 				);

--- a/modules/apps/commerce/commerce-address-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/commerce/commerce-address-web/src/main/resources/META-INF/resources/view.jsp
@@ -211,7 +211,7 @@ CommerceCountriesDisplayContext commerceCountriesDisplayContext = (CommerceCount
 
 				form[
 					'<portlet:namespace />deleteCountryIds'
-				].value = Liferay.Util.listCheckedExcept(
+				].value = Liferay.Util.getCheckedCheckboxes(
 					form,
 					'<portlet:namespace />allRowIds'
 				);

--- a/modules/apps/commerce/commerce-availability-estimate-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/commerce/commerce-availability-estimate-web/src/main/resources/META-INF/resources/view.jsp
@@ -139,7 +139,7 @@ CommerceAvailabilityEstimateDisplayContext commerceAvailabilityEstimateDisplayCo
 
 				form[
 					'<portlet:namespace />deleteCommerceAvailabilityEstimateIds'
-				].value = Liferay.Util.listCheckedExcept(
+				].value = Liferay.Util.getCheckedCheckboxes(
 					form,
 					'<portlet:namespace />allRowIds'
 				);

--- a/modules/apps/commerce/commerce-currency-web/src/main/resources/META-INF/resources/commerce_currency/currencies.jsp
+++ b/modules/apps/commerce/commerce-currency-web/src/main/resources/META-INF/resources/commerce_currency/currencies.jsp
@@ -183,7 +183,7 @@ CommerceCurrenciesDisplayContext commerceCurrenciesDisplayContext = (CommerceCur
 					'<%= Constants.DELETE %>';
 				form[
 					'<portlet:namespace />deleteCommerceCurrencyIds'
-				].value = Liferay.Util.listCheckedExcept(
+				].value = Liferay.Util.getCheckedCheckboxes(
 					form,
 					'<portlet:namespace />allRowIds'
 				);
@@ -204,7 +204,7 @@ CommerceCurrenciesDisplayContext commerceCurrenciesDisplayContext = (CommerceCur
 					'updateExchangeRates';
 				form[
 					'<portlet:namespace />updateCommerceCurrencyExchangeRateIds'
-				].value = Liferay.Util.listCheckedExcept(
+				].value = Liferay.Util.getCheckedCheckboxes(
 					form,
 					'<portlet:namespace />allRowIds'
 				);

--- a/modules/apps/commerce/commerce-item-selector-web/src/main/resources/META-INF/resources/country_item_selector.jsp
+++ b/modules/apps/commerce/commerce-item-selector-web/src/main/resources/META-INF/resources/country_item_selector.jsp
@@ -118,7 +118,7 @@ PortletURL portletURL = commerceCountryItemSelectorViewDisplayContext.getPortlet
 		Liferay.Util.getOpener().Liferay.fire(
 			'<%= HtmlUtil.escapeJS(itemSelectedEventName) %>',
 			{
-				data: Liferay.Util.listCheckedExcept(
+				data: Liferay.Util.getCheckedCheckboxes(
 					commerceCountrySelectorWrapper,
 					'<portlet:namespace />allRowIds'
 				),

--- a/modules/apps/commerce/commerce-item-selector-web/src/main/resources/META-INF/resources/price_list_item_selector.jsp
+++ b/modules/apps/commerce/commerce-item-selector-web/src/main/resources/META-INF/resources/price_list_item_selector.jsp
@@ -124,7 +124,7 @@ PortletURL portletURL = commercePriceListItemSelectorViewDisplayContext.getPortl
 		Liferay.Util.getOpener().Liferay.fire(
 			'<%= HtmlUtil.escapeJS(itemSelectedEventName) %>',
 			{
-				data: Liferay.Util.listCheckedExcept(
+				data: Liferay.Util.getCheckedCheckboxes(
 					commercePriceListSelectorWrapper,
 					'<portlet:namespace />allRowIds'
 				),

--- a/modules/apps/commerce/commerce-item-selector-web/src/main/resources/META-INF/resources/pricing_class_item_selector.jsp
+++ b/modules/apps/commerce/commerce-item-selector-web/src/main/resources/META-INF/resources/pricing_class_item_selector.jsp
@@ -116,7 +116,7 @@ PortletURL portletURL = commercePricingClassItemSelectorViewDisplayContext.getPo
 		Liferay.Util.getOpener().Liferay.fire(
 			'<%= HtmlUtil.escapeJS(itemSelectedEventName) %>',
 			{
-				data: Liferay.Util.listCheckedExcept(
+				data: Liferay.Util.getCheckedCheckboxes(
 					commercePricingClassSelectorWrapper,
 					'<portlet:namespace />allRowIds'
 				),

--- a/modules/apps/commerce/commerce-item-selector-web/src/main/resources/META-INF/resources/product_instance_item_selector.jsp
+++ b/modules/apps/commerce/commerce-item-selector-web/src/main/resources/META-INF/resources/product_instance_item_selector.jsp
@@ -112,7 +112,7 @@ PortletURL portletURL = commerceProductInstanceItemSelectorViewDisplayContext.ge
 		Liferay.Util.getOpener().Liferay.fire(
 			'<%= HtmlUtil.escapeJS(commerceProductInstanceItemSelectorViewDisplayContext.getItemSelectedEventName()) %>',
 			{
-				data: Liferay.Util.listCheckedExcept(
+				data: Liferay.Util.getCheckedCheckboxes(
 					cpInstanceSelectorWrapper,
 					'<portlet:namespace />allRowIds'
 				),

--- a/modules/apps/commerce/commerce-item-selector-web/src/main/resources/META-INF/resources/warehouse_item_selector.jsp
+++ b/modules/apps/commerce/commerce-item-selector-web/src/main/resources/META-INF/resources/warehouse_item_selector.jsp
@@ -102,7 +102,7 @@ for (ManagementBarFilterItem managementBarFilterItem : managementBarFilterItems)
 		Liferay.Util.getOpener().Liferay.fire(
 			'<%= HtmlUtil.escapeJS(itemSelectedEventName) %>',
 			{
-				data: Liferay.Util.listCheckedExcept(
+				data: Liferay.Util.getCheckedCheckboxes(
 					commerceInventoryWarehouseSelectorWrapper,
 					'<portlet:namespace />allRowIds'
 				),

--- a/modules/apps/commerce/commerce-product-item-selector-web/src/main/resources/META-INF/resources/instance_item_selector.jsp
+++ b/modules/apps/commerce/commerce-product-item-selector-web/src/main/resources/META-INF/resources/instance_item_selector.jsp
@@ -120,7 +120,7 @@ PortletURL portletURL = cpInstanceItemSelectorViewDisplayContext.getPortletURL()
 		Liferay.Util.getOpener().Liferay.fire(
 			'<%= HtmlUtil.escapeJS(itemSelectedEventName) %>',
 			{
-				data: Liferay.Util.listCheckedExcept(
+				data: Liferay.Util.getCheckedCheckboxes(
 					cpInstanceSelectorWrapper,
 					'<portlet:namespace />allRowIds'
 				),

--- a/modules/apps/commerce/commerce-product-item-selector-web/src/main/resources/META-INF/resources/option_item_selector.jsp
+++ b/modules/apps/commerce/commerce-product-item-selector-web/src/main/resources/META-INF/resources/option_item_selector.jsp
@@ -104,7 +104,7 @@ PortletURL portletURL = cpOptionItemSelectorViewDisplayContext.getPortletURL();
 		Liferay.Util.getOpener().Liferay.fire(
 			'<%= HtmlUtil.escapeJS(itemSelectedEventName) %>',
 			{
-				data: Liferay.Util.listCheckedExcept(
+				data: Liferay.Util.getCheckedCheckboxes(
 					cpOptionSelectorWrapper,
 					'<portlet:namespace />allRowIds'
 				),

--- a/modules/apps/commerce/commerce-product-item-selector-web/src/main/resources/META-INF/resources/specification_option_item_selector.jsp
+++ b/modules/apps/commerce/commerce-product-item-selector-web/src/main/resources/META-INF/resources/specification_option_item_selector.jsp
@@ -104,7 +104,7 @@ PortletURL portletURL = cpSpecificationOptionItemSelectorViewDisplayContext.getP
 		Liferay.Util.getOpener().Liferay.fire(
 			'<%= HtmlUtil.escapeJS(itemSelectedEventName) %>',
 			{
-				data: Liferay.Util.listCheckedExcept(
+				data: Liferay.Util.getCheckedCheckboxes(
 					cpSpecificationOptionSelectorWrapper,
 					'<portlet:namespace />allRowIds'
 				),

--- a/modules/apps/commerce/commerce-product-measurement-unit-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/commerce/commerce-product-measurement-unit-web/src/main/resources/META-INF/resources/view.jsp
@@ -172,7 +172,7 @@ CPMeasurementUnitsDisplayContext cpMeasurementUnitsDisplayContext = (CPMeasureme
 
 				form[
 					'<portlet:namespace />deleteCPMeasurementUnitIds'
-				].value = Liferay.Util.listCheckedExcept(
+				].value = Liferay.Util.getCheckedCheckboxes(
 					form,
 					'<portlet:namespace />allRowIds'
 				);

--- a/modules/apps/commerce/commerce-product-options-web/src/main/resources/META-INF/resources/view_cp_option_categories.jsp
+++ b/modules/apps/commerce/commerce-product-options-web/src/main/resources/META-INF/resources/view_cp_option_categories.jsp
@@ -195,7 +195,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "specifications"));
 				'<%= Constants.DELETE %>';
 			form[
 				'<portlet:namespace />deleteCPOptionCategoryIds'
-			].value = Liferay.Util.listCheckedExcept(
+			].value = Liferay.Util.getCheckedCheckboxes(
 				form,
 				'<portlet:namespace />allRowIds'
 			);

--- a/modules/apps/commerce/commerce-product-options-web/src/main/resources/META-INF/resources/view_cp_specification_options.jsp
+++ b/modules/apps/commerce/commerce-product-options-web/src/main/resources/META-INF/resources/view_cp_specification_options.jsp
@@ -209,7 +209,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "specifications"));
 				'<%= Constants.DELETE %>';
 			form[
 				'<portlet:namespace />deleteCPSpecificationOptionIds'
-			].value = Liferay.Util.listCheckedExcept(
+			].value = Liferay.Util.getCheckedCheckboxes(
 				form,
 				'<portlet:namespace />allRowIds'
 			);

--- a/modules/apps/commerce/commerce-product-tax-category-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/commerce/commerce-product-tax-category-web/src/main/resources/META-INF/resources/view.jsp
@@ -140,7 +140,7 @@ CPTaxCategoryDisplayContext cpTaxCategoryDisplayContext = (CPTaxCategoryDisplayC
 
 				form[
 					'<portlet:namespace />deleteCPTaxCategoryIds'
-				].value = Liferay.Util.listCheckedExcept(
+				].value = Liferay.Util.getCheckedCheckboxes(
 					form,
 					'<portlet:namespace />allRowIds'
 				);

--- a/modules/apps/commerce/commerce-product-type-grouped-web/src/main/resources/META-INF/resources/view_cp_definition_grouped_entries.jsp
+++ b/modules/apps/commerce/commerce-product-type-grouped-web/src/main/resources/META-INF/resources/view_cp_definition_grouped_entries.jsp
@@ -201,7 +201,7 @@ renderResponse.setTitle(cpDefinition.getName(themeDisplay.getLanguageId()));
 				'<%= Constants.DELETE %>';
 			form[
 				'<portlet:namespace />deleteCPDefinitionGroupedEntryIds'
-			].value = Liferay.Util.listCheckedExcept(
+			].value = Liferay.Util.getCheckedCheckboxes(
 				form,
 				'<portlet:namespace />allRowIds'
 			);

--- a/modules/apps/commerce/commerce-warehouse-web/src/main/resources/META-INF/resources/js/warehouseChannels.js
+++ b/modules/apps/commerce/commerce-warehouse-web/src/main/resources/META-INF/resources/js/warehouseChannels.js
@@ -16,7 +16,7 @@ export default function ({namespace}) {
 	const form = document.getElementById(`${namespace}fm`);
 
 	function fulfillCommerceChannelIds() {
-		const values = Liferay.Util.listCheckedExcept(
+		const values = Liferay.Util.getCheckedCheckboxes(
 			form,
 			`${namespace}allRowIds`
 		);

--- a/modules/apps/commerce/commerce-warehouse-web/src/main/resources/META-INF/resources/js/warehouseChannels.js
+++ b/modules/apps/commerce/commerce-warehouse-web/src/main/resources/META-INF/resources/js/warehouseChannels.js
@@ -12,14 +12,13 @@
  * details.
  */
 
+import {getCheckedCheckboxes} from 'frontend-js-web';
+
 export default function ({namespace}) {
 	const form = document.getElementById(`${namespace}fm`);
 
 	function fulfillCommerceChannelIds() {
-		const values = Liferay.Util.getCheckedCheckboxes(
-			form,
-			`${namespace}allRowIds`
-		);
+		const values = getCheckedCheckboxes(form, `${namespace}allRowIds`);
 
 		form[`${namespace}commerceChannelIds`].value = values;
 	}

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/js/DepotAdminManagementToolbarPropsTransformer.js
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/js/DepotAdminManagementToolbarPropsTransformer.js
@@ -28,7 +28,7 @@ export default function propsTransformer({
 			if (form) {
 				postForm(form, {
 					data: {
-						deleteEntryIds: Liferay.Util.listCheckedExcept(
+						deleteEntryIds: Liferay.Util.getCheckedCheckboxes(
 							form,
 							`${portletNamespace}allRowIds`
 						),

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/js/DepotAdminManagementToolbarPropsTransformer.js
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/js/DepotAdminManagementToolbarPropsTransformer.js
@@ -12,7 +12,11 @@
  * details.
  */
 
-import {openSimpleInputModal, postForm} from 'frontend-js-web';
+import {
+	getCheckedCheckboxes,
+	openSimpleInputModal,
+	postForm,
+} from 'frontend-js-web';
 
 import confirmDepotEntryDeletion from './confirmDepotEntryDeletion.es';
 
@@ -28,7 +32,7 @@ export default function propsTransformer({
 			if (form) {
 				postForm(form, {
 					data: {
-						deleteEntryIds: Liferay.Util.getCheckedCheckboxes(
+						deleteEntryIds: getCheckedCheckboxes(
 							form,
 							`${portletNamespace}allRowIds`
 						),

--- a/modules/apps/dispatch/dispatch-web/src/main/resources/META-INF/resources/dispatch_trigger_toolbar.jsp
+++ b/modules/apps/dispatch/dispatch-web/src/main/resources/META-INF/resources/dispatch_trigger_toolbar.jsp
@@ -91,7 +91,9 @@ DispatchTriggerDisplayContext dispatchTriggerDisplayContext = (DispatchTriggerDi
 
 			form.setAttribute('method', 'post');
 			form['<%= Constants.CMD %>'].value = '<%= Constants.DELETE %>';
-			form['deleteDispatchTriggerIds'].value = Liferay.Util.listCheckedExcept(
+			form[
+				'deleteDispatchTriggerIds'
+			].value = Liferay.Util.getCheckedCheckboxes(
 				form,
 				'<portlet:namespace />allRowIds'
 			);

--- a/modules/apps/dispatch/dispatch-web/src/main/resources/META-INF/resources/trigger/js/DispatchLogManagementToolbarPropsTransformer.js
+++ b/modules/apps/dispatch/dispatch-web/src/main/resources/META-INF/resources/trigger/js/DispatchLogManagementToolbarPropsTransformer.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {postForm} from 'frontend-js-web';
+import {getCheckedCheckboxes, postForm} from 'frontend-js-web';
 
 export default function propsTransformer({portletNamespace, ...otherProps}) {
 	return {
@@ -37,7 +37,7 @@ export default function propsTransformer({portletNamespace, ...otherProps}) {
 					if (form) {
 						postForm(form, {
 							data: {
-								deleteDispatchLogIds: Liferay.Util.getCheckedCheckboxes(
+								deleteDispatchLogIds: getCheckedCheckboxes(
 									form,
 									`${portletNamespace}allRowIds`
 								),

--- a/modules/apps/dispatch/dispatch-web/src/main/resources/META-INF/resources/trigger/js/DispatchLogManagementToolbarPropsTransformer.js
+++ b/modules/apps/dispatch/dispatch-web/src/main/resources/META-INF/resources/trigger/js/DispatchLogManagementToolbarPropsTransformer.js
@@ -37,7 +37,7 @@ export default function propsTransformer({portletNamespace, ...otherProps}) {
 					if (form) {
 						postForm(form, {
 							data: {
-								deleteDispatchLogIds: Liferay.Util.listCheckedExcept(
+								deleteDispatchLogIds: Liferay.Util.getCheckedCheckboxes(
 									form,
 									`${portletNamespace}allRowIds`
 								),

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/js/ManagementToolbarPropsTransformer.js
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/js/ManagementToolbarPropsTransformer.js
@@ -50,7 +50,7 @@ export default function propsTransformer({
 						if (recordSetIds) {
 							recordSetIds.setAttribute(
 								'value',
-								Liferay.Util.listCheckedExcept(
+								Liferay.Util.getCheckedCheckboxes(
 									searchContainer,
 									`${portletNamespace}allRowIds`
 								)

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/js/ManagementToolbarPropsTransformer.js
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/js/ManagementToolbarPropsTransformer.js
@@ -12,6 +12,8 @@
  * details.
  */
 
+import {getCheckedCheckboxes} from 'frontend-js-web';
+
 export default function propsTransformer({
 	additionalProps: {deleteRecordSetsURL},
 	portletNamespace,
@@ -50,7 +52,7 @@ export default function propsTransformer({
 						if (recordSetIds) {
 							recordSetIds.setAttribute(
 								'value',
-								Liferay.Util.getCheckedCheckboxes(
+								getCheckedCheckboxes(
 									searchContainer,
 									`${portletNamespace}allRowIds`
 								)

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/js/ViewRecordsManagementToolbarPropsTransformer.js
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/js/ViewRecordsManagementToolbarPropsTransformer.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {postForm} from 'frontend-js-web';
+import {getCheckedCheckboxes, postForm} from 'frontend-js-web';
 
 export default function propsTransformer({
 	additionalProps: {deleteRecordURL},
@@ -47,7 +47,7 @@ export default function propsTransformer({
 					if (searchContainer) {
 						postForm(form, {
 							data: {
-								recordIds: Liferay.Util.getCheckedCheckboxes(
+								recordIds: getCheckedCheckboxes(
 									searchContainer,
 									`${portletNamespace}allRowIds`
 								),

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/js/ViewRecordsManagementToolbarPropsTransformer.js
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/js/ViewRecordsManagementToolbarPropsTransformer.js
@@ -47,7 +47,7 @@ export default function propsTransformer({
 					if (searchContainer) {
 						postForm(form, {
 							data: {
-								recordIds: Liferay.Util.listCheckedExcept(
+								recordIds: Liferay.Util.getCheckedCheckboxes(
 									searchContainer,
 									`${portletNamespace}allRowIds`
 								),

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-web/src/main/resources/META-INF/resources/js/DDMDataProviderManagementToolbarPropsTransformer.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-web/src/main/resources/META-INF/resources/js/DDMDataProviderManagementToolbarPropsTransformer.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {postForm} from 'frontend-js-web';
+import {getCheckedCheckboxes, postForm} from 'frontend-js-web';
 
 export default function propsTransformer({
 	additionalProps: {deleteDataProviderURL},
@@ -41,7 +41,7 @@ export default function propsTransformer({
 					if (form && searchContainer) {
 						postForm(form, {
 							data: {
-								deleteDataProviderInstanceIds: Liferay.Util.getCheckedCheckboxes(
+								deleteDataProviderInstanceIds: getCheckedCheckboxes(
 									searchContainer,
 									`${portletNamespace}allRowIds`
 								),

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-web/src/main/resources/META-INF/resources/js/DDMDataProviderManagementToolbarPropsTransformer.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-web/src/main/resources/META-INF/resources/js/DDMDataProviderManagementToolbarPropsTransformer.js
@@ -41,7 +41,7 @@ export default function propsTransformer({
 					if (form && searchContainer) {
 						postForm(form, {
 							data: {
-								deleteDataProviderInstanceIds: Liferay.Util.listCheckedExcept(
+								deleteDataProviderInstanceIds: Liferay.Util.getCheckedCheckboxes(
 									searchContainer,
 									`${portletNamespace}allRowIds`
 								),

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/DDMFormAdminManagementToolbarPropsTransformer.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/DDMFormAdminManagementToolbarPropsTransformer.js
@@ -36,7 +36,7 @@ export default function propsTransformer({
 			if (form && searchContainer) {
 				postForm(form, {
 					data: {
-						deleteFormInstanceIds: Liferay.Util.listCheckedExcept(
+						deleteFormInstanceIds: Liferay.Util.getCheckedCheckboxes(
 							searchContainer,
 							`${portletNamespace}allRowIds`
 						),
@@ -64,7 +64,7 @@ export default function propsTransformer({
 			if (form && searchContainer) {
 				postForm(form, {
 					data: {
-						deleteStructureIds: Liferay.Util.listCheckedExcept(
+						deleteStructureIds: Liferay.Util.getCheckedCheckboxes(
 							searchContainer,
 							`${portletNamespace}allRowIds`
 						),

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/DDMFormAdminManagementToolbarPropsTransformer.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/DDMFormAdminManagementToolbarPropsTransformer.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {postForm} from 'frontend-js-web';
+import {getCheckedCheckboxes, postForm} from 'frontend-js-web';
 
 export default function propsTransformer({
 	additionalProps: {deleteFormInstanceURL, deleteStructureURL},
@@ -36,7 +36,7 @@ export default function propsTransformer({
 			if (form && searchContainer) {
 				postForm(form, {
 					data: {
-						deleteFormInstanceIds: Liferay.Util.getCheckedCheckboxes(
+						deleteFormInstanceIds: getCheckedCheckboxes(
 							searchContainer,
 							`${portletNamespace}allRowIds`
 						),
@@ -64,7 +64,7 @@ export default function propsTransformer({
 			if (form && searchContainer) {
 				postForm(form, {
 					data: {
-						deleteStructureIds: Liferay.Util.getCheckedCheckboxes(
+						deleteStructureIds: getCheckedCheckboxes(
 							searchContainer,
 							`${portletNamespace}allRowIds`
 						),

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/DDMFormViewFormInstanceRecordsManagementToolbarPropsTransformer.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/DDMFormViewFormInstanceRecordsManagementToolbarPropsTransformer.js
@@ -41,7 +41,7 @@ export default function propsTransformer({
 					if (form && searchContainer) {
 						postForm(form, {
 							data: {
-								deleteFormInstanceRecordIds: Liferay.Util.listCheckedExcept(
+								deleteFormInstanceRecordIds: Liferay.Util.getCheckedCheckboxes(
 									searchContainer,
 									`${portletNamespace}allRowIds`
 								),

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/DDMFormViewFormInstanceRecordsManagementToolbarPropsTransformer.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/DDMFormViewFormInstanceRecordsManagementToolbarPropsTransformer.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {postForm} from 'frontend-js-web';
+import {getCheckedCheckboxes, postForm} from 'frontend-js-web';
 
 export default function propsTransformer({
 	additionalProps: {deleteFormInstanceRecordURL},
@@ -41,7 +41,7 @@ export default function propsTransformer({
 					if (form && searchContainer) {
 						postForm(form, {
 							data: {
-								deleteFormInstanceRecordIds: Liferay.Util.getCheckedCheckboxes(
+								deleteFormInstanceRecordIds: getCheckedCheckboxes(
 									searchContainer,
 									`${portletNamespace}allRowIds`
 								),

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/DDMStructureManagementToolbarPropsTransformer.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/DDMStructureManagementToolbarPropsTransformer.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {postForm} from 'frontend-js-web';
+import {getCheckedCheckboxes, postForm} from 'frontend-js-web';
 
 export default function propsTransformer({
 	additionalProps: {deleteStructuresURL},
@@ -41,7 +41,7 @@ export default function propsTransformer({
 					if (form && searchContainer) {
 						postForm(form, {
 							data: {
-								deleteStructureIds: Liferay.Util.getCheckedCheckboxes(
+								deleteStructureIds: getCheckedCheckboxes(
 									searchContainer,
 									`${portletNamespace}allRowIds`
 								),

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/DDMStructureManagementToolbarPropsTransformer.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/DDMStructureManagementToolbarPropsTransformer.js
@@ -41,7 +41,7 @@ export default function propsTransformer({
 					if (form && searchContainer) {
 						postForm(form, {
 							data: {
-								deleteStructureIds: Liferay.Util.listCheckedExcept(
+								deleteStructureIds: Liferay.Util.getCheckedCheckboxes(
 									searchContainer,
 									`${portletNamespace}allRowIds`
 								),

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/DDMTemplateManagementToolbarPropsTransformer.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/DDMTemplateManagementToolbarPropsTransformer.js
@@ -41,7 +41,7 @@ export default function propsTransformer({
 					if (form && searchContainer) {
 						postForm(form, {
 							data: {
-								deleteTemplateIds: Liferay.Util.listCheckedExcept(
+								deleteTemplateIds: Liferay.Util.getCheckedCheckboxes(
 									searchContainer,
 									`${portletNamespace}allRowIds`
 								),

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/DDMTemplateManagementToolbarPropsTransformer.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/DDMTemplateManagementToolbarPropsTransformer.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {postForm} from 'frontend-js-web';
+import {getCheckedCheckboxes, postForm} from 'frontend-js-web';
 
 export default function propsTransformer({
 	additionalProps: {deleteTemplatesURL},
@@ -41,7 +41,7 @@ export default function propsTransformer({
 					if (form && searchContainer) {
 						postForm(form, {
 							data: {
-								deleteTemplateIds: Liferay.Util.getCheckedCheckboxes(
+								deleteTemplateIds: getCheckedCheckboxes(
 									searchContainer,
 									`${portletNamespace}allRowIds`
 								),

--- a/modules/apps/expando/expando-web/src/main/resources/META-INF/resources/js/ExpandoManagementToolbarPropsTransformer.js
+++ b/modules/apps/expando/expando-web/src/main/resources/META-INF/resources/js/ExpandoManagementToolbarPropsTransformer.js
@@ -32,7 +32,7 @@ export default function propsTransformer({
 				);
 
 				if (columnIds) {
-					var checkedIds = Liferay.Util.listCheckedExcept(
+					var checkedIds = Liferay.Util.getCheckedCheckboxes(
 						form,
 						`${portletNamespace}allRowIds`
 					);

--- a/modules/apps/expando/expando-web/src/main/resources/META-INF/resources/js/ExpandoManagementToolbarPropsTransformer.js
+++ b/modules/apps/expando/expando-web/src/main/resources/META-INF/resources/js/ExpandoManagementToolbarPropsTransformer.js
@@ -12,6 +12,8 @@
  * details.
  */
 
+import {getCheckedCheckboxes} from 'frontend-js-web';
+
 export default function propsTransformer({
 	additionalProps: {deleteExpandosURL},
 	portletNamespace,
@@ -32,7 +34,7 @@ export default function propsTransformer({
 				);
 
 				if (columnIds) {
-					var checkedIds = Liferay.Util.getCheckedCheckboxes(
+					var checkedIds = getCheckedCheckboxes(
 						form,
 						`${portletNamespace}allRowIds`
 					);

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/js/ExportImportManagementToolbarPropsTransformer.js
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/js/ExportImportManagementToolbarPropsTransformer.js
@@ -34,7 +34,7 @@ export default function propsTransformer({portletNamespace, ...otherProps}) {
 						postForm(form, {
 							data: {
 								cmd: 'delete',
-								deleteBackgroundTaskIds: Liferay.Util.listCheckedExcept(
+								deleteBackgroundTaskIds: Liferay.Util.getCheckedCheckboxes(
 									form,
 									`${portletNamespace}allRowIds`
 								),

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/js/ExportImportManagementToolbarPropsTransformer.js
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/js/ExportImportManagementToolbarPropsTransformer.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {postForm} from 'frontend-js-web';
+import {getCheckedCheckboxes, postForm} from 'frontend-js-web';
 
 export default function propsTransformer({portletNamespace, ...otherProps}) {
 	return {
@@ -34,7 +34,7 @@ export default function propsTransformer({portletNamespace, ...otherProps}) {
 						postForm(form, {
 							data: {
 								cmd: 'delete',
-								deleteBackgroundTaskIds: Liferay.Util.getCheckedCheckboxes(
+								deleteBackgroundTaskIds: getCheckedCheckboxes(
 									form,
 									`${portletNamespace}allRowIds`
 								),

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/ViewContributedFragmentEntriesManagementToolbarPropsTransformer.js
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/ViewContributedFragmentEntriesManagementToolbarPropsTransformer.js
@@ -26,7 +26,7 @@ export default function propsTransformer({
 			return;
 		}
 
-		const contributedEntryKeys = Liferay.Util.listCheckedExcept(
+		const contributedEntryKeys = Liferay.Util.getCheckedCheckboxes(
 			form,
 			`${portletNamespace}allRowIds`
 		);

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/ViewContributedFragmentEntriesManagementToolbarPropsTransformer.js
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/ViewContributedFragmentEntriesManagementToolbarPropsTransformer.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {openSelectionModal} from 'frontend-js-web';
+import {getCheckedCheckboxes, openSelectionModal} from 'frontend-js-web';
 
 export default function propsTransformer({
 	additionalProps: {copyContributedEntryURL, selectFragmentCollectionURL},
@@ -26,7 +26,7 @@ export default function propsTransformer({
 			return;
 		}
 
-		const contributedEntryKeys = Liferay.Util.getCheckedCheckboxes(
+		const contributedEntryKeys = getCheckedCheckboxes(
 			form,
 			`${portletNamespace}allRowIds`
 		);

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/ViewFragmentEntriesManagementToolbarPropsTransformer.js
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/ViewFragmentEntriesManagementToolbarPropsTransformer.js
@@ -46,7 +46,7 @@ export default function propsTransformer({
 			return;
 		}
 
-		const fragmentEntryIds = Liferay.Util.listCheckedExcept(
+		const fragmentEntryIds = Liferay.Util.getCheckedCheckboxes(
 			form,
 			`${portletNamespace}allRowIds`
 		);
@@ -110,13 +110,13 @@ export default function propsTransformer({
 			return;
 		}
 
-		const fragmentCompositionIds = Liferay.Util.listCheckedExcept(
+		const fragmentCompositionIds = Liferay.Util.getCheckedCheckboxes(
 			form,
 			`${portletNamespace}allRowIds`,
 			`${portletNamespace}rowIdsFragmentComposition`
 		);
 
-		const fragmentEntryIds = Liferay.Util.listCheckedExcept(
+		const fragmentEntryIds = Liferay.Util.getCheckedCheckboxes(
 			form,
 			`${portletNamespace}allRowIds`,
 			`${portletNamespace}rowIdsFragmentEntry`

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/ViewFragmentEntriesManagementToolbarPropsTransformer.js
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/ViewFragmentEntriesManagementToolbarPropsTransformer.js
@@ -12,7 +12,11 @@
  * details.
  */
 
-import {openSelectionModal, openSimpleInputModal} from 'frontend-js-web';
+import {
+	getCheckedCheckboxes,
+	openSelectionModal,
+	openSimpleInputModal,
+} from 'frontend-js-web';
 
 import openDeleteFragmentModal from './openDeleteFragmentModal';
 
@@ -46,7 +50,7 @@ export default function propsTransformer({
 			return;
 		}
 
-		const fragmentEntryIds = Liferay.Util.getCheckedCheckboxes(
+		const fragmentEntryIds = getCheckedCheckboxes(
 			form,
 			`${portletNamespace}allRowIds`
 		);
@@ -110,13 +114,13 @@ export default function propsTransformer({
 			return;
 		}
 
-		const fragmentCompositionIds = Liferay.Util.getCheckedCheckboxes(
+		const fragmentCompositionIds = getCheckedCheckboxes(
 			form,
 			`${portletNamespace}allRowIds`,
 			`${portletNamespace}rowIdsFragmentComposition`
 		);
 
-		const fragmentEntryIds = Liferay.Util.getCheckedCheckboxes(
+		const fragmentEntryIds = getCheckedCheckboxes(
 			form,
 			`${portletNamespace}allRowIds`,
 			`${portletNamespace}rowIdsFragmentEntry`

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -452,6 +452,9 @@
 			return typeof val === 'function';
 		},
 
+		/**
+		 * @deprecated As of Cavanaugh (7.4.x), replaced by `get_checkboxes.js`
+		 */
 		listCheckboxesExcept(form, except, name, checked) {
 			form = Util.getDOM(form);
 
@@ -485,6 +488,9 @@
 				.join();
 		},
 
+		/**
+		 * @deprecated As of Cavanaugh (7.4.x), replaced by `import {getCheckedCheckboxes} from 'frontend-js-web';`
+		 */
 		listCheckedExcept(form, except, name) {
 			return Util.listCheckboxesExcept(form, except, name, true);
 		},
@@ -508,6 +514,9 @@
 				.join(delimeter || ',');
 		},
 
+		/**
+		 * @deprecated As of Cavanaugh (7.4.x), replaced by `import {getUncheckedCheckboxes} from 'frontend-js-web';`
+		 */
 		listUncheckedExcept(form, except, name) {
 			return Util.listCheckboxesExcept(form, except, name, false);
 		},
@@ -834,7 +843,7 @@
 				() => {
 					Util.toggleDisabled(
 						buttonId,
-						!Util.listCheckedExcept(form, ignoreFieldName)
+						!Util.getCheckedCheckboxes(form, ignoreFieldName)
 					);
 				},
 				'input[type=checkbox]'

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
@@ -114,3 +114,7 @@ export {default as runScriptsInElement} from './liferay/util/run_scripts_in_elem
 export {default as selectFolder} from './liferay/util/select_folder';
 export {default as toggleControls} from './liferay/util/toggle_controls';
 export {default as toggleDisabled} from './liferay/util/toggle_disabled';
+export {
+	getCheckedCheckboxes,
+	getUncheckedCheckboxes,
+} from './liferay/util/get_checkboxes';

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
@@ -52,6 +52,10 @@ import postForm from './util/form/post_form.es';
 import setFormValues from './util/form/set_form_values.es';
 import formatStorage from './util/format_storage.es';
 import formatXML from './util/format_xml.es';
+import {
+	getCheckedCheckboxes,
+	getUncheckedCheckboxes,
+} from './util/get_checkboxes';
 import getCropRegion from './util/get_crop_region.es';
 import getDOM from './util/get_dom';
 import getElement from './util/get_element';
@@ -206,6 +210,8 @@ Liferay.Util.focusFormField = focusFormField;
 
 Liferay.Util.formatStorage = formatStorage;
 Liferay.Util.formatXML = formatXML;
+Liferay.Util.getCheckedCheckboxes = getCheckedCheckboxes;
+Liferay.Util.getUncheckedCheckboxes = getUncheckedCheckboxes;
 Liferay.Util.getCropRegion = getCropRegion;
 
 /**

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/liferay.d.ts
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/liferay.d.ts
@@ -303,6 +303,18 @@ declare module Liferay {
 		/* Returns a formatted XML */
 		export function formatXML(content: string, options?: Object): string;
 
+		export function getCheckedCheckboxes(
+			form: HTMLFormElement,
+			except: string,
+			name?: string
+		): Array<number> | [];
+
+		export function getUncheckedCheckboxes(
+			form: HTMLFormElement,
+			except: string,
+			name?: string
+		): Array<number> | [];
+
 		/**
 		 * Returns dimensions and coordinates representing a cropped region
 		 */

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/get_checkboxes.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/get_checkboxes.js
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+function getCheckboxes(form, except, name, state) {
+	if (typeof form === 'string') {
+		form = document.querySelector(form);
+	}
+	else {
+		form = form._node || form;
+	}
+
+	let selector = 'input[type=checkbox]';
+
+	if (name) {
+		selector += `[name=${name}]`;
+	}
+
+	const checkboxes = Array.from(form.querySelectorAll(selector));
+
+	if (!checkboxes.length) {
+		return [];
+	}
+
+	return checkboxes
+		.reduce((previous, item) => {
+			const {checked, disabled, name, value} = item;
+
+			if (value && name !== except && checked === state && !disabled) {
+				previous.push(value);
+			}
+
+			return previous;
+		}, [])
+		.join();
+}
+
+export function getCheckedCheckboxes(form, except, name) {
+	return getCheckboxes(form, except, name, true);
+}
+
+export function getUncheckedCheckboxes(form, except, name) {
+	return getCheckboxes(form, except, name, false);
+}

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/TemplatesManagementToolbarPropsTransformer.js
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/TemplatesManagementToolbarPropsTransformer.js
@@ -45,7 +45,7 @@ export default function propsTransformer({
 					if (kbTemplateIds) {
 						kbTemplateIds.setAttribute(
 							'value',
-							Liferay.Util.listCheckedExcept(
+							Liferay.Util.getCheckedCheckboxes(
 								form,
 								`${portletNamespace}allRowIds`
 							)

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/TemplatesManagementToolbarPropsTransformer.js
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/TemplatesManagementToolbarPropsTransformer.js
@@ -12,6 +12,8 @@
  * details.
  */
 
+import {getCheckedCheckboxes} from 'frontend-js-web';
+
 export default function propsTransformer({
 	additionalProps: {deleteKBTemplatesURL},
 	portletNamespace,
@@ -45,7 +47,7 @@ export default function propsTransformer({
 					if (kbTemplateIds) {
 						kbTemplateIds.setAttribute(
 							'value',
-							Liferay.Util.getCheckedCheckboxes(
+							getCheckedCheckboxes(
 								form,
 								`${portletNamespace}allRowIds`
 							)

--- a/modules/apps/my-subscriptions/my-subscriptions-web/src/main/resources/META-INF/resources/js/MySubscriptionsManagementToolbarPropsTransformer.js
+++ b/modules/apps/my-subscriptions/my-subscriptions-web/src/main/resources/META-INF/resources/js/MySubscriptionsManagementToolbarPropsTransformer.js
@@ -32,7 +32,7 @@ export default function propsTransformer({portletNamespace, ...otherProps}) {
 				if (subscriptionIds) {
 					subscriptionIds.setAttribute(
 						'value',
-						Liferay.Util.listCheckedExcept(
+						Liferay.Util.getCheckedCheckboxes(
 							form,
 							`${portletNamespace}allRowIds`
 						)

--- a/modules/apps/my-subscriptions/my-subscriptions-web/src/main/resources/META-INF/resources/js/MySubscriptionsManagementToolbarPropsTransformer.js
+++ b/modules/apps/my-subscriptions/my-subscriptions-web/src/main/resources/META-INF/resources/js/MySubscriptionsManagementToolbarPropsTransformer.js
@@ -12,6 +12,8 @@
  * details.
  */
 
+import {getCheckedCheckboxes} from 'frontend-js-web';
+
 export default function propsTransformer({portletNamespace, ...otherProps}) {
 	return {
 		...otherProps,
@@ -32,7 +34,7 @@ export default function propsTransformer({portletNamespace, ...otherProps}) {
 				if (subscriptionIds) {
 					subscriptionIds.setAttribute(
 						'value',
-						Liferay.Util.getCheckedCheckboxes(
+						getCheckedCheckboxes(
 							form,
 							`${portletNamespace}allRowIds`
 						)

--- a/modules/apps/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/js/NotificationsManagementToolbarPropsTransformer.js
+++ b/modules/apps/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/js/NotificationsManagementToolbarPropsTransformer.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {postForm} from 'frontend-js-web';
+import {getCheckedCheckboxes, postForm} from 'frontend-js-web';
 
 export default function propsTransformer({
 	additionalProps: {
@@ -29,7 +29,7 @@ export default function propsTransformer({
 		if (form) {
 			postForm(form, {
 				data: {
-					deleteEntryIds: Liferay.Util.getCheckedCheckboxes(
+					deleteEntryIds: getCheckedCheckboxes(
 						form,
 						`${portletNamespace}allRowIds`
 					),

--- a/modules/apps/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/js/NotificationsManagementToolbarPropsTransformer.js
+++ b/modules/apps/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/js/NotificationsManagementToolbarPropsTransformer.js
@@ -29,7 +29,7 @@ export default function propsTransformer({
 		if (form) {
 			postForm(form, {
 				data: {
-					deleteEntryIds: Liferay.Util.listCheckedExcept(
+					deleteEntryIds: Liferay.Util.getCheckedCheckboxes(
 						form,
 						`${portletNamespace}allRowIds`
 					),

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/js/OAuth2ApplicationsManagementToolbarPropsTransformer.js
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/js/OAuth2ApplicationsManagementToolbarPropsTransformer.js
@@ -37,7 +37,7 @@ export default function propsTransformer({
 					if (form) {
 						postForm(form, {
 							data: {
-								oAuth2ApplicationIds: Liferay.Util.listCheckedExcept(
+								oAuth2ApplicationIds: Liferay.Util.getCheckedCheckboxes(
 									form,
 									`${portletNamespace}allRowIds`
 								),

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/js/OAuth2ApplicationsManagementToolbarPropsTransformer.js
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/js/OAuth2ApplicationsManagementToolbarPropsTransformer.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {postForm} from 'frontend-js-web';
+import {getCheckedCheckboxes, postForm} from 'frontend-js-web';
 
 export default function propsTransformer({
 	additionalProps: {deleteOAuth2ApplicationsURL},
@@ -37,7 +37,7 @@ export default function propsTransformer({
 					if (form) {
 						postForm(form, {
 							data: {
-								oAuth2ApplicationIds: Liferay.Util.getCheckedCheckboxes(
+								oAuth2ApplicationIds: getCheckedCheckboxes(
 									form,
 									`${portletNamespace}allRowIds`
 								),

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/js/OAuth2AuthorizationsManagementToolbarPropsTransformer.js
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/js/OAuth2AuthorizationsManagementToolbarPropsTransformer.js
@@ -37,7 +37,7 @@ export default function propsTransformer({
 					if (form) {
 						postForm(form, {
 							data: {
-								oAuth2AuthorizationIds: Liferay.Util.listCheckedExcept(
+								oAuth2AuthorizationIds: Liferay.Util.getCheckedCheckboxes(
 									form,
 									`${portletNamespace}allRowIds`
 								),

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/js/OAuth2AuthorizationsManagementToolbarPropsTransformer.js
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/js/OAuth2AuthorizationsManagementToolbarPropsTransformer.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {postForm} from 'frontend-js-web';
+import {getCheckedCheckboxes, postForm} from 'frontend-js-web';
 
 export default function propsTransformer({
 	additionalProps: {revokeOAuth2AuthorizationsURL},
@@ -37,7 +37,7 @@ export default function propsTransformer({
 					if (form) {
 						postForm(form, {
 							data: {
-								oAuth2AuthorizationIds: Liferay.Util.getCheckedCheckboxes(
+								oAuth2AuthorizationIds: getCheckedCheckboxes(
 									form,
 									`${portletNamespace}allRowIds`
 								),

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/connected_applications/js/oAuth2ConnectedApplicationsManagementToolbarPropsTransformer.js
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/connected_applications/js/oAuth2ConnectedApplicationsManagementToolbarPropsTransformer.js
@@ -37,7 +37,7 @@ export default function propsTransformer({
 					if (form) {
 						postForm(form, {
 							data: {
-								oAuth2AuthorizationIds: Liferay.Util.listCheckedExcept(
+								oAuth2AuthorizationIds: Liferay.Util.getCheckedCheckboxes(
 									form,
 									`${portletNamespace}allRowIds`
 								),

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/connected_applications/js/oAuth2ConnectedApplicationsManagementToolbarPropsTransformer.js
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/connected_applications/js/oAuth2ConnectedApplicationsManagementToolbarPropsTransformer.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {postForm} from 'frontend-js-web';
+import {getCheckedCheckboxes, postForm} from 'frontend-js-web';
 
 export default function propsTransformer({
 	additionalProps: {revokeOauthAuthorizationsURL},
@@ -37,7 +37,7 @@ export default function propsTransformer({
 					if (form) {
 						postForm(form, {
 							data: {
-								oAuth2AuthorizationIds: Liferay.Util.getCheckedCheckboxes(
+								oAuth2AuthorizationIds: getCheckedCheckboxes(
 									form,
 									`${portletNamespace}allRowIds`
 								),

--- a/modules/apps/password-policies-admin/password-policies-admin-web/src/main/resources/META-INF/resources/js/EditPasswordPolicyAssignmentsManagementToolbarPropsTransformer.js
+++ b/modules/apps/password-policies-admin/password-policies-admin-web/src/main/resources/META-INF/resources/js/EditPasswordPolicyAssignmentsManagementToolbarPropsTransformer.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {openSelectionModal} from 'frontend-js-web';
+import {getCheckedCheckboxes, openSelectionModal} from 'frontend-js-web';
 
 function addEntity(portletNamespace, inputName, entity) {
 	const addUserIdsInput = document.getElementById(
@@ -41,10 +41,7 @@ function deleteEntities(portletNamespace, inputName) {
 		if (form && input) {
 			input.setAttribute(
 				'value',
-				Liferay.Util.getCheckedCheckboxes(
-					form,
-					`${portletNamespace}allRowIds`
-				)
+				getCheckedCheckboxes(form, `${portletNamespace}allRowIds`)
 			);
 
 			submitForm(form);

--- a/modules/apps/password-policies-admin/password-policies-admin-web/src/main/resources/META-INF/resources/js/EditPasswordPolicyAssignmentsManagementToolbarPropsTransformer.js
+++ b/modules/apps/password-policies-admin/password-policies-admin-web/src/main/resources/META-INF/resources/js/EditPasswordPolicyAssignmentsManagementToolbarPropsTransformer.js
@@ -41,7 +41,7 @@ function deleteEntities(portletNamespace, inputName) {
 		if (form && input) {
 			input.setAttribute(
 				'value',
-				Liferay.Util.listCheckedExcept(
+				Liferay.Util.getCheckedCheckboxes(
 					form,
 					`${portletNamespace}allRowIds`
 				)

--- a/modules/apps/password-policies-admin/password-policies-admin-web/src/main/resources/META-INF/resources/js/ManagementToolbarDefaultPropsTransformer.js
+++ b/modules/apps/password-policies-admin/password-policies-admin-web/src/main/resources/META-INF/resources/js/ManagementToolbarDefaultPropsTransformer.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {createActionURL} from 'frontend-js-web';
+import {createActionURL, getCheckedCheckboxes} from 'frontend-js-web';
 
 const ACTIONS = {
 	deletePasswordPolicies(portletNamespace, basePortletURL) {
@@ -36,10 +36,7 @@ const ACTIONS = {
 			if (passwordPolicyIdsInput) {
 				passwordPolicyIdsInput.setAttribute(
 					'value',
-					Liferay.Util.getCheckedCheckboxes(
-						form,
-						`${portletNamespace}allRowIds`
-					)
+					getCheckedCheckboxes(form, `${portletNamespace}allRowIds`)
 				);
 			}
 

--- a/modules/apps/password-policies-admin/password-policies-admin-web/src/main/resources/META-INF/resources/js/ManagementToolbarDefaultPropsTransformer.js
+++ b/modules/apps/password-policies-admin/password-policies-admin-web/src/main/resources/META-INF/resources/js/ManagementToolbarDefaultPropsTransformer.js
@@ -36,7 +36,7 @@ const ACTIONS = {
 			if (passwordPolicyIdsInput) {
 				passwordPolicyIdsInput.setAttribute(
 					'value',
-					Liferay.Util.listCheckedExcept(
+					Liferay.Util.getCheckedCheckboxes(
 						form,
 						`${portletNamespace}allRowIds`
 					)

--- a/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/js/RedirectManagementToolbarPropsTransformer.js
+++ b/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/js/RedirectManagementToolbarPropsTransformer.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {postForm} from 'frontend-js-web';
+import {getCheckedCheckboxes, postForm} from 'frontend-js-web';
 
 export default function propsTransformer({
 	additionalProps: {deleteRedirectEntriesURL},
@@ -28,7 +28,7 @@ export default function propsTransformer({
 				if (form) {
 					postForm(form, {
 						data: {
-							deleteEntryIds: Liferay.Util.getCheckedCheckboxes(
+							deleteEntryIds: getCheckedCheckboxes(
 								form,
 								`${portletNamespace}allRowIds`
 							),

--- a/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/js/RedirectManagementToolbarPropsTransformer.js
+++ b/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/js/RedirectManagementToolbarPropsTransformer.js
@@ -28,7 +28,7 @@ export default function propsTransformer({
 				if (form) {
 					postForm(form, {
 						data: {
-							deleteEntryIds: Liferay.Util.listCheckedExcept(
+							deleteEntryIds: Liferay.Util.getCheckedCheckboxes(
 								form,
 								`${portletNamespace}allRowIds`
 							),

--- a/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/js/RedirectNotFoundEntriesManagementToolbarPropsTransformer.js
+++ b/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/js/RedirectNotFoundEntriesManagementToolbarPropsTransformer.js
@@ -25,7 +25,7 @@ export default function propsTransformer({
 		if (form) {
 			postForm(form, {
 				data: {
-					deleteEntryIds: Liferay.Util.listCheckedExcept(
+					deleteEntryIds: Liferay.Util.getCheckedCheckboxes(
 						form,
 						`${portletNamespace}allRowIds`
 					),
@@ -42,7 +42,7 @@ export default function propsTransformer({
 		if (form) {
 			postForm(form, {
 				data: {
-					deleteEntryIds: Liferay.Util.listCheckedExcept(
+					deleteEntryIds: Liferay.Util.getCheckedCheckboxes(
 						form,
 						`${portletNamespace}allRowIds`
 					),

--- a/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/js/RedirectNotFoundEntriesManagementToolbarPropsTransformer.js
+++ b/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/js/RedirectNotFoundEntriesManagementToolbarPropsTransformer.js
@@ -42,7 +42,7 @@ export default function propsTransformer({
 		if (form) {
 			postForm(form, {
 				data: {
-					deleteEntryIds: Liferay.Util.getCheckedCheckboxes(
+					deleteEntryIds: getCheckedCheckboxes(
 						form,
 						`${portletNamespace}allRowIds`
 					),

--- a/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/js/RedirectNotFoundEntriesManagementToolbarPropsTransformer.js
+++ b/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/js/RedirectNotFoundEntriesManagementToolbarPropsTransformer.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {postForm} from 'frontend-js-web';
+import {getCheckedCheckboxes, postForm} from 'frontend-js-web';
 
 export default function propsTransformer({
 	additionalProps: {editRedirectNotFoundEntriesURL},
@@ -25,7 +25,7 @@ export default function propsTransformer({
 		if (form) {
 			postForm(form, {
 				data: {
-					deleteEntryIds: Liferay.Util.getCheckedCheckboxes(
+					deleteEntryIds: getCheckedCheckboxes(
 						form,
 						`${portletNamespace}allRowIds`
 					),

--- a/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/edit_role_permissions.jsp
+++ b/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/edit_role_permissions.jsp
@@ -376,11 +376,11 @@ if (!portletName.equals(PortletKeys.SERVER_ADMIN)) {
 		Liferay.Util.postForm(form, {
 			data: {
 				redirect: '<%= HtmlUtil.escapeJS(redirect) %>',
-				selectedTargets: Liferay.Util.listCheckedExcept(
+				selectedTargets: Liferay.Util.getCheckedCheckboxes(
 					form,
 					'<portlet:namespace />allRowIds'
 				),
-				unselectedTargets: Liferay.Util.listUncheckedExcept(
+				unselectedTargets: Liferay.Util.getUncheckedCheckboxes(
 					form,
 					'<portlet:namespace />allRowIds'
 				),

--- a/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/js/EditRoleAssignmentsManagementToolbarPropsTransformer.js
+++ b/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/js/EditRoleAssignmentsManagementToolbarPropsTransformer.js
@@ -34,7 +34,7 @@ export default function propsTransformer({
 			return;
 		}
 
-		const ids = Liferay.Util.listCheckedExcept(
+		const ids = Liferay.Util.getCheckedCheckboxes(
 			form,
 			`${portletNamespace}allRowIds`
 		);

--- a/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/js/EditRoleAssignmentsManagementToolbarPropsTransformer.js
+++ b/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/js/EditRoleAssignmentsManagementToolbarPropsTransformer.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {postForm} from 'frontend-js-web';
+import {getCheckedCheckboxes, postForm} from 'frontend-js-web';
 
 import addAssignees from './add_assignees';
 
@@ -34,10 +34,7 @@ export default function propsTransformer({
 			return;
 		}
 
-		const ids = Liferay.Util.getCheckedCheckboxes(
-			form,
-			`${portletNamespace}allRowIds`
-		);
+		const ids = getCheckedCheckboxes(form, `${portletNamespace}allRowIds`);
 
 		const data = {
 			assignmentsRedirect: portletURL,

--- a/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/js/ViewRolesManagementToolbarPropsTransformer.js
+++ b/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/js/ViewRolesManagementToolbarPropsTransformer.js
@@ -28,7 +28,7 @@ export default function propsTransformer({
 				return;
 			}
 
-			const deleteRoleIds = Liferay.Util.listCheckedExcept(
+			const deleteRoleIds = Liferay.Util.getCheckedCheckboxes(
 				form,
 				`${portletNamespace}allRowIds`
 			);

--- a/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/js/ViewRolesManagementToolbarPropsTransformer.js
+++ b/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/js/ViewRolesManagementToolbarPropsTransformer.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {postForm} from 'frontend-js-web';
+import {getCheckedCheckboxes, postForm} from 'frontend-js-web';
 
 export default function propsTransformer({
 	additionalProps: {deleteRolesURL},
@@ -28,7 +28,7 @@ export default function propsTransformer({
 				return;
 			}
 
-			const deleteRoleIds = Liferay.Util.getCheckedCheckboxes(
+			const deleteRoleIds = getCheckedCheckboxes(
 				form,
 				`${portletNamespace}allRowIds`
 			);

--- a/modules/apps/roles/roles-item-selector-web/src/main/resources/META-INF/resources/role_item_selector.jsp
+++ b/modules/apps/roles/roles-item-selector-web/src/main/resources/META-INF/resources/role_item_selector.jsp
@@ -85,7 +85,7 @@ RoleItemSelectorViewDisplayContext roleItemSelectorViewDisplayContext = (RoleIte
 				'change',
 				'.entry input',
 				(event) => {
-					var checked = Liferay.Util.listCheckedExcept(
+					var checked = Liferay.Util.getCheckedCheckboxes(
 						document.getElementById(
 							'<portlet:namespace /><%= roleItemSelectorViewDisplayContext.getSearchContainerId() %>'
 						),

--- a/modules/apps/roles/roles-selector-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/roles/roles-selector-web/src/main/resources/META-INF/resources/view.jsp
@@ -225,11 +225,11 @@ SearchContainer<?> searchContainer = (SearchContainer<?>)request.getAttribute("l
 		Util.postForm(form, {
 			data: {
 				redirect: redirect,
-				addUserGroupIds: Util.listCheckedExcept(
+				addUserGroupIds: Util.getCheckedCheckboxes(
 					form,
 					'<portlet:namespace />allRowIds'
 				),
-				removeUserGroupIds: Util.listUncheckedExcept(
+				removeUserGroupIds: Util.getUncheckedCheckboxes(
 					form,
 					'<portlet:namespace />allRowIds'
 				),
@@ -246,11 +246,11 @@ SearchContainer<?> searchContainer = (SearchContainer<?>)request.getAttribute("l
 		Util.postForm(form, {
 			data: {
 				redirect: redirect,
-				addUserIds: Util.listCheckedExcept(
+				addUserIds: Util.getCheckedCheckboxes(
 					form,
 					'<portlet:namespace />allRowIds'
 				),
-				removeUserIds: Util.listUncheckedExcept(
+				removeUserIds: Util.getUncheckedCheckboxes(
 					form,
 					'<portlet:namespace />allRowIds'
 				),

--- a/modules/apps/staging/staging-processes-web/src/main/resources/META-INF/resources/js/StagingProcessesWebToolbarPropsTransformer.js
+++ b/modules/apps/staging/staging-processes-web/src/main/resources/META-INF/resources/js/StagingProcessesWebToolbarPropsTransformer.js
@@ -34,7 +34,7 @@ export default function propsTransformer({portletNamespace, ...otherProps}) {
 						postForm(form, {
 							data: {
 								cmd: 'delete',
-								deleteBackgroundTaskIds: Liferay.Util.listCheckedExcept(
+								deleteBackgroundTaskIds: Liferay.Util.getCheckedCheckboxes(
 									form,
 									`${portletNamespace}allRowIds`
 								),

--- a/modules/apps/staging/staging-processes-web/src/main/resources/META-INF/resources/js/StagingProcessesWebToolbarPropsTransformer.js
+++ b/modules/apps/staging/staging-processes-web/src/main/resources/META-INF/resources/js/StagingProcessesWebToolbarPropsTransformer.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {postForm} from 'frontend-js-web';
+import {getCheckedCheckboxes, postForm} from 'frontend-js-web';
 
 export default function propsTransformer({portletNamespace, ...otherProps}) {
 	return {
@@ -34,7 +34,7 @@ export default function propsTransformer({portletNamespace, ...otherProps}) {
 						postForm(form, {
 							data: {
 								cmd: 'delete',
-								deleteBackgroundTaskIds: Liferay.Util.getCheckedCheckboxes(
+								deleteBackgroundTaskIds: getCheckedCheckboxes(
 									form,
 									`${portletNamespace}allRowIds`
 								),

--- a/modules/apps/style-book/style-book-web/src/main/resources/META-INF/resources/js/StyleBookManagementToolbarPropsTransformer.js
+++ b/modules/apps/style-book/style-book-web/src/main/resources/META-INF/resources/js/StyleBookManagementToolbarPropsTransformer.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {openSimpleInputModal} from 'frontend-js-web';
+import {getCheckedCheckboxes, openSimpleInputModal} from 'frontend-js-web';
 
 import openDeleteStyleBookModal from './openDeleteStyleBookModal';
 
@@ -34,10 +34,7 @@ export default function propsTransformer({
 
 		styleBookEntryIds.setAttribute(
 			'value',
-			Liferay.Util.getCheckedCheckboxes(
-				form,
-				`${portletNamespace}allRowIds`
-			)
+			getCheckedCheckboxes(form, `${portletNamespace}allRowIds`)
 		);
 
 		const styleBookEntryFm = document.getElementById(

--- a/modules/apps/style-book/style-book-web/src/main/resources/META-INF/resources/js/StyleBookManagementToolbarPropsTransformer.js
+++ b/modules/apps/style-book/style-book-web/src/main/resources/META-INF/resources/js/StyleBookManagementToolbarPropsTransformer.js
@@ -34,7 +34,10 @@ export default function propsTransformer({
 
 		styleBookEntryIds.setAttribute(
 			'value',
-			Liferay.Util.listCheckedExcept(form, `${portletNamespace}allRowIds`)
+			Liferay.Util.getCheckedCheckboxes(
+				form,
+				`${portletNamespace}allRowIds`
+			)
 		);
 
 		const styleBookEntryFm = document.getElementById(

--- a/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/TranslationManagementToolbarPropsTransformer.js
+++ b/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/TranslationManagementToolbarPropsTransformer.js
@@ -37,7 +37,7 @@ export default function propsTransformer({portletNamespace, ...otherProps}) {
 					if (form) {
 						postForm(form, {
 							data: {
-								deleteEntryIds: Liferay.Util.listCheckedExcept(
+								deleteEntryIds: Liferay.Util.getCheckedCheckboxes(
 									form,
 									`${portletNamespace}allRowIds`
 								),

--- a/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/TranslationManagementToolbarPropsTransformer.js
+++ b/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/TranslationManagementToolbarPropsTransformer.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {postForm} from 'frontend-js-web';
+import {getCheckedCheckboxes, postForm} from 'frontend-js-web';
 
 export default function propsTransformer({portletNamespace, ...otherProps}) {
 	return {
@@ -37,7 +37,7 @@ export default function propsTransformer({portletNamespace, ...otherProps}) {
 					if (form) {
 						postForm(form, {
 							data: {
-								deleteEntryIds: Liferay.Util.getCheckedCheckboxes(
+								deleteEntryIds: getCheckedCheckboxes(
 									form,
 									`${portletNamespace}allRowIds`
 								),

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/add_uad_export_processes.jsp
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/add_uad_export_processes.jsp
@@ -145,7 +145,7 @@ renderResponse.setTitle(StringBundler.concat(selectedUser.getFullName(), " - ", 
 			if (applicationKeys) {
 				applicationKeys.setAttribute(
 					'value',
-					Liferay.Util.listCheckedExcept(
+					Liferay.Util.getCheckedCheckboxes(
 						form,
 						'<portlet:namespace />allRowIds',
 						'<portlet:namespace />rowIds'

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/view_uad_entities.jsp
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/view_uad_entities.jsp
@@ -217,7 +217,7 @@ long[] groupIds = viewUADEntitiesDisplay.getGroupIds();
 					if (applicationKeys) {
 						applicationKeys.setAttribute(
 							'value',
-							Liferay.Util.listCheckedExcept(
+							Liferay.Util.getCheckedCheckboxes(
 								form,
 								'<portlet:namespace />allRowIds'
 							)
@@ -236,7 +236,7 @@ long[] groupIds = viewUADEntitiesDisplay.getGroupIds();
 						);
 
 						if (<%= primaryKeysVar %>) {
-							var primaryKeys = Liferay.Util.listCheckedExcept(
+							var primaryKeys = Liferay.Util.getCheckedCheckboxes(
 								form,
 								'<portlet:namespace />allRowIds',
 								'<portlet:namespace />rowIds<%= typeClass.getSimpleName() %>'

--- a/modules/apps/user-groups-admin/user-groups-admin-web/src/main/resources/META-INF/resources/js/EditUserGroupAssignmentsManagementToolbarPropsTransformer.js
+++ b/modules/apps/user-groups-admin/user-groups-admin-web/src/main/resources/META-INF/resources/js/EditUserGroupAssignmentsManagementToolbarPropsTransformer.js
@@ -55,7 +55,7 @@ export default function propsTransformer({
 			postForm(form, {
 				data: {
 					redirect: portletURL,
-					removeUserIds: Liferay.Util.listCheckedExcept(
+					removeUserIds: Liferay.Util.getCheckedCheckboxes(
 						form,
 						`${portletNamespace}allRowIds`
 					),

--- a/modules/apps/user-groups-admin/user-groups-admin-web/src/main/resources/META-INF/resources/js/EditUserGroupAssignmentsManagementToolbarPropsTransformer.js
+++ b/modules/apps/user-groups-admin/user-groups-admin-web/src/main/resources/META-INF/resources/js/EditUserGroupAssignmentsManagementToolbarPropsTransformer.js
@@ -12,7 +12,11 @@
  * details.
  */
 
-import {openSelectionModal, postForm} from 'frontend-js-web';
+import {
+	getCheckedCheckboxes,
+	openSelectionModal,
+	postForm,
+} from 'frontend-js-web';
 
 export default function propsTransformer({
 	additionalProps: {
@@ -55,7 +59,7 @@ export default function propsTransformer({
 			postForm(form, {
 				data: {
 					redirect: portletURL,
-					removeUserIds: Liferay.Util.getCheckedCheckboxes(
+					removeUserIds: getCheckedCheckboxes(
 						form,
 						`${portletNamespace}allRowIds`
 					),

--- a/modules/apps/user-groups-admin/user-groups-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/user-groups-admin/user-groups-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -80,7 +80,7 @@ PortletURL portletURL = viewUserGroupsManagementToolbarDisplayContext.getPortlet
 	window.<portlet:namespace />deleteUserGroups = function () {
 		<portlet:namespace />doDeleteUserGroup(
 			'<%= UserGroup.class.getName() %>',
-			Liferay.Util.listCheckedExcept(
+			Liferay.Util.getCheckedCheckboxes(
 				document.<portlet:namespace />fm,
 				'<portlet:namespace />allRowIds'
 			)

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -112,7 +112,7 @@ else {
 	function <portlet:namespace />deleteOrganizations(organizationsRedirect) {
 		<portlet:namespace />doDeleteOrganization(
 			'<%= Organization.class.getName() %>',
-			Liferay.Util.listCheckedExcept(
+			Liferay.Util.getCheckedCheckboxes(
 				document.<portlet:namespace />fm,
 				'<portlet:namespace />allRowIds',
 				'<portlet:namespace />rowIdsOrganization'
@@ -137,7 +137,7 @@ else {
 
 			Liferay.Util.postForm(form, {
 				data: {
-					deleteUserIds: Liferay.Util.listCheckedExcept(
+					deleteUserIds: Liferay.Util.getCheckedCheckboxes(
 						form,
 						'<portlet:namespace />allRowIds',
 						'<portlet:namespace />rowIdsUser'

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/view_tree.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/view_tree.jsp
@@ -204,7 +204,7 @@ if (organization != null) {
 		Liferay.Util.postForm(form, {
 			data: {
 				deleteOrganizationIds: organizationIds,
-				deleteUserIds: Liferay.Util.listCheckedExcept(
+				deleteUserIds: Liferay.Util.getCheckedCheckboxes(
 					form,
 					'<portlet:namespace />allRowIds',
 					'<portlet:namespace />rowIdsUser'
@@ -225,12 +225,12 @@ if (organization != null) {
 
 		Liferay.Util.postForm(form, {
 			data: {
-				removeOrganizationIds: Liferay.Util.listCheckedExcept(
+				removeOrganizationIds: Liferay.Util.getCheckedCheckboxes(
 					form,
 					'<portlet:namespace />allRowIds',
 					'<portlet:namespace />rowIdsOrganization'
 				),
-				removeUserIds: Liferay.Util.listCheckedExcept(
+				removeUserIds: Liferay.Util.getCheckedCheckboxes(
 					form,
 					'<portlet:namespace />allRowIds',
 					'<portlet:namespace />rowIdsUser'

--- a/modules/dxp/apps/akismet/akismet-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/dxp/apps/akismet/akismet-web/src/main/resources/META-INF/resources/view.jsp
@@ -30,7 +30,7 @@ request.setAttribute("view.jsp-portletURL", portletURL);
 
 <aui:script>
 	window['<portlet:namespace />deleteMBMessages'] = function (dicussion) {
-		var deleteMBMessageIds = Liferay.Util.listCheckedExcept(
+		var deleteMBMessageIds = Liferay.Util.getCheckedCheckboxes(
 			document.<portlet:namespace />fm,
 			'<portlet:namespace />allRowIds'
 		);
@@ -59,7 +59,7 @@ request.setAttribute("view.jsp-portletURL", portletURL);
 	};
 
 	window['<portlet:namespace />notSpamMBMessages'] = function () {
-		var notSpamMBMessageIds = Liferay.Util.listCheckedExcept(
+		var notSpamMBMessageIds = Liferay.Util.getCheckedCheckboxes(
 			document.<portlet:namespace />fm,
 			'<portlet:namespace />allRowIds'
 		);

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/RankingPortletManagementToolbarPropsTransformer.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/RankingPortletManagementToolbarPropsTransformer.js
@@ -30,7 +30,7 @@ export default function propsTransformer({
 		if (form && searchContainer) {
 			postForm(form, {
 				data: {
-					actionFormInstanceIds: Liferay.Util.listCheckedExcept(
+					actionFormInstanceIds: Liferay.Util.getCheckedCheckboxes(
 						searchContainer,
 						`${portletNamespace}allRowIds`
 					),
@@ -50,7 +50,7 @@ export default function propsTransformer({
 		if (form && searchContainer) {
 			postForm(form, {
 				data: {
-					actionFormInstanceIds: Liferay.Util.listCheckedExcept(
+					actionFormInstanceIds: Liferay.Util.getCheckedCheckboxes(
 						searchContainer,
 						`${portletNamespace}allRowIds`
 					),
@@ -75,7 +75,7 @@ export default function propsTransformer({
 			if (form && searchContainer) {
 				postForm(form, {
 					data: {
-						actionFormInstanceIds: Liferay.Util.listCheckedExcept(
+						actionFormInstanceIds: Liferay.Util.getCheckedCheckboxes(
 							searchContainer,
 							`${portletNamespace}allRowIds`
 						),

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/RankingPortletManagementToolbarPropsTransformer.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/RankingPortletManagementToolbarPropsTransformer.js
@@ -9,7 +9,7 @@
  * distribution rights of the Software.
  */
 
-import {postForm} from 'frontend-js-web';
+import {getCheckedCheckboxes, postForm} from 'frontend-js-web';
 
 export default function propsTransformer({
 	additionalProps: {
@@ -30,7 +30,7 @@ export default function propsTransformer({
 		if (form && searchContainer) {
 			postForm(form, {
 				data: {
-					actionFormInstanceIds: Liferay.Util.getCheckedCheckboxes(
+					actionFormInstanceIds: getCheckedCheckboxes(
 						searchContainer,
 						`${portletNamespace}allRowIds`
 					),
@@ -50,7 +50,7 @@ export default function propsTransformer({
 		if (form && searchContainer) {
 			postForm(form, {
 				data: {
-					actionFormInstanceIds: Liferay.Util.getCheckedCheckboxes(
+					actionFormInstanceIds: getCheckedCheckboxes(
 						searchContainer,
 						`${portletNamespace}allRowIds`
 					),
@@ -75,7 +75,7 @@ export default function propsTransformer({
 			if (form && searchContainer) {
 				postForm(form, {
 					data: {
-						actionFormInstanceIds: Liferay.Util.getCheckedCheckboxes(
+						actionFormInstanceIds: getCheckedCheckboxes(
 							searchContainer,
 							`${portletNamespace}allRowIds`
 						),

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/js/KaleoFormsAdminManagementToolbarPropsTransformer.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/js/KaleoFormsAdminManagementToolbarPropsTransformer.js
@@ -43,7 +43,7 @@ export default function propsTransformer({
 
 					form.setAttribute('method', 'post');
 
-					kaleoProcessIdsElement.value = Liferay.Util.listCheckedExcept(
+					kaleoProcessIdsElement.value = Liferay.Util.getCheckedCheckboxes(
 						searchContainer,
 						`${portletNamespace}allRowIds`
 					);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/js/KaleoFormsAdminManagementToolbarPropsTransformer.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/js/KaleoFormsAdminManagementToolbarPropsTransformer.js
@@ -9,6 +9,8 @@
  * distribution rights of the Software.
  */
 
+import {getCheckedCheckboxes} from 'frontend-js-web';
+
 export default function propsTransformer({
 	additionalProps: {deleteKaleoProcessURL},
 	portletNamespace,
@@ -43,7 +45,7 @@ export default function propsTransformer({
 
 					form.setAttribute('method', 'post');
 
-					kaleoProcessIdsElement.value = Liferay.Util.getCheckedCheckboxes(
+					kaleoProcessIdsElement.value = getCheckedCheckboxes(
 						searchContainer,
 						`${portletNamespace}allRowIds`
 					);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/js/KaleoFormsViewRecordsManagementToolbarPropsTransformer.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/js/KaleoFormsViewRecordsManagementToolbarPropsTransformer.js
@@ -38,7 +38,7 @@ export default function propsTransformer({
 					if (form && searchContainer) {
 						postForm(form, {
 							data: {
-								ddlRecordIds: Liferay.Util.listCheckedExcept(
+								ddlRecordIds: Liferay.Util.getCheckedCheckboxes(
 									searchContainer,
 									`${portletNamespace}allRowIds`
 								),

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/js/KaleoFormsViewRecordsManagementToolbarPropsTransformer.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/js/KaleoFormsViewRecordsManagementToolbarPropsTransformer.js
@@ -9,7 +9,7 @@
  * distribution rights of the Software.
  */
 
-import {postForm} from 'frontend-js-web';
+import {getCheckedCheckboxes, postForm} from 'frontend-js-web';
 
 export default function propsTransformer({
 	additionalProps: {deleteDDLRecordURL},
@@ -38,7 +38,7 @@ export default function propsTransformer({
 					if (form && searchContainer) {
 						postForm(form, {
 							data: {
-								ddlRecordIds: Liferay.Util.getCheckedCheckboxes(
+								ddlRecordIds: getCheckedCheckboxes(
 									searchContainer,
 									`${portletNamespace}allRowIds`
 								),


### PR DESCRIPTION
Manually sending because CI is complaining. Original PR is https://github.com/liferay-frontend/liferay-portal/pull/2195

# Original Description
## As part of this PR I've done the following:
1. Make a new file called `get_checkboxes.js` file to contain the boilerplate and the two spin-off utils
2. Renamed the 3 functions in question to better reflect what they do
3. Change the usages to reflect the new function names
4. Deprecate the old utils so that if any customers are using them nothing breaks for them

## 🧪 Testing
This can be tested by going to the Blogs portlet, making a couple blogs, selecting them and clicking on the delete `trash` icon