### PR TITLE
LPS-154280 Avoid running more times to get SharingConfiguration in a …

### DIFF
--- a/modules/apps/sharing/sharing-document-library/src/main/java/com/liferay/sharing/document/library/internal/constants/SharingDLWebKeys.java
+++ b/modules/apps/sharing/sharing-document-library/src/main/java/com/liferay/sharing/document/library/internal/constants/SharingDLWebKeys.java
@@ -21,4 +21,6 @@ public class SharingDLWebKeys {
 
 	public static final String FILE_ENTRY = "FILE_ENTRY";
 
+	public static final String SHARING_CONFIGURATION = "SHARING_CONFIGURATION";
+
 }

--- a/modules/apps/sharing/sharing-document-library/src/main/java/com/liferay/sharing/document/library/internal/display/context/SharingDLDisplayContextFactory.java
+++ b/modules/apps/sharing/sharing-document-library/src/main/java/com/liferay/sharing/document/library/internal/display/context/SharingDLDisplayContextFactory.java
@@ -30,6 +30,7 @@ import com.liferay.sharing.configuration.SharingConfigurationFactory;
 import com.liferay.sharing.display.context.util.SharingDropdownItemFactory;
 import com.liferay.sharing.display.context.util.SharingMenuItemFactory;
 import com.liferay.sharing.display.context.util.SharingToolbarItemFactory;
+import com.liferay.sharing.document.library.internal.constants.SharingDLWebKeys;
 import com.liferay.sharing.security.permission.SharingPermission;
 import com.liferay.sharing.service.SharingEntryLocalService;
 
@@ -80,13 +81,8 @@ public class SharingDLDisplayContextFactory implements DLDisplayContextFactory {
 		HttpServletResponse httpServletResponse, FileVersion fileVersion) {
 
 		try {
-			ThemeDisplay themeDisplay =
-				(ThemeDisplay)httpServletRequest.getAttribute(
-					WebKeys.THEME_DISPLAY);
-
 			SharingConfiguration sharingConfiguration =
-				_sharingConfigurationFactory.getGroupSharingConfiguration(
-					themeDisplay.getSiteGroup());
+				_getSharingConfiguration(httpServletRequest);
 
 			if (!sharingConfiguration.isEnabled()) {
 				return parentDLViewFileVersionDisplayContext;
@@ -111,6 +107,31 @@ public class SharingDLDisplayContextFactory implements DLDisplayContextFactory {
 					"display context for file version " + fileVersion,
 				portalException);
 		}
+	}
+
+	private SharingConfiguration _getSharingConfiguration(
+		HttpServletRequest httpServletRequest) {
+
+		SharingConfiguration sharingConfiguration =
+			(SharingConfiguration)httpServletRequest.getAttribute(
+				SharingDLWebKeys.SHARING_CONFIGURATION);
+
+		if (sharingConfiguration != null) {
+			return sharingConfiguration;
+		}
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		sharingConfiguration =
+			_sharingConfigurationFactory.getGroupSharingConfiguration(
+				themeDisplay.getSiteGroup());
+
+		httpServletRequest.setAttribute(
+			SharingDLWebKeys.SHARING_CONFIGURATION, sharingConfiguration);
+
+		return sharingConfiguration;
 	}
 
 	@Reference


### PR DESCRIPTION
…request.This will be invoked when viewing entries. When viewing one file entry, it will be invoked 3 times (After LPS-153703 fix, it will be invoked 2 times). If one folder has 20 file entries, in a request, it will be invoked 60(40) times. SharingConfigurationFactory.getGroupSharingConfiguration() includes service invocation.