### PR TITLE
LPS-150996 Export `sub` and import it throughout the codebase

### DIFF
--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/js/AccountOrganizationsManagementToolbarPropsTransformer.js
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/js/AccountOrganizationsManagementToolbarPropsTransformer.js
@@ -16,6 +16,7 @@ import {
 	getCheckedCheckboxes,
 	openSelectionModal,
 	postForm,
+	sub,
 } from 'frontend-js-web';
 
 export default function propsTransformer({portletNamespace, ...otherProps}) {
@@ -82,7 +83,7 @@ export default function propsTransformer({portletNamespace, ...otherProps}) {
 						});
 					}
 				},
-				title: Liferay.Util.sub(
+				title: sub(
 					Liferay.Language.get('assign-organizations-to-x'),
 					data?.accountEntryName
 				),

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/js/AccountUsersManagementToolbarPropsTransformer.js
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/js/AccountUsersManagementToolbarPropsTransformer.js
@@ -16,6 +16,7 @@ import {
 	getCheckedCheckboxes,
 	openSelectionModal,
 	postForm,
+	sub,
 } from 'frontend-js-web';
 
 export default function propsTransformer({
@@ -88,7 +89,7 @@ export default function propsTransformer({
 						});
 					}
 				},
-				title: Liferay.Util.sub(
+				title: sub(
 					Liferay.Language.get('assign-users-to-x'),
 					accountEntryName
 				),

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_groups_admin/js/AccountGroupAccountEntriesManagementToolbarPropsTransformer.js
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_groups_admin/js/AccountGroupAccountEntriesManagementToolbarPropsTransformer.js
@@ -16,6 +16,7 @@ import {
 	getCheckedCheckboxes,
 	openSelectionModal,
 	postForm,
+	sub,
 } from 'frontend-js-web';
 
 export default function propsTransformer({
@@ -87,7 +88,7 @@ export default function propsTransformer({
 						});
 					}
 				},
-				title: Liferay.Util.sub(
+				title: sub(
 					Liferay.Language.get('assign-accounts-to-x'),
 					accountGroupName
 				),

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_users_admin/js/AccountUserEmailDomainValidator.es.js
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_users_admin/js/AccountUserEmailDomainValidator.es.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {PortletBase} from 'frontend-js-web';
+import {PortletBase, sub} from 'frontend-js-web';
 import {Config} from 'metal-state';
 
 class AccountUserEmailDomainValidator extends PortletBase {
@@ -99,7 +99,7 @@ class AccountUserEmailDomainValidator extends PortletBase {
 				if (!!blockedDomains && blockedDomains.includes(emailDomain)) {
 					hasError = true;
 
-					errorMessage = Liferay.Util.sub(
+					errorMessage = sub(
 						Liferay.Language.get('x-is-a-blocked-domain'),
 						emailDomain
 					);
@@ -110,7 +110,7 @@ class AccountUserEmailDomainValidator extends PortletBase {
 				) {
 					hasError = true;
 
-					errorMessage = Liferay.Util.sub(
+					errorMessage = sub(
 						Liferay.Language.get(
 							'x-is-not-a-valid-domain-for-the-following-accounts-x'
 						),

--- a/modules/apps/adaptive-media/adaptive-media-web/src/main/resources/META-INF/resources/adaptive_media/js/AdaptiveMediaProgress.js
+++ b/modules/apps/adaptive-media/adaptive-media-web/src/main/resources/META-INF/resources/adaptive_media/js/AdaptiveMediaProgress.js
@@ -16,7 +16,7 @@ import ClayButton from '@clayui/button';
 import ClayIcon from '@clayui/icon';
 import ClayProgressBar from '@clayui/progress-bar';
 import {useIsMounted, useTimeout} from '@liferay/frontend-js-react-web';
-import {fetch} from 'frontend-js-web';
+import {fetch, sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useCallback, useEffect, useState} from 'react';
 
@@ -147,7 +147,7 @@ const AdaptiveMediaProgress = ({
 
 					{imagesFailed === 1
 						? Liferay.Language.get('1-image-failed-process')
-						: Liferay.Util.sub(
+						: sub(
 								Liferay.Language.get('x-images-failed-process'),
 								imagesFailed
 						  )}

--- a/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/js/CategoryActionDropdownPropsTransformer.js
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/js/CategoryActionDropdownPropsTransformer.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {openModal, openSelectionModal, openToast} from 'frontend-js-web';
+import {openModal, openSelectionModal, openToast, sub} from 'frontend-js-web';
 
 import openDeleteCategoryModal from './openDeleteCategoryModal';
 
@@ -50,7 +50,7 @@ const ACTIONS = {
 
 				if (categoryId === parentCategoryId) {
 					openToast({
-						message: Liferay.Util.sub(
+						message: sub(
 							Liferay.Language.get(
 								'unable-to-move-the-category-x-into-itself'
 							),
@@ -80,10 +80,7 @@ const ACTIONS = {
 			},
 			selectEventName: `${portletNamespace}selectCategory`,
 			size: 'md',
-			title: Liferay.Util.sub(
-				Liferay.Language.get('move-x'),
-				categoryTitle
-			),
+			title: sub(Liferay.Language.get('move-x'), categoryTitle),
 			url: selectParentCategoryURL,
 		});
 	},

--- a/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/js/openDeleteCategoryModal.js
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/js/openDeleteCategoryModal.js
@@ -12,6 +12,8 @@
  * details.
  */
 
+import {sub} from 'frontend-js-web';
+
 export default function openDeleteCategoryModal({
 	message,
 	multiple = false,
@@ -39,7 +41,7 @@ export default function openDeleteCategoryModal({
 			},
 		],
 		status: 'danger',
-		title: Liferay.Util.sub(
+		title: sub(
 			Liferay.Language.get('delete-x'),
 			multiple
 				? Liferay.Language.get('categories')

--- a/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/js/openDeleteVocabularyModal.js
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/js/openDeleteVocabularyModal.js
@@ -12,6 +12,8 @@
  * details.
  */
 
+import {sub} from 'frontend-js-web';
+
 export default function openDeleteVocabularyModal({
 	multiple = false,
 	onDelete,
@@ -36,7 +38,7 @@ export default function openDeleteVocabularyModal({
 			},
 		],
 		status: 'danger',
-		title: Liferay.Util.sub(
+		title: sub(
 			Liferay.Language.get('delete-x'),
 			multiple
 				? Liferay.Language.get('vocabularies')

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/Source.js
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/Source.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {delegate, toggleSelectBox} from 'frontend-js-web';
+import {delegate, sub, toggleSelectBox} from 'frontend-js-web';
 
 export default function ({classTypes, namespace}) {
 	const mapDDMStructures = {};
@@ -400,7 +400,7 @@ export default function ({classTypes, namespace}) {
 				});
 			},
 			selectEventName: `${namespace}selectDDMStructureField`,
-			title: Liferay.Util.sub(
+			title: sub(
 				Liferay.Language.get('select-x'),
 				Liferay.Language.get('structure-field')
 			),

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/openDeleteAssetEntryListModal.js
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/openDeleteAssetEntryListModal.js
@@ -12,6 +12,8 @@
  * details.
  */
 
+import {sub} from 'frontend-js-web';
+
 export default function openDeleteAssetEntryListModal({
 	multiple = false,
 	onDelete,
@@ -38,7 +40,7 @@ export default function openDeleteAssetEntryListModal({
 			},
 		],
 		status: 'danger',
-		title: Liferay.Util.sub(
+		title: sub(
 			Liferay.Language.get('delete-x'),
 			multiple
 				? Liferay.Language.get('collections')

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/js/Source.js
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/js/Source.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {delegate, toggleSelectBox} from 'frontend-js-web';
+import {delegate, sub, toggleSelectBox} from 'frontend-js-web';
 
 const ANY = 'any';
 const SELECT_MORE_THAN_ONE = 'select-more-than-one';
@@ -390,7 +390,7 @@ export default function ({assetPublisherNamespace, classTypes, namespace}) {
 				});
 			},
 			selectEventName: `${namespace}selectDDMStructureField`,
-			title: Liferay.Util.sub(
+			title: sub(
 				Liferay.Language.get('select-x'),
 				Liferay.Language.get('structure-field')
 			),

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/AssetCategoriesSelectorTag.es.js
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/AssetCategoriesSelectorTag.es.js
@@ -12,6 +12,7 @@
  * details.
  */
 
+import {sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
 
@@ -69,7 +70,7 @@ export default function (props) {
 				<p
 					className="small text-secondary"
 					dangerouslySetInnerHTML={{
-						__html: Liferay.Util.sub(
+						__html: sub(
 							Liferay.Language.get(
 								'x-learn-how-x-to-tailor-categories-to-your-needs'
 							),

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/AssetVocabularyCategoriesSelector.es.js
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/AssetVocabularyCategoriesSelector.es.js
@@ -19,7 +19,7 @@ import ClayIcon from '@clayui/icon';
 import ClayMultiSelect, {itemLabelFilter} from '@clayui/multi-select';
 import {usePrevious} from '@liferay/frontend-js-react-web';
 import classNames from 'classnames';
-import {openSelectionModal} from 'frontend-js-web';
+import {openSelectionModal, sub as subUtil} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useEffect, useState} from 'react';
 
@@ -169,7 +169,7 @@ function AssetVocabulariesCategoriesSelector({
 			selectEventName: eventName,
 			size: 'md',
 			title: label
-				? Liferay.Util.sub(Liferay.Language.get('select-x'), label)
+				? subUtil(Liferay.Language.get('select-x'), label)
 				: Liferay.Language.get('select-categories'),
 			url,
 		});

--- a/modules/apps/asset/asset-tags-admin-web/src/main/resources/META-INF/resources/js/openDeleteTagModal.js
+++ b/modules/apps/asset/asset-tags-admin-web/src/main/resources/META-INF/resources/js/openDeleteTagModal.js
@@ -12,6 +12,8 @@
  * details.
  */
 
+import {sub} from 'frontend-js-web';
+
 export default function openDeleteTagModal({multiple = false, onDelete}) {
 	Liferay.Util.openModal({
 		bodyHTML: Liferay.Language.get('are-you-sure-you-want-to-delete-this'),
@@ -33,7 +35,7 @@ export default function openDeleteTagModal({multiple = false, onDelete}) {
 			},
 		],
 		status: 'danger',
-		title: Liferay.Util.sub(
+		title: sub(
 			Liferay.Language.get('delete-x'),
 			multiple
 				? Liferay.Language.get('tags')

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/ChangeTrackingChangesView.js
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/ChangeTrackingChangesView.js
@@ -27,6 +27,7 @@ import ClayTable from '@clayui/table';
 import ClayToolbar from '@clayui/toolbar';
 import classNames from 'classnames';
 import {ManagementToolbar} from 'frontend-js-components-web';
+import {sub} from 'frontend-js-web';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 import {CSSTransition} from 'react-transition-group';
 
@@ -291,7 +292,7 @@ export default function ChangeTrackingChangesView({
 						key = Liferay.Language.get('x-deleted-a-x-x-ago');
 					}
 
-					model.description = Liferay.Util.sub(
+					model.description = sub(
 						key,
 						model.userName,
 						model.typeName,
@@ -308,7 +309,7 @@ export default function ChangeTrackingChangesView({
 						key = Liferay.Language.get('x-deleted-a-x-in-x-x-ago');
 					}
 
-					model.description = Liferay.Util.sub(
+					model.description = sub(
 						key,
 						model.userName,
 						model.typeName,
@@ -1720,7 +1721,7 @@ export default function ChangeTrackingChangesView({
 					</ClayTable.Cell>
 
 					<ClayTable.Cell className="table-cell-expand-smallest">
-						{Liferay.Util.sub(
+						{sub(
 							Liferay.Language.get('x-ago'),
 							node.timeDescription
 						)}
@@ -2359,7 +2360,7 @@ export default function ChangeTrackingChangesView({
 			<ManagementToolbar.ResultsBarItem>
 				<span className="component-text text-truncate-inline">
 					<span className="text-truncate">
-						{Liferay.Util.sub(
+						{sub(
 							renderState.changes &&
 								renderState.changes.length === 1
 								? Liferay.Language.get('x-result-for')

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/ChangeTrackingComments.js
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/ChangeTrackingComments.js
@@ -18,7 +18,7 @@ import {Align, ClayDropDownWithItems} from '@clayui/drop-down';
 import ClayForm, {ClayInput} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import ClaySticker from '@clayui/sticker';
-import {fetch} from 'frontend-js-web';
+import {fetch, sub} from 'frontend-js-web';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 
 const CTEditComment = ({handleCancel, handleSave, initialValue}) => {
@@ -479,7 +479,7 @@ export default function ChangeTrackingComments({
 				<div className="container-fluid">
 					<ul className="tbar-nav">
 						<li className="tbar-item tbar-item-expand">
-							{Liferay.Util.sub(
+							{sub(
 								count === 1
 									? Liferay.Language.get('x-comment')
 									: Liferay.Language.get('x-comments'),

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/ManageCollaborators.js
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/ManageCollaborators.js
@@ -35,7 +35,7 @@ import ClayModal, {useModal} from '@clayui/modal';
 import ClayMultiSelect from '@clayui/multi-select';
 import ClaySticker from '@clayui/sticker';
 import ClayTable from '@clayui/table';
-import {fetch, objectToFormData} from 'frontend-js-web';
+import {fetch, objectToFormData, sub} from 'frontend-js-web';
 import React, {useCallback, useRef, useState} from 'react';
 
 const CollaboratorRow = ({
@@ -385,7 +385,7 @@ const ManageCollaborators = ({
 
 					if (!isEmailAddressValid(item.value)) {
 						return Promise.resolve({
-							error: Liferay.Util.sub(
+							error: sub(
 								Liferay.Language.get(
 									'x-is-not-a-valid-email-address'
 								),
@@ -424,7 +424,7 @@ const ManageCollaborators = ({
 							}
 
 							return {
-								error: Liferay.Util.sub(
+								error: sub(
 									Liferay.Language.get(
 										'user-x-does-not-exist'
 									),
@@ -597,10 +597,7 @@ const ManageCollaborators = ({
 
 			if (
 				!confirm(
-					Liferay.Util.sub(
-						key,
-						publicationsUserRoleEmailAddresses.join(', ')
-					)
+					sub(key, publicationsUserRoleEmailAddresses.join(', '))
 				)
 			) {
 				return;

--- a/modules/apps/commerce/commerce-channel-web/src/main/resources/META-INF/resources/js/CommerceChannelSite.js
+++ b/modules/apps/commerce/commerce-channel-web/src/main/resources/META-INF/resources/js/CommerceChannelSite.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {delegate, openSelectionModal} from 'frontend-js-web';
+import {delegate, openSelectionModal, sub} from 'frontend-js-web';
 
 export default function ({
 	itemSelectorUrl,
@@ -73,7 +73,7 @@ export default function ({
 							searchContainer.updateDataStore();
 						},
 						selectEventName: 'sitesSelectItem',
-						title: Liferay.Util.sub(
+						title: sub(
 							Liferay.Language.get('select-x'),
 							Liferay.Language.get('site')
 						),

--- a/modules/apps/commerce/commerce-frontend-js/src/main/resources/META-INF/resources/components/global_search/GlobalSearch.js
+++ b/modules/apps/commerce/commerce-frontend-js/src/main/resources/META-INF/resources/components/global_search/GlobalSearch.js
@@ -17,6 +17,7 @@ import {ClayInput} from '@clayui/form';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import ClaySticker from '@clayui/sticker';
 import {useIsMounted} from '@liferay/frontend-js-react-web';
+import {sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 
@@ -267,7 +268,7 @@ function GlobalSearch({
 												}
 											)}
 										>
-											{Liferay.Util.sub(
+											{sub(
 												Liferay.Language.get(
 													'search-x-in-catalog'
 												),
@@ -318,7 +319,7 @@ function GlobalSearch({
 													}
 												)}
 											>
-												{Liferay.Util.sub(
+												{sub(
 													Liferay.Language.get(
 														'search-x-in-orders'
 													),
@@ -370,7 +371,7 @@ function GlobalSearch({
 												}
 											)}
 										>
-											{Liferay.Util.sub(
+											{sub(
 												Liferay.Language.get(
 													'search-x-in-accounts'
 												),

--- a/modules/apps/commerce/commerce-frontend-js/src/main/resources/META-INF/resources/components/quantity_selector/RulesPopover.js
+++ b/modules/apps/commerce/commerce-frontend-js/src/main/resources/META-INF/resources/components/quantity_selector/RulesPopover.js
@@ -15,6 +15,7 @@
 import ClayPopover from '@clayui/popover';
 import {ReactPortal} from '@liferay/frontend-js-react-web';
 import classNames from 'classnames';
+import {sub} from 'frontend-js-web';
 import React, {useLayoutEffect, useRef, useState} from 'react';
 
 export default function RulesPopover({
@@ -87,7 +88,7 @@ export default function RulesPopover({
 								'text-danger': errors.includes('min'),
 							})}
 							dangerouslySetInnerHTML={{
-								__html: Liferay.Util.sub(
+								__html: sub(
 									Liferay.Language.get(
 										'min-quantity-per-order-is-x'
 									),
@@ -105,7 +106,7 @@ export default function RulesPopover({
 								'text-danger': errors.includes('max'),
 							})}
 							dangerouslySetInnerHTML={{
-								__html: Liferay.Util.sub(
+								__html: sub(
 									Liferay.Language.get(
 										'max-quantity-per-order-is-x'
 									),
@@ -123,8 +124,8 @@ export default function RulesPopover({
 								'text-danger': errors.includes('multiple'),
 							})}
 							dangerouslySetInnerHTML={{
-								__html: Liferay.Util.sub(
-									Liferay.Util.sub(
+								__html: sub(
+									sub(
 										Liferay.Language.get(
 											'quantity-must-be-a-multiple-of-x'
 										),

--- a/modules/apps/commerce/commerce-product-definitions-web/src/main/resources/META-INF/resources/js/EditDisplayLayout.js
+++ b/modules/apps/commerce/commerce-product-definitions-web/src/main/resources/META-INF/resources/js/EditDisplayLayout.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {delegate} from 'frontend-js-web';
+import {delegate, sub} from 'frontend-js-web';
 
 export default function ({
 	displayPageItemSelectorUrl,
@@ -75,7 +75,7 @@ export default function ({
 					searchContainer.updateDataStore();
 				},
 				selectEventName: 'productDefinitionsSelectItem',
-				title: Liferay.Util.sub(
+				title: sub(
 					Liferay.Language.get('select-x'),
 					Liferay.Language.get('product')
 				),

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/AuditGraphApp/EmptyAuditBarChart.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/AuditGraphApp/EmptyAuditBarChart.js
@@ -13,6 +13,7 @@
  */
 
 import ClayEmptyState from '@clayui/empty-state';
+import {sub} from 'frontend-js-web';
 import React from 'react';
 import {
 	BarChart,
@@ -28,7 +29,7 @@ export default function EmptyAuditBarChart({learnHowURL}) {
 	const description = learnHowURL && (
 		<div
 			dangerouslySetInnerHTML={{
-				__html: Liferay.Util.sub(
+				__html: sub(
 					Liferay.Language.get(
 						'x-learn-how-x-to-tailor-categories-to-your-needs'
 					),

--- a/modules/apps/data-engine/data-engine-js-components-web/package.json
+++ b/modules/apps/data-engine/data-engine-js-components-web/package.json
@@ -1,6 +1,7 @@
 {
 	"dependencies": {
 		"dom-align": "1.10.4",
+		"frontend-js-web": "*",
 		"moment": "^2.22.2"
 	},
 	"jest": {

--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/custom/form/components/PartialResults.tsx
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/custom/form/components/PartialResults.tsx
@@ -13,6 +13,7 @@
  */
 
 import {useResource} from '@clayui/data-provider';
+import {sub} from 'frontend-js-web';
 import React, {useEffect, useState} from 'react';
 
 // @ts-ignore
@@ -71,14 +72,12 @@ const PartialResults: React.FC<IProps> = ({reportDataURL}) => {
 						<div className="align-items-center">
 							<span className="lfr-de__partial-results-title text-truncate">
 								{totalItems === 1
-									? Liferay.Util.sub(
-											Liferay.Language.get('x-entry'),
-											[totalItems]
-									  )
-									: Liferay.Util.sub(
-											Liferay.Language.get('x-entries'),
-											[totalItems]
-									  )}
+									? sub(Liferay.Language.get('x-entry'), [
+											totalItems,
+									  ])
+									: sub(Liferay.Language.get('x-entries'), [
+											totalItems,
+									  ])}
 							</span>
 						</div>
 

--- a/modules/apps/data-engine/data-engine-js-components-web/tsconfig.json
+++ b/modules/apps/data-engine/data-engine-js-components-web/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "984c0b4e3e9210428e26946e5e442cd135e496c3",
+	"@generated": "0352eebcea8943fb70090d8182ff86a222cd4206",
 	"@overrides": {
 	},
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT OUTSIDE @overrides **",
@@ -13,6 +13,9 @@
 		"moduleResolution": "node",
 		"outDir": "./types",
 		"paths": {
+			"frontend-js-web": [
+				"../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts"
+			]
 		},
 		"sourceMap": false,
 		"strict": true,
@@ -29,5 +32,8 @@
 		"../../../global.d.ts"
 	],
 	"references": [
+		{
+			"path": "../../frontend-js/frontend-js-web"
+		}
 	]
 }

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/field-sets/FieldSetModal.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/field-sets/FieldSetModal.js
@@ -30,6 +30,7 @@ import {
 	pagesStructureReducer,
 } from 'data-engine-js-components-web/js/core/reducers/index.es';
 import {pageReducer} from 'data-engine-js-components-web/js/custom/form/reducers/index.es';
+import {sub} from 'frontend-js-web';
 import {default as React, useCallback, useState} from 'react';
 
 import {FormBuilder} from '../../FormBuilder';
@@ -99,7 +100,7 @@ const ModalContent = ({
 
 			if (fieldsWithoutOptions.length) {
 				throw new Error(
-					Liferay.Util.sub(
+					sub(
 						Liferay.Language.get(
 							'at-least-one-option-should-be-set-for-field-x'
 						),

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/js/DepotRoles.js
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/js/DepotRoles.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {delegate, openSelectionModal} from 'frontend-js-web';
+import {delegate, openSelectionModal, sub} from 'frontend-js-web';
 
 export default function ({
 	portletNamespace,
@@ -158,7 +158,7 @@ export default function ({
 						},
 						selectEventName,
 						selectedData: searchContainer.getData(true),
-						title: Liferay.Util.sub(
+						title: sub(
 							Liferay.Language.get('select-x'),
 							Liferay.Language.get('role')
 						),

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/DLManagementToolbarPropsTransformer.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/DLManagementToolbarPropsTransformer.js
@@ -17,6 +17,7 @@ import {
 	navigate,
 	openModal,
 	openSelectionModal,
+	sub,
 } from 'frontend-js-web';
 
 import {collectDigitalSignature} from './digital-signature/DigitalSignatureUtil';
@@ -227,7 +228,7 @@ export default function propsTransformer({
 			},
 			selectEventName: `${portletNamespace}selectFolder`,
 			size: 'lg',
-			title: Liferay.Util.sub(dialogTitle, [selectedItems]),
+			title: sub(dialogTitle, [selectedItems]),
 			url: selectFolderURL,
 		});
 	};

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/FileEntryPicker.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/FileEntryPicker.js
@@ -16,6 +16,7 @@ import {ClayButtonWithIcon} from '@clayui/button';
 import ClayForm, {ClayInput} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import classNames from 'classnames';
+import {sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useEffect, useState} from 'react';
 
@@ -89,7 +90,7 @@ const FileNamePicker = ({
 					<ClayForm.FeedbackItem>
 						<ClayIcon className="mr-1" symbol="exclamation-full" />
 
-						{Liferay.Util.sub(
+						{sub(
 							Liferay.Language.get(
 								'please-enter-a-file-with-a-valid-file-size-no-larger-than-x'
 							),

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/categorization/categories/EditCategoriesModal.es.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/categorization/categories/EditCategoriesModal.es.js
@@ -19,7 +19,7 @@ import ClayLoadingIndicator from '@clayui/loading-indicator';
 import ClayModal from '@clayui/modal';
 import {useIsMounted} from '@liferay/frontend-js-react-web';
 import {AssetCategoriesSelector} from 'asset-taglib';
-import {fetch} from 'frontend-js-web';
+import {fetch, sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useCallback, useContext, useEffect, useState} from 'react';
 
@@ -69,7 +69,7 @@ const EditCategoriesModal = ({
 			);
 		}
 
-		return Liferay.Util.sub(
+		return sub(
 			Liferay.Language.get(
 				'you-are-editing-the-common-categories-for-x-items.-select-edit-or-replace-current-categories'
 			),

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/categorization/tags/EditTagsModal.es.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/categorization/tags/EditTagsModal.es.js
@@ -19,7 +19,7 @@ import ClayLoadingIndicator from '@clayui/loading-indicator';
 import ClayModal from '@clayui/modal';
 import {useIsMounted} from '@liferay/frontend-js-react-web';
 import {AssetTagsSelector} from 'asset-taglib';
-import {fetch} from 'frontend-js-web';
+import {fetch, sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useCallback, useContext, useEffect, useState} from 'react';
 
@@ -94,7 +94,7 @@ const EditTagsModal = ({
 			);
 		}
 
-		return Liferay.Util.sub(
+		return sub(
 			Liferay.Language.get(
 				'you-are-editing-the-common-tags-for-x-items.-select-edit-or-replace-current-tags'
 			),

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/data-engine/DataEngineLayoutBuilderHandler.es.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/data-engine/DataEngineLayoutBuilderHandler.es.js
@@ -12,6 +12,8 @@
  * details.
  */
 
+import {sub} from 'frontend-js-web';
+
 import {
 	getDataEngineStructure,
 	getInputLocalizedValues,
@@ -64,7 +66,7 @@ export default function DataEngineLayoutBuilderHandler({namespace}) {
 
 		if (!nameInput.value || !name[defaultLanguageId]) {
 			Liferay.Util.openToast({
-				message: Liferay.Util.sub(
+				message: sub(
 					Liferay.Language.get(
 						'please-enter-a-valid-title-for-the-default-language-x'
 					),

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/digital-signature/DigitalSignatureUtil.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/digital-signature/DigitalSignatureUtil.js
@@ -19,6 +19,7 @@ import {
 	navigate,
 	objectToFormData,
 	openModal,
+	sub,
 } from 'frontend-js-web';
 
 const MAXIMUM_SELECTED_FILES = 10;
@@ -27,21 +28,21 @@ const translatedKeys = {
 	cancel: Liferay.Language.get('cancel'),
 	continue: Liferay.Language.get('continue'),
 	deselected: Liferay.Language.get('deselected'),
-	maximum_files_message: Liferay.Util.sub(
+	maximum_files_message: sub(
 		Liferay.Language.get('maximum-of-x-files-per-envelope'),
 		MAXIMUM_SELECTED_FILES
 	),
 };
 
 const _invalidFileExtensionContent = (invalidFileExtensions) =>
-	`${Liferay.Util.sub(
+	`${sub(
 		Liferay.Language.get(
 			'these-file-extensions-are-not-supported-by-docusign-and-have-been-x'
 		),
 		_translatedStrongKeys(translatedKeys.deselected)
 	)}
 
-	<p class="mt-2">${Liferay.Util.sub(
+	<p class="mt-2">${sub(
 		Liferay.Language.get('please-x-or-x-to-choose-new-documents'),
 		_translatedStrongKeys(translatedKeys.continue),
 		_translatedStrongKeys(translatedKeys.cancel)
@@ -58,7 +59,7 @@ const _invalidFileExtensionContent = (invalidFileExtensions) =>
 const _invalidFileCountContent = (
 	extendedMessage
 ) => `<div class="alert alert-warning">
-		${Liferay.Util.sub(
+		${sub(
 			Liferay.Language.get(
 				'you-have-exceeded-the-maximum-amount-of-x-files-allowed-per-envelope'
 			),
@@ -67,7 +68,7 @@ const _invalidFileCountContent = (
 
 		${
 			extendedMessage
-				? `<div class="mt-2">${Liferay.Util.sub(
+				? `<div class="mt-2">${sub(
 						Liferay.Language.get(
 							'please-x-or-x-to-remove-files-in-your-envelope'
 						),
@@ -138,7 +139,7 @@ const _showWarningModal = ({
 		status: 'warning',
 		title:
 			invalidFileExtensions.length === 0
-				? Liferay.Util.sub(
+				? sub(
 						Liferay.Language.get('maximum-of-x-files-per-envelope'),
 						MAXIMUM_SELECTED_FILES
 				  )

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/components/share-form/ShareFormModalBody.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/components/share-form/ShareFormModalBody.es.js
@@ -12,6 +12,7 @@
  * details.
  */
 
+import {sub} from 'frontend-js-web';
 import React, {useState} from 'react';
 
 import Email from './Email.es';
@@ -25,10 +26,7 @@ export function ShareFormModalBody({
 }) {
 	const [addresses, setAddresses] = useState([]);
 	const [message, setMessage] = useState(
-		Liferay.Util.sub(
-			Liferay.Language.get('please-fill-out-this-form-x'),
-			url
-		)
+		sub(Liferay.Language.get('please-fill-out-this-form-x'), url)
 	);
 	const [subject, setSubject] = useState(
 		localizedName[themeDisplay.getLanguageId()]

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/components/share-form/openShareFormModal.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/components/share-form/openShareFormModal.es.js
@@ -16,6 +16,7 @@ import ClayButton from '@clayui/button';
 import {ClayIconSpriteContext} from '@clayui/icon';
 import ClayModal, {useModal} from '@clayui/modal';
 import {render} from '@liferay/frontend-js-react-web';
+import {sub} from 'frontend-js-web';
 import React, {useRef} from 'react';
 import {unmountComponentAtNode} from 'react-dom';
 
@@ -33,10 +34,7 @@ export function Modal({
 	const {observer} = useModal({onClose});
 	const emailContentRef = useRef({
 		addresses: [],
-		message: Liferay.Util.sub(
-			Liferay.Language.get('please-fill-out-this-form-x'),
-			url
-		),
+		message: sub(Liferay.Language.get('please-fill-out-this-form-x'), url),
 		subject: localizedName[themeDisplay.getLanguageId()],
 	});
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/pages/FormBuilder.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/pages/FormBuilder.es.js
@@ -27,6 +27,7 @@ import {
 	useFormState,
 } from 'data-engine-js-components-web';
 import {DragLayer, MultiPanelSidebar} from 'data-engine-taglib';
+import {sub} from 'frontend-js-web';
 import React, {
 	useCallback,
 	useContext,
@@ -353,7 +354,7 @@ export function FormBuilder() {
 	const onShareClick = useCallback(async () => {
 		const url = await getFormUrl();
 
-		emailContentRef.current.message = Liferay.Util.sub(
+		emailContentRef.current.message = sub(
 			Liferay.Language.get('please-fill-out-this-form-x'),
 			url
 		);

--- a/modules/apps/fragment/fragment-collection-filter-category/src/main/resources/META-INF/resources/js/SelectCategory.es.js
+++ b/modules/apps/fragment/fragment-collection-filter-category/src/main/resources/META-INF/resources/js/SelectCategory.es.js
@@ -18,6 +18,7 @@ import {
 	getCollectionFilterValue,
 	setCollectionFilterValue,
 } from '@liferay/fragment-renderer-collection-filter-impl';
+import {sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useEffect, useState} from 'react';
 
@@ -107,7 +108,7 @@ export default function SelectCategory({
 			)?.label || label;
 	}
 	else if (selectedCategoryIds.length > 1) {
-		label = Liferay.Util.sub(
+		label = sub(
 			Liferay.Language.get('x-selected'),
 			selectedCategoryIds.length
 		);

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/fragment-editor/FragmentEditor.js
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/fragment-editor/FragmentEditor.js
@@ -23,6 +23,7 @@ import {
 	fetch,
 	objectToFormData,
 	openToast,
+	sub,
 } from 'frontend-js-web';
 import React, {useCallback, useEffect, useState} from 'react';
 
@@ -366,7 +367,7 @@ const FragmentEditor = ({
 						<div className="javascript source-editor">
 							<CodeMirrorEditor
 								codeFooterText="}"
-								codeHeaderHelpText={Liferay.Util.sub(
+								codeHeaderHelpText={sub(
 									Liferay.Language.get(
 										'parameter-x-provides-access-to-the-current-fragment-node-use-it-to-manipulate-fragment-components'
 									),

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/openDeleteFragmentCollectionModal.js
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/openDeleteFragmentCollectionModal.js
@@ -12,6 +12,8 @@
  * details.
  */
 
+import {sub} from 'frontend-js-web';
+
 export default function openDeleteFragmentCollectionModal({
 	multiple = false,
 	onDelete,
@@ -38,7 +40,7 @@ export default function openDeleteFragmentCollectionModal({
 			},
 		],
 		status: 'danger',
-		title: Liferay.Util.sub(
+		title: sub(
 			Liferay.Language.get('delete-x'),
 			multiple
 				? Liferay.Language.get('fragment-sets')

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/openDeleteFragmentCollectionResourceModal.js
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/openDeleteFragmentCollectionResourceModal.js
@@ -12,6 +12,8 @@
  * details.
  */
 
+import {sub} from 'frontend-js-web';
+
 export default function openDeleteFragmentCollectionResourceModal({
 	multiple = false,
 	onDelete,
@@ -36,7 +38,7 @@ export default function openDeleteFragmentCollectionResourceModal({
 			},
 		],
 		status: 'danger',
-		title: Liferay.Util.sub(
+		title: sub(
 			Liferay.Language.get('delete-x'),
 			multiple
 				? Liferay.Language.get('resources')

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/openDeleteFragmentModal.js
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/openDeleteFragmentModal.js
@@ -12,6 +12,8 @@
  * details.
  */
 
+import {sub} from 'frontend-js-web';
+
 export default function openDeleteFragmentModal({multiple = false, onDelete}) {
 	Liferay.Util.openModal({
 		bodyHTML: Liferay.Language.get(
@@ -35,7 +37,7 @@ export default function openDeleteFragmentModal({multiple = false, onDelete}) {
 			},
 		],
 		status: 'danger',
-		title: Liferay.Util.sub(
+		title: sub(
 			Liferay.Language.get('delete-x'),
 			multiple
 				? Liferay.Language.get('fragments')

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/BulkActions.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/BulkActions.js
@@ -15,7 +15,7 @@
 import ClayIcon from '@clayui/icon';
 import ClayLink from '@clayui/link';
 import classNames from 'classnames';
-import {postForm} from 'frontend-js-web';
+import {postForm, sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useContext, useEffect, useState} from 'react';
 
@@ -152,7 +152,7 @@ function BulkActions({
 						<ul className="navbar-nav">
 							<li className="nav-item">
 								<span className="text-truncate">
-									{Liferay.Util.sub(
+									{sub(
 										Liferay.Language.get(
 											'x-of-x-items-selected'
 										),

--- a/modules/apps/frontend-icons/frontend-icons-web/src/main/resources/META-INF/resources/js/pages/instance_settings/AddIconPackModal.tsx
+++ b/modules/apps/frontend-icons/frontend-icons-web/src/main/resources/META-INF/resources/js/pages/instance_settings/AddIconPackModal.tsx
@@ -19,7 +19,7 @@ import ClayLoadingIndicator from '@clayui/loading-indicator';
 import ClayModal, {useModal} from '@clayui/modal';
 import ClayPanel from '@clayui/panel';
 import classNames from 'classnames';
-import {fetch, openToast} from 'frontend-js-web';
+import {fetch, openToast, sub} from 'frontend-js-web';
 import React, {useMemo, useRef, useState} from 'react';
 
 import {getSpritemap} from '../../index';
@@ -186,7 +186,7 @@ export default function AddIconPackModal({
 						{errorNameTaken && (
 							<ClayForm.FeedbackGroup>
 								<ClayForm.FeedbackItem>
-									{`${Liferay.Util.sub(
+									{`${sub(
 										Liferay.Language.get(
 											'x-is-already-the-name-of-an-icon-pack'
 										),
@@ -303,7 +303,7 @@ function IconPicker({
 
 										{!!totalSelectedIconsFromPack && (
 											<b className="ml-auto">
-												{Liferay.Util.sub(
+												{sub(
 													Liferay.Language.get(
 														'x-icons-selected'
 													),

--- a/modules/apps/frontend-icons/frontend-icons-web/src/main/resources/META-INF/resources/js/pages/instance_settings/index.tsx
+++ b/modules/apps/frontend-icons/frontend-icons-web/src/main/resources/META-INF/resources/js/pages/instance_settings/index.tsx
@@ -17,7 +17,7 @@ import {ClayDropDownWithItems} from '@clayui/drop-down';
 import {ClayInput} from '@clayui/form';
 import ClayLayout from '@clayui/layout';
 import ClayPanel from '@clayui/panel';
-import {fetch, openToast} from 'frontend-js-web';
+import {fetch, openToast, sub} from 'frontend-js-web';
 import React, {useMemo, useState} from 'react';
 
 import AddIconPackModal from './AddIconPackModal';
@@ -93,7 +93,7 @@ export default function InstanceIconConfiguration({
 	const handleDelete = (iconPackName: string) => {
 		if (
 			!confirm(
-				Liferay.Util.sub(
+				sub(
 					Liferay.Language.get(
 						'are-you-sure-you-want-to-delete-the-x-icon-pack'
 					),

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts
@@ -699,3 +699,14 @@ export function toggleSelectBox(
 	value: any,
 	toggleBoxId: string
 ): void;
+
+export function createResourceURL(
+	basePortletURL: string,
+	parameters?: Object
+): URL;
+
+export function sub(
+	string: string,
+	data: string | number | string[] | number[] | Array<string> | Array<number>,
+	...args: string[] | number[]
+): string;

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
@@ -112,6 +112,7 @@ export {default as removeEntitySelection} from './liferay/util/remove_entity_sel
 export {default as showCapsLock} from './liferay/util/show_caps_lock';
 export {default as runScriptsInElement} from './liferay/util/run_scripts_in_element.es';
 export {default as selectFolder} from './liferay/util/select_folder';
+export {default as sub} from './liferay/util/sub';
 export {default as toggleBoxes} from './liferay/util/toggle_boxes';
 export {default as toggleControls} from './liferay/util/toggle_controls';
 export {default as toggleDisabled} from './liferay/util/toggle_disabled';

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/CreationMenu.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/CreationMenu.js
@@ -16,6 +16,7 @@ import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
 import ClayDropDown from '@clayui/drop-down';
 import ClayIcon from '@clayui/icon';
 import classNames from 'classnames';
+import {sub} from 'frontend-js-web';
 import React, {useContext, useRef, useState} from 'react';
 
 import getDataAttributes from '../get_data_attributes';
@@ -208,7 +209,7 @@ const CreationMenu = ({
 							</div>
 
 							<div className="dropdown-caption">
-								{Liferay.Util.sub(
+								{sub(
 									Liferay.Language.get(
 										'showing-x-of-x-elements'
 									),

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ResultsBar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ResultsBar.js
@@ -15,7 +15,7 @@
 import ClayLabel from '@clayui/label';
 import ClayLink from '@clayui/link';
 import {ManagementToolbar} from 'frontend-js-components-web';
-import {navigate} from 'frontend-js-web';
+import {navigate, sub} from 'frontend-js-web';
 import React from 'react';
 
 const ResultsBar = ({
@@ -32,7 +32,7 @@ const ResultsBar = ({
 				>
 					<span className="component-text text-truncate-inline">
 						<span className="text-truncate">
-							{Liferay.Util.sub(
+							{sub(
 								itemsTotal === 1
 									? Liferay.Language.get('x-result-for')
 									: Liferay.Language.get('x-results-for'),

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/SelectionControls.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/SelectionControls.js
@@ -14,6 +14,7 @@
 
 import {ClayCheckbox} from '@clayui/form';
 import {ManagementToolbar} from 'frontend-js-components-web';
+import {sub} from 'frontend-js-web';
 import React, {useContext, useEffect, useRef, useState} from 'react';
 
 import {EVENT_MANAGEMENT_TOOLBAR_TOGGLE_ALL_ITEMS} from '../constants';
@@ -184,7 +185,7 @@ const SelectionControls = ({
 						<span className="navbar-text">
 							{selectedItems === itemsTotal
 								? Liferay.Language.get('all-selected')
-								: `${Liferay.Util.sub(
+								: `${sub(
 										Liferay.Language.get('x-of-x'),
 										selectedItems,
 										itemsTotal

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/image_selector/js/BrowseImage.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/image_selector/js/BrowseImage.js
@@ -12,6 +12,7 @@
  * details.
  */
 
+import {sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -42,7 +43,7 @@ const BrowseImage = ({
 					<span
 						className="pr-1"
 						dangerouslySetInnerHTML={{
-							__html: Liferay.Util.sub(
+							__html: sub(
 								Liferay.Language.get(
 									'drag-and-drop-to-upload-or-x'
 								),
@@ -63,7 +64,7 @@ const BrowseImage = ({
 				<span
 					className="pl-1"
 					dangerouslySetInnerHTML={{
-						__html: Liferay.Util.sub(
+						__html: sub(
 							Liferay.Language.get('maximum-size-x'),
 							Liferay.Util.formatStorage(
 								parseInt(maxFileSize, 10)

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/image_selector/js/ImageSelector.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/image_selector/js/ImageSelector.js
@@ -15,7 +15,7 @@
 import ClayIcon from '@clayui/icon';
 import {State} from '@liferay/frontend-js-state-web';
 import classNames from 'classnames';
-import {STATUS_CODE} from 'frontend-js-web';
+import {STATUS_CODE, sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useEffect, useRef, useState} from 'react';
 
@@ -82,7 +82,7 @@ const ImageSelector = ({
 		}
 		else if (errorType === STATUS_CODE.SC_FILE_EXTENSION_EXCEPTION) {
 			if (validExtensions) {
-				message = Liferay.Util.sub(
+				message = sub(
 					Liferay.Language.get(
 						'please-enter-a-file-with-a-valid-extension-x'
 					),
@@ -90,7 +90,7 @@ const ImageSelector = ({
 				);
 			}
 			else {
-				message = Liferay.Util.sub(
+				message = sub(
 					Liferay.Language.get(
 						'please-enter-a-file-with-a-valid-file-type'
 					)
@@ -103,7 +103,7 @@ const ImageSelector = ({
 			);
 		}
 		else if (errorType === STATUS_CODE.SC_FILE_SIZE_EXCEPTION) {
-			message = Liferay.Util.sub(
+			message = sub(
 				Liferay.Language.get(
 					'please-enter-a-file-with-a-valid-file-size-no-larger-than-x'
 				),
@@ -114,7 +114,7 @@ const ImageSelector = ({
 			const maxUploadRequestSize =
 				Liferay.PropsValues.UPLOAD_SERVLET_REQUEST_IMPL_MAX_SIZE;
 
-			message = Liferay.Util.sub(
+			message = sub(
 				Liferay.Language.get(
 					'request-is-larger-than-x-and-could-not-be-processed'
 				),
@@ -218,7 +218,7 @@ const ImageSelector = ({
 		const bytesTotalSpaceIndex = bytesTotal.indexOf(STR_SPACE);
 
 		setProgressData(
-			Liferay.Util.sub(
+			sub(
 				TPL_PROGRESS_DATA,
 				bytesLoaded.substring(0, bytesLoadedSpaceIndex),
 				bytesLoaded.substring(bytesLoadedSpaceIndex + 1),

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/item_selector_uploader/js/SingleFileUploader.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/item_selector_uploader/js/SingleFileUploader.js
@@ -18,6 +18,7 @@ import ClayLayout from '@clayui/layout';
 import ClayProgressBar from '@clayui/progress-bar';
 import {useIsMounted} from '@liferay/frontend-js-react-web';
 import classNames from 'classnames';
+import {sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useEffect, useMemo, useState} from 'react';
 import {ErrorCode, useDropzone} from 'react-dropzone';
@@ -52,14 +53,14 @@ function SingleFileUploader({
 
 	const CLIENT_ERRORS = useMemo(
 		() => ({
-			[ErrorCode.FileInvalidType]: Liferay.Util.sub(
+			[ErrorCode.FileInvalidType]: sub(
 				Liferay.Language.get(
 					'please-enter-a-file-with-a-valid-extension-x'
 				),
 				[validExtensions]
 			),
 
-			[ErrorCode.FileTooLarge]: Liferay.Util.sub(
+			[ErrorCode.FileTooLarge]: sub(
 				Liferay.Language.get(
 					'please-enter-a-file-with-a-valid-file-size-no-larger-than-x'
 				),

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/item_selector_uploader/js/utils/getUploadErrorMessage.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/item_selector_uploader/js/utils/getUploadErrorMessage.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {STATUS_CODE} from 'frontend-js-web';
+import {STATUS_CODE, sub} from 'frontend-js-web';
 
 export default function getUploadErrorMessage(error, maxFileSize) {
 	let message = Liferay.Language.get(
@@ -31,7 +31,7 @@ export default function getUploadErrorMessage(error, maxFileSize) {
 				break;
 			case STATUS_CODE.SC_FILE_EXTENSION_EXCEPTION:
 				if (error.message) {
-					message = Liferay.Util.sub(
+					message = sub(
 						Liferay.Language.get(
 							'please-enter-a-file-with-a-valid-extension-x'
 						),
@@ -53,7 +53,7 @@ export default function getUploadErrorMessage(error, maxFileSize) {
 				break;
 			case STATUS_CODE.SC_FILE_SIZE_EXCEPTION:
 			case STATUS_CODE.SC_UPLOAD_REQUEST_CONTENT_LENGTH_EXCEPTION:
-				message = Liferay.Util.sub(
+				message = sub(
 					Liferay.Language.get(
 						'please-enter-a-file-with-a-valid-file-size-no-larger-than-x'
 					),
@@ -65,7 +65,7 @@ export default function getUploadErrorMessage(error, maxFileSize) {
 				const maxUploadRequestSize =
 					Liferay.PropsValues.UPLOAD_SERVLET_REQUEST_IMPL_MAX_SIZE;
 
-				message = Liferay.Util.sub(
+				message = sub(
 					Liferay.Language.get(
 						'request-is-larger-than-x-and-could-not-be-processed'
 					),

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/js/ItemSelectorRepositoryEntryBrowser.es.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/js/ItemSelectorRepositoryEntryBrowser.es.js
@@ -20,6 +20,7 @@ import {
 	PortletBase,
 	STATUS_CODE,
 	delegate,
+	sub,
 } from 'frontend-js-web';
 import {Config} from 'metal-state';
 import ReactDOM from 'react-dom';
@@ -278,7 +279,7 @@ class ItemSelectorRepositoryEntryBrowser extends PortletBase {
 					break;
 				case STATUS_CODE.SC_FILE_EXTENSION_EXCEPTION:
 					if (error.message) {
-						message = Liferay.Util.sub(
+						message = sub(
 							Liferay.Language.get(
 								'please-enter-a-file-with-a-valid-extension-x'
 							),
@@ -300,7 +301,7 @@ class ItemSelectorRepositoryEntryBrowser extends PortletBase {
 					break;
 				case STATUS_CODE.SC_FILE_SIZE_EXCEPTION:
 				case STATUS_CODE.SC_UPLOAD_REQUEST_CONTENT_LENGTH_EXCEPTION:
-					message = Liferay.Util.sub(
+					message = sub(
 						Liferay.Language.get(
 							'please-enter-a-file-with-a-valid-file-size-no-larger-than-x'
 						),
@@ -313,7 +314,7 @@ class ItemSelectorRepositoryEntryBrowser extends PortletBase {
 						Liferay.PropsValues
 							.UPLOAD_SERVLET_REQUEST_IMPL_MAX_SIZE;
 
-					message = Liferay.Util.sub(
+					message = sub(
 						Liferay.Language.get(
 							'request-is-larger-than-x-and-could-not-be-processed'
 						),
@@ -487,7 +488,7 @@ class ItemSelectorRepositoryEntryBrowser extends PortletBase {
 				this._previewFile(file);
 			}
 			else {
-				errorMessage = Liferay.Util.sub(
+				errorMessage = sub(
 					Liferay.Language.get(
 						'please-enter-a-file-with-a-valid-file-size-no-larger-than-x'
 					),
@@ -496,7 +497,7 @@ class ItemSelectorRepositoryEntryBrowser extends PortletBase {
 			}
 		}
 		else {
-			errorMessage = Liferay.Util.sub(
+			errorMessage = sub(
 				Liferay.Language.get(
 					'please-enter-a-file-with-a-valid-extension-x'
 				),

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/DataEngineLayoutBuilderHandler.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/DataEngineLayoutBuilderHandler.es.js
@@ -12,6 +12,8 @@
  * details.
  */
 
+import {sub} from 'frontend-js-web';
+
 const isElementInnerSelector = (element, ...selectors) =>
 	!selectors.some((selector) => element.closest(selector));
 
@@ -81,7 +83,7 @@ export default function DataEngineLayoutBuilderHandler({namespace}) {
 
 		if (!nameInput.value && !name[defaultLanguageId]) {
 			Liferay.Util.openToast({
-				message: Liferay.Util.sub(
+				message: sub(
 					Liferay.Language.get(
 						'please-enter-a-valid-title-for-the-default-language-x'
 					),

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/ImageInput.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/ImageInput.es.js
@@ -15,6 +15,7 @@
 import ClayButton from '@clayui/button';
 import ClayForm, {ClayInput} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
+import {sub} from 'frontend-js-web';
 import React, {useRef, useState} from 'react';
 
 export default function ImageInput({name, portletNamespace, previewURL}) {
@@ -72,7 +73,7 @@ export default function ImageInput({name, portletNamespace, previewURL}) {
 								monospaced
 								onClick={() => inputRef.current?.click()}
 								small
-								title={Liferay.Util.sub(
+								title={sub(
 									fileName
 										? Liferay.Language.get('change-x')
 										: Liferay.Language.get('select-x'),

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {debounce, fetch, navigate, openToast} from 'frontend-js-web';
+import {debounce, fetch, navigate, openToast, sub} from 'frontend-js-web';
 
 import {LocaleChangedHandler} from './LocaleChangedHandler.es';
 
@@ -81,7 +81,7 @@ export default function _JournalPortlet({
 
 		if (!titleInputComponent?.getValue(defaultLanguageId)) {
 			showAlert(
-				Liferay.Util.sub(
+				sub(
 					Liferay.Language.get(
 						'please-enter-a-valid-title-for-the-default-language-x'
 					),
@@ -135,7 +135,7 @@ export default function _JournalPortlet({
 		else {
 			if (showErrors) {
 				showAlert(
-					Liferay.Util.sub(
+					sub(
 						Liferay.Language.get(
 							'please-enter-a-valid-title-for-the-default-language-x'
 						),

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/miller_columns/DragPreview.js
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/miller_columns/DragPreview.js
@@ -12,6 +12,7 @@
  * details.
  */
 
+import {sub} from 'frontend-js-web';
 import React, {useEffect, useRef, useState} from 'react';
 import {useDragLayer} from 'react-dnd';
 
@@ -50,12 +51,7 @@ export default function DragPreview({rtl}) {
 	useEffect(() => {
 		if (items) {
 			if (items.length > 1) {
-				setLabel(
-					Liferay.Util.sub(
-						Liferay.Language.get('x-elements'),
-						items.length
-					)
-				);
+				setLabel(sub(Liferay.Language.get('x-elements'), items.length));
 			}
 			else {
 				const [item] = items;

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/openDeleteLayoutModal.js
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/openDeleteLayoutModal.js
@@ -12,6 +12,8 @@
  * details.
  */
 
+import {sub} from 'frontend-js-web';
+
 export default function openDeleteLayoutModal({
 	message,
 	multiple = false,
@@ -37,7 +39,7 @@ export default function openDeleteLayoutModal({
 			},
 		],
 		status: 'danger',
-		title: Liferay.Util.sub(
+		title: sub(
 			Liferay.Language.get('delete-x'),
 			multiple
 				? Liferay.Language.get('pages')

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/modal/openDeletePageTemplateModal.js
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/modal/openDeletePageTemplateModal.js
@@ -12,6 +12,8 @@
  * details.
  */
 
+import {sub} from 'frontend-js-web';
+
 export default function openDeletePageTemplateModal({
 	message,
 	onDelete,
@@ -39,6 +41,6 @@ export default function openDeletePageTemplateModal({
 			},
 		],
 		status: 'danger',
-		title: Liferay.Util.sub(Liferay.Language.get('delete-x'), title),
+		title: sub(Liferay.Language.get('delete-x'), title),
 	});
 }

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/js/MBPortlet.es.js
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/js/MBPortlet.es.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {fetch} from 'frontend-js-web';
+import {fetch, sub} from 'frontend-js-web';
 
 const RECENTLY_REMOVED_ATTACHMENTS = {
 	multiple: Liferay.Language.get('x-recently-removed-attachments'),
@@ -334,7 +334,7 @@ class MBPortlet {
 				if (attachments.deleted.length > 0) {
 					deletedAttachmentsElement.style.display = 'initial';
 					deletedAttachmentsElement.innerHTML =
-						Liferay.Util.sub(
+						sub(
 							attachments.deleted.length > 1
 								? RECENTLY_REMOVED_ATTACHMENTS.multiple
 								: RECENTLY_REMOVED_ATTACHMENTS.single,

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Attachment/Attachment.tsx
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Attachment/Attachment.tsx
@@ -24,7 +24,7 @@ import {
 	FieldChangeEventHandler,
 	ReactFieldBase as FieldBase,
 } from 'dynamic-data-mapping-form-field-type';
-import {openSelectionModal} from 'frontend-js-web';
+import {openSelectionModal, sub} from 'frontend-js-web';
 import React, {ChangeEventHandler, useRef, useState} from 'react';
 
 import './Attachment.scss';
@@ -44,7 +44,7 @@ function validateFileExtension(
 	if (!isValidExtension) {
 		return {
 			displayErrors: true,
-			errorMessage: Liferay.Util.sub(
+			errorMessage: sub(
 				Liferay.Language.get(
 					'please-enter-a-file-with-a-valid-extension-x'
 				),
@@ -63,7 +63,7 @@ function validateFileSize(
 	if (maxFileSize === 0 && fileSize > overallMaximumUploadRequestSize) {
 		return {
 			displayErrors: true,
-			errorMessage: Liferay.Util.sub(
+			errorMessage: sub(
 				Liferay.Language.get(
 					'file-size-is-larger-than-the-allowed-overall-maximum-upload-request-size-x'
 				),
@@ -79,7 +79,7 @@ function validateFileSize(
 	) {
 		return {
 			displayErrors: true,
-			errorMessage: Liferay.Util.sub(
+			errorMessage: sub(
 				Liferay.Language.get(
 					'please-enter-a-file-with-a-valid-file-size-no-larger-than-x'
 				),

--- a/modules/apps/object/object-web/package.json
+++ b/modules/apps/object/object-web/package.json
@@ -3,6 +3,7 @@
 		"@types/codemirror": "^5.60.5",
 		"codemirror": "^5.59.0",
 		"frontend-js-components-web": "*",
+		"frontend-js-web": "*",
 		"text-mask-core": "^5.1.2"
 	},
 	"name": "@liferay/object-web",

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/EditObjectField.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/EditObjectField.tsx
@@ -23,7 +23,7 @@ import {
 	closeSidePanel,
 	openToast,
 } from '@liferay/object-js-components-web';
-import {fetch} from 'frontend-js-web';
+import {fetch, sub} from 'frontend-js-web';
 import React, {useEffect, useMemo, useRef, useState} from 'react';
 import {createTextMaskInputElement} from 'text-mask-core';
 
@@ -376,7 +376,7 @@ function MaxLengthProperties({
 				{settings.showCounter && (
 					<Input
 						error={errors.maxLength}
-						feedbackMessage={Liferay.Util.sub(
+						feedbackMessage={sub(
 							Liferay.Language.get(
 								'set-the-maximum-number-of-characters-accepted-this-value-cant-be-less-than-x-or-greater-than-x'
 							),
@@ -418,7 +418,7 @@ function AttachmentProperties({
 				{settings.showFilesInDocumentsAndMedia && (
 					<Input
 						error={errors.storageDLFolderPath}
-						feedbackMessage={Liferay.Util.sub(
+						feedbackMessage={sub(
 							Liferay.Language.get(
 								'input-the-path-of-the-chosen-folder-in-documents-and-media-an-example-of-a-valid-path-is-x'
 							),

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModalDeleteObjectDefinition.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModalDeleteObjectDefinition.tsx
@@ -14,7 +14,7 @@
 
 import {ClayModalProvider, useModal} from '@clayui/modal';
 import {Observer} from '@clayui/modal/lib/types';
-import {createResourceURL, fetch} from 'frontend-js-web';
+import {createResourceURL, fetch, sub} from 'frontend-js-web';
 import React, {useEffect, useState} from 'react';
 
 import {HEADERS} from '../utils/constants';
@@ -43,7 +43,7 @@ function ModalDeleteObjectDefinition({
 				title={Liferay.Language.get('deletion-not-allowed')}
 			>
 				<div>
-					{Liferay.Util.sub(
+					{sub(
 						Liferay.Language.get(
 							'x-has-active-relationships-and-cannot-be-deleted'
 						),
@@ -52,7 +52,7 @@ function ModalDeleteObjectDefinition({
 				</div>
 
 				<div>
-					{Liferay.Util.sub(
+					{sub(
 						Liferay.Language.get(
 							'to-delete-x,-you-must-first-delete-its-relationships'
 						),
@@ -69,7 +69,7 @@ function ModalDeleteObjectDefinition({
 
 	return code === 0 ? (
 		<DangerModal
-			errorMessage={Liferay.Util.sub(
+			errorMessage={sub(
 				Liferay.Language.get('input-does-not-match-x'),
 				`${name}`
 			)}
@@ -87,7 +87,7 @@ function ModalDeleteObjectDefinition({
 
 			<p
 				dangerouslySetInnerHTML={{
-					__html: Liferay.Util.sub(
+					__html: sub(
 						Liferay.Language.get('x-has-x-object-entries'),
 						`<strong>${name}</strong>`,
 						`${objectEntriesCount}`
@@ -103,7 +103,7 @@ function ModalDeleteObjectDefinition({
 
 			<p
 				dangerouslySetInnerHTML={{
-					__html: Liferay.Util.sub(
+					__html: sub(
 						Liferay.Language.get('please-enter-x-to-confirm'),
 						`<strong>${name}</strong>`
 					),
@@ -156,7 +156,7 @@ export default function ModalWithProvider({
 				objectDefinitionId: itemData.id,
 				p_p_resource_id:
 					'/object_definitions/get_object_definition_delete_info',
-			})
+			}).href
 		);
 
 		const {
@@ -188,7 +188,7 @@ export default function ModalWithProvider({
 
 		if (response.ok) {
 			Liferay.Util.openToast({
-				message: Liferay.Util.sub(
+				message: sub(
 					Liferay.Language.get('x-was-deleted-successfully'),
 					`<strong>${objectDefinition?.name}</strong>`
 				),

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModalDeleteObjectRelationship.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModalDeleteObjectRelationship.tsx
@@ -14,7 +14,7 @@
 
 import {ClayModalProvider, useModal} from '@clayui/modal';
 import {Observer} from '@clayui/modal/lib/types';
-import {fetch} from 'frontend-js-web';
+import {fetch, sub} from 'frontend-js-web';
 import React, {useEffect, useState} from 'react';
 
 import {HEADERS} from '../utils/constants';
@@ -66,7 +66,7 @@ function ModalDeleteObjectRelationship({
 
 			<p
 				dangerouslySetInnerHTML={{
-					__html: Liferay.Util.sub(
+					__html: sub(
 						Liferay.Language.get(
 							'please-type-the-relationship-name-x-to-confirm'
 						),

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectFieldFormBase.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectFieldFormBase.tsx
@@ -23,7 +23,7 @@ import {
 	invalidateRequired,
 	useForm,
 } from '@liferay/object-js-components-web';
-import {fetch} from 'frontend-js-web';
+import {fetch, sub} from 'frontend-js-web';
 import React, {ChangeEventHandler, ReactNode, useMemo, useState} from 'react';
 
 import {HEADERS} from '../utils/constants';
@@ -292,7 +292,7 @@ export function useObjectFieldForm({
 			const lastChar = folderPath[folderPath.length - 1];
 
 			if (forbiddenLastChars?.some((char) => char === lastChar)) {
-				return Liferay.Util.sub(
+				return sub(
 					Liferay.Language.get(
 						'the-folder-name-cannot-end-with-the-following-characters-x'
 					),
@@ -303,7 +303,7 @@ export function useObjectFieldForm({
 			// folder name cannot contain invalid characters
 
 			if (forbiddenChars?.some((symbol) => folderPath.includes(symbol))) {
-				return Liferay.Util.sub(
+				return sub(
 					Liferay.Language.get(
 						'the-folder-name-cannot-contain-the-following-invalid-characters-x'
 					),
@@ -319,7 +319,7 @@ export function useObjectFieldForm({
 				forbiddenNames &&
 				folderPath.split('/').some((name) => reservedNames.has(name))
 			) {
-				return Liferay.Util.sub(
+				return sub(
 					Liferay.Language.get(
 						'the-folder-name-cannot-have-a-reserved-word-such-as-x'
 					),
@@ -367,7 +367,7 @@ export function useObjectFieldForm({
 				errors.maximumFileSize = REQUIRED_MSG;
 			}
 			else if (settings.maximumFileSize > uploadRequestSizeLimit) {
-				errors.maximumFileSize = Liferay.Util.sub(
+				errors.maximumFileSize = sub(
 					Liferay.Language.get(
 						'file-size-is-larger-than-the-allowed-overall-maximum-upload-request-size-x-mb'
 					),
@@ -375,7 +375,7 @@ export function useObjectFieldForm({
 				);
 			}
 			else if (settings.maximumFileSize < 0) {
-				errors.maximumFileSize = Liferay.Util.sub(
+				errors.maximumFileSize = sub(
 					Liferay.Language.get(
 						'only-integers-greater-than-or-equal-to-x-are-allowed'
 					),

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/modules/frontend-js-web.d.ts
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/modules/frontend-js-web.d.ts
@@ -13,19 +13,3 @@
  */
 
 type HTTPMethods = 'GET' | 'POST' | 'DELETE' | 'PUT';
-
-declare module 'frontend-js-web' {
-	function fetch(
-		url: string | Request,
-		options?: {
-			body?: string;
-			headers?: {[key: string]: string} | Headers;
-			method?: HTTPMethods;
-		}
-	): Promise<{
-		json: () => Promise<unknown>;
-		ok: boolean;
-		status: number;
-	}>;
-	const createResourceURL: any;
-}

--- a/modules/apps/object/object-web/tsconfig.json
+++ b/modules/apps/object/object-web/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "cf6d69bd91d21e7955bfb61004d4f3225b130460",
+	"@generated": "e30120567787497c5b17af0ad4a3c5a25f213c20",
 	"@overrides": {
 	},
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT OUTSIDE @overrides **",
@@ -15,6 +15,9 @@
 		"paths": {
 			"frontend-js-components-web": [
 				"../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.d.ts"
+			],
+			"frontend-js-web": [
+				"../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts"
 			]
 		},
 		"sourceMap": false,
@@ -34,6 +37,9 @@
 	"references": [
 		{
 			"path": "../../frontend-js/frontend-js-components-web"
+		},
+		{
+			"path": "../../frontend-js/frontend-js-web"
 		}
 	]
 }

--- a/modules/apps/password-policies-admin/password-policies-admin-web/src/main/resources/META-INF/resources/js/EditPasswordPolicyAssignmentsManagementToolbarPropsTransformer.js
+++ b/modules/apps/password-policies-admin/password-policies-admin-web/src/main/resources/META-INF/resources/js/EditPasswordPolicyAssignmentsManagementToolbarPropsTransformer.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {getCheckedCheckboxes, openSelectionModal} from 'frontend-js-web';
+import {getCheckedCheckboxes, openSelectionModal, sub} from 'frontend-js-web';
 
 function addEntity(portletNamespace, inputName, entity) {
 	const addUserIdsInput = document.getElementById(
@@ -89,7 +89,7 @@ export default function propsTransformer({
 					}
 				},
 				selectEventName: `${portletNamespace}selectMember`,
-				title: Liferay.Util.sub(
+				title: sub(
 					Liferay.Language.get('add-assignees-to-x'),
 					passwordPolicyName
 				),

--- a/modules/apps/portal-search/portal-search-admin-web/src/main/resources/META-INF/resources/js/ExecutionScope.es.js
+++ b/modules/apps/portal-search/portal-search-admin-web/src/main/resources/META-INF/resources/js/ExecutionScope.es.js
@@ -22,6 +22,7 @@ import ClaySticker from '@clayui/sticker';
 import ClayToolbar from '@clayui/toolbar';
 import {ClayTooltipProvider} from '@clayui/tooltip';
 import {ManagementToolbar} from 'frontend-js-components-web';
+import {sub} from 'frontend-js-web';
 import React, {useEffect, useState} from 'react';
 
 const DEFAULT_DELTA = 10;
@@ -164,7 +165,7 @@ function InstanceSelector({selected, setSelected, virtualInstances}) {
 							<ClayToolbar.Section>
 								<span className="component-text text-truncate-inline">
 									<span className="text-truncate">
-										{Liferay.Util.sub(
+										{sub(
 											Liferay.Language.get(
 												'x-instances-selected'
 											),
@@ -235,7 +236,7 @@ function InstanceSelector({selected, setSelected, virtualInstances}) {
 										</ClayList.ItemTitle>
 
 										<ClayList.ItemText>
-											{Liferay.Util.sub(
+											{sub(
 												Liferay.Language.get(
 													'instance-id-x'
 												),

--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/js/ContentOptions.js
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/js/ContentOptions.js
@@ -16,6 +16,7 @@ import ClayButton from '@clayui/button';
 import ClayDropDown from '@clayui/drop-down';
 import ClayForm, {ClaySelectWithOption} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
+import {sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useContext, useState} from 'react';
 
@@ -23,15 +24,15 @@ import {AddPanelContext} from './AddPanel';
 
 const OPTIONS = [
 	{
-		label: Liferay.Util.sub(Liferay.Language.get('x-items'), 4),
+		label: sub(Liferay.Language.get('x-items'), 4),
 		value: 4,
 	},
 	{
-		label: Liferay.Util.sub(Liferay.Language.get('x-items'), 8),
+		label: sub(Liferay.Language.get('x-items'), 8),
 		value: 8,
 	},
 	{
-		label: Liferay.Util.sub(Liferay.Language.get('x-items'), 10),
+		label: sub(Liferay.Language.get('x-items'), 10),
 		value: 10,
 	},
 ];

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/js/LayoutFinder.es.js
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/js/LayoutFinder.es.js
@@ -14,7 +14,7 @@
 
 import ClayIcon from '@clayui/icon';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
-import {fetch, objectToFormData, openToast} from 'frontend-js-web';
+import {fetch, objectToFormData, openToast, sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useCallback, useState} from 'react';
 
@@ -213,7 +213,7 @@ function LayoutFinder(props) {
 					{totalCount > MAX_ITEMS_TO_SHOW && (
 						<div>
 							<div className="mb-3 mt-3 text-center">
-								{Liferay.Util.sub(
+								{sub(
 									Liferay.Language.get(
 										'there-are-x-more-results-narrow-your-searc-to-get-more-precise-results'
 									),

--- a/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/js/DestinationUrlInput.js
+++ b/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/js/DestinationUrlInput.js
@@ -15,6 +15,7 @@
 import {ClayButtonWithIcon} from '@clayui/button';
 import ClayForm, {ClayInput} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
+import {sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
 
@@ -113,7 +114,7 @@ const DestinationUrlInput = ({
 					<div
 						className="small"
 						dangerouslySetInnerHTML={{
-							__html: Liferay.Util.sub(
+							__html: sub(
 								Liferay.Language.get('enter-an-absolute-url'),
 								'<em>',
 								'</em>'

--- a/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/js/GroupLabels.es.js
+++ b/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/js/GroupLabels.es.js
@@ -15,7 +15,7 @@
 import ClayButton from '@clayui/button';
 import ClayIcon from '@clayui/icon';
 import ClayLabel from '@clayui/label';
-import {openSelectionModal} from 'frontend-js-web';
+import {openSelectionModal, sub} from 'frontend-js-web';
 import React, {useEffect, useState} from 'react';
 
 export default function GroupLabels({
@@ -110,7 +110,7 @@ export default function GroupLabels({
 						},
 						selectEventName: `${portletNamespace}selectGroup${target}`,
 						selectedData: groupIds,
-						title: Liferay.Util.sub(
+						title: sub(
 							Liferay.Language.get('select-x'),
 							Liferay.Language.get('site')
 						),

--- a/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/js/add_assignees.js
+++ b/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/js/add_assignees.js
@@ -12,7 +12,12 @@
  * details.
  */
 
-import {createPortletURL, openSelectionModal, postForm} from 'frontend-js-web';
+import {
+	createPortletURL,
+	openSelectionModal,
+	postForm,
+	sub,
+} from 'frontend-js-web';
 
 export default function addAssignees({
 	editRoleAssignmentsURL,
@@ -56,10 +61,7 @@ export default function addAssignees({
 			}
 		},
 		selectEventName: `${portletNamespace}selectAssignees`,
-		title: Liferay.Util.sub(
-			Liferay.Language.get('add-assignees-to-x'),
-			roleName
-		),
+		title: sub(Liferay.Language.get('add-assignees-to-x'), roleName),
 		url: selectAssigneesURL,
 	});
 }

--- a/modules/apps/sharing/sharing-taglib/src/main/resources/META-INF/resources/collaborators/js/components/Collaborators.es.js
+++ b/modules/apps/sharing/sharing-taglib/src/main/resources/META-INF/resources/collaborators/js/components/Collaborators.es.js
@@ -16,7 +16,7 @@ import ClayButton from '@clayui/button';
 import ClayIcon from '@clayui/icon';
 import ClayLayout from '@clayui/layout';
 import ClaySticker from '@clayui/sticker';
-import {fetch} from 'frontend-js-web';
+import {fetch, sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useEffect, useState} from 'react';
 
@@ -78,7 +78,7 @@ const Collaborators = ({
 				<ClayLayout.ContentCol className="collaborators-owner">
 					<div
 						className="lfr-portal-tooltip"
-						data-title={Liferay.Util.sub(
+						data-title={sub(
 							Liferay.Language.get('x-is-the-owner'),
 							owner.fullName
 						)}
@@ -109,13 +109,13 @@ const Collaborators = ({
 									className="lfr-portal-tooltip"
 									data-title={
 										moreCollaboratorsCount === 1
-											? Liferay.Util.sub(
+											? sub(
 													Liferay.Language.get(
 														'x-more-collaborator'
 													),
 													moreCollaboratorsCount
 											  )
-											: Liferay.Util.sub(
+											: sub(
 													Liferay.Language.get(
 														'x-more-collaborators'
 													),

--- a/modules/apps/sharing/sharing-web/src/main/resources/META-INF/resources/manage_collaborators/js/ManageCollaborators.es.js
+++ b/modules/apps/sharing/sharing-web/src/main/resources/META-INF/resources/manage_collaborators/js/ManageCollaborators.es.js
@@ -21,7 +21,7 @@ import ClayLoadingIndicator from '@clayui/loading-indicator';
 import ClaySticker from '@clayui/sticker';
 import {useTimeout} from '@liferay/frontend-js-react-web';
 import classNames from 'classnames';
-import {fetch, objectToFormData} from 'frontend-js-web';
+import {fetch, objectToFormData, sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useEffect, useState} from 'react';
 
@@ -103,7 +103,7 @@ const ManageCollaborators = ({
 	};
 
 	const getTooltipDate = (expirationDate) => {
-		return Liferay.Util.sub(
+		return sub(
 			Liferay.Language.get('until-x'),
 			new Date(expirationDate).toLocaleDateString(
 				Liferay.ThemeDisplay.getBCP47LanguageId()

--- a/modules/apps/sharing/sharing-web/src/main/resources/META-INF/resources/sharing/js/Sharing.es.js
+++ b/modules/apps/sharing/sharing-web/src/main/resources/META-INF/resources/sharing/js/Sharing.es.js
@@ -25,7 +25,7 @@ import ClayIcon from '@clayui/icon';
 import ClayModal from '@clayui/modal';
 import ClayMultiSelect from '@clayui/multi-select';
 import ClaySticker from '@clayui/sticker';
-import {fetch, objectToFormData} from 'frontend-js-web';
+import {fetch, objectToFormData, sub} from 'frontend-js-web';
 import React, {useCallback, useRef, useState} from 'react';
 
 function filterDuplicateItems(items) {
@@ -183,7 +183,7 @@ const Sharing = ({
 
 					if (!isEmailAddressValid(item.value)) {
 						return Promise.resolve({
-							error: Liferay.Util.sub(
+							error: sub(
 								Liferay.Language.get(
 									'x-is-not-a-valid-email-address'
 								),
@@ -202,7 +202,7 @@ const Sharing = ({
 						.then((response) => response.json())
 						.then(({userExists}) => ({
 							error: !userExists
-								? Liferay.Util.sub(
+								? sub(
 										Liferay.Language.get(
 											'user-x-does-not-exist'
 										),

--- a/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/js/openDeleteSiteNavigationMenuModal.js
+++ b/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/js/openDeleteSiteNavigationMenuModal.js
@@ -12,6 +12,8 @@
  * details.
  */
 
+import {sub} from 'frontend-js-web';
+
 export default function openDeleteSiteNavigationMenuModal({
 	multiple = false,
 	onDelete,
@@ -36,7 +38,7 @@ export default function openDeleteSiteNavigationMenuModal({
 			},
 		],
 		status: 'danger',
-		title: Liferay.Util.sub(
+		title: sub(
 			Liferay.Language.get('delete-x'),
 			multiple
 				? Liferay.Language.get('navigation-menus')

--- a/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/site_navigation_menu_editor/components/DragPreview.js
+++ b/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/site_navigation_menu_editor/components/DragPreview.js
@@ -12,6 +12,7 @@
  * details.
  */
 
+import {sub} from 'frontend-js-web';
 import React, {useEffect, useRef, useState} from 'react';
 import {useDragLayer} from 'react-dnd';
 
@@ -67,7 +68,7 @@ export default function DragPreview() {
 
 			setLabel(
 				descendantsCount
-					? Liferay.Util.sub(
+					? sub(
 							Liferay.Language.get('x-elements'),
 							descendantsCount + 1
 					  )

--- a/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/site_navigation_menu_editor/components/MenuItem.js
+++ b/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/site_navigation_menu_editor/components/MenuItem.js
@@ -21,7 +21,7 @@ import ClayLayout from '@clayui/layout';
 import ClayModal, {useModal} from '@clayui/modal';
 import {useIsMounted} from '@liferay/frontend-js-react-web';
 import classNames from 'classnames';
-import {fetch, objectToFormData, openToast} from 'frontend-js-web';
+import {fetch, objectToFormData, openToast, sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
 
@@ -159,7 +159,7 @@ export function MenuItem({item}) {
 					style={itemStyle}
 				>
 					<ClayCheckbox
-						aria-label={Liferay.Util.sub(
+						aria-label={sub(
 							Liferay.Language.get('select-x'),
 							`${title} (${type})`
 						)}
@@ -215,7 +215,7 @@ export function MenuItem({item}) {
 
 								<ClayLayout.ContentCol gutters>
 									<ClayButtonWithIcon
-										aria-label={Liferay.Util.sub(
+										aria-label={sub(
 											Liferay.Language.get('delete-x'),
 											`${title} (${type})`
 										)}

--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/js/openDeleteSiteModal.js
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/js/openDeleteSiteModal.js
@@ -12,6 +12,8 @@
  * details.
  */
 
+import {sub} from 'frontend-js-web';
+
 export default function openDeleteSiteModal({multiple = false, onDelete}) {
 	Liferay.Util.openModal({
 		bodyHTML: Liferay.Language.get(
@@ -35,7 +37,7 @@ export default function openDeleteSiteModal({multiple = false, onDelete}) {
 			},
 		],
 		status: 'danger',
-		title: Liferay.Util.sub(
+		title: sub(
 			Liferay.Language.get('delete-x'),
 			multiple
 				? Liferay.Language.get('sites')

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/js/OrganizationsManagementToolbarPropsTransformer.js
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/js/OrganizationsManagementToolbarPropsTransformer.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {openSelectionModal} from 'frontend-js-web';
+import {openSelectionModal, sub} from 'frontend-js-web';
 
 export default function propsTransformer({portletNamespace, ...otherProps}) {
 	const deleteSelectedOrganizations = () => {
@@ -53,7 +53,7 @@ export default function propsTransformer({portletNamespace, ...otherProps}) {
 					submitForm(addGroupOrganizationsFm);
 				}
 			},
-			title: Liferay.Util.sub(
+			title: sub(
 				Liferay.Language.get('assign-organizations-to-this-x'),
 				itemData?.groupTypeLabel
 			),

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/js/UserGroupsManagementToolbarPropsTransformer.js
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/js/UserGroupsManagementToolbarPropsTransformer.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {addParams, openSelectionModal} from 'frontend-js-web';
+import {addParams, openSelectionModal, sub} from 'frontend-js-web';
 
 export default function propsTransformer({portletNamespace, ...otherProps}) {
 	const deleteSelectedUserGroups = () => {
@@ -98,7 +98,7 @@ export default function propsTransformer({portletNamespace, ...otherProps}) {
 				}
 			},
 			selectEventName: `${portletNamespace}selectUserGroups`,
-			title: Liferay.Util.sub(
+			title: sub(
 				Liferay.Language.get('assign-user-groups-to-this-x'),
 				itemData?.groupTypeLabel
 			),

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/js/UserManagementToolbarPropsTransformer.js
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/js/UserManagementToolbarPropsTransformer.js
@@ -12,7 +12,12 @@
  * details.
  */
 
-import {addParams, getPortletId, openSelectionModal} from 'frontend-js-web';
+import {
+	addParams,
+	getPortletId,
+	openSelectionModal,
+	sub,
+} from 'frontend-js-web';
 
 export default function propsTransformer({portletNamespace, ...otherProps}) {
 	const deleteSelectedUsers = () => {
@@ -96,7 +101,7 @@ export default function propsTransformer({portletNamespace, ...otherProps}) {
 					submitForm(addGroupUsersFm);
 				}
 			},
-			title: Liferay.Util.sub(
+			title: sub(
 				Liferay.Language.get('assign-users-to-this-x'),
 				itemData?.groupTypeLabel
 			),

--- a/modules/apps/style-book/style-book-web/src/main/resources/META-INF/resources/js/openDeleteStyleBookModal.js
+++ b/modules/apps/style-book/style-book-web/src/main/resources/META-INF/resources/js/openDeleteStyleBookModal.js
@@ -12,6 +12,8 @@
  * details.
  */
 
+import {sub} from 'frontend-js-web';
+
 export default function openDeleteStyleBookModal({multiple = false, onDelete}) {
 	Liferay.Util.openModal({
 		bodyHTML: Liferay.Language.get(
@@ -35,7 +37,7 @@ export default function openDeleteStyleBookModal({multiple = false, onDelete}) {
 			},
 		],
 		status: 'danger',
-		title: Liferay.Util.sub(
+		title: sub(
 			Liferay.Language.get('delete-x'),
 			multiple
 				? Liferay.Language.get('style-books')

--- a/modules/apps/style-book/style-book-web/src/main/resources/META-INF/resources/js/style-book-editor/PreviewSelector.js
+++ b/modules/apps/style-book/style-book-web/src/main/resources/META-INF/resources/js/style-book-editor/PreviewSelector.js
@@ -15,6 +15,7 @@
 import ClayButton from '@clayui/button';
 import ClayDropDown, {Align} from '@clayui/drop-down';
 import ClayIcon from '@clayui/icon';
+import {sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useEffect, useState} from 'react';
 
@@ -228,7 +229,7 @@ export function LayoutSelector({layoutType}) {
 				{totalLayouts > recentLayouts.length && (
 					<>
 						<ClayDropDown.Caption>
-							{Liferay.Util.sub(
+							{sub(
 								Liferay.Language.get('showing-x-of-x-items'),
 								recentLayouts.length,
 								totalLayouts

--- a/modules/apps/template/template-web/src/main/resources/META-INF/resources/js/ddm_template_editor/components/Editor.js
+++ b/modules/apps/template/template-web/src/main/resources/META-INF/resources/js/ddm_template_editor/components/Editor.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {openToast} from 'frontend-js-web';
+import {openToast, sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useContext, useEffect, useRef, useState} from 'react';
 
@@ -64,7 +64,7 @@ export function Editor({autocompleteData, initialScript, mode}) {
 				setScript(event.script);
 
 				openToast({
-					message: Liferay.Util.sub(
+					message: sub(
 						Liferay.Language.get('x-imported'),
 						event.fileName
 					),

--- a/modules/apps/template/template-web/src/main/resources/META-INF/resources/js/modal/openDeleteTemplateModal.js
+++ b/modules/apps/template/template-web/src/main/resources/META-INF/resources/js/modal/openDeleteTemplateModal.js
@@ -12,6 +12,8 @@
  * details.
  */
 
+import {sub} from 'frontend-js-web';
+
 export default function openDeleteTemplateModal({multiple = false, onDelete}) {
 	Liferay.Util.openModal({
 		bodyHTML: Liferay.Language.get('are-you-sure-you-want-to-delete-this'),
@@ -33,7 +35,7 @@ export default function openDeleteTemplateModal({multiple = false, onDelete}) {
 			},
 		],
 		status: 'danger',
-		title: Liferay.Util.sub(
+		title: sub(
 			Liferay.Language.get('delete-x'),
 			multiple
 				? Liferay.Language.get('templates')

--- a/modules/apps/user-groups-admin/user-groups-admin-web/src/main/resources/META-INF/resources/js/EditUserGroupAssignmentsManagementToolbarPropsTransformer.js
+++ b/modules/apps/user-groups-admin/user-groups-admin-web/src/main/resources/META-INF/resources/js/EditUserGroupAssignmentsManagementToolbarPropsTransformer.js
@@ -16,6 +16,7 @@ import {
 	getCheckedCheckboxes,
 	openSelectionModal,
 	postForm,
+	sub,
 } from 'frontend-js-web';
 
 export default function propsTransformer({
@@ -44,10 +45,7 @@ export default function propsTransformer({
 				}
 			},
 			selectEventName: `${portletNamespace}selectUsers`,
-			title: Liferay.Util.sub(
-				Liferay.Language.get('add-users-to-x'),
-				userGroupName
-			),
+			title: sub(Liferay.Language.get('add-users-to-x'), userGroupName),
 			url: selectUsersURL,
 		});
 	};

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/js/WikiPortlet.es.js
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/js/WikiPortlet.es.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {fetch} from 'frontend-js-web';
+import {fetch, sub} from 'frontend-js-web';
 
 const CONFIRM_DISCARD_IMAGES = Liferay.Language.get(
 	'uploads-are-in-progress-confirmation'
@@ -132,7 +132,7 @@ class WikiPortlet {
 			formatSelect.selectedIndex
 		].text.trim();
 
-		const confirmMessage = Liferay.Util.sub(
+		const confirmMessage = sub(
 			this._strings.confirmLoseFormatting,
 			this._currentFormatLabel,
 			newFormat

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/D3OrganizationChart.js
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/D3OrganizationChart.js
@@ -10,7 +10,7 @@
  */
 
 import * as d3 from 'd3';
-import {openToast} from 'frontend-js-web';
+import {openToast, sub} from 'frontend-js-web';
 
 import {getAccount} from './data/accounts';
 import {getOrganization} from './data/organizations';
@@ -432,14 +432,14 @@ class D3OrganizationChart {
 
 					const message =
 						nodesToBeMoved.length === 1
-							? Liferay.Util.sub(
+							? sub(
 									Liferay.Language.get(
 										'x-will-be-moved-into-x'
 									),
 									nodesToBeMoved[0].data.name,
 									target.data.name
 							  )
-							: Liferay.Util.sub(
+							: sub(
 									Liferay.Language.get(
 										'x-items-will-be-moved-into-x'
 									),
@@ -490,7 +490,7 @@ class D3OrganizationChart {
 				if (rejectedNodes.length) {
 					rejectedNodes.forEach((node) => {
 						openToast({
-							message: Liferay.Util.sub(
+							message: sub(
 								Liferay.Language.get('x-could-not-be-moved'),
 								node.data.name
 							),

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/menu/AccountMenuContent.js
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/menu/AccountMenuContent.js
@@ -10,6 +10,7 @@
  */
 
 import ClayDropDown from '@clayui/drop-down';
+import {sub} from 'frontend-js-web';
 import React, {useContext} from 'react';
 
 import ChartContext from '../ChartContext';
@@ -22,12 +23,7 @@ export default function AccountMenuContent({closeMenu, data, parentData}) {
 
 	function handleDelete() {
 		if (
-			confirm(
-				Liferay.Util.sub(
-					Liferay.Language.get('x-will-be-deleted'),
-					data.name
-				)
-			)
+			confirm(sub(Liferay.Language.get('x-will-be-deleted'), data.name))
 		) {
 			deleteAccount(data.id).then(() => {
 				chartInstanceRef.current.deleteNodes([data], true);
@@ -40,7 +36,7 @@ export default function AccountMenuContent({closeMenu, data, parentData}) {
 	function handleRemove() {
 		if (
 			confirm(
-				Liferay.Util.sub(
+				sub(
 					Liferay.Language.get('x-will-be-removed-from-x'),
 					data.name,
 					parentData.name

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/menu/OrganizationMenuContent.js
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/menu/OrganizationMenuContent.js
@@ -10,6 +10,7 @@
  */
 
 import ClayDropDown from '@clayui/drop-down';
+import {sub} from 'frontend-js-web';
 import React, {useContext} from 'react';
 
 import ChartContext from '../ChartContext';
@@ -22,12 +23,7 @@ export default function OrganizationMenuContent({closeMenu, data, parentData}) {
 
 	function handleDelete() {
 		if (
-			confirm(
-				Liferay.Util.sub(
-					Liferay.Language.get('x-will-be-deleted'),
-					data.name
-				)
-			)
+			confirm(sub(Liferay.Language.get('x-will-be-deleted'), data.name))
 		) {
 			deleteOrganization(data.id).then(() => {
 				chartInstanceRef.current.deleteNodes([data], true);
@@ -40,7 +36,7 @@ export default function OrganizationMenuContent({closeMenu, data, parentData}) {
 	function handleRemove() {
 		if (
 			confirm(
-				Liferay.Util.sub(
+				sub(
 					Liferay.Language.get('x-will-be-removed-from-x'),
 					data.name,
 					parentData.name

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/menu/UserMenuContent.js
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/menu/UserMenuContent.js
@@ -10,6 +10,7 @@
  */
 
 import ClayDropDown from '@clayui/drop-down';
+import {sub} from 'frontend-js-web';
 import React, {useContext} from 'react';
 
 import ChartContext from '../ChartContext';
@@ -26,12 +27,7 @@ export default function AccountMenuContent({closeMenu, data, parentData}) {
 
 	function handleDelete() {
 		if (
-			confirm(
-				Liferay.Util.sub(
-					Liferay.Language.get('x-will-be-deleted'),
-					data.name
-				)
-			)
+			confirm(sub(Liferay.Language.get('x-will-be-deleted'), data.name))
 		) {
 			deleteUser(data.id).then(() => {
 				chartInstanceRef.current.deleteNodes([data], true);
@@ -44,7 +40,7 @@ export default function AccountMenuContent({closeMenu, data, parentData}) {
 	function handleRemove() {
 		if (
 			confirm(
-				Liferay.Util.sub(
+				sub(
 					Liferay.Language.get('x-will-be-removed-from-x'),
 					data.name,
 					parentData.name

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/modals/AddAccountsModal.js
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/modals/AddAccountsModal.js
@@ -14,7 +14,7 @@ import ClayForm, {ClayInput, ClayRadio, ClayRadioGroup} from '@clayui/form';
 import ClayModal from '@clayui/modal';
 import ClayMultiSelect from '@clayui/multi-select';
 import classNames from 'classnames';
-import {openToast} from 'frontend-js-web';
+import {openToast, sub} from 'frontend-js-web';
 import React, {useContext, useEffect, useMemo, useState} from 'react';
 
 import ChartContext from '../ChartContext';
@@ -22,7 +22,7 @@ import {createAccount, getAccounts, updateAccount} from '../data/accounts';
 
 function showNotFoundError(name) {
 	openToast({
-		message: Liferay.Util.sub(Liferay.Language.get('x-not-found'), name),
+		message: sub(Liferay.Language.get('x-not-found'), name),
 		type: 'danger',
 	});
 }
@@ -73,7 +73,7 @@ export default function AddOrganizationModal({
 			createAccount(newAccountName, [parentData.id])
 				.then((accountData) => {
 					openToast({
-						message: Liferay.Util.sub(
+						message: sub(
 							Liferay.Language.get('1-account-was-added-to-x'),
 							parentData.name
 						),
@@ -133,13 +133,13 @@ export default function AddOrganizationModal({
 
 					const message =
 						nodeChildren.length === 1
-							? Liferay.Util.sub(
+							? sub(
 									Liferay.Language.get(
 										'1-account-was-added-to-x'
 									),
 									parentData.name
 							  )
-							: Liferay.Util.sub(
+							: sub(
 									Liferay.Language.get(
 										'x-accounts-were-added-to-x'
 									),

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/modals/AddOrganizationsModal.js
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/modals/AddOrganizationsModal.js
@@ -15,7 +15,7 @@ import ClayIcon from '@clayui/icon';
 import ClayModal from '@clayui/modal';
 import ClayMultiSelect from '@clayui/multi-select';
 import classNames from 'classnames';
-import {openToast} from 'frontend-js-web';
+import {openToast, sub} from 'frontend-js-web';
 import React, {useContext, useState} from 'react';
 
 import ChartContext from '../ChartContext';
@@ -67,13 +67,13 @@ export default function AddOrganizationModal({
 				if (newOrganizationsDetails.length) {
 					const message =
 						newOrganizationsDetails.length === 1
-							? Liferay.Util.sub(
+							? sub(
 									Liferay.Language.get(
 										'1-organization-was-added-to-x'
 									),
 									parentData.name
 							  )
-							: Liferay.Util.sub(
+							: sub(
 									Liferay.Language.get(
 										'x-organizations-were-added-to-x'
 									),

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/modals/InviteUsersModal.js
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/modals/InviteUsersModal.js
@@ -15,7 +15,7 @@ import ClayIcon from '@clayui/icon';
 import ClayModal from '@clayui/modal';
 import ClayMultiSelect from '@clayui/multi-select';
 import classNames from 'classnames';
-import {openToast} from 'frontend-js-web';
+import {openToast, sub} from 'frontend-js-web';
 import React, {useContext, useEffect, useState} from 'react';
 
 import ChartContext from '../ChartContext';
@@ -64,11 +64,11 @@ export default function InviteUserModal({closeModal, observer, parentData}) {
 			.then((users) => {
 				const message =
 					users.length === 1
-						? Liferay.Util.sub(
+						? sub(
 								Liferay.Language.get('1-user-was-added-to-x'),
 								parentData.name
 						  )
-						: Liferay.Util.sub(
+						: sub(
 								Liferay.Language.get('x-users-were-added-to-x'),
 								users.length,
 								parentData.name

--- a/modules/dxp/apps/commerce/commerce-shop-by-diagram-web/src/main/resources/META-INF/resources/js/DiagramTable/DiagramTable.js
+++ b/modules/dxp/apps/commerce/commerce-shop-by-diagram-web/src/main/resources/META-INF/resources/js/DiagramTable/DiagramTable.js
@@ -18,7 +18,7 @@ import {
 	useCommerceAccount,
 	useCommerceCart,
 } from 'commerce-frontend-js/utilities/hooks';
-import {openToast} from 'frontend-js-web';
+import {openToast, sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 
@@ -280,7 +280,7 @@ function DiagramTable({
 								? Liferay.Language.get(
 										'the-product-was-successfully-added-to-the-cart'
 								  )
-								: Liferay.Util.sub(
+								: sub(
 										Liferay.Language.get(
 											'x-products-were-successfully-added-to-the-cart'
 										),

--- a/modules/dxp/apps/commerce/commerce-shop-by-diagram-web/src/main/resources/META-INF/resources/js/components/StorefrontTooltipContent.js
+++ b/modules/dxp/apps/commerce/commerce-shop-by-diagram-web/src/main/resources/META-INF/resources/js/components/StorefrontTooltipContent.js
@@ -16,6 +16,7 @@ import ClaySticker from '@clayui/sticker';
 import {useIsMounted} from '@liferay/frontend-js-react-web';
 import AddToCart from 'commerce-frontend-js/components/add_to_cart/AddToCart';
 import {isProductPurchasable} from 'commerce-frontend-js/utilities/index';
+import {sub} from 'frontend-js-web';
 import React, {useEffect, useState} from 'react';
 
 import {getCartItems} from '../utilities/data';
@@ -85,7 +86,7 @@ function SkuContent({
 						displayType="warning"
 						title={Liferay.Language.get('alert')}
 					>
-						{Liferay.Util.sub(
+						{sub(
 							Liferay.Language.get('x-has-been-replaced-by-x'),
 							mappedProduct.sku,
 							product.sku


### PR DESCRIPTION
Original PR -> https://github.com/liferay-frontend/liferay-portal/pull/2223

Has been marked ready for manual forward by QA

# Original description

This is a plausible experiment to try and change the approach of doing what the export PR (https://github.com/liferay-frontend/liferay-portal/pull/2133) wanted to do but in a segmented manner.

I've added a few new commits to this PR, fixing the valid CI errors where modules were overriding our `Liferay.Util.sub`, basically not allowing us to do the simple switch to the imported sub.

## A couple hiccups

### The case of object-web defining types

The object-web module is defining types for the utils it is using from `frontend-js-web`, which is kinda weird, but okay. What I did is I removed that whole segment of the file, imported `frontend-js-web` and exported the getResourceURL method in our `frontend-js-web/index.d.ts` type file.

### The possible-impossible swap to imported sub

`ddm-form-web/Report.tsx` is being tested inside `ddm-form-web/test/js/pages/Report.js` where it is assigning a mock function to `Liferay.Util.sub` and I couldn’t figure out a way of making the tests pass with the imported `sub`, atleast without havily modifying the test which isn’t the scope of this task. That’s why I decided to leave the usage as is - using `Liferay.Util.sub` instead of the the imported `sub`.

The same thing is happening in `layout-content-page-editor` has the same testing issues. Gonna need the owners of that module to adapt their tests and probably do the import swap themselves.

Same thing happening inside `translation-web`

## Previous comments

Alright, so the problem with the 2 modules was that they weren't using our new modernized version of `sub` even though they use `Liferay.Util.sub`.

The `segments-experiment-web` is using [this overridden variant of Liferay.Util.sub()](https://github.com/liferay/liferay-portal/blob/master/modules/dxp/apps/segments/segments-experiment-web/jest-setup.config.js).

The `digital-signature-web` is also using some alternate version but I haven't managed to find it. All I know is that our modern `sub` function doesn't get invoked when using `Liferay.Util.sub()` inside of the module.