### PR TITLE
Lps 153483

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/filters/absoluteredirects/AbsoluteRedirectsFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/absoluteredirects/AbsoluteRedirectsFilter.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.servlet.filters.absoluteredirects;
 
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.NoSuchVirtualHostException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -26,6 +27,7 @@ import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.servlet.filters.BasePortalFilter;
 import com.liferay.portal.util.PortalInstances;
+import com.liferay.portal.util.PropsValues;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -61,10 +63,19 @@ public class AbsoluteRedirectsFilter
 		// Company id needs to always be called here so that it's properly set
 		// in subsequent calls
 
-		long companyId = PortalInstances.getCompanyId(httpServletRequest);
+		try {
+			PortalInstances.getCompanyId(
+				httpServletRequest, PropsValues.VIRTUAL_HOSTS_STRICT_ACCESS);
+		}
+		catch (NoSuchVirtualHostException noSuchVirtualHostException) {
+			_log.error(noSuchVirtualHostException);
 
-		if (_log.isDebugEnabled()) {
-			_log.debug("Company id " + companyId);
+			httpServletRequest.setAttribute(
+				WebKeys.UNKNOWN_VIRTUAL_HOST, Boolean.TRUE);
+
+			httpServletResponse.sendError(HttpServletResponse.SC_NOT_FOUND);
+
+			return null;
 		}
 
 		PortalUtil.getCurrentCompleteURL(httpServletRequest);

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -2556,6 +2556,10 @@ public class PropsValues {
 	public static final String[] VIRTUAL_HOSTS_IGNORE_EXTENSIONS =
 		PropsUtil.getArray(PropsKeys.VIRTUAL_HOSTS_IGNORE_EXTENSIONS);
 
+	public static final boolean VIRTUAL_HOSTS_STRICT_ACCESS =
+		GetterUtil.getBoolean(
+			PropsUtil.get(PropsKeys.VIRTUAL_HOSTS_STRICT_ACCESS));
+
 	public static final String[] VIRTUAL_HOSTS_VALID_HOSTS = PropsUtil.getArray(
 		PropsKeys.VIRTUAL_HOSTS_VALID_HOSTS);
 

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -8746,6 +8746,16 @@
     virtual.hosts.valid.hosts=*
     #virtual.hosts.valid.hosts=localhost,127.0.0.1,[::1],[0:0:0:0:0:0:0:1]
 
+    #
+    # Set this to true to enable strict virtual host access. When disabled,
+    # portal falls back to default virtual host when request comes through
+    # invalid virtual host. When enabled, portal shows 404 page when request
+    # comes through invalid virtual host.
+    #
+    # Env: LIFERAY_VIRTUAL_PERIOD_HOSTS_PERIOD_STRICT_PERIOD_ACCESS
+    #
+    virtual.hosts.strict.access=false
+
 ##
 ## Work Directory
 ##

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -2948,6 +2948,9 @@ public interface PropsKeys {
 	public static final String VIRTUAL_HOSTS_IGNORE_PATHS =
 		"virtual.hosts.ignore.paths";
 
+	public static final String VIRTUAL_HOSTS_STRICT_ACCESS =
+		"virtual.hosts.strict.access";
+
 	public static final String VIRTUAL_HOSTS_VALID_HOSTS =
 		"virtual.hosts.valid.hosts";
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/WebKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/WebKeys.java
@@ -675,6 +675,8 @@ public interface WebKeys {
 	public static final String UNIQUE_ELEMENT_IDS =
 		"LIFERAY_SHARED_UNIQUE_ELEMENT_IDS";
 
+	public static final String UNKNOWN_VIRTUAL_HOST = "UNKNOWN_VIRTUAL_HOST";
+
 	public static final String UPLOAD_EXCEPTION = "UPLOAD_EXCEPTION";
 
 	public static final String USER = "USER";

--- a/portal-web/docroot/errors/code.jsp
+++ b/portal-web/docroot/errors/code.jsp
@@ -43,6 +43,9 @@ String xRequestWith = request.getHeader(HttpHeaders.X_REQUESTED_WITH);
 %>
 
 <c:choose>
+	<c:when test="<%= GetterUtil.getBoolean(request.getAttribute(WebKeys.UNKNOWN_VIRTUAL_HOST)) %>">
+		Unknown virtual host name : <%= PortalUtil.getHost(request) %>
+	</c:when>
 	<c:when test="<%= !Validator.isBlank(dynamicIncludeKey) %>">
 		<liferay-util:dynamic-include key="<%= dynamicIncludeKey %>" />
 	</c:when>

--- a/portal-web/docroot/errors/init.jsp
+++ b/portal-web/docroot/errors/init.jsp
@@ -25,6 +25,7 @@ page import="com.liferay.portal.kernel.log.Log" %><%@
 page import="com.liferay.portal.kernel.log.LogFactoryUtil" %><%@
 page import="com.liferay.portal.kernel.model.LayoutSet" %><%@
 page import="com.liferay.portal.kernel.servlet.HttpHeaders" %><%@
+page import="com.liferay.portal.kernel.util.GetterUtil" %><%@
 page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
 page import="com.liferay.portal.kernel.util.JavaConstants" %><%@
 page import="com.liferay.portal.kernel.util.PortalUtil" %><%@


### PR DESCRIPTION
@david-truong to turn this on, set "virtual.hosts.strict.access=true" in portal-ext.properties
Then you can only access the portal via existing virtual hosts, except hosts listed in "virtual.hosts.ignore.hosts" portal property which is an existing one not added in this pull. Its default value is ```    virtual.hosts.ignore.hosts=\
        127.0.0.1,\
        localhost```
This means if someone messes up with virtual.hosts.ignore.hosts initially, then portal won't be accessible anymore. Use this with caution.