### PR TITLE
LPS-155240 Make CETConfigurationFactory wait for portal to be initial…

### DIFF
--- a/modules/apps/client-extension/client-extension-type-impl/src/main/java/com/liferay/client/extension/type/internal/configuration/CETConfigurationFactory.java
+++ b/modules/apps/client-extension/client-extension-type-impl/src/main/java/com/liferay/client/extension/type/internal/configuration/CETConfigurationFactory.java
@@ -20,6 +20,7 @@ import com.liferay.client.extension.type.manager.CETManager;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PropertiesUtil;
@@ -121,5 +122,8 @@ public class CETConfigurationFactory {
 
 	@Reference
 	private CompanyLocalService _companyLocalService;
+
+	@Reference(target = ModuleServiceLifecycle.PORTAL_INITIALIZED, unbind = "-")
+	private ModuleServiceLifecycle _moduleServiceLifecycle;
 
 }


### PR DESCRIPTION
…ized before activating

This is necessary so that the factory doesn't kick in before the DB has been populated.
Otherwise, the default company may be missing and initialization fails.

This is more probable in docker deployments than in regular ones, where you don't usually
have installed OSGi configurations prior to DB initialization.