### PR TITLE
LPS-147197 Update react-dom import, to match spec from React 18

### DIFF
--- a/tools/create_remote_app.sh
+++ b/tools/create_remote_app.sh
@@ -249,7 +249,7 @@ EOF
 
 	cat <<EOF > index.js
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 
 import HelloBar from './routes/hello-bar/pages/HelloBar';
 import HelloFoo from './routes/hello-foo/pages/HelloFoo';
@@ -269,11 +269,14 @@ const App = ({ route }) => {
 };
 
 class WebComponent extends HTMLElement {
+	root = null;
+
 	connectedCallback() {
-		ReactDOM.render(
-			<App route={this.getAttribute("route")} />,
-			this
-		);
+		if (!this.root) {
+      		this.root = createRoot(this);
+
+      		this.root.render(<App route={this.getAttribute("route")} />);
+    	}
 	}
 }
 


### PR DESCRIPTION
Related to: https://liferay.slack.com/archives/C03CAD9EF/p1654837932595909

https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-client-rendering-apis

When we created the remote_app.sh script was thinking for React 17. But then React released version 18 with this breaking change.

https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-client-rendering-apis

The PR solves it