### PR TITLE
LPS-145457 Provide ways to determine if a Schema should be batch importable/exportable

### DIFF
--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountAddressResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountAddressResourceImpl.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -49,6 +50,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -713,6 +715,14 @@ public abstract class BaseAccountAddressResourceImpl
 		for (AccountAddress accountAddress : accountAddresses) {
 			deleteAccountAddress(accountAddress.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE", "UPDATE");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountGroupResourceImpl.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -49,6 +50,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -545,6 +547,14 @@ public abstract class BaseAccountGroupResourceImpl
 		for (AccountGroup accountGroup : accountGroups) {
 			deleteAccountGroup(accountGroup.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountMemberResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountMemberResourceImpl.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -49,6 +50,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -544,6 +546,14 @@ public abstract class BaseAccountMemberResourceImpl
 			java.util.Collection<AccountMember> accountMembers,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountOrganizationResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountOrganizationResourceImpl.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -49,6 +50,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -475,6 +477,14 @@ public abstract class BaseAccountOrganizationResourceImpl
 			java.util.Collection<AccountOrganization> accountOrganizations,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountResourceImpl.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -50,6 +51,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -615,6 +617,14 @@ public abstract class BaseAccountResourceImpl
 		for (Account account : accounts) {
 			deleteAccount(account.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/account-address.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/account-address.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.account.dto.v1_0.AccountAddress
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Account)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/account-group.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/account-group.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.account.dto.v1_0.AccountGroup
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Account)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/account-member.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/account-member.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.account.dto.v1_0.AccountMember
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Account)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/account-organization.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/account-organization.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.account.dto.v1_0.AccountOrganization
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Account)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/account.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/account.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.account.dto.v1_0.Account
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Account)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseAttachmentResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseAttachmentResourceImpl.java
@@ -31,6 +31,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -50,6 +51,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -683,6 +685,14 @@ public abstract class BaseAttachmentResourceImpl
 			java.util.Collection<Attachment> attachments,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseCatalogResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseCatalogResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -545,6 +547,14 @@ public abstract class BaseCatalogResourceImpl
 		for (Catalog catalog : catalogs) {
 			deleteCatalog(catalog.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseCategoryResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -230,6 +232,14 @@ public abstract class BaseCategoryResourceImpl
 			java.util.Collection<Category> categories,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseMappedProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseMappedProductResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -461,6 +463,14 @@ public abstract class BaseMappedProductResourceImpl
 		for (MappedProduct mappedProduct : mappedProducts) {
 			deleteMappedProduct(mappedProduct.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseOptionCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseOptionCategoryResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -376,6 +378,14 @@ public abstract class BaseOptionCategoryResourceImpl
 		for (OptionCategory optionCategory : optionCategories) {
 			deleteOptionCategory(optionCategory.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseOptionResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseOptionResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -466,6 +468,14 @@ public abstract class BaseOptionResourceImpl
 		for (Option option : options) {
 			deleteOption(option.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseOptionValueResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseOptionValueResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -552,6 +554,14 @@ public abstract class BaseOptionValueResourceImpl
 		for (OptionValue optionValue : optionValues) {
 			deleteOptionValue(optionValue.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BasePinResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BasePinResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -361,6 +363,14 @@ public abstract class BasePinResourceImpl
 		for (Pin pin : pins) {
 			deletePin(pin.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductAccountGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductAccountGroupResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -293,6 +295,14 @@ public abstract class BaseProductAccountGroupResourceImpl
 		for (ProductAccountGroup productAccountGroup : productAccountGroups) {
 			deleteProductAccountGroup(productAccountGroup.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductChannelResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -283,6 +285,14 @@ public abstract class BaseProductChannelResourceImpl
 		for (ProductChannel productChannel : productChannels) {
 			deleteProductChannel(productChannel.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductGroupProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductGroupProductResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -389,6 +391,14 @@ public abstract class BaseProductGroupProductResourceImpl
 		for (ProductGroupProduct productGroupProduct : productGroupProducts) {
 			deleteProductGroupProduct(productGroupProduct.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductGroupResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -463,6 +465,14 @@ public abstract class BaseProductGroupResourceImpl
 		for (ProductGroup productGroup : productGroups) {
 			deleteProductGroup(productGroup.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductOptionResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductOptionResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -417,6 +419,14 @@ public abstract class BaseProductOptionResourceImpl
 		for (ProductOption productOption : productOptions) {
 			deleteProductOption(productOption.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductOptionValueResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductOptionValueResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -220,6 +222,14 @@ public abstract class BaseProductOptionValueResourceImpl
 			java.util.Collection<ProductOptionValue> productOptionValues,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -542,6 +544,14 @@ public abstract class BaseProductResourceImpl
 		for (Product product : products) {
 			deleteProduct(product.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductSpecificationResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductSpecificationResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -214,6 +216,14 @@ public abstract class BaseProductSpecificationResourceImpl
 			java.util.Collection<ProductSpecification> productSpecifications,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseRelatedProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseRelatedProductResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -423,6 +425,14 @@ public abstract class BaseRelatedProductResourceImpl
 		for (RelatedProduct relatedProduct : relatedProducts) {
 			deleteRelatedProduct(relatedProduct.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseSkuResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseSkuResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -570,6 +572,14 @@ public abstract class BaseSkuResourceImpl
 		for (Sku sku : skus) {
 			deleteSku(sku.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseSpecificationResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseSpecificationResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -383,6 +385,14 @@ public abstract class BaseSpecificationResourceImpl
 		for (Specification specification : specifications) {
 			deleteSpecification(specification.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/attachment.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/attachment.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.catalog.dto.v1_0.Attachment
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/catalog.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/catalog.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.catalog.dto.v1_0.Catalog
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/category.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/category.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.catalog.dto.v1_0.Category
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/mapped-product.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/mapped-product.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.catalog.dto.v1_0.MappedProduct
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/option-category.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/option-category.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.catalog.dto.v1_0.OptionCategory
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/option-value.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/option-value.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.catalog.dto.v1_0.OptionValue
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/option.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/option.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.catalog.dto.v1_0.Option
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/pin.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/pin.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.catalog.dto.v1_0.Pin
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/product-account-group.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/product-account-group.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.catalog.dto.v1_0.ProductAccountGroup
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/product-channel.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/product-channel.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.catalog.dto.v1_0.ProductChannel
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/product-group-product.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/product-group-product.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.catalog.dto.v1_0.ProductGroupProduct
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/product-group.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/product-group.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.catalog.dto.v1_0.ProductGroup
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/product-option-value.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/product-option-value.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.catalog.dto.v1_0.ProductOptionValue
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/product-option.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/product-option.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.catalog.dto.v1_0.ProductOption
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/product-specification.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/product-specification.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.catalog.dto.v1_0.ProductSpecification
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/product.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/product.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.catalog.dto.v1_0.Product
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/related-product.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/related-product.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.catalog.dto.v1_0.RelatedProduct
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/sku.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/sku.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.catalog.dto.v1_0.Sku
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/specification.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/specification.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.catalog.dto.v1_0.Specification
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseChannelResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -627,6 +629,14 @@ public abstract class BaseChannelResourceImpl
 		for (Channel channel : channels) {
 			deleteChannel(channel.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("UPSERT", "INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE", "UPDATE");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BasePaymentMethodGroupRelOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BasePaymentMethodGroupRelOrderTypeResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -278,6 +280,14 @@ public abstract class BasePaymentMethodGroupRelOrderTypeResourceImpl
 				paymentMethodGroupRelOrderType.
 					getPaymentMethodGroupRelOrderTypeId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BasePaymentMethodGroupRelTermResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BasePaymentMethodGroupRelTermResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -275,6 +277,14 @@ public abstract class BasePaymentMethodGroupRelTermResourceImpl
 			deletePaymentMethodGroupRelTerm(
 				paymentMethodGroupRelTerm.getPaymentMethodGroupRelTermId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseShippingFixedOptionOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseShippingFixedOptionOrderTypeResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -277,6 +279,14 @@ public abstract class BaseShippingFixedOptionOrderTypeResourceImpl
 				shippingFixedOptionOrderType.
 					getShippingFixedOptionOrderTypeId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseShippingFixedOptionTermResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseShippingFixedOptionTermResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -275,6 +277,14 @@ public abstract class BaseShippingFixedOptionTermResourceImpl
 			deleteShippingFixedOptionTerm(
 				shippingFixedOptionTerm.getShippingFixedOptionTermId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseShippingMethodResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseShippingMethodResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -125,6 +127,14 @@ public abstract class BaseShippingMethodResourceImpl
 			java.util.Collection<ShippingMethod> shippingMethods,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseTaxCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseTaxCategoryResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -148,6 +150,14 @@ public abstract class BaseTaxCategoryResourceImpl
 			java.util.Collection<TaxCategory> taxCategories,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/channel.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/channel.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.channel.dto.v1_0.Channel
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Channel)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/payment-method-group-rel-order-type.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/payment-method-group-rel-order-type.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.channel.dto.v1_0.PaymentMethodGroupRelOrderType
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Channel)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/payment-method-group-rel-term.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/payment-method-group-rel-term.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.channel.dto.v1_0.PaymentMethodGroupRelTerm
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Channel)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/shipping-fixed-option-order-type.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/shipping-fixed-option-order-type.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.channel.dto.v1_0.ShippingFixedOptionOrderType
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Channel)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/shipping-fixed-option-term.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/shipping-fixed-option-term.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.channel.dto.v1_0.ShippingFixedOptionTerm
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Channel)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/shipping-method.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/shipping-method.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.channel.dto.v1_0.ShippingMethod
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Channel)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/tax-category.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/tax-category.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.channel.dto.v1_0.TaxCategory
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Channel)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/BaseWarehouseItemResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/BaseWarehouseItemResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -584,6 +586,14 @@ public abstract class BaseWarehouseItemResourceImpl
 		for (WarehouseItem warehouseItem : warehouseItems) {
 			deleteWarehouseItem(warehouseItem.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/BaseWarehouseResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/BaseWarehouseResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -335,6 +337,14 @@ public abstract class BaseWarehouseResourceImpl
 			java.util.Collection<Warehouse> warehouses,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/warehouse-item.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/warehouse-item.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.inventory.dto.v1_0.WarehouseItem
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Inventory)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/warehouse.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/warehouse.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.inventory.dto.v1_0.Warehouse
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Inventory)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderItemResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderItemResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -719,6 +721,14 @@ public abstract class BaseOrderItemResourceImpl
 		for (OrderItem orderItem : orderItems) {
 			deleteOrderItem(orderItem.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("UPSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE", "UPDATE");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderNoteResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderNoteResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -528,6 +530,14 @@ public abstract class BaseOrderNoteResourceImpl
 		for (OrderNote orderNote : orderNotes) {
 			deleteOrderNote(orderNote.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -466,6 +468,14 @@ public abstract class BaseOrderResourceImpl
 		for (Order order : orders) {
 			deleteOrder(order.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleAccountGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleAccountGroupResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -392,6 +394,14 @@ public abstract class BaseOrderRuleAccountGroupResourceImpl
 			deleteOrderRuleAccountGroup(
 				orderRuleAccountGroup.getOrderRuleAccountGroupId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleAccountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleAccountResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -378,6 +380,14 @@ public abstract class BaseOrderRuleAccountResourceImpl
 		for (OrderRuleAccount orderRuleAccount : orderRuleAccounts) {
 			deleteOrderRuleAccount(orderRuleAccount.getOrderRuleAccountId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleChannelResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -386,6 +388,14 @@ public abstract class BaseOrderRuleChannelResourceImpl
 		for (OrderRuleChannel orderRuleChannel : orderRuleChannels) {
 			deleteOrderRuleChannel(orderRuleChannel.getOrderRuleChannelId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleOrderTypeResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -377,6 +379,14 @@ public abstract class BaseOrderRuleOrderTypeResourceImpl
 			deleteOrderRuleOrderType(
 				orderRuleOrderType.getOrderRuleOrderTypeId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -455,6 +457,14 @@ public abstract class BaseOrderRuleResourceImpl
 		for (OrderRule orderRule : orderRules) {
 			deleteOrderRule(orderRule.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderTypeChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderTypeChannelResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -381,6 +383,14 @@ public abstract class BaseOrderTypeChannelResourceImpl
 		for (OrderTypeChannel orderTypeChannel : orderTypeChannels) {
 			deleteOrderTypeChannel(orderTypeChannel.getOrderTypeChannelId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderTypeResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -517,6 +519,14 @@ public abstract class BaseOrderTypeResourceImpl
 		for (OrderType orderType : orderTypes) {
 			deleteOrderType(orderType.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseTermOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseTermOrderTypeResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -374,6 +376,14 @@ public abstract class BaseTermOrderTypeResourceImpl
 		for (TermOrderType termOrderType : termOrderTypes) {
 			deleteTermOrderType(termOrderType.getTermOrderTypeId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseTermResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseTermResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -448,6 +450,14 @@ public abstract class BaseTermResourceImpl
 		for (Term term : terms) {
 			deleteTerm(term.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/order-item.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/order-item.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.order.dto.v1_0.OrderItem
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Order)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/order-note.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/order-note.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.order.dto.v1_0.OrderNote
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Order)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/order-rule-account-group.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/order-rule-account-group.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.order.dto.v1_0.OrderRuleAccountGroup
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Order)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/order-rule-account.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/order-rule-account.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.order.dto.v1_0.OrderRuleAccount
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Order)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/order-rule-channel.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/order-rule-channel.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.order.dto.v1_0.OrderRuleChannel
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Order)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/order-rule-order-type.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/order-rule-order-type.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.order.dto.v1_0.OrderRuleOrderType
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Order)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/order-rule.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/order-rule.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.order.dto.v1_0.OrderRule
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Order)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/order-type-channel.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/order-type-channel.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.order.dto.v1_0.OrderTypeChannel
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Order)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/order-type.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/order-type.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.order.dto.v1_0.OrderType
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Order)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/order.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/order.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.order.dto.v1_0.Order
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Order)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/term-order-type.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/term-order-type.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.order.dto.v1_0.TermOrderType
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Order)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/term.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/term.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.order.dto.v1_0.Term
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Order)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountAccountGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountAccountGroupResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -395,6 +397,14 @@ public abstract class BaseDiscountAccountGroupResourceImpl
 
 			deleteDiscountAccountGroup(discountAccountGroup.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountCategoryResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -378,6 +380,14 @@ public abstract class BaseDiscountCategoryResourceImpl
 		for (DiscountCategory discountCategory : discountCategories) {
 			deleteDiscountCategory(discountCategory.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountProductResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -378,6 +380,14 @@ public abstract class BaseDiscountProductResourceImpl
 		for (DiscountProduct discountProduct : discountProducts) {
 			deleteDiscountProduct(discountProduct.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -450,6 +452,14 @@ public abstract class BaseDiscountResourceImpl
 		for (Discount discount : discounts) {
 			deleteDiscount(discount.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountRuleResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountRuleResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -427,6 +429,14 @@ public abstract class BaseDiscountRuleResourceImpl
 		for (DiscountRule discountRule : discountRules) {
 			deleteDiscountRule(discountRule.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BasePriceEntryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BasePriceEntryResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -528,6 +530,14 @@ public abstract class BasePriceEntryResourceImpl
 		for (PriceEntry priceEntry : priceEntries) {
 			deletePriceEntry(priceEntry.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BasePriceListAccountGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BasePriceListAccountGroupResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -396,6 +398,14 @@ public abstract class BasePriceListAccountGroupResourceImpl
 
 			deletePriceListAccountGroup(priceListAccountGroup.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BasePriceListResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BasePriceListResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -460,6 +462,14 @@ public abstract class BasePriceListResourceImpl
 		for (PriceList priceList : priceLists) {
 			deletePriceList(priceList.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseTierPriceResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseTierPriceResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -528,6 +530,14 @@ public abstract class BaseTierPriceResourceImpl
 		for (TierPrice tierPrice : tierPrices) {
 			deleteTierPrice(tierPrice.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountAccountGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountAccountGroupResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -403,6 +405,14 @@ public abstract class BaseDiscountAccountGroupResourceImpl
 			deleteDiscountAccountGroup(
 				discountAccountGroup.getDiscountAccountGroupId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountAccountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountAccountResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -385,6 +387,14 @@ public abstract class BaseDiscountAccountResourceImpl
 		for (DiscountAccount discountAccount : discountAccounts) {
 			deleteDiscountAccount(discountAccount.getDiscountAccountId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountCategoryResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -385,6 +387,14 @@ public abstract class BaseDiscountCategoryResourceImpl
 		for (DiscountCategory discountCategory : discountCategories) {
 			deleteDiscountCategory(discountCategory.getDiscountCategoryId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountChannelResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -385,6 +387,14 @@ public abstract class BaseDiscountChannelResourceImpl
 		for (DiscountChannel discountChannel : discountChannels) {
 			deleteDiscountChannel(discountChannel.getDiscountChannelId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountOrderTypeResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -386,6 +388,14 @@ public abstract class BaseDiscountOrderTypeResourceImpl
 		for (DiscountOrderType discountOrderType : discountOrderTypes) {
 			deleteDiscountOrderType(discountOrderType.getDiscountOrderTypeId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountProductGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountProductGroupResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -403,6 +405,14 @@ public abstract class BaseDiscountProductGroupResourceImpl
 			deleteDiscountProductGroup(
 				discountProductGroup.getDiscountProductGroupId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountProductResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -385,6 +387,14 @@ public abstract class BaseDiscountProductResourceImpl
 		for (DiscountProduct discountProduct : discountProducts) {
 			deleteDiscountProduct(discountProduct.getDiscountProductId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -455,6 +457,14 @@ public abstract class BaseDiscountResourceImpl
 		for (Discount discount : discounts) {
 			deleteDiscount(discount.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountRuleResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountRuleResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -438,6 +440,14 @@ public abstract class BaseDiscountRuleResourceImpl
 		for (DiscountRule discountRule : discountRules) {
 			deleteDiscountRule(discountRule.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountSkuResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountSkuResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -370,6 +372,14 @@ public abstract class BaseDiscountSkuResourceImpl
 		for (DiscountSku discountSku : discountSkus) {
 			deleteDiscountSku(discountSku.getDiscountSkuId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceEntryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceEntryResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -529,6 +531,14 @@ public abstract class BasePriceEntryResourceImpl
 		for (PriceEntry priceEntry : priceEntries) {
 			deletePriceEntry(priceEntry.getPriceEntryId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListAccountGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListAccountGroupResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -392,6 +394,14 @@ public abstract class BasePriceListAccountGroupResourceImpl
 			deletePriceListAccountGroup(
 				priceListAccountGroup.getPriceListAccountGroupId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListAccountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListAccountResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -378,6 +380,14 @@ public abstract class BasePriceListAccountResourceImpl
 		for (PriceListAccount priceListAccount : priceListAccounts) {
 			deletePriceListAccount(priceListAccount.getPriceListAccountId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListChannelResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -386,6 +388,14 @@ public abstract class BasePriceListChannelResourceImpl
 		for (PriceListChannel priceListChannel : priceListChannels) {
 			deletePriceListChannel(priceListChannel.getPriceListChannelId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListDiscountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListDiscountResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -369,6 +371,14 @@ public abstract class BasePriceListDiscountResourceImpl
 		for (PriceListDiscount priceListDiscount : priceListDiscounts) {
 			deletePriceListDiscount(priceListDiscount.getPriceListDiscountId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListOrderTypeResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -369,6 +371,14 @@ public abstract class BasePriceListOrderTypeResourceImpl
 			deletePriceListOrderType(
 				priceListOrderType.getPriceListOrderTypeId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -455,6 +457,14 @@ public abstract class BasePriceListResourceImpl
 		for (PriceList priceList : priceLists) {
 			deletePriceList(priceList.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceModifierCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceModifierCategoryResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -406,6 +408,14 @@ public abstract class BasePriceModifierCategoryResourceImpl
 			deletePriceModifierCategory(
 				priceModifierCategory.getPriceModifierCategoryId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceModifierProductGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceModifierProductGroupResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -412,6 +414,14 @@ public abstract class BasePriceModifierProductGroupResourceImpl
 			deletePriceModifierProductGroup(
 				priceModifierProductGroup.getPriceModifierProductGroupId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceModifierProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceModifierProductResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -405,6 +407,14 @@ public abstract class BasePriceModifierProductResourceImpl
 			deletePriceModifierProduct(
 				priceModifierProduct.getPriceModifierProductId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceModifierResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceModifierResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -562,6 +564,14 @@ public abstract class BasePriceModifierResourceImpl
 		for (PriceModifier priceModifier : priceModifiers) {
 			deletePriceModifier(priceModifier.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseTierPriceResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseTierPriceResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -523,6 +525,14 @@ public abstract class BaseTierPriceResourceImpl
 		for (TierPrice tierPrice : tierPrices) {
 			deleteTierPrice(tierPrice.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/discount-account-group.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/discount-account-group.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v1_0.DiscountAccountGroup
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/discount-category.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/discount-category.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v1_0.DiscountCategory
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/discount-product.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/discount-product.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v1_0.DiscountProduct
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/discount-rule.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/discount-rule.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v1_0.DiscountRule
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/discount.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/discount.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v1_0.Discount
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/price-entry.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/price-entry.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v1_0.PriceEntry
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/price-list-account-group.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/price-list-account-group.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v1_0.PriceListAccountGroup
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/price-list.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/price-list.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v1_0.PriceList
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/tier-price.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/tier-price.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v1_0.TierPrice
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/discount-account-group.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/discount-account-group.properties
@@ -5,5 +5,7 @@
 api.version=v2.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v2_0.DiscountAccountGroup
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/discount-account.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/discount-account.properties
@@ -5,5 +5,7 @@
 api.version=v2.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v2_0.DiscountAccount
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/discount-category.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/discount-category.properties
@@ -5,5 +5,7 @@
 api.version=v2.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v2_0.DiscountCategory
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/discount-channel.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/discount-channel.properties
@@ -5,5 +5,7 @@
 api.version=v2.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v2_0.DiscountChannel
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/discount-order-type.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/discount-order-type.properties
@@ -5,5 +5,7 @@
 api.version=v2.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v2_0.DiscountOrderType
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/discount-product-group.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/discount-product-group.properties
@@ -5,5 +5,7 @@
 api.version=v2.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v2_0.DiscountProductGroup
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/discount-product.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/discount-product.properties
@@ -5,5 +5,7 @@
 api.version=v2.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v2_0.DiscountProduct
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/discount-rule.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/discount-rule.properties
@@ -5,5 +5,7 @@
 api.version=v2.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v2_0.DiscountRule
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/discount-sku.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/discount-sku.properties
@@ -5,5 +5,7 @@
 api.version=v2.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v2_0.DiscountSku
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/discount.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/discount.properties
@@ -5,5 +5,7 @@
 api.version=v2.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v2_0.Discount
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/price-entry.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/price-entry.properties
@@ -5,5 +5,7 @@
 api.version=v2.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v2_0.PriceEntry
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/price-list-account-group.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/price-list-account-group.properties
@@ -5,5 +5,7 @@
 api.version=v2.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v2_0.PriceListAccountGroup
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/price-list-account.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/price-list-account.properties
@@ -5,5 +5,7 @@
 api.version=v2.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v2_0.PriceListAccount
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/price-list-channel.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/price-list-channel.properties
@@ -5,5 +5,7 @@
 api.version=v2.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v2_0.PriceListChannel
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/price-list-discount.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/price-list-discount.properties
@@ -5,5 +5,7 @@
 api.version=v2.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v2_0.PriceListDiscount
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/price-list-order-type.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/price-list-order-type.properties
@@ -5,5 +5,7 @@
 api.version=v2.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v2_0.PriceListOrderType
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/price-list.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/price-list.properties
@@ -5,5 +5,7 @@
 api.version=v2.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v2_0.PriceList
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/price-modifier-category.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/price-modifier-category.properties
@@ -5,5 +5,7 @@
 api.version=v2.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v2_0.PriceModifierCategory
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/price-modifier-product-group.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/price-modifier-product-group.properties
@@ -5,5 +5,7 @@
 api.version=v2.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v2_0.PriceModifierProductGroup
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/price-modifier-product.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/price-modifier-product.properties
@@ -5,5 +5,7 @@
 api.version=v2.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v2_0.PriceModifierProduct
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/price-modifier.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/price-modifier.properties
@@ -5,5 +5,7 @@
 api.version=v2.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v2_0.PriceModifier
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/tier-price.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/tier-price.properties
@@ -5,5 +5,7 @@
 api.version=v2.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v2_0.TierPrice
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/BaseShipmentItemResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/BaseShipmentItemResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -463,6 +465,14 @@ public abstract class BaseShipmentItemResourceImpl
 		for (ShipmentItem shipmentItem : shipmentItems) {
 			deleteShipmentItem(shipmentItem.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/BaseShipmentResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/BaseShipmentResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -746,6 +748,14 @@ public abstract class BaseShipmentResourceImpl
 		for (Shipment shipment : shipments) {
 			deleteShipment(shipment.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("UPSERT", "INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/shipment-item.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/shipment-item.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.shipment.dto.v1_0.ShipmentItem
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Shipment)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/shipment.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/shipment.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.shipment.dto.v1_0.Shipment
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Shipment)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseAvailabilityEstimateResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseAvailabilityEstimateResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -389,6 +391,14 @@ public abstract class BaseAvailabilityEstimateResourceImpl
 
 			deleteAvailabilityEstimate(availabilityEstimate.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("UPDATE");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseMeasurementUnitResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseMeasurementUnitResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -617,6 +619,14 @@ public abstract class BaseMeasurementUnitResourceImpl
 		for (MeasurementUnit measurementUnit : measurementUnits) {
 			deleteMeasurementUnit(measurementUnit.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseTaxCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseTaxCategoryResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -353,6 +355,14 @@ public abstract class BaseTaxCategoryResourceImpl
 		for (TaxCategory taxCategory : taxCategories) {
 			deleteTaxCategory(taxCategory.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("UPDATE");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseWarehouseResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseWarehouseResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -360,6 +362,14 @@ public abstract class BaseWarehouseResourceImpl
 		for (Warehouse warehouse : warehouses) {
 			deleteWarehouse(warehouse.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("UPDATE");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/availability-estimate.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/availability-estimate.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.site.setting.dto.v1_0.AvailabilityEstimate
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Site.Setting)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/measurement-unit.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/measurement-unit.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.site.setting.dto.v1_0.MeasurementUnit
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Site.Setting)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/tax-category.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/tax-category.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.site.setting.dto.v1_0.TaxCategory
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Site.Setting)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/warehouse.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/warehouse.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.admin.site.setting.dto.v1_0.Warehouse
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Site.Setting)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartCommentResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartCommentResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -392,6 +394,14 @@ public abstract class BaseCartCommentResourceImpl
 		for (CartComment cartComment : cartComments) {
 			deleteCartComment(cartComment.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE", "UPDATE");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartItemResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartItemResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -459,6 +461,14 @@ public abstract class BaseCartItemResourceImpl
 		for (CartItem cartItem : cartItems) {
 			deleteCartItem(cartItem.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE", "UPDATE");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartResourceImpl.java
@@ -31,6 +31,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -50,6 +51,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -603,6 +605,14 @@ public abstract class BaseCartResourceImpl
 		for (Cart cart : carts) {
 			deleteCart(cart.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE", "UPDATE");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BasePaymentMethodResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BasePaymentMethodResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -116,6 +118,14 @@ public abstract class BasePaymentMethodResourceImpl
 			java.util.Collection<PaymentMethod> paymentMethods,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseShippingMethodResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseShippingMethodResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -116,6 +118,14 @@ public abstract class BaseShippingMethodResourceImpl
 			java.util.Collection<ShippingMethod> shippingMethods,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/cart-comment.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/cart-comment.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.delivery.cart.dto.v1_0.CartComment
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Delivery.Cart)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/cart-item.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/cart-item.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.delivery.cart.dto.v1_0.CartItem
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Delivery.Cart)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/cart.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/cart.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.delivery.cart.dto.v1_0.Cart
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Delivery.Cart)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/payment-method.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/payment-method.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.delivery.cart.dto.v1_0.PaymentMethod
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Delivery.Cart)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/shipping-method.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/shipping-method.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.delivery.cart.dto.v1_0.ShippingMethod
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Delivery.Cart)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseAttachmentResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseAttachmentResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -189,6 +191,14 @@ public abstract class BaseAttachmentResourceImpl
 			java.util.Collection<Attachment> attachments,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseCategoryResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -131,6 +133,14 @@ public abstract class BaseCategoryResourceImpl
 			java.util.Collection<Category> categories,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseMappedProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseMappedProductResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -151,6 +153,14 @@ public abstract class BaseMappedProductResourceImpl
 			java.util.Collection<MappedProduct> mappedProducts,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BasePinResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BasePinResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -147,6 +149,14 @@ public abstract class BasePinResourceImpl
 			java.util.Collection<Pin> pins,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseProductOptionResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseProductOptionResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -132,6 +134,14 @@ public abstract class BaseProductOptionResourceImpl
 			java.util.Collection<ProductOption> productOptions,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseProductResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -188,6 +190,14 @@ public abstract class BaseProductResourceImpl
 			java.util.Collection<Product> products,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseProductSpecificationResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseProductSpecificationResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -135,6 +137,14 @@ public abstract class BaseProductSpecificationResourceImpl
 			java.util.Collection<ProductSpecification> productSpecifications,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseRelatedProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseRelatedProductResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -142,6 +144,14 @@ public abstract class BaseRelatedProductResourceImpl
 			java.util.Collection<RelatedProduct> relatedProducts,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseSkuResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseSkuResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -138,6 +140,14 @@ public abstract class BaseSkuResourceImpl
 			java.util.Collection<Sku> skus,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/attachment.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/attachment.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.delivery.catalog.dto.v1_0.Attachment
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Delivery.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/category.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/category.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.delivery.catalog.dto.v1_0.Category
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Delivery.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/mapped-product.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/mapped-product.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.delivery.catalog.dto.v1_0.MappedProduct
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Delivery.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/pin.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/pin.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.delivery.catalog.dto.v1_0.Pin
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Delivery.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/product-option.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/product-option.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.delivery.catalog.dto.v1_0.ProductOption
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Delivery.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/product-specification.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/product-specification.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.delivery.catalog.dto.v1_0.ProductSpecification
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Delivery.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/product.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/product.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.delivery.catalog.dto.v1_0.Product
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Delivery.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/related-product.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/related-product.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.delivery.catalog.dto.v1_0.RelatedProduct
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Delivery.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/sku.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/sku.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.delivery.catalog.dto.v1_0.Sku
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Delivery.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataDefinitionFieldLinkResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataDefinitionFieldLinkResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -127,6 +129,14 @@ public abstract class BaseDataDefinitionFieldLinkResourceImpl
 				dataDefinitionFieldLinks,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataDefinitionResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataDefinitionResourceImpl.java
@@ -34,6 +34,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.odata.entity.EntityModel;
@@ -57,6 +58,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -763,6 +765,14 @@ public abstract class BaseDataDefinitionResourceImpl
 		for (DataDefinition dataDefinition : dataDefinitions) {
 			deleteDataDefinition(dataDefinition.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE", "UPDATE");
 	}
 
 	@Override

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataLayoutResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataLayoutResourceImpl.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -49,6 +50,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -539,6 +541,14 @@ public abstract class BaseDataLayoutResourceImpl
 		for (DataLayout dataLayout : dataLayouts) {
 			deleteDataLayout(dataLayout.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("UPDATE");
 	}
 
 	@Override

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataListViewResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataListViewResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -459,6 +461,14 @@ public abstract class BaseDataListViewResourceImpl
 		for (DataListView dataListView : dataListViews) {
 			deleteDataListView(dataListView.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("UPDATE");
 	}
 
 	@Override

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataRecordCollectionResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataRecordCollectionResourceImpl.java
@@ -34,6 +34,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.odata.entity.EntityModel;
@@ -57,6 +58,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -730,6 +732,14 @@ public abstract class BaseDataRecordCollectionResourceImpl
 
 			deleteDataRecordCollection(dataRecordCollection.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("UPDATE");
 	}
 
 	@Override

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataRecordResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataRecordResourceImpl.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -49,6 +50,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -675,6 +677,14 @@ public abstract class BaseDataRecordResourceImpl
 		for (DataRecord dataRecord : dataRecords) {
 			deleteDataRecord(dataRecord.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE", "UPDATE");
 	}
 
 	@Override

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/data-definition-field-link.properties
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/data-definition-field-link.properties
@@ -5,5 +5,7 @@
 api.version=v2.0
 batch.engine.entity.class.name=com.liferay.data.engine.rest.dto.v2_0.DataDefinitionFieldLink
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Data.Engine.REST)
 osgi.jaxrs.resource=true

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/data-definition.properties
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/data-definition.properties
@@ -5,5 +5,7 @@
 api.version=v2.0
 batch.engine.entity.class.name=com.liferay.data.engine.rest.dto.v2_0.DataDefinition
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Data.Engine.REST)
 osgi.jaxrs.resource=true

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/data-layout.properties
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/data-layout.properties
@@ -5,5 +5,7 @@
 api.version=v2.0
 batch.engine.entity.class.name=com.liferay.data.engine.rest.dto.v2_0.DataLayout
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Data.Engine.REST)
 osgi.jaxrs.resource=true

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/data-list-view.properties
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/data-list-view.properties
@@ -5,5 +5,7 @@
 api.version=v2.0
 batch.engine.entity.class.name=com.liferay.data.engine.rest.dto.v2_0.DataListView
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Data.Engine.REST)
 osgi.jaxrs.resource=true

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/data-record-collection.properties
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/data-record-collection.properties
@@ -5,5 +5,7 @@
 api.version=v2.0
 batch.engine.entity.class.name=com.liferay.data.engine.rest.dto.v2_0.DataRecordCollection
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Data.Engine.REST)
 osgi.jaxrs.resource=true

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/data-record.properties
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/data-record.properties
@@ -5,5 +5,7 @@
 api.version=v2.0
 batch.engine.entity.class.name=com.liferay.data.engine.rest.dto.v2_0.DataRecord
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Data.Engine.REST)
 osgi.jaxrs.resource=true

--- a/modules/apps/digital-signature/digital-signature-rest-impl/src/main/java/com/liferay/digital/signature/rest/internal/resource/v1_0/BaseDSEnvelopeResourceImpl.java
+++ b/modules/apps/digital-signature/digital-signature-rest-impl/src/main/java/com/liferay/digital/signature/rest/internal/resource/v1_0/BaseDSEnvelopeResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -276,6 +278,14 @@ public abstract class BaseDSEnvelopeResourceImpl
 			java.util.Collection<DSEnvelope> dsEnvelopes,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/digital-signature/digital-signature-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/ds-envelope.properties
+++ b/modules/apps/digital-signature/digital-signature-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/ds-envelope.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.digital.signature.rest.dto.v1_0.DSEnvelope
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Digital.Signature.REST)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/java/com/liferay/headless/admin/address/internal/resource/v1_0/BaseCountryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/java/com/liferay/headless/admin/address/internal/resource/v1_0/BaseCountryResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -606,6 +608,14 @@ public abstract class BaseCountryResourceImpl
 		for (Country country : countries) {
 			deleteCountry(country.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE", "UPDATE");
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/java/com/liferay/headless/admin/address/internal/resource/v1_0/BaseRegionResourceImpl.java
+++ b/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/java/com/liferay/headless/admin/address/internal/resource/v1_0/BaseRegionResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -582,6 +584,14 @@ public abstract class BaseRegionResourceImpl
 		for (Region region : regions) {
 			deleteRegion(region.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE", "UPDATE");
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/country.properties
+++ b/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/country.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.admin.address.dto.v1_0.Country
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Admin.Address)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/region.properties
+++ b/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/region.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.admin.address.dto.v1_0.Region
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Admin.Address)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/resource/v1_0/BaseListTypeDefinitionResourceImpl.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/resource/v1_0/BaseListTypeDefinitionResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -487,6 +489,14 @@ public abstract class BaseListTypeDefinitionResourceImpl
 		for (ListTypeDefinition listTypeDefinition : listTypeDefinitions) {
 			deleteListTypeDefinition(listTypeDefinition.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE", "UPDATE");
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/resource/v1_0/BaseListTypeEntryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/resource/v1_0/BaseListTypeEntryResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -459,6 +461,14 @@ public abstract class BaseListTypeEntryResourceImpl
 		for (ListTypeEntry listTypeEntry : listTypeEntries) {
 			deleteListTypeEntry(listTypeEntry.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("UPDATE");
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/list-type-definition.properties
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/list-type-definition.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.admin.list.type.dto.v1_0.ListTypeDefinition
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Admin.List.Type)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/list-type-entry.properties
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/list-type-entry.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.admin.list.type.dto.v1_0.ListTypeEntry
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Admin.List.Type)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseKeywordResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseKeywordResourceImpl.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.odata.entity.EntityModel;
@@ -56,6 +57,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -935,6 +937,14 @@ public abstract class BaseKeywordResourceImpl
 		for (Keyword keyword : keywords) {
 			deleteKeyword(keyword.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("UPDATE");
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyCategoryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyCategoryResourceImpl.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.odata.entity.EntityModel;
@@ -56,6 +57,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -1007,6 +1009,14 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 		for (TaxonomyCategory taxonomyCategory : taxonomyCategories) {
 			deleteTaxonomyCategory(taxonomyCategory.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("UPSERT", "INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE", "UPDATE");
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyVocabularyResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyVocabularyResourceImpl.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.odata.entity.EntityModel;
@@ -56,6 +57,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -1262,6 +1264,14 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 		for (TaxonomyVocabulary taxonomyVocabulary : taxonomyVocabularies) {
 			deleteTaxonomyVocabulary(taxonomyVocabulary.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("UPSERT", "INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE", "UPDATE");
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/keyword.properties
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/keyword.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.admin.taxonomy.dto.v1_0.Keyword
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Admin.Taxonomy)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/taxonomy-category.properties
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/taxonomy-category.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.admin.taxonomy.dto.v1_0.TaxonomyCategory
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Admin.Taxonomy)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/taxonomy-vocabulary.properties
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/taxonomy-vocabulary.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.admin.taxonomy.dto.v1_0.TaxonomyVocabulary
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Admin.Taxonomy)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseAccountResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseAccountResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -945,6 +947,14 @@ public abstract class BaseAccountResourceImpl
 		for (Account account : accounts) {
 			deleteAccount(account.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("UPSERT", "INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE", "UPDATE");
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseAccountRoleResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseAccountRoleResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -740,6 +742,14 @@ public abstract class BaseAccountRoleResourceImpl
 			java.util.Collection<AccountRole> accountRoles,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseEmailAddressResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseEmailAddressResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -180,6 +182,14 @@ public abstract class BaseEmailAddressResourceImpl
 			java.util.Collection<EmailAddress> emailAddresses,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseOrganizationResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseOrganizationResourceImpl.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -49,6 +50,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -1278,6 +1280,14 @@ public abstract class BaseOrganizationResourceImpl
 		for (Organization organization : organizations) {
 			deleteOrganization(organization.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("UPSERT", "INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE", "UPDATE");
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BasePhoneResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BasePhoneResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -180,6 +182,14 @@ public abstract class BasePhoneResourceImpl
 			java.util.Collection<Phone> phones,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BasePostalAddressResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BasePostalAddressResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -186,6 +188,14 @@ public abstract class BasePostalAddressResourceImpl
 			java.util.Collection<PostalAddress> postalAddresses,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseRoleResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseRoleResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -433,6 +435,14 @@ public abstract class BaseRoleResourceImpl
 			java.util.Collection<Role> roles,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSegmentResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSegmentResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -164,6 +166,14 @@ public abstract class BaseSegmentResourceImpl
 			java.util.Collection<Segment> segments,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSegmentUserResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSegmentUserResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -123,6 +125,14 @@ public abstract class BaseSegmentUserResourceImpl
 			java.util.Collection<SegmentUser> segmentUsers,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSiteResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSiteResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -172,6 +174,14 @@ public abstract class BaseSiteResourceImpl
 			java.util.Collection<Site> sites,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSubscriptionResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSubscriptionResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -177,6 +179,14 @@ public abstract class BaseSubscriptionResourceImpl
 			java.util.Collection<Subscription> subscriptions,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseUserAccountResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseUserAccountResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -1421,6 +1423,14 @@ public abstract class BaseUserAccountResourceImpl
 		for (UserAccount userAccount : userAccounts) {
 			deleteUserAccount(userAccount.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("UPSERT", "INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE", "UPDATE");
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseUserGroupResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseUserGroupResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -679,6 +681,14 @@ public abstract class BaseUserGroupResourceImpl
 		for (UserGroup userGroup : userGroups) {
 			deleteUserGroup(userGroup.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("UPSERT", "INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE", "UPDATE");
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseWebUrlResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseWebUrlResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -180,6 +182,14 @@ public abstract class BaseWebUrlResourceImpl
 			java.util.Collection<WebUrl> webUrls,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/account-role.properties
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/account-role.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.admin.user.dto.v1_0.AccountRole
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Admin.User)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/account.properties
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/account.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.admin.user.dto.v1_0.Account
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Admin.User)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/email-address.properties
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/email-address.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.admin.user.dto.v1_0.EmailAddress
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Admin.User)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/organization.properties
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/organization.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.admin.user.dto.v1_0.Organization
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Admin.User)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/phone.properties
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/phone.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.admin.user.dto.v1_0.Phone
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Admin.User)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/postal-address.properties
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/postal-address.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.admin.user.dto.v1_0.PostalAddress
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Admin.User)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/role.properties
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/role.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.admin.user.dto.v1_0.Role
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Admin.User)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/segment-user.properties
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/segment-user.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.admin.user.dto.v1_0.SegmentUser
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Admin.User)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/segment.properties
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/segment.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.admin.user.dto.v1_0.Segment
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Admin.User)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/site.properties
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/site.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.admin.user.dto.v1_0.Site
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Admin.User)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/subscription.properties
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/subscription.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.admin.user.dto.v1_0.Subscription
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Admin.User)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/user-account.properties
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/user-account.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.admin.user.dto.v1_0.UserAccount
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Admin.User)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/user-group.properties
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/user-group.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.admin.user.dto.v1_0.UserGroup
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Admin.User)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/web-url.properties
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/web-url.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.admin.user.dto.v1_0.WebUrl
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Admin.User)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingImageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingImageResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -49,6 +50,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -391,6 +393,14 @@ public abstract class BaseBlogPostingImageResourceImpl
 		for (BlogPostingImage blogPostingImage : blogPostingImages) {
 			deleteBlogPostingImage(blogPostingImage.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingResourceImpl.java
@@ -35,6 +35,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.odata.entity.EntityModel;
@@ -58,6 +59,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -1174,6 +1176,14 @@ public abstract class BaseBlogPostingResourceImpl
 		for (BlogPosting blogPosting : blogPostings) {
 			deleteBlogPosting(blogPosting.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("UPSERT", "INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE", "UPDATE");
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseCommentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseCommentResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -1466,6 +1468,14 @@ public abstract class BaseCommentResourceImpl
 		for (Comment comment : comments) {
 			deleteComment(comment.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("UPDATE");
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentElementResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentElementResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -201,6 +203,14 @@ public abstract class BaseContentElementResourceImpl
 			java.util.Collection<ContentElement> contentElements,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentSetElementResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentSetElementResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -337,6 +339,14 @@ public abstract class BaseContentSetElementResourceImpl
 			java.util.Collection<ContentSetElement> contentSetElements,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentStructureResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentStructureResourceImpl.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.odata.entity.EntityModel;
@@ -56,6 +57,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -622,6 +624,14 @@ public abstract class BaseContentStructureResourceImpl
 			java.util.Collection<ContentStructure> contentStructures,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentTemplateResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentTemplateResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -241,6 +243,14 @@ public abstract class BaseContentTemplateResourceImpl
 			java.util.Collection<ContentTemplate> contentTemplates,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentFolderResourceImpl.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.odata.entity.EntityModel;
@@ -56,6 +57,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -1285,6 +1287,14 @@ public abstract class BaseDocumentFolderResourceImpl
 		for (DocumentFolder documentFolder : documentFolders) {
 			deleteDocumentFolder(documentFolder.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE", "UPDATE");
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentResourceImpl.java
@@ -35,6 +35,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.odata.entity.EntityModel;
@@ -59,6 +60,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -1484,6 +1486,14 @@ public abstract class BaseDocumentResourceImpl
 		for (Document document : documents) {
 			deleteDocument(document.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("UPSERT", "INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE", "UPDATE");
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseArticleResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseArticleResourceImpl.java
@@ -34,6 +34,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.odata.entity.EntityModel;
@@ -57,6 +58,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -1644,6 +1646,14 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 
 			deleteKnowledgeBaseArticle(knowledgeBaseArticle.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("UPSERT", "INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE", "UPDATE");
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseAttachmentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseAttachmentResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -49,6 +50,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -388,6 +390,14 @@ public abstract class BaseKnowledgeBaseAttachmentResourceImpl
 
 			deleteKnowledgeBaseAttachment(knowledgeBaseAttachment.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseFolderResourceImpl.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.odata.entity.EntityModel;
@@ -56,6 +57,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -1081,6 +1083,14 @@ public abstract class BaseKnowledgeBaseFolderResourceImpl
 		for (KnowledgeBaseFolder knowledgeBaseFolder : knowledgeBaseFolders) {
 			deleteKnowledgeBaseFolder(knowledgeBaseFolder.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("UPSERT", "INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE", "UPDATE");
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseLanguageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseLanguageResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -147,6 +149,14 @@ public abstract class BaseLanguageResourceImpl
 			java.util.Collection<Language> languages,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardAttachmentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardAttachmentResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -49,6 +50,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -527,6 +529,14 @@ public abstract class BaseMessageBoardAttachmentResourceImpl
 
 			deleteMessageBoardAttachment(messageBoardAttachment.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardMessageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardMessageResourceImpl.java
@@ -34,6 +34,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.odata.entity.EntityModel;
@@ -57,6 +58,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -1522,6 +1524,14 @@ public abstract class BaseMessageBoardMessageResourceImpl
 		for (MessageBoardMessage messageBoardMessage : messageBoardMessages) {
 			deleteMessageBoardMessage(messageBoardMessage.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("UPSERT", "INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE", "UPDATE");
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardSectionResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardSectionResourceImpl.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.odata.entity.EntityModel;
@@ -56,6 +57,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -1043,6 +1045,14 @@ public abstract class BaseMessageBoardSectionResourceImpl
 		for (MessageBoardSection messageBoardSection : messageBoardSections) {
 			deleteMessageBoardSection(messageBoardSection.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE", "UPDATE");
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardThreadResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardThreadResourceImpl.java
@@ -34,6 +34,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.odata.entity.EntityModel;
@@ -57,6 +58,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -1362,6 +1364,14 @@ public abstract class BaseMessageBoardThreadResourceImpl
 		for (MessageBoardThread messageBoardThread : messageBoardThreads) {
 			deleteMessageBoardThread(messageBoardThread.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE", "UPDATE");
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseNavigationMenuResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseNavigationMenuResourceImpl.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.odata.entity.EntityModel;
@@ -56,6 +57,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -695,6 +697,14 @@ public abstract class BaseNavigationMenuResourceImpl
 		for (NavigationMenu navigationMenu : navigationMenus) {
 			deleteNavigationMenu(navigationMenu.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("UPDATE");
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseSitePageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseSitePageResourceImpl.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -49,6 +50,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -372,6 +374,14 @@ public abstract class BaseSitePageResourceImpl
 			java.util.Collection<SitePage> sitePages,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentFolderResourceImpl.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.odata.entity.EntityModel;
@@ -56,6 +57,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -1370,6 +1372,14 @@ public abstract class BaseStructuredContentFolderResourceImpl
 
 			deleteStructuredContentFolder(structuredContentFolder.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE", "UPDATE");
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentResourceImpl.java
@@ -35,6 +35,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.odata.entity.EntityModel;
@@ -58,6 +59,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -1941,6 +1943,14 @@ public abstract class BaseStructuredContentResourceImpl
 		for (StructuredContent structuredContent : structuredContents) {
 			deleteStructuredContent(structuredContent.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("UPSERT", "INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE", "UPDATE");
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiNodeResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiNodeResourceImpl.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.odata.entity.EntityModel;
@@ -56,6 +57,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -885,6 +887,14 @@ public abstract class BaseWikiNodeResourceImpl
 		for (WikiNode wikiNode : wikiNodes) {
 			deleteWikiNode(wikiNode.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("UPSERT", "INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("UPDATE");
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiPageAttachmentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiPageAttachmentResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -49,6 +50,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -359,6 +361,14 @@ public abstract class BaseWikiPageAttachmentResourceImpl
 		for (WikiPageAttachment wikiPageAttachment : wikiPageAttachments) {
 			deleteWikiPageAttachment(wikiPageAttachment.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiPageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiPageResourceImpl.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.odata.entity.EntityModel;
@@ -56,6 +57,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -834,6 +836,14 @@ public abstract class BaseWikiPageResourceImpl
 		for (WikiPage wikiPage : wikiPages) {
 			deleteWikiPage(wikiPage.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("UPSERT", "INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("UPDATE");
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/blog-posting-image.properties
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/blog-posting-image.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.delivery.dto.v1_0.BlogPostingImage
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/blog-posting.properties
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/blog-posting.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.delivery.dto.v1_0.BlogPosting
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/comment.properties
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/comment.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.delivery.dto.v1_0.Comment
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/content-element.properties
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/content-element.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.delivery.dto.v1_0.ContentElement
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/content-set-element.properties
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/content-set-element.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.delivery.dto.v1_0.ContentSetElement
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/content-structure.properties
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/content-structure.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.delivery.dto.v1_0.ContentStructure
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/content-template.properties
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/content-template.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.delivery.dto.v1_0.ContentTemplate
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/document-folder.properties
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/document-folder.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.delivery.dto.v1_0.DocumentFolder
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/document.properties
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/document.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.delivery.dto.v1_0.Document
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/knowledge-base-article.properties
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/knowledge-base-article.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.delivery.dto.v1_0.KnowledgeBaseArticle
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/knowledge-base-attachment.properties
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/knowledge-base-attachment.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.delivery.dto.v1_0.KnowledgeBaseAttachment
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/knowledge-base-folder.properties
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/knowledge-base-folder.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.delivery.dto.v1_0.KnowledgeBaseFolder
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/language.properties
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/language.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.delivery.dto.v1_0.Language
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/message-board-attachment.properties
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/message-board-attachment.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.delivery.dto.v1_0.MessageBoardAttachment
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/message-board-message.properties
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/message-board-message.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.delivery.dto.v1_0.MessageBoardMessage
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/message-board-section.properties
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/message-board-section.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.delivery.dto.v1_0.MessageBoardSection
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/message-board-thread.properties
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/message-board-thread.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.delivery.dto.v1_0.MessageBoardThread
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/navigation-menu.properties
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/navigation-menu.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.delivery.dto.v1_0.NavigationMenu
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/site-page.properties
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/site-page.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.delivery.dto.v1_0.SitePage
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/structured-content-folder.properties
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/structured-content-folder.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.delivery.dto.v1_0.StructuredContentFolder
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/structured-content.properties
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/structured-content.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.delivery.dto.v1_0.StructuredContent
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/wiki-node.properties
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/wiki-node.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.delivery.dto.v1_0.WikiNode
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/wiki-page-attachment.properties
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/wiki-page-attachment.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.delivery.dto.v1_0.WikiPageAttachment
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/wiki-page.properties
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/wiki-page.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.delivery.dto.v1_0.WikiPage
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormDocumentResourceImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormDocumentResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -47,6 +48,7 @@ import java.io.Serializable;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -191,6 +193,14 @@ public abstract class BaseFormDocumentResourceImpl
 		for (FormDocument formDocument : formDocuments) {
 			deleteFormDocument(formDocument.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormRecordResourceImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormRecordResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -378,6 +380,14 @@ public abstract class BaseFormRecordResourceImpl
 			java.util.Collection<FormRecord> formRecords,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("UPDATE");
 	}
 
 	@Override

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormResourceImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormResourceImpl.java
@@ -31,6 +31,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -51,6 +52,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -225,6 +227,14 @@ public abstract class BaseFormResourceImpl
 			java.util.Collection<Form> forms,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormStructureResourceImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormStructureResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -158,6 +160,14 @@ public abstract class BaseFormStructureResourceImpl
 			java.util.Collection<FormStructure> formStructures,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/form-document.properties
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/form-document.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.form.dto.v1_0.FormDocument
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Form)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/form-record.properties
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/form-record.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.form.dto.v1_0.FormRecord
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Form)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/form-structure.properties
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/form-structure.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.form.dto.v1_0.FormStructure
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Form)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/form.properties
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/form.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.form.dto.v1_0.Form
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Form)
 osgi.jaxrs.resource=true

--- a/modules/apps/notification/notification-rest-impl/src/main/java/com/liferay/notification/rest/internal/resource/v1_0/BaseNotificationTemplateResourceImpl.java
+++ b/modules/apps/notification/notification-rest-impl/src/main/java/com/liferay/notification/rest/internal/resource/v1_0/BaseNotificationTemplateResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -547,6 +549,14 @@ public abstract class BaseNotificationTemplateResourceImpl
 
 			deleteNotificationTemplate(notificationTemplate.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE", "UPDATE");
 	}
 
 	@Override

--- a/modules/apps/notification/notification-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/notification-template.properties
+++ b/modules/apps/notification/notification-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/notification-template.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.notification.rest.dto.v1_0.NotificationTemplate
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Notification.REST)
 osgi.jaxrs.resource=true

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectActionResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectActionResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -507,6 +509,14 @@ public abstract class BaseObjectActionResourceImpl
 		for (ObjectAction objectAction : objectActions) {
 			deleteObjectAction(objectAction.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE", "UPDATE");
 	}
 
 	@Override

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectDefinitionResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectDefinitionResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -565,6 +567,14 @@ public abstract class BaseObjectDefinitionResourceImpl
 		for (ObjectDefinition objectDefinition : objectDefinitions) {
 			deleteObjectDefinition(objectDefinition.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE", "UPDATE");
 	}
 
 	@Override

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectFieldResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectFieldResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -514,6 +516,14 @@ public abstract class BaseObjectFieldResourceImpl
 		for (ObjectField objectField : objectFields) {
 			deleteObjectField(objectField.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE", "UPDATE");
 	}
 
 	@Override

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectLayoutResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectLayoutResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -427,6 +429,14 @@ public abstract class BaseObjectLayoutResourceImpl
 		for (ObjectLayout objectLayout : objectLayouts) {
 			deleteObjectLayout(objectLayout.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("UPDATE");
 	}
 
 	@Override

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectRelationshipResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectRelationshipResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -452,6 +454,14 @@ public abstract class BaseObjectRelationshipResourceImpl
 		for (ObjectRelationship objectRelationship : objectRelationships) {
 			deleteObjectRelationship(objectRelationship.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("UPDATE");
 	}
 
 	@Override

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectValidationRuleResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectValidationRuleResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -561,6 +563,14 @@ public abstract class BaseObjectValidationRuleResourceImpl
 
 			deleteObjectValidationRule(objectValidationRule.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE", "UPDATE");
 	}
 
 	@Override

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectViewResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectViewResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -456,6 +458,14 @@ public abstract class BaseObjectViewResourceImpl
 		for (ObjectView objectView : objectViews) {
 			deleteObjectView(objectView.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("UPDATE");
 	}
 
 	@Override

--- a/modules/apps/object/object-admin-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/object-action.properties
+++ b/modules/apps/object/object-admin-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/object-action.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.object.admin.rest.dto.v1_0.ObjectAction
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Object.Admin.REST)
 osgi.jaxrs.resource=true

--- a/modules/apps/object/object-admin-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/object-definition.properties
+++ b/modules/apps/object/object-admin-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/object-definition.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.object.admin.rest.dto.v1_0.ObjectDefinition
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Object.Admin.REST)
 osgi.jaxrs.resource=true

--- a/modules/apps/object/object-admin-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/object-field.properties
+++ b/modules/apps/object/object-admin-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/object-field.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.object.admin.rest.dto.v1_0.ObjectField
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Object.Admin.REST)
 osgi.jaxrs.resource=true

--- a/modules/apps/object/object-admin-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/object-layout.properties
+++ b/modules/apps/object/object-admin-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/object-layout.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.object.admin.rest.dto.v1_0.ObjectLayout
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Object.Admin.REST)
 osgi.jaxrs.resource=true

--- a/modules/apps/object/object-admin-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/object-relationship.properties
+++ b/modules/apps/object/object-admin-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/object-relationship.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.object.admin.rest.dto.v1_0.ObjectRelationship
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Object.Admin.REST)
 osgi.jaxrs.resource=true

--- a/modules/apps/object/object-admin-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/object-validation-rule.properties
+++ b/modules/apps/object/object-admin-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/object-validation-rule.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.object.admin.rest.dto.v1_0.ObjectValidationRule
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Object.Admin.REST)
 osgi.jaxrs.resource=true

--- a/modules/apps/object/object-admin-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/object-view.properties
+++ b/modules/apps/object/object-admin-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/object-view.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.object.admin.rest.dto.v1_0.ObjectView
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Object.Admin.REST)
 osgi.jaxrs.resource=true

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -109,6 +109,10 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 							"batch.engine.task.item.delegate.name",
 							objectDefinition.getShortName()
 						).put(
+							"batch.planner.export.enabled", "true"
+						).put(
+							"batch.planner.import.enabled", "true"
+						).put(
 							"osgi.jaxrs.application.select",
 							"(osgi.jaxrs.name=" + objectDefinition.getName() +
 								")"

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseObjectEntryResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -776,6 +778,14 @@ public abstract class BaseObjectEntryResourceImpl
 		for (ObjectEntry objectEntry : objectEntries) {
 			deleteObjectEntry(objectEntry.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE", "UPDATE");
 	}
 
 	@Override

--- a/modules/apps/object/object-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/object-entry.properties
+++ b/modules/apps/object/object-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/object-entry.properties
@@ -5,4 +5,6 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.object.rest.dto.v1_0.ObjectEntry
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=false
 osgi.jaxrs.resource=true

--- a/modules/apps/portal-vulcan/portal-vulcan-api/bnd.bnd
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Vulcan API
 Bundle-SymbolicName: com.liferay.portal.vulcan.api
-Bundle-Version: 9.10.1
+Bundle-Version: 9.11.0
 Export-Package:\
 	com.liferay.portal.vulcan.accept.language,\
 	com.liferay.portal.vulcan.aggregation,\

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/batch/engine/VulcanBatchEngineTaskItemDelegate.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/batch/engine/VulcanBatchEngineTaskItemDelegate.java
@@ -29,6 +29,7 @@ import java.io.Serializable;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.osgi.annotation.versioning.ProviderType;
 
@@ -45,6 +46,14 @@ public interface VulcanBatchEngineTaskItemDelegate<T> {
 	public void delete(
 			Collection<T> items, Map<String, Serializable> parameters)
 		throws Exception;
+
+	public default Set<String> getAvailableCreateStrategies() {
+		return null;
+	}
+
+	public default Set<String> getAvailableUpdateStrategies() {
+		return null;
+	}
 
 	public EntityModel getEntityModel(Map<String, List<String>> multivaluedMap)
 		throws Exception;

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/batch/engine/packageinfo
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/batch/engine/packageinfo
@@ -1,1 +1,1 @@
-version 1.2.0
+version 1.3.0

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/BaseAccountCategoryForecastResourceImpl.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/BaseAccountCategoryForecastResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -157,6 +159,14 @@ public abstract class BaseAccountCategoryForecastResourceImpl
 				accountCategoryForecasts,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/BaseAccountForecastResourceImpl.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/BaseAccountForecastResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -145,6 +147,14 @@ public abstract class BaseAccountForecastResourceImpl
 			java.util.Collection<AccountForecast> accountForecasts,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/BaseSkuForecastResourceImpl.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/BaseSkuForecastResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -143,6 +145,14 @@ public abstract class BaseSkuForecastResourceImpl
 			java.util.Collection<SkuForecast> skuForecasts,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/account-category-forecast.properties
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/account-category-forecast.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.machine.learning.dto.v1_0.AccountCategoryForecast
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Machine.Learning)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/account-forecast.properties
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/account-forecast.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.machine.learning.dto.v1_0.AccountForecast
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Machine.Learning)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/sku-forecast.properties
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/sku-forecast.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.commerce.machine.learning.dto.v1_0.SkuForecast
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Machine.Learning)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseAssigneeMetricResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseAssigneeMetricResourceImpl.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -49,6 +50,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -130,6 +132,14 @@ public abstract class BaseAssigneeMetricResourceImpl
 			java.util.Collection<AssigneeMetric> assigneeMetrics,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseAssigneeResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseAssigneeResourceImpl.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -49,6 +50,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -114,6 +116,14 @@ public abstract class BaseAssigneeResourceImpl
 			java.util.Collection<Assignee> assignees,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseCalendarResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseCalendarResourceImpl.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -97,6 +99,14 @@ public abstract class BaseCalendarResourceImpl
 			java.util.Collection<Calendar> calendars,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseIndexResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseIndexResourceImpl.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -129,6 +131,14 @@ public abstract class BaseIndexResourceImpl
 			java.util.Collection<Index> indexes,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseInstanceResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseInstanceResourceImpl.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -436,6 +438,14 @@ public abstract class BaseInstanceResourceImpl
 			java.util.Collection<Instance> instances,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseNodeMetricResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseNodeMetricResourceImpl.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -160,6 +162,14 @@ public abstract class BaseNodeMetricResourceImpl
 			java.util.Collection<NodeMetric> nodeMetrics,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseNodeResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseNodeResourceImpl.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -258,6 +260,14 @@ public abstract class BaseNodeResourceImpl
 			java.util.Collection<Node> nodes,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseProcessMetricResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseProcessMetricResourceImpl.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -179,6 +181,14 @@ public abstract class BaseProcessMetricResourceImpl
 			java.util.Collection<ProcessMetric> processMetrics,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseProcessResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseProcessResourceImpl.java
@@ -28,6 +28,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.io.Serializable;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -378,6 +380,14 @@ public abstract class BaseProcessResourceImpl
 		for (Process process : processes) {
 			deleteProcess(process.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("UPDATE");
 	}
 
 	@Override

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseProcessVersionResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseProcessVersionResourceImpl.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -113,6 +115,14 @@ public abstract class BaseProcessVersionResourceImpl
 			java.util.Collection<ProcessVersion> processVersions,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseReindexStatusResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseReindexStatusResourceImpl.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -99,6 +101,14 @@ public abstract class BaseReindexStatusResourceImpl
 			java.util.Collection<ReindexStatus> reindexStatuses,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseRoleResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseRoleResourceImpl.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -118,6 +120,14 @@ public abstract class BaseRoleResourceImpl
 			java.util.Collection<Role> roles,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseSLAResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseSLAResourceImpl.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -438,6 +440,14 @@ public abstract class BaseSLAResourceImpl
 		for (SLA sla : slas) {
 			deleteSLA(sla.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("UPDATE");
 	}
 
 	@Override

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseTaskResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseTaskResourceImpl.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -49,6 +50,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -406,6 +408,14 @@ public abstract class BaseTaskResourceImpl
 			java.util.Collection<Task> tasks,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseTimeRangeResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseTimeRangeResourceImpl.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -97,6 +99,14 @@ public abstract class BaseTimeRangeResourceImpl
 			java.util.Collection<TimeRange> timeRanges,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/assignee-metric.properties
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/assignee-metric.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.portal.workflow.metrics.rest.dto.v1_0.AssigneeMetric
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Portal.Workflow.Metrics.REST)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/assignee.properties
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/assignee.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.portal.workflow.metrics.rest.dto.v1_0.Assignee
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Portal.Workflow.Metrics.REST)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/calendar.properties
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/calendar.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.portal.workflow.metrics.rest.dto.v1_0.Calendar
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Portal.Workflow.Metrics.REST)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/index.properties
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/index.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.portal.workflow.metrics.rest.dto.v1_0.Index
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Portal.Workflow.Metrics.REST)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/instance.properties
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/instance.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.portal.workflow.metrics.rest.dto.v1_0.Instance
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Portal.Workflow.Metrics.REST)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/node-metric.properties
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/node-metric.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.portal.workflow.metrics.rest.dto.v1_0.NodeMetric
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Portal.Workflow.Metrics.REST)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/node.properties
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/node.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.portal.workflow.metrics.rest.dto.v1_0.Node
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Portal.Workflow.Metrics.REST)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/process-metric.properties
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/process-metric.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.portal.workflow.metrics.rest.dto.v1_0.ProcessMetric
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Portal.Workflow.Metrics.REST)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/process-version.properties
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/process-version.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.portal.workflow.metrics.rest.dto.v1_0.ProcessVersion
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Portal.Workflow.Metrics.REST)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/process.properties
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/process.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.portal.workflow.metrics.rest.dto.v1_0.Process
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Portal.Workflow.Metrics.REST)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/reindex-status.properties
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/reindex-status.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.portal.workflow.metrics.rest.dto.v1_0.ReindexStatus
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Portal.Workflow.Metrics.REST)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/role.properties
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/role.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.portal.workflow.metrics.rest.dto.v1_0.Role
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Portal.Workflow.Metrics.REST)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/sla.properties
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/sla.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.portal.workflow.metrics.rest.dto.v1_0.SLA
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Portal.Workflow.Metrics.REST)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/task.properties
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/task.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.portal.workflow.metrics.rest.dto.v1_0.Task
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Portal.Workflow.Metrics.REST)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/time-range.properties
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/time-range.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.portal.workflow.metrics.rest.dto.v1_0.TimeRange
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Portal.Workflow.Metrics.REST)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseFieldMappingInfoResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseFieldMappingInfoResourceImpl.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -49,6 +50,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -113,6 +115,14 @@ public abstract class BaseFieldMappingInfoResourceImpl
 			java.util.Collection<FieldMappingInfo> fieldMappingInfos,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseKeywordQueryContributorResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseKeywordQueryContributorResourceImpl.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -105,6 +107,14 @@ public abstract class BaseKeywordQueryContributorResourceImpl
 				keywordQueryContributors,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseModelPrefilterContributorResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseModelPrefilterContributorResourceImpl.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -105,6 +107,14 @@ public abstract class BaseModelPrefilterContributorResourceImpl
 				modelPrefilterContributors,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseQueryPrefilterContributorResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseQueryPrefilterContributorResourceImpl.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -105,6 +107,14 @@ public abstract class BaseQueryPrefilterContributorResourceImpl
 				queryPrefilterContributors,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSXPBlueprintResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSXPBlueprintResourceImpl.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -49,6 +50,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -450,6 +452,14 @@ public abstract class BaseSXPBlueprintResourceImpl
 		for (SXPBlueprint sxpBlueprint : sxpBlueprints) {
 			deleteSXPBlueprint(sxpBlueprint.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE");
 	}
 
 	@Override

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSXPElementResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSXPElementResourceImpl.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -49,6 +50,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -444,6 +446,14 @@ public abstract class BaseSXPElementResourceImpl
 		for (SXPElement sxpElement : sxpElements) {
 			deleteSXPElement(sxpElement.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray("PARTIAL_UPDATE");
 	}
 
 	@Override

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSXPParameterContributorDefinitionResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSXPParameterContributorDefinitionResourceImpl.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -107,6 +109,14 @@ public abstract class BaseSXPParameterContributorDefinitionResourceImpl
 				sxpParameterContributorDefinitions,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSearchableAssetNameDisplayResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSearchableAssetNameDisplayResourceImpl.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -49,6 +50,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -118,6 +120,14 @@ public abstract class BaseSearchableAssetNameDisplayResourceImpl
 				searchableAssetNameDisplays,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSearchableAssetNameResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSearchableAssetNameResourceImpl.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -103,6 +105,14 @@ public abstract class BaseSearchableAssetNameResourceImpl
 			java.util.Collection<SearchableAssetName> searchableAssetNames,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/field-mapping-info.properties
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/field-mapping-info.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.search.experiences.rest.dto.v1_0.FieldMappingInfo
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Search.Experiences.REST)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/keyword-query-contributor.properties
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/keyword-query-contributor.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.search.experiences.rest.dto.v1_0.KeywordQueryContributor
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Search.Experiences.REST)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/model-prefilter-contributor.properties
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/model-prefilter-contributor.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.search.experiences.rest.dto.v1_0.ModelPrefilterContributor
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Search.Experiences.REST)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/query-prefilter-contributor.properties
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/query-prefilter-contributor.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.search.experiences.rest.dto.v1_0.QueryPrefilterContributor
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Search.Experiences.REST)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/searchable-asset-name-display.properties
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/searchable-asset-name-display.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.search.experiences.rest.dto.v1_0.SearchableAssetNameDisplay
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Search.Experiences.REST)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/searchable-asset-name.properties
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/searchable-asset-name.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.search.experiences.rest.dto.v1_0.SearchableAssetName
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Search.Experiences.REST)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/sxp-blueprint.properties
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/sxp-blueprint.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.search.experiences.rest.dto.v1_0.SXPBlueprint
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Search.Experiences.REST)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/sxp-element.properties
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/sxp-element.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.search.experiences.rest.dto.v1_0.SXPElement
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Search.Experiences.REST)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/sxp-parameter-contributor-definition.properties
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/sxp-parameter-contributor-definition.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.search.experiences.rest.dto.v1_0.SXPParameterContributorDefinition
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Search.Experiences.REST)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/BaseExperimentResourceImpl.java
+++ b/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/BaseExperimentResourceImpl.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -47,6 +48,7 @@ import java.io.Serializable;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -187,6 +189,14 @@ public abstract class BaseExperimentResourceImpl
 		for (Experiment experiment : experiments) {
 			deleteExperiment(experiment.getId());
 		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/BaseStatusResourceImpl.java
+++ b/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/BaseStatusResourceImpl.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -48,6 +49,7 @@ import java.io.Serializable;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -192,6 +194,14 @@ public abstract class BaseStatusResourceImpl
 			java.util.Collection<Status> statuses,
 			Map<String, Serializable> parameters)
 		throws Exception {
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
 	}
 
 	@Override

--- a/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/experiment.properties
+++ b/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/experiment.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.segments.asah.rest.dto.v1_0.Experiment
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=false
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Segments.Asah.REST)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/status.properties
+++ b/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/status.properties
@@ -5,5 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.segments.asah.rest.dto.v1_0.Status
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=true
+batch.planner.export.enabled=false
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Segments.Asah.REST)
 osgi.jaxrs.resource=true

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
@@ -797,6 +797,22 @@ public class FreeMarkerTool {
 		return OpenAPIParserUtil.getVersion(openAPIYAML);
 	}
 
+	public Set<String> getVulcanBatchImplementationCreateStrategies(
+		List<JavaMethodSignature> javaMethodSignatures,
+		Map<String, String> properties) {
+
+		return ResourceOpenAPIParser.
+			getVulcanBatchImplementationCreateStrategies(
+				javaMethodSignatures, properties);
+	}
+
+	public Set<String> getVulcanBatchImplementationUpdateStrategies(
+		List<JavaMethodSignature> javaMethodSignatures) {
+
+		return ResourceOpenAPIParser.
+			getVulcanBatchImplementationUpdateStrategies(javaMethodSignatures);
+	}
+
 	public boolean hasHTTPMethod(
 		JavaMethodSignature javaMethodSignature, String... httpMethods) {
 
@@ -873,6 +889,13 @@ public class FreeMarkerTool {
 		}
 
 		return false;
+	}
+
+	public boolean hasReadVulcanBatchImplementation(
+		List<JavaMethodSignature> javaMethodSignatures) {
+
+		return ResourceOpenAPIParser.hasReadVulcanBatchImplementation(
+			javaMethodSignatures);
 	}
 
 	public boolean hasRequestBodyMediaType(

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/ResourceOpenAPIParser.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/ResourceOpenAPIParser.java
@@ -257,6 +257,81 @@ public class ResourceOpenAPIParser {
 		return sb.toString();
 	}
 
+	public static Set<String> getVulcanBatchImplementationCreateStrategies(
+		List<JavaMethodSignature> javaMethodSignatures,
+		Map<String, String> properties) {
+
+		Set<String> propertyNames = properties.keySet();
+		Set<String> strategies = new HashSet<>();
+
+		for (JavaMethodSignature javaMethodSignature : javaMethodSignatures) {
+			String methodName = javaMethodSignature.getMethodName();
+			String parentSchemaName = javaMethodSignature.getParentSchemaName();
+			String schemaName = javaMethodSignature.getSchemaName();
+
+			if (parentSchemaName == null) {
+				parentSchemaName = "";
+			}
+
+			if (methodName.equals("post" + parentSchemaName + schemaName)) {
+				strategies.add("INSERT");
+			}
+			else if (methodName.equals(
+						StringBundler.concat(
+							"put", parentSchemaName, schemaName,
+							"ByExternalReferenceCode")) &&
+					 propertyNames.contains("externalReferenceCode")) {
+
+				strategies.add("UPSERT");
+			}
+		}
+
+		return strategies;
+	}
+
+	public static Set<String> getVulcanBatchImplementationUpdateStrategies(
+		List<JavaMethodSignature> javaMethodSignatures) {
+
+		Set<String> strategies = new HashSet<>();
+
+		for (JavaMethodSignature javaMethodSignature : javaMethodSignatures) {
+			String methodName = javaMethodSignature.getMethodName();
+			String schemaName = javaMethodSignature.getSchemaName();
+
+			if (methodName.equals("put" + schemaName)) {
+				strategies.add("UPDATE");
+			}
+			else if (methodName.equals("patch" + schemaName)) {
+				strategies.add("PARTIAL_UPDATE");
+			}
+		}
+
+		return strategies;
+	}
+
+	public static boolean hasReadVulcanBatchImplementation(
+		List<JavaMethodSignature> javaMethodSignatures) {
+
+		for (JavaMethodSignature javaMethodSignature : javaMethodSignatures) {
+			String methodName = javaMethodSignature.getMethodName();
+			String parentSchemaName = javaMethodSignature.getParentSchemaName();
+			String schemaName = javaMethodSignature.getSchemaName();
+
+			if (parentSchemaName == null) {
+				parentSchemaName = "";
+			}
+
+			if (methodName.equals(
+					StringBundler.concat(
+						"get", parentSchemaName, schemaName, "sPage"))) {
+
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 	public static boolean hasResourceBatchJavaMethodSignatures(
 		List<JavaMethodSignature> javaMethodSignatures) {
 

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.odata.entity.EntityModel;
@@ -51,6 +52,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -448,6 +450,22 @@ public abstract class Base${schemaName}ResourceImpl
 					delete${schemaName}(${schemaVarName}.get${schemaName}Id());
 				}
 			</#if>
+		}
+
+		public Set<String> getAvailableCreateStrategies() {
+			return SetUtil.fromArray(
+				<#if createStrategies?has_content>
+					"${createStrategies?join("\",\"")}"
+				</#if>
+			);
+		}
+
+		public Set<String> getAvailableUpdateStrategies() {
+			return SetUtil.fromArray(
+				<#if updateStrategies?has_content>
+					"${updateStrategies?join("\",\"")}"
+				</#if>
+			);
 		}
 
 		@Override

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/properties.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/properties.ftl
@@ -11,6 +11,8 @@ api.version=${openAPIYAML.info.version}
 <#if !stringUtil.equals(schemaName, "openapi") && generateBatch>
 batch.engine.entity.class.name=${javaDataType}
 batch.engine.task.item.delegate=true
+batch.planner.import.enabled=${freeMarkerTool.getVulcanBatchImplementationCreateStrategies(javaMethodSignatures, freeMarkerTool.getDTOProperties(configYAML, openAPIYAML, schema))?has_content?c}
+batch.planner.export.enabled=${freeMarkerTool.hasReadVulcanBatchImplementation(javaMethodSignatures)?c}
 </#if>
 <#if configYAML.resourceApplicationSelect??>
 osgi.jaxrs.application.select=${configYAML.resourceApplicationSelect}


### PR DESCRIPTION
Forwarded manually from this PR: https://github.com/liferay-frontend/liferay-portal/pull/2304

---

This PR contains the code to determine programatically if a schema should be batch importable/exportable.

The following features has been included:

- Two new methods in the `VulcanBatchEngineTaskItemDelegate` interface. Those methods have a default implementation:

```
	public default Set<String> getAvailableCreateStrategies() {
		return null;
	}

	public default Set<String> getAvailableUpdateStrategies() {
		return null;
	}
```
**NOTE:** Each API Resource implementation will implement those methods without the `@Override` annotation **to avoid including changes that breaks previous versions.**

For example, for API Resource implementations that can manage any type of create and update strategies, the implementation would be the following:

```
	public Set<String> getAvailableCreateStrategies() {
		return SetUtil.fromArray("UPSERT", "INSERT");
	}

	public Set<String> getAvailableUpdateStrategies() {
		return SetUtil.fromArray("PARTIAL_UPDATE", "UPDATE");
	}
```
With this change, it will be possible to determine the available strategies for each Schema.


- Two new properties to determine if the Schema can be included in the Import and Export processes. That means the Schema is batch importable / batch exportable (because it contains a proper implementation of the `create` and `read` methods of the `VulcanBatchEngineTaskItemDelegate` interface).

```
batch.planner.import.enabled=true
batch.planner.export.enabled=true
```