### PR TITLE
LPS-155215 and LPS-154159 Fix SF Errors

### DIFF
--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/service/test/LayoutPermissionTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/service/test/LayoutPermissionTest.java
@@ -96,9 +96,7 @@ public class LayoutPermissionTest {
 	}
 
 	@Test
-	public void testContainsWithUpdateLayoutBasicPermission()
-		throws Exception {
-
+	public void testContainsWithUpdateLayoutBasicPermission() throws Exception {
 		PermissionChecker permissionChecker = _getPermissionChecker(
 			ActionKeys.UPDATE_LAYOUT_BASIC);
 

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectDefinitionResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectDefinitionResourceImpl.java
@@ -197,8 +197,7 @@ public class ObjectDefinitionResourceImpl
 			_objectDefinitionService.updateCustomObjectDefinition(
 				objectDefinitionId,
 				GetterUtil.getLong(
-					objectDefinition.getAccountEntryRestrictedObjectFieldId(),
-					0),
+					objectDefinition.getAccountEntryRestrictedObjectFieldId()),
 				0, GetterUtil.get(objectDefinition.getTitleObjectFieldId(), 0),
 				GetterUtil.getBoolean(
 					objectDefinition.getAccountEntryRestricted()),


### PR DESCRIPTION
Brian could you please develop a habit of running the Source Formatter prior to making commits that might break SF, or, if that is not feasible for you, consider developing some sort of system to catch these SF errors before they get merged into upstream? In the past ~24 hours you've introduced 3 SF breakages (that we've found so far), which has caused a lot of havoc and delay on one of my colleague's pull requests that has already been stalling for much longer than we would have liked.

For reference, these are the commits that caused these breakages:
https://github.com/liferay/liferay-portal/commit/6c9e4dd457ac8f20f05ea99f2bdfbd4e0ecb9e4d
https://github.com/liferay/liferay-portal/commit/d775bd4197ff8d8a3524035066aff9aafb0350e0