### PR TITLE
LPS-155870 Optimize VulcanBatchEngineTaskItemDelegate implementation to improve Import / Export capabilities

### DIFF
--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountAddressResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountAddressResourceImpl.java
@@ -704,6 +704,9 @@ public abstract class BaseAccountAddressResourceImpl
 			java.util.Collection<AccountAddress> accountAddresses,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -750,7 +753,8 @@ public abstract class BaseAccountAddressResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountMemberResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountMemberResourceImpl.java
@@ -539,6 +539,9 @@ public abstract class BaseAccountMemberResourceImpl
 			java.util.Collection<AccountMember> accountMembers,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -546,6 +549,9 @@ public abstract class BaseAccountMemberResourceImpl
 			java.util.Collection<AccountMember> accountMembers,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -581,7 +587,8 @@ public abstract class BaseAccountMemberResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -611,6 +618,9 @@ public abstract class BaseAccountMemberResourceImpl
 			java.util.Collection<AccountMember> accountMembers,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountOrganizationResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountOrganizationResourceImpl.java
@@ -470,6 +470,9 @@ public abstract class BaseAccountOrganizationResourceImpl
 			java.util.Collection<AccountOrganization> accountOrganizations,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -477,6 +480,9 @@ public abstract class BaseAccountOrganizationResourceImpl
 			java.util.Collection<AccountOrganization> accountOrganizations,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -512,7 +518,8 @@ public abstract class BaseAccountOrganizationResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -542,6 +549,9 @@ public abstract class BaseAccountOrganizationResourceImpl
 			java.util.Collection<AccountOrganization> accountOrganizations,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseAttachmentResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseAttachmentResourceImpl.java
@@ -678,6 +678,9 @@ public abstract class BaseAttachmentResourceImpl
 			java.util.Collection<Attachment> attachments,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -685,6 +688,9 @@ public abstract class BaseAttachmentResourceImpl
 			java.util.Collection<Attachment> attachments,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -720,7 +726,8 @@ public abstract class BaseAttachmentResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -750,6 +757,9 @@ public abstract class BaseAttachmentResourceImpl
 			java.util.Collection<Attachment> attachments,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseCategoryResourceImpl.java
@@ -225,6 +225,9 @@ public abstract class BaseCategoryResourceImpl
 			java.util.Collection<Category> categories,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -232,6 +235,9 @@ public abstract class BaseCategoryResourceImpl
 			java.util.Collection<Category> categories,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -267,7 +273,8 @@ public abstract class BaseCategoryResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -297,6 +304,9 @@ public abstract class BaseCategoryResourceImpl
 			java.util.Collection<Category> categories,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseMappedProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseMappedProductResourceImpl.java
@@ -452,6 +452,9 @@ public abstract class BaseMappedProductResourceImpl
 			java.util.Collection<MappedProduct> mappedProducts,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -498,7 +501,8 @@ public abstract class BaseMappedProductResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseOptionCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseOptionCategoryResourceImpl.java
@@ -413,7 +413,8 @@ public abstract class BaseOptionCategoryResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseOptionValueResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseOptionValueResourceImpl.java
@@ -543,6 +543,9 @@ public abstract class BaseOptionValueResourceImpl
 			java.util.Collection<OptionValue> optionValues,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -589,7 +592,8 @@ public abstract class BaseOptionValueResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BasePinResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BasePinResourceImpl.java
@@ -352,6 +352,9 @@ public abstract class BasePinResourceImpl
 			java.util.Collection<Pin> pins,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -398,7 +401,8 @@ public abstract class BasePinResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductAccountGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductAccountGroupResourceImpl.java
@@ -284,6 +284,9 @@ public abstract class BaseProductAccountGroupResourceImpl
 			java.util.Collection<ProductAccountGroup> productAccountGroups,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -330,7 +333,8 @@ public abstract class BaseProductAccountGroupResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -360,6 +364,9 @@ public abstract class BaseProductAccountGroupResourceImpl
 			java.util.Collection<ProductAccountGroup> productAccountGroups,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductChannelResourceImpl.java
@@ -274,6 +274,9 @@ public abstract class BaseProductChannelResourceImpl
 			java.util.Collection<ProductChannel> productChannels,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -320,7 +323,8 @@ public abstract class BaseProductChannelResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -350,6 +354,9 @@ public abstract class BaseProductChannelResourceImpl
 			java.util.Collection<ProductChannel> productChannels,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductGroupProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductGroupProductResourceImpl.java
@@ -380,6 +380,9 @@ public abstract class BaseProductGroupProductResourceImpl
 			java.util.Collection<ProductGroupProduct> productGroupProducts,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -426,7 +429,8 @@ public abstract class BaseProductGroupProductResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -456,6 +460,9 @@ public abstract class BaseProductGroupProductResourceImpl
 			java.util.Collection<ProductGroupProduct> productGroupProducts,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductOptionResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductOptionResourceImpl.java
@@ -408,6 +408,9 @@ public abstract class BaseProductOptionResourceImpl
 			java.util.Collection<ProductOption> productOptions,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -454,7 +457,8 @@ public abstract class BaseProductOptionResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductOptionValueResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductOptionValueResourceImpl.java
@@ -215,6 +215,9 @@ public abstract class BaseProductOptionValueResourceImpl
 			java.util.Collection<ProductOptionValue> productOptionValues,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -222,6 +225,9 @@ public abstract class BaseProductOptionValueResourceImpl
 			java.util.Collection<ProductOptionValue> productOptionValues,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -257,7 +263,8 @@ public abstract class BaseProductOptionValueResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -287,6 +294,9 @@ public abstract class BaseProductOptionValueResourceImpl
 			java.util.Collection<ProductOptionValue> productOptionValues,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductSpecificationResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductSpecificationResourceImpl.java
@@ -209,6 +209,9 @@ public abstract class BaseProductSpecificationResourceImpl
 			java.util.Collection<ProductSpecification> productSpecifications,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -216,6 +219,9 @@ public abstract class BaseProductSpecificationResourceImpl
 			java.util.Collection<ProductSpecification> productSpecifications,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -251,7 +257,8 @@ public abstract class BaseProductSpecificationResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -281,6 +288,9 @@ public abstract class BaseProductSpecificationResourceImpl
 			java.util.Collection<ProductSpecification> productSpecifications,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseRelatedProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseRelatedProductResourceImpl.java
@@ -414,6 +414,9 @@ public abstract class BaseRelatedProductResourceImpl
 			java.util.Collection<RelatedProduct> relatedProducts,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -460,7 +463,8 @@ public abstract class BaseRelatedProductResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -490,6 +494,9 @@ public abstract class BaseRelatedProductResourceImpl
 			java.util.Collection<RelatedProduct> relatedProducts,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseSkuResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseSkuResourceImpl.java
@@ -561,6 +561,9 @@ public abstract class BaseSkuResourceImpl
 			java.util.Collection<Sku> skus,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BasePaymentMethodGroupRelOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BasePaymentMethodGroupRelOrderTypeResourceImpl.java
@@ -264,6 +264,9 @@ public abstract class BasePaymentMethodGroupRelOrderTypeResourceImpl
 				paymentMethodGroupRelOrderTypes,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -315,7 +318,8 @@ public abstract class BasePaymentMethodGroupRelOrderTypeResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -346,6 +350,9 @@ public abstract class BasePaymentMethodGroupRelOrderTypeResourceImpl
 				paymentMethodGroupRelOrderTypes,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BasePaymentMethodGroupRelTermResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BasePaymentMethodGroupRelTermResourceImpl.java
@@ -262,6 +262,9 @@ public abstract class BasePaymentMethodGroupRelTermResourceImpl
 				paymentMethodGroupRelTerms,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -312,7 +315,8 @@ public abstract class BasePaymentMethodGroupRelTermResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -343,6 +347,9 @@ public abstract class BasePaymentMethodGroupRelTermResourceImpl
 				paymentMethodGroupRelTerms,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseShippingFixedOptionOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseShippingFixedOptionOrderTypeResourceImpl.java
@@ -263,6 +263,9 @@ public abstract class BaseShippingFixedOptionOrderTypeResourceImpl
 				shippingFixedOptionOrderTypes,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -314,7 +317,8 @@ public abstract class BaseShippingFixedOptionOrderTypeResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -345,6 +349,9 @@ public abstract class BaseShippingFixedOptionOrderTypeResourceImpl
 				shippingFixedOptionOrderTypes,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseShippingFixedOptionTermResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseShippingFixedOptionTermResourceImpl.java
@@ -262,6 +262,9 @@ public abstract class BaseShippingFixedOptionTermResourceImpl
 				shippingFixedOptionTerms,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -312,7 +315,8 @@ public abstract class BaseShippingFixedOptionTermResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -343,6 +347,9 @@ public abstract class BaseShippingFixedOptionTermResourceImpl
 				shippingFixedOptionTerms,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseShippingMethodResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseShippingMethodResourceImpl.java
@@ -176,7 +176,7 @@ public abstract class BaseShippingMethodResourceImpl
 		}
 		else {
 			throw new NotSupportedException(
-				"One of the following parameters must be informed: [channelId]");
+				"One of the following parameters must be specified: [channelId]");
 		}
 	}
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseShippingMethodResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseShippingMethodResourceImpl.java
@@ -56,6 +56,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.UriInfo;
@@ -120,6 +121,9 @@ public abstract class BaseShippingMethodResourceImpl
 			java.util.Collection<ShippingMethod> shippingMethods,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -127,6 +131,9 @@ public abstract class BaseShippingMethodResourceImpl
 			java.util.Collection<ShippingMethod> shippingMethods,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -162,8 +169,15 @@ public abstract class BaseShippingMethodResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return getChannelShippingMethodsPage(
-			Long.parseLong((String)parameters.get("channelId")), pagination);
+		if (parameters.containsKey("channelId")) {
+			return getChannelShippingMethodsPage(
+				Long.parseLong((String)parameters.get("channelId")),
+				pagination);
+		}
+		else {
+			throw new NotSupportedException(
+				"One of the following parameters must be informed: [channelId]");
+		}
 	}
 
 	@Override
@@ -193,6 +207,9 @@ public abstract class BaseShippingMethodResourceImpl
 			java.util.Collection<ShippingMethod> shippingMethods,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseTaxCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseTaxCategoryResourceImpl.java
@@ -143,6 +143,9 @@ public abstract class BaseTaxCategoryResourceImpl
 			java.util.Collection<TaxCategory> taxCategories,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -150,6 +153,9 @@ public abstract class BaseTaxCategoryResourceImpl
 			java.util.Collection<TaxCategory> taxCategories,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -185,7 +191,8 @@ public abstract class BaseTaxCategoryResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -215,6 +222,9 @@ public abstract class BaseTaxCategoryResourceImpl
 			java.util.Collection<TaxCategory> taxCategories,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/BaseWarehouseItemResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/BaseWarehouseItemResourceImpl.java
@@ -575,6 +575,9 @@ public abstract class BaseWarehouseItemResourceImpl
 			java.util.Collection<WarehouseItem> warehouseItems,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -621,7 +624,8 @@ public abstract class BaseWarehouseItemResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/BaseWarehouseResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/BaseWarehouseResourceImpl.java
@@ -330,6 +330,9 @@ public abstract class BaseWarehouseResourceImpl
 			java.util.Collection<Warehouse> warehouses,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -337,6 +340,9 @@ public abstract class BaseWarehouseResourceImpl
 			java.util.Collection<Warehouse> warehouses,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -402,6 +408,9 @@ public abstract class BaseWarehouseResourceImpl
 			java.util.Collection<Warehouse> warehouses,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderNoteResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderNoteResourceImpl.java
@@ -519,6 +519,9 @@ public abstract class BaseOrderNoteResourceImpl
 			java.util.Collection<OrderNote> orderNotes,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -565,7 +568,8 @@ public abstract class BaseOrderNoteResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleAccountGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleAccountGroupResourceImpl.java
@@ -380,6 +380,9 @@ public abstract class BaseOrderRuleAccountGroupResourceImpl
 			java.util.Collection<OrderRuleAccountGroup> orderRuleAccountGroups,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -429,7 +432,8 @@ public abstract class BaseOrderRuleAccountGroupResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -459,6 +463,9 @@ public abstract class BaseOrderRuleAccountGroupResourceImpl
 			java.util.Collection<OrderRuleAccountGroup> orderRuleAccountGroups,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleAccountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleAccountResourceImpl.java
@@ -369,6 +369,9 @@ public abstract class BaseOrderRuleAccountResourceImpl
 			java.util.Collection<OrderRuleAccount> orderRuleAccounts,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -415,7 +418,8 @@ public abstract class BaseOrderRuleAccountResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -445,6 +449,9 @@ public abstract class BaseOrderRuleAccountResourceImpl
 			java.util.Collection<OrderRuleAccount> orderRuleAccounts,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleChannelResourceImpl.java
@@ -377,6 +377,9 @@ public abstract class BaseOrderRuleChannelResourceImpl
 			java.util.Collection<OrderRuleChannel> orderRuleChannels,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -423,7 +426,8 @@ public abstract class BaseOrderRuleChannelResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -453,6 +457,9 @@ public abstract class BaseOrderRuleChannelResourceImpl
 			java.util.Collection<OrderRuleChannel> orderRuleChannels,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleOrderTypeResourceImpl.java
@@ -367,6 +367,9 @@ public abstract class BaseOrderRuleOrderTypeResourceImpl
 			java.util.Collection<OrderRuleOrderType> orderRuleOrderTypes,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -414,7 +417,8 @@ public abstract class BaseOrderRuleOrderTypeResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -444,6 +448,9 @@ public abstract class BaseOrderRuleOrderTypeResourceImpl
 			java.util.Collection<OrderRuleOrderType> orderRuleOrderTypes,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderTypeChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderTypeChannelResourceImpl.java
@@ -372,6 +372,9 @@ public abstract class BaseOrderTypeChannelResourceImpl
 			java.util.Collection<OrderTypeChannel> orderTypeChannels,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -418,7 +421,8 @@ public abstract class BaseOrderTypeChannelResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -448,6 +452,9 @@ public abstract class BaseOrderTypeChannelResourceImpl
 			java.util.Collection<OrderTypeChannel> orderTypeChannels,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseTermOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseTermOrderTypeResourceImpl.java
@@ -365,6 +365,9 @@ public abstract class BaseTermOrderTypeResourceImpl
 			java.util.Collection<TermOrderType> termOrderTypes,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -411,7 +414,8 @@ public abstract class BaseTermOrderTypeResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -441,6 +445,9 @@ public abstract class BaseTermOrderTypeResourceImpl
 			java.util.Collection<TermOrderType> termOrderTypes,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountAccountGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountAccountGroupResourceImpl.java
@@ -384,6 +384,9 @@ public abstract class BaseDiscountAccountGroupResourceImpl
 			java.util.Collection<DiscountAccountGroup> discountAccountGroups,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -432,7 +435,8 @@ public abstract class BaseDiscountAccountGroupResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -462,6 +466,9 @@ public abstract class BaseDiscountAccountGroupResourceImpl
 			java.util.Collection<DiscountAccountGroup> discountAccountGroups,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountCategoryResourceImpl.java
@@ -369,6 +369,9 @@ public abstract class BaseDiscountCategoryResourceImpl
 			java.util.Collection<DiscountCategory> discountCategories,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -415,7 +418,8 @@ public abstract class BaseDiscountCategoryResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -445,6 +449,9 @@ public abstract class BaseDiscountCategoryResourceImpl
 			java.util.Collection<DiscountCategory> discountCategories,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountProductResourceImpl.java
@@ -369,6 +369,9 @@ public abstract class BaseDiscountProductResourceImpl
 			java.util.Collection<DiscountProduct> discountProducts,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -415,7 +418,8 @@ public abstract class BaseDiscountProductResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -445,6 +449,9 @@ public abstract class BaseDiscountProductResourceImpl
 			java.util.Collection<DiscountProduct> discountProducts,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountRuleResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountRuleResourceImpl.java
@@ -418,6 +418,9 @@ public abstract class BaseDiscountRuleResourceImpl
 			java.util.Collection<DiscountRule> discountRules,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -464,7 +467,8 @@ public abstract class BaseDiscountRuleResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BasePriceEntryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BasePriceEntryResourceImpl.java
@@ -519,6 +519,9 @@ public abstract class BasePriceEntryResourceImpl
 			java.util.Collection<PriceEntry> priceEntries,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -565,7 +568,8 @@ public abstract class BasePriceEntryResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BasePriceListAccountGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BasePriceListAccountGroupResourceImpl.java
@@ -385,6 +385,9 @@ public abstract class BasePriceListAccountGroupResourceImpl
 			java.util.Collection<PriceListAccountGroup> priceListAccountGroups,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -433,7 +436,8 @@ public abstract class BasePriceListAccountGroupResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -463,6 +467,9 @@ public abstract class BasePriceListAccountGroupResourceImpl
 			java.util.Collection<PriceListAccountGroup> priceListAccountGroups,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseTierPriceResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseTierPriceResourceImpl.java
@@ -519,6 +519,9 @@ public abstract class BaseTierPriceResourceImpl
 			java.util.Collection<TierPrice> tierPrices,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -565,7 +568,8 @@ public abstract class BaseTierPriceResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountAccountGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountAccountGroupResourceImpl.java
@@ -391,6 +391,9 @@ public abstract class BaseDiscountAccountGroupResourceImpl
 			java.util.Collection<DiscountAccountGroup> discountAccountGroups,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -440,7 +443,8 @@ public abstract class BaseDiscountAccountGroupResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -470,6 +474,9 @@ public abstract class BaseDiscountAccountGroupResourceImpl
 			java.util.Collection<DiscountAccountGroup> discountAccountGroups,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountAccountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountAccountResourceImpl.java
@@ -376,6 +376,9 @@ public abstract class BaseDiscountAccountResourceImpl
 			java.util.Collection<DiscountAccount> discountAccounts,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -422,7 +425,8 @@ public abstract class BaseDiscountAccountResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -452,6 +456,9 @@ public abstract class BaseDiscountAccountResourceImpl
 			java.util.Collection<DiscountAccount> discountAccounts,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountCategoryResourceImpl.java
@@ -376,6 +376,9 @@ public abstract class BaseDiscountCategoryResourceImpl
 			java.util.Collection<DiscountCategory> discountCategories,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -422,7 +425,8 @@ public abstract class BaseDiscountCategoryResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -452,6 +456,9 @@ public abstract class BaseDiscountCategoryResourceImpl
 			java.util.Collection<DiscountCategory> discountCategories,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountChannelResourceImpl.java
@@ -376,6 +376,9 @@ public abstract class BaseDiscountChannelResourceImpl
 			java.util.Collection<DiscountChannel> discountChannels,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -422,7 +425,8 @@ public abstract class BaseDiscountChannelResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -452,6 +456,9 @@ public abstract class BaseDiscountChannelResourceImpl
 			java.util.Collection<DiscountChannel> discountChannels,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountOrderTypeResourceImpl.java
@@ -377,6 +377,9 @@ public abstract class BaseDiscountOrderTypeResourceImpl
 			java.util.Collection<DiscountOrderType> discountOrderTypes,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -423,7 +426,8 @@ public abstract class BaseDiscountOrderTypeResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -453,6 +457,9 @@ public abstract class BaseDiscountOrderTypeResourceImpl
 			java.util.Collection<DiscountOrderType> discountOrderTypes,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountProductGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountProductGroupResourceImpl.java
@@ -391,6 +391,9 @@ public abstract class BaseDiscountProductGroupResourceImpl
 			java.util.Collection<DiscountProductGroup> discountProductGroups,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -440,7 +443,8 @@ public abstract class BaseDiscountProductGroupResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -470,6 +474,9 @@ public abstract class BaseDiscountProductGroupResourceImpl
 			java.util.Collection<DiscountProductGroup> discountProductGroups,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountProductResourceImpl.java
@@ -376,6 +376,9 @@ public abstract class BaseDiscountProductResourceImpl
 			java.util.Collection<DiscountProduct> discountProducts,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -422,7 +425,8 @@ public abstract class BaseDiscountProductResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -452,6 +456,9 @@ public abstract class BaseDiscountProductResourceImpl
 			java.util.Collection<DiscountProduct> discountProducts,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountRuleResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountRuleResourceImpl.java
@@ -429,6 +429,9 @@ public abstract class BaseDiscountRuleResourceImpl
 			java.util.Collection<DiscountRule> discountRules,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -475,7 +478,8 @@ public abstract class BaseDiscountRuleResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountSkuResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountSkuResourceImpl.java
@@ -361,6 +361,9 @@ public abstract class BaseDiscountSkuResourceImpl
 			java.util.Collection<DiscountSku> discountSkus,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -407,7 +410,8 @@ public abstract class BaseDiscountSkuResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -437,6 +441,9 @@ public abstract class BaseDiscountSkuResourceImpl
 			java.util.Collection<DiscountSku> discountSkus,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceEntryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceEntryResourceImpl.java
@@ -520,6 +520,9 @@ public abstract class BasePriceEntryResourceImpl
 			java.util.Collection<PriceEntry> priceEntries,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -566,7 +569,8 @@ public abstract class BasePriceEntryResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListAccountGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListAccountGroupResourceImpl.java
@@ -380,6 +380,9 @@ public abstract class BasePriceListAccountGroupResourceImpl
 			java.util.Collection<PriceListAccountGroup> priceListAccountGroups,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -429,7 +432,8 @@ public abstract class BasePriceListAccountGroupResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -459,6 +463,9 @@ public abstract class BasePriceListAccountGroupResourceImpl
 			java.util.Collection<PriceListAccountGroup> priceListAccountGroups,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListAccountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListAccountResourceImpl.java
@@ -369,6 +369,9 @@ public abstract class BasePriceListAccountResourceImpl
 			java.util.Collection<PriceListAccount> priceListAccounts,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -415,7 +418,8 @@ public abstract class BasePriceListAccountResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -445,6 +449,9 @@ public abstract class BasePriceListAccountResourceImpl
 			java.util.Collection<PriceListAccount> priceListAccounts,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListChannelResourceImpl.java
@@ -377,6 +377,9 @@ public abstract class BasePriceListChannelResourceImpl
 			java.util.Collection<PriceListChannel> priceListChannels,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -423,7 +426,8 @@ public abstract class BasePriceListChannelResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -453,6 +457,9 @@ public abstract class BasePriceListChannelResourceImpl
 			java.util.Collection<PriceListChannel> priceListChannels,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListDiscountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListDiscountResourceImpl.java
@@ -360,6 +360,9 @@ public abstract class BasePriceListDiscountResourceImpl
 			java.util.Collection<PriceListDiscount> priceListDiscounts,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -406,7 +409,8 @@ public abstract class BasePriceListDiscountResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -436,6 +440,9 @@ public abstract class BasePriceListDiscountResourceImpl
 			java.util.Collection<PriceListDiscount> priceListDiscounts,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListOrderTypeResourceImpl.java
@@ -359,6 +359,9 @@ public abstract class BasePriceListOrderTypeResourceImpl
 			java.util.Collection<PriceListOrderType> priceListOrderTypes,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -406,7 +409,8 @@ public abstract class BasePriceListOrderTypeResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -436,6 +440,9 @@ public abstract class BasePriceListOrderTypeResourceImpl
 			java.util.Collection<PriceListOrderType> priceListOrderTypes,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceModifierCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceModifierCategoryResourceImpl.java
@@ -394,6 +394,9 @@ public abstract class BasePriceModifierCategoryResourceImpl
 			java.util.Collection<PriceModifierCategory> priceModifierCategories,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -443,7 +446,8 @@ public abstract class BasePriceModifierCategoryResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -473,6 +477,9 @@ public abstract class BasePriceModifierCategoryResourceImpl
 			java.util.Collection<PriceModifierCategory> priceModifierCategories,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceModifierProductGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceModifierProductGroupResourceImpl.java
@@ -399,6 +399,9 @@ public abstract class BasePriceModifierProductGroupResourceImpl
 				priceModifierProductGroups,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -449,7 +452,8 @@ public abstract class BasePriceModifierProductGroupResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -480,6 +484,9 @@ public abstract class BasePriceModifierProductGroupResourceImpl
 				priceModifierProductGroups,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceModifierProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceModifierProductResourceImpl.java
@@ -393,6 +393,9 @@ public abstract class BasePriceModifierProductResourceImpl
 			java.util.Collection<PriceModifierProduct> priceModifierProducts,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -442,7 +445,8 @@ public abstract class BasePriceModifierProductResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -472,6 +476,9 @@ public abstract class BasePriceModifierProductResourceImpl
 			java.util.Collection<PriceModifierProduct> priceModifierProducts,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceModifierResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceModifierResourceImpl.java
@@ -553,6 +553,9 @@ public abstract class BasePriceModifierResourceImpl
 			java.util.Collection<PriceModifier> priceModifiers,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -599,7 +602,8 @@ public abstract class BasePriceModifierResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseTierPriceResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseTierPriceResourceImpl.java
@@ -514,6 +514,9 @@ public abstract class BaseTierPriceResourceImpl
 			java.util.Collection<TierPrice> tierPrices,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -560,7 +563,8 @@ public abstract class BaseTierPriceResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/BaseShipmentItemResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/BaseShipmentItemResourceImpl.java
@@ -454,6 +454,9 @@ public abstract class BaseShipmentItemResourceImpl
 			java.util.Collection<ShipmentItem> shipmentItems,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -500,7 +503,8 @@ public abstract class BaseShipmentItemResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseAvailabilityEstimateResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseAvailabilityEstimateResourceImpl.java
@@ -378,6 +378,9 @@ public abstract class BaseAvailabilityEstimateResourceImpl
 			java.util.Collection<AvailabilityEstimate> availabilityEstimates,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -426,7 +429,8 @@ public abstract class BaseAvailabilityEstimateResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseTaxCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseTaxCategoryResourceImpl.java
@@ -344,6 +344,9 @@ public abstract class BaseTaxCategoryResourceImpl
 			java.util.Collection<TaxCategory> taxCategories,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -390,7 +393,8 @@ public abstract class BaseTaxCategoryResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseWarehouseResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseWarehouseResourceImpl.java
@@ -351,6 +351,9 @@ public abstract class BaseWarehouseResourceImpl
 			java.util.Collection<Warehouse> warehouses,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -397,7 +400,8 @@ public abstract class BaseWarehouseResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartCommentResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartCommentResourceImpl.java
@@ -383,6 +383,9 @@ public abstract class BaseCartCommentResourceImpl
 			java.util.Collection<CartComment> cartComments,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -429,7 +432,8 @@ public abstract class BaseCartCommentResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartItemResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartItemResourceImpl.java
@@ -450,6 +450,9 @@ public abstract class BaseCartItemResourceImpl
 			java.util.Collection<CartItem> cartItems,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -496,7 +499,8 @@ public abstract class BaseCartItemResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartResourceImpl.java
@@ -594,6 +594,9 @@ public abstract class BaseCartResourceImpl
 			java.util.Collection<Cart> carts,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -640,7 +643,8 @@ public abstract class BaseCartResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BasePaymentMethodResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BasePaymentMethodResourceImpl.java
@@ -56,6 +56,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.UriInfo;
@@ -111,6 +112,9 @@ public abstract class BasePaymentMethodResourceImpl
 			java.util.Collection<PaymentMethod> paymentMethods,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -118,6 +122,9 @@ public abstract class BasePaymentMethodResourceImpl
 			java.util.Collection<PaymentMethod> paymentMethods,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -153,8 +160,14 @@ public abstract class BasePaymentMethodResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return getCartPaymentMethodsPage(
-			Long.parseLong((String)parameters.get("cartId")));
+		if (parameters.containsKey("cartId")) {
+			return getCartPaymentMethodsPage(
+				Long.parseLong((String)parameters.get("cartId")));
+		}
+		else {
+			throw new NotSupportedException(
+				"One of the following parameters must be informed: [cartId]");
+		}
 	}
 
 	@Override
@@ -184,6 +197,9 @@ public abstract class BasePaymentMethodResourceImpl
 			java.util.Collection<PaymentMethod> paymentMethods,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BasePaymentMethodResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BasePaymentMethodResourceImpl.java
@@ -166,7 +166,7 @@ public abstract class BasePaymentMethodResourceImpl
 		}
 		else {
 			throw new NotSupportedException(
-				"One of the following parameters must be informed: [cartId]");
+				"One of the following parameters must be specified: [cartId]");
 		}
 	}
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseShippingMethodResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseShippingMethodResourceImpl.java
@@ -56,6 +56,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.UriInfo;
@@ -111,6 +112,9 @@ public abstract class BaseShippingMethodResourceImpl
 			java.util.Collection<ShippingMethod> shippingMethods,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -118,6 +122,9 @@ public abstract class BaseShippingMethodResourceImpl
 			java.util.Collection<ShippingMethod> shippingMethods,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -153,8 +160,14 @@ public abstract class BaseShippingMethodResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return getCartShippingMethodsPage(
-			Long.parseLong((String)parameters.get("cartId")));
+		if (parameters.containsKey("cartId")) {
+			return getCartShippingMethodsPage(
+				Long.parseLong((String)parameters.get("cartId")));
+		}
+		else {
+			throw new NotSupportedException(
+				"One of the following parameters must be informed: [cartId]");
+		}
 	}
 
 	@Override
@@ -184,6 +197,9 @@ public abstract class BaseShippingMethodResourceImpl
 			java.util.Collection<ShippingMethod> shippingMethods,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseShippingMethodResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseShippingMethodResourceImpl.java
@@ -166,7 +166,7 @@ public abstract class BaseShippingMethodResourceImpl
 		}
 		else {
 			throw new NotSupportedException(
-				"One of the following parameters must be informed: [cartId]");
+				"One of the following parameters must be specified: [cartId]");
 		}
 	}
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseAttachmentResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseAttachmentResourceImpl.java
@@ -184,6 +184,9 @@ public abstract class BaseAttachmentResourceImpl
 			java.util.Collection<Attachment> attachments,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -191,6 +194,9 @@ public abstract class BaseAttachmentResourceImpl
 			java.util.Collection<Attachment> attachments,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -226,7 +232,8 @@ public abstract class BaseAttachmentResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -256,6 +263,9 @@ public abstract class BaseAttachmentResourceImpl
 			java.util.Collection<Attachment> attachments,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseCategoryResourceImpl.java
@@ -126,6 +126,9 @@ public abstract class BaseCategoryResourceImpl
 			java.util.Collection<Category> categories,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -133,6 +136,9 @@ public abstract class BaseCategoryResourceImpl
 			java.util.Collection<Category> categories,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -168,7 +174,8 @@ public abstract class BaseCategoryResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -198,6 +205,9 @@ public abstract class BaseCategoryResourceImpl
 			java.util.Collection<Category> categories,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseMappedProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseMappedProductResourceImpl.java
@@ -146,6 +146,9 @@ public abstract class BaseMappedProductResourceImpl
 			java.util.Collection<MappedProduct> mappedProducts,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -153,6 +156,9 @@ public abstract class BaseMappedProductResourceImpl
 			java.util.Collection<MappedProduct> mappedProducts,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -188,7 +194,8 @@ public abstract class BaseMappedProductResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -218,6 +225,9 @@ public abstract class BaseMappedProductResourceImpl
 			java.util.Collection<MappedProduct> mappedProducts,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BasePinResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BasePinResourceImpl.java
@@ -142,6 +142,9 @@ public abstract class BasePinResourceImpl
 			java.util.Collection<Pin> pins,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -149,6 +152,9 @@ public abstract class BasePinResourceImpl
 			java.util.Collection<Pin> pins,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -184,7 +190,8 @@ public abstract class BasePinResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -214,6 +221,9 @@ public abstract class BasePinResourceImpl
 			java.util.Collection<Pin> pins,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseProductOptionResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseProductOptionResourceImpl.java
@@ -127,6 +127,9 @@ public abstract class BaseProductOptionResourceImpl
 			java.util.Collection<ProductOption> productOptions,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -134,6 +137,9 @@ public abstract class BaseProductOptionResourceImpl
 			java.util.Collection<ProductOption> productOptions,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -169,7 +175,8 @@ public abstract class BaseProductOptionResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -199,6 +206,9 @@ public abstract class BaseProductOptionResourceImpl
 			java.util.Collection<ProductOption> productOptions,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseProductResourceImpl.java
@@ -183,6 +183,9 @@ public abstract class BaseProductResourceImpl
 			java.util.Collection<Product> products,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -190,6 +193,9 @@ public abstract class BaseProductResourceImpl
 			java.util.Collection<Product> products,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -225,7 +231,8 @@ public abstract class BaseProductResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -255,6 +262,9 @@ public abstract class BaseProductResourceImpl
 			java.util.Collection<Product> products,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseProductSpecificationResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseProductSpecificationResourceImpl.java
@@ -130,6 +130,9 @@ public abstract class BaseProductSpecificationResourceImpl
 			java.util.Collection<ProductSpecification> productSpecifications,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -137,6 +140,9 @@ public abstract class BaseProductSpecificationResourceImpl
 			java.util.Collection<ProductSpecification> productSpecifications,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -172,7 +178,8 @@ public abstract class BaseProductSpecificationResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -202,6 +209,9 @@ public abstract class BaseProductSpecificationResourceImpl
 			java.util.Collection<ProductSpecification> productSpecifications,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseRelatedProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseRelatedProductResourceImpl.java
@@ -137,6 +137,9 @@ public abstract class BaseRelatedProductResourceImpl
 			java.util.Collection<RelatedProduct> relatedProducts,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -144,6 +147,9 @@ public abstract class BaseRelatedProductResourceImpl
 			java.util.Collection<RelatedProduct> relatedProducts,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -179,7 +185,8 @@ public abstract class BaseRelatedProductResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -209,6 +216,9 @@ public abstract class BaseRelatedProductResourceImpl
 			java.util.Collection<RelatedProduct> relatedProducts,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseSkuResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseSkuResourceImpl.java
@@ -133,6 +133,9 @@ public abstract class BaseSkuResourceImpl
 			java.util.Collection<Sku> skus,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -140,6 +143,9 @@ public abstract class BaseSkuResourceImpl
 			java.util.Collection<Sku> skus,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -175,7 +181,8 @@ public abstract class BaseSkuResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -205,6 +212,9 @@ public abstract class BaseSkuResourceImpl
 			java.util.Collection<Sku> skus,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataDefinitionFieldLinkResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataDefinitionFieldLinkResourceImpl.java
@@ -56,6 +56,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.UriInfo;
@@ -121,6 +122,9 @@ public abstract class BaseDataDefinitionFieldLinkResourceImpl
 				dataDefinitionFieldLinks,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -129,6 +133,9 @@ public abstract class BaseDataDefinitionFieldLinkResourceImpl
 				dataDefinitionFieldLinks,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -164,9 +171,15 @@ public abstract class BaseDataDefinitionFieldLinkResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return getDataDefinitionDataDefinitionFieldLinksPage(
-			Long.parseLong((String)parameters.get("dataDefinitionId")),
-			(String)parameters.get("fieldName"));
+		if (parameters.containsKey("dataDefinitionId")) {
+			return getDataDefinitionDataDefinitionFieldLinksPage(
+				Long.parseLong((String)parameters.get("dataDefinitionId")),
+				(String)parameters.get("fieldName"));
+		}
+		else {
+			throw new NotSupportedException(
+				"One of the following parameters must be informed: [dataDefinitionId]");
+		}
 	}
 
 	@Override
@@ -197,6 +210,9 @@ public abstract class BaseDataDefinitionFieldLinkResourceImpl
 				dataDefinitionFieldLinks,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataDefinitionFieldLinkResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataDefinitionFieldLinkResourceImpl.java
@@ -178,7 +178,7 @@ public abstract class BaseDataDefinitionFieldLinkResourceImpl
 		}
 		else {
 			throw new NotSupportedException(
-				"One of the following parameters must be informed: [dataDefinitionId]");
+				"One of the following parameters must be specified: [dataDefinitionId]");
 		}
 	}
 

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataDefinitionResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataDefinitionResourceImpl.java
@@ -754,6 +754,9 @@ public abstract class BaseDataDefinitionResourceImpl
 			java.util.Collection<DataDefinition> dataDefinitions,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -800,7 +803,8 @@ public abstract class BaseDataDefinitionResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataLayoutResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataLayoutResourceImpl.java
@@ -509,10 +509,17 @@ public abstract class BaseDataLayoutResourceImpl
 			"createStrategy", "INSERT");
 
 		if ("INSERT".equalsIgnoreCase(createStrategy)) {
-			dataLayoutUnsafeConsumer =
-				dataLayout -> postDataDefinitionDataLayout(
-					Long.parseLong((String)parameters.get("dataDefinitionId")),
-					dataLayout);
+			if (parameters.containsKey("dataDefinitionId")) {
+				dataLayoutUnsafeConsumer =
+					dataLayout -> postDataDefinitionDataLayout(
+						Long.parseLong(
+							(String)parameters.get("dataDefinitionId")),
+						dataLayout);
+			}
+			else {
+				throw new NotSupportedException(
+					"One of the following parameters must be informed: [dataDefinitionId]");
+			}
 		}
 
 		if (dataLayoutUnsafeConsumer == null) {
@@ -576,9 +583,15 @@ public abstract class BaseDataLayoutResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return getDataDefinitionDataLayoutsPage(
-			Long.parseLong((String)parameters.get("dataDefinitionId")),
-			(String)parameters.get("keywords"), pagination, sorts);
+		if (parameters.containsKey("dataDefinitionId")) {
+			return getDataDefinitionDataLayoutsPage(
+				Long.parseLong((String)parameters.get("dataDefinitionId")),
+				(String)parameters.get("keywords"), pagination, sorts);
+		}
+		else {
+			throw new NotSupportedException(
+				"One of the following parameters must be informed: [dataDefinitionId]");
+		}
 	}
 
 	@Override

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataLayoutResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataLayoutResourceImpl.java
@@ -518,7 +518,7 @@ public abstract class BaseDataLayoutResourceImpl
 			}
 			else {
 				throw new NotSupportedException(
-					"One of the following parameters must be informed: [dataDefinitionId]");
+					"One of the following parameters must be specified: [dataDefinitionId]");
 			}
 		}
 
@@ -590,7 +590,7 @@ public abstract class BaseDataLayoutResourceImpl
 		}
 		else {
 			throw new NotSupportedException(
-				"One of the following parameters must be informed: [dataDefinitionId]");
+				"One of the following parameters must be specified: [dataDefinitionId]");
 		}
 	}
 

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataListViewResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataListViewResourceImpl.java
@@ -438,7 +438,7 @@ public abstract class BaseDataListViewResourceImpl
 			}
 			else {
 				throw new NotSupportedException(
-					"One of the following parameters must be informed: [dataDefinitionId]");
+					"One of the following parameters must be specified: [dataDefinitionId]");
 			}
 		}
 
@@ -510,7 +510,7 @@ public abstract class BaseDataListViewResourceImpl
 		}
 		else {
 			throw new NotSupportedException(
-				"One of the following parameters must be informed: [dataDefinitionId]");
+				"One of the following parameters must be specified: [dataDefinitionId]");
 		}
 	}
 

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataListViewResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataListViewResourceImpl.java
@@ -429,10 +429,17 @@ public abstract class BaseDataListViewResourceImpl
 			"createStrategy", "INSERT");
 
 		if ("INSERT".equalsIgnoreCase(createStrategy)) {
-			dataListViewUnsafeConsumer =
-				dataListView -> postDataDefinitionDataListView(
-					Long.parseLong((String)parameters.get("dataDefinitionId")),
-					dataListView);
+			if (parameters.containsKey("dataDefinitionId")) {
+				dataListViewUnsafeConsumer =
+					dataListView -> postDataDefinitionDataListView(
+						Long.parseLong(
+							(String)parameters.get("dataDefinitionId")),
+						dataListView);
+			}
+			else {
+				throw new NotSupportedException(
+					"One of the following parameters must be informed: [dataDefinitionId]");
+			}
 		}
 
 		if (dataListViewUnsafeConsumer == null) {
@@ -496,9 +503,15 @@ public abstract class BaseDataListViewResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return getDataDefinitionDataListViewsPage(
-			Long.parseLong((String)parameters.get("dataDefinitionId")),
-			(String)parameters.get("keywords"), pagination, sorts);
+		if (parameters.containsKey("dataDefinitionId")) {
+			return getDataDefinitionDataListViewsPage(
+				Long.parseLong((String)parameters.get("dataDefinitionId")),
+				(String)parameters.get("keywords"), pagination, sorts);
+		}
+		else {
+			throw new NotSupportedException(
+				"One of the following parameters must be informed: [dataDefinitionId]");
+		}
 	}
 
 	@Override

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataRecordCollectionResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataRecordCollectionResourceImpl.java
@@ -696,10 +696,18 @@ public abstract class BaseDataRecordCollectionResourceImpl
 			"createStrategy", "INSERT");
 
 		if ("INSERT".equalsIgnoreCase(createStrategy)) {
-			dataRecordCollectionUnsafeConsumer =
-				dataRecordCollection -> postDataDefinitionDataRecordCollection(
-					Long.parseLong((String)parameters.get("dataDefinitionId")),
-					dataRecordCollection);
+			if (parameters.containsKey("dataDefinitionId")) {
+				dataRecordCollectionUnsafeConsumer =
+					dataRecordCollection ->
+						postDataDefinitionDataRecordCollection(
+							Long.parseLong(
+								(String)parameters.get("dataDefinitionId")),
+							dataRecordCollection);
+			}
+			else {
+				throw new NotSupportedException(
+					"One of the following parameters must be informed: [dataDefinitionId]");
+			}
 		}
 
 		if (dataRecordCollectionUnsafeConsumer == null) {
@@ -767,9 +775,15 @@ public abstract class BaseDataRecordCollectionResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return getDataDefinitionDataRecordCollectionsPage(
-			Long.parseLong((String)parameters.get("dataDefinitionId")),
-			(String)parameters.get("keywords"), pagination);
+		if (parameters.containsKey("dataDefinitionId")) {
+			return getDataDefinitionDataRecordCollectionsPage(
+				Long.parseLong((String)parameters.get("dataDefinitionId")),
+				(String)parameters.get("keywords"), pagination);
+		}
+		else {
+			throw new NotSupportedException(
+				"One of the following parameters must be informed: [dataDefinitionId]");
+		}
 	}
 
 	@Override

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataRecordCollectionResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataRecordCollectionResourceImpl.java
@@ -706,7 +706,7 @@ public abstract class BaseDataRecordCollectionResourceImpl
 			}
 			else {
 				throw new NotSupportedException(
-					"One of the following parameters must be informed: [dataDefinitionId]");
+					"One of the following parameters must be specified: [dataDefinitionId]");
 			}
 		}
 
@@ -782,7 +782,7 @@ public abstract class BaseDataRecordCollectionResourceImpl
 		}
 		else {
 			throw new NotSupportedException(
-				"One of the following parameters must be informed: [dataDefinitionId]");
+				"One of the following parameters must be specified: [dataDefinitionId]");
 		}
 	}
 

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataRecordResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataRecordResourceImpl.java
@@ -661,7 +661,7 @@ public abstract class BaseDataRecordResourceImpl
 			}
 			else {
 				throw new NotSupportedException(
-					"One of the following parameters must be informed: [dataDefinitionId, dataRecordCollectionId]");
+					"One of the following parameters must be specified: [dataDefinitionId, dataRecordCollectionId]");
 			}
 		}
 
@@ -741,7 +741,7 @@ public abstract class BaseDataRecordResourceImpl
 		}
 		else {
 			throw new NotSupportedException(
-				"One of the following parameters must be informed: [dataDefinitionId, dataRecordCollectionId]");
+				"One of the following parameters must be specified: [dataDefinitionId, dataRecordCollectionId]");
 		}
 	}
 

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataRecordResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataRecordResourceImpl.java
@@ -645,10 +645,24 @@ public abstract class BaseDataRecordResourceImpl
 			"createStrategy", "INSERT");
 
 		if ("INSERT".equalsIgnoreCase(createStrategy)) {
-			dataRecordUnsafeConsumer =
-				dataRecord -> postDataDefinitionDataRecord(
-					Long.parseLong((String)parameters.get("dataDefinitionId")),
-					dataRecord);
+			if (parameters.containsKey("dataDefinitionId")) {
+				dataRecordUnsafeConsumer =
+					dataRecord -> postDataDefinitionDataRecord(
+						Long.parseLong(
+							(String)parameters.get("dataDefinitionId")),
+						dataRecord);
+			}
+			else if (parameters.containsKey("dataRecordCollectionId")) {
+				dataRecordUnsafeConsumer =
+					dataRecord -> postDataRecordCollectionDataRecord(
+						Long.parseLong(
+							(String)parameters.get("dataRecordCollectionId")),
+						dataRecord);
+			}
+			else {
+				throw new NotSupportedException(
+					"One of the following parameters must be informed: [dataDefinitionId, dataRecordCollectionId]");
+			}
 		}
 
 		if (dataRecordUnsafeConsumer == null) {
@@ -712,10 +726,23 @@ public abstract class BaseDataRecordResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return getDataDefinitionDataRecordsPage(
-			Long.parseLong((String)parameters.get("dataDefinitionId")),
-			Long.parseLong((String)parameters.get("dataListViewId")),
-			(String)parameters.get("keywords"), pagination, sorts);
+		if (parameters.containsKey("dataDefinitionId")) {
+			return getDataDefinitionDataRecordsPage(
+				Long.parseLong((String)parameters.get("dataDefinitionId")),
+				Long.parseLong((String)parameters.get("dataListViewId")),
+				(String)parameters.get("keywords"), pagination, sorts);
+		}
+		else if (parameters.containsKey("dataRecordCollectionId")) {
+			return getDataRecordCollectionDataRecordsPage(
+				Long.parseLong(
+					(String)parameters.get("dataRecordCollectionId")),
+				Long.parseLong((String)parameters.get("dataListViewId")),
+				(String)parameters.get("keywords"), pagination, sorts);
+		}
+		else {
+			throw new NotSupportedException(
+				"One of the following parameters must be informed: [dataDefinitionId, dataRecordCollectionId]");
+		}
 	}
 
 	@Override

--- a/modules/apps/digital-signature/digital-signature-rest-impl/src/main/java/com/liferay/digital/signature/rest/internal/resource/v1_0/BaseDSEnvelopeResourceImpl.java
+++ b/modules/apps/digital-signature/digital-signature-rest-impl/src/main/java/com/liferay/digital/signature/rest/internal/resource/v1_0/BaseDSEnvelopeResourceImpl.java
@@ -247,12 +247,13 @@ public abstract class BaseDSEnvelopeResourceImpl
 			"createStrategy", "INSERT");
 
 		if ("INSERT".equalsIgnoreCase(createStrategy)) {
-			dsEnvelopeUnsafeConsumer = dsEnvelope -> {
-			};
-
 			if (parameters.containsKey("siteId")) {
 				dsEnvelopeUnsafeConsumer = dsEnvelope -> postSiteDSEnvelope(
 					(Long)parameters.get("siteId"), dsEnvelope);
+			}
+			else {
+				throw new NotSupportedException(
+					"One of the following parameters must be informed: [siteId]");
 			}
 		}
 
@@ -278,6 +279,9 @@ public abstract class BaseDSEnvelopeResourceImpl
 			java.util.Collection<DSEnvelope> dsEnvelopes,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -318,7 +322,8 @@ public abstract class BaseDSEnvelopeResourceImpl
 				(Long)parameters.get("siteId"), pagination);
 		}
 		else {
-			return null;
+			throw new NotSupportedException(
+				"One of the following parameters must be informed: [siteId]");
 		}
 	}
 
@@ -349,6 +354,9 @@ public abstract class BaseDSEnvelopeResourceImpl
 			java.util.Collection<DSEnvelope> dsEnvelopes,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/digital-signature/digital-signature-rest-impl/src/main/java/com/liferay/digital/signature/rest/internal/resource/v1_0/BaseDSEnvelopeResourceImpl.java
+++ b/modules/apps/digital-signature/digital-signature-rest-impl/src/main/java/com/liferay/digital/signature/rest/internal/resource/v1_0/BaseDSEnvelopeResourceImpl.java
@@ -253,7 +253,7 @@ public abstract class BaseDSEnvelopeResourceImpl
 			}
 			else {
 				throw new NotSupportedException(
-					"One of the following parameters must be informed: [siteId]");
+					"One of the following parameters must be specified: [siteId]");
 			}
 		}
 
@@ -323,7 +323,7 @@ public abstract class BaseDSEnvelopeResourceImpl
 		}
 		else {
 			throw new NotSupportedException(
-				"One of the following parameters must be informed: [siteId]");
+				"One of the following parameters must be specified: [siteId]");
 		}
 	}
 

--- a/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/java/com/liferay/headless/admin/address/internal/resource/v1_0/BaseCountryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/java/com/liferay/headless/admin/address/internal/resource/v1_0/BaseCountryResourceImpl.java
@@ -643,7 +643,8 @@ public abstract class BaseCountryResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/java/com/liferay/headless/admin/address/internal/resource/v1_0/BaseRegionResourceImpl.java
+++ b/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/java/com/liferay/headless/admin/address/internal/resource/v1_0/BaseRegionResourceImpl.java
@@ -562,7 +562,7 @@ public abstract class BaseRegionResourceImpl
 			}
 			else {
 				throw new NotSupportedException(
-					"One of the following parameters must be informed: [countryId]");
+					"One of the following parameters must be specified: [countryId]");
 			}
 		}
 

--- a/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/java/com/liferay/headless/admin/address/internal/resource/v1_0/BaseRegionResourceImpl.java
+++ b/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/java/com/liferay/headless/admin/address/internal/resource/v1_0/BaseRegionResourceImpl.java
@@ -555,8 +555,15 @@ public abstract class BaseRegionResourceImpl
 			"createStrategy", "INSERT");
 
 		if ("INSERT".equalsIgnoreCase(createStrategy)) {
-			regionUnsafeConsumer = region -> postCountryRegion(
-				Long.parseLong((String)parameters.get("countryId")), region);
+			if (parameters.containsKey("countryId")) {
+				regionUnsafeConsumer = region -> postCountryRegion(
+					Long.parseLong((String)parameters.get("countryId")),
+					region);
+			}
+			else {
+				throw new NotSupportedException(
+					"One of the following parameters must be informed: [countryId]");
+			}
 		}
 
 		if (regionUnsafeConsumer == null) {
@@ -619,10 +626,17 @@ public abstract class BaseRegionResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return getCountryRegionsPage(
-			Long.parseLong((String)parameters.get("countryId")),
-			Boolean.parseBoolean((String)parameters.get("active")), search,
-			pagination, sorts);
+		if (parameters.containsKey("countryId")) {
+			return getCountryRegionsPage(
+				Long.parseLong((String)parameters.get("countryId")),
+				Boolean.parseBoolean((String)parameters.get("active")), search,
+				pagination, sorts);
+		}
+		else {
+			return getRegionsPage(
+				Boolean.parseBoolean((String)parameters.get("active")), search,
+				pagination, sorts);
+		}
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/resource/v1_0/BaseListTypeEntryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/resource/v1_0/BaseListTypeEntryResourceImpl.java
@@ -428,11 +428,17 @@ public abstract class BaseListTypeEntryResourceImpl
 			"createStrategy", "INSERT");
 
 		if ("INSERT".equalsIgnoreCase(createStrategy)) {
-			listTypeEntryUnsafeConsumer =
-				listTypeEntry -> postListTypeDefinitionListTypeEntry(
-					Long.parseLong(
-						(String)parameters.get("listTypeDefinitionId")),
-					listTypeEntry);
+			if (parameters.containsKey("listTypeDefinitionId")) {
+				listTypeEntryUnsafeConsumer =
+					listTypeEntry -> postListTypeDefinitionListTypeEntry(
+						Long.parseLong(
+							(String)parameters.get("listTypeDefinitionId")),
+						listTypeEntry);
+			}
+			else {
+				throw new NotSupportedException(
+					"One of the following parameters must be informed: [listTypeDefinitionId]");
+			}
 		}
 
 		if (listTypeEntryUnsafeConsumer == null) {
@@ -496,7 +502,8 @@ public abstract class BaseListTypeEntryResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/resource/v1_0/BaseListTypeEntryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/resource/v1_0/BaseListTypeEntryResourceImpl.java
@@ -437,7 +437,7 @@ public abstract class BaseListTypeEntryResourceImpl
 			}
 			else {
 				throw new NotSupportedException(
-					"One of the following parameters must be informed: [listTypeDefinitionId]");
+					"One of the following parameters must be specified: [listTypeDefinitionId]");
 			}
 		}
 

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseKeywordResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseKeywordResourceImpl.java
@@ -909,7 +909,7 @@ public abstract class BaseKeywordResourceImpl
 			}
 			else {
 				throw new NotSupportedException(
-					"One of the following parameters must be informed: [assetLibraryId, siteId]");
+					"One of the following parameters must be specified: [assetLibraryId, siteId]");
 			}
 		}
 
@@ -985,7 +985,7 @@ public abstract class BaseKeywordResourceImpl
 		}
 		else {
 			throw new NotSupportedException(
-				"One of the following parameters must be informed: [assetLibraryId, siteId]");
+				"One of the following parameters must be specified: [assetLibraryId, siteId]");
 		}
 	}
 

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseKeywordResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseKeywordResourceImpl.java
@@ -899,9 +899,6 @@ public abstract class BaseKeywordResourceImpl
 			"createStrategy", "INSERT");
 
 		if ("INSERT".equalsIgnoreCase(createStrategy)) {
-			keywordUnsafeConsumer = keyword -> {
-			};
-
 			if (parameters.containsKey("assetLibraryId")) {
 				keywordUnsafeConsumer = keyword -> postAssetLibraryKeyword(
 					(Long)parameters.get("assetLibraryId"), keyword);
@@ -909,6 +906,10 @@ public abstract class BaseKeywordResourceImpl
 			else if (parameters.containsKey("siteId")) {
 				keywordUnsafeConsumer = keyword -> postSiteKeyword(
 					(Long)parameters.get("siteId"), keyword);
+			}
+			else {
+				throw new NotSupportedException(
+					"One of the following parameters must be informed: [assetLibraryId, siteId]");
 			}
 		}
 
@@ -983,7 +984,8 @@ public abstract class BaseKeywordResourceImpl
 				sorts);
 		}
 		else {
-			return null;
+			throw new NotSupportedException(
+				"One of the following parameters must be informed: [assetLibraryId, siteId]");
 		}
 	}
 

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyCategoryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyCategoryResourceImpl.java
@@ -974,7 +974,7 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 			}
 			else {
 				throw new NotSupportedException(
-					"One of the following parameters must be informed: [taxonomyVocabularyId]");
+					"One of the following parameters must be specified: [taxonomyVocabularyId]");
 			}
 		}
 

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyCategoryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyCategoryResourceImpl.java
@@ -965,11 +965,17 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 			"createStrategy", "INSERT");
 
 		if ("INSERT".equalsIgnoreCase(createStrategy)) {
-			taxonomyCategoryUnsafeConsumer =
-				taxonomyCategory -> postTaxonomyVocabularyTaxonomyCategory(
-					Long.parseLong(
-						(String)parameters.get("taxonomyVocabularyId")),
-					taxonomyCategory);
+			if (parameters.containsKey("taxonomyVocabularyId")) {
+				taxonomyCategoryUnsafeConsumer =
+					taxonomyCategory -> postTaxonomyVocabularyTaxonomyCategory(
+						Long.parseLong(
+							(String)parameters.get("taxonomyVocabularyId")),
+						taxonomyCategory);
+			}
+			else {
+				throw new NotSupportedException(
+					"One of the following parameters must be informed: [taxonomyVocabularyId]");
+			}
 		}
 
 		if ("UPSERT".equalsIgnoreCase(createStrategy)) {
@@ -1044,7 +1050,8 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyVocabularyResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyVocabularyResourceImpl.java
@@ -1349,9 +1349,6 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 			"createStrategy", "INSERT");
 
 		if ("INSERT".equalsIgnoreCase(createStrategy)) {
-			taxonomyVocabularyUnsafeConsumer = taxonomyVocabulary -> {
-			};
-
 			if (parameters.containsKey("assetLibraryId")) {
 				taxonomyVocabularyUnsafeConsumer =
 					taxonomyVocabulary -> postAssetLibraryTaxonomyVocabulary(
@@ -1362,6 +1359,10 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 				taxonomyVocabularyUnsafeConsumer =
 					taxonomyVocabulary -> postSiteTaxonomyVocabulary(
 						(Long)parameters.get("siteId"), taxonomyVocabulary);
+			}
+			else {
+				throw new NotSupportedException(
+					"One of the following parameters must be informed: [assetLibraryId, siteId]");
 			}
 		}
 
@@ -1436,7 +1437,8 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyVocabularyResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyVocabularyResourceImpl.java
@@ -1362,7 +1362,7 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 			}
 			else {
 				throw new NotSupportedException(
-					"One of the following parameters must be informed: [assetLibraryId, siteId]");
+					"One of the following parameters must be specified: [assetLibraryId, siteId]");
 			}
 		}
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseAccountResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseAccountResourceImpl.java
@@ -982,7 +982,14 @@ public abstract class BaseAccountResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return getAccountsPage(search, filter, pagination, sorts);
+		if (parameters.containsKey("organizationId")) {
+			return getOrganizationAccountsPage(
+				(String)parameters.get("organizationId"), search, filter,
+				pagination, sorts);
+		}
+		else {
+			return getAccountsPage(search, filter, pagination, sorts);
+		}
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseAccountRoleResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseAccountRoleResourceImpl.java
@@ -715,9 +715,16 @@ public abstract class BaseAccountRoleResourceImpl
 			"createStrategy", "INSERT");
 
 		if ("INSERT".equalsIgnoreCase(createStrategy)) {
-			accountRoleUnsafeConsumer = accountRole -> postAccountAccountRole(
-				Long.parseLong((String)parameters.get("accountId")),
-				accountRole);
+			if (parameters.containsKey("accountId")) {
+				accountRoleUnsafeConsumer =
+					accountRole -> postAccountAccountRole(
+						Long.parseLong((String)parameters.get("accountId")),
+						accountRole);
+			}
+			else {
+				throw new NotSupportedException(
+					"One of the following parameters must be informed: [accountId]");
+			}
 		}
 
 		if (accountRoleUnsafeConsumer == null) {
@@ -742,6 +749,9 @@ public abstract class BaseAccountRoleResourceImpl
 			java.util.Collection<AccountRole> accountRoles,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -777,9 +787,15 @@ public abstract class BaseAccountRoleResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return getAccountAccountRolesPage(
-			Long.parseLong((String)parameters.get("accountId")),
-			(String)parameters.get("keywords"), filter, pagination, sorts);
+		if (parameters.containsKey("accountId")) {
+			return getAccountAccountRolesPage(
+				Long.parseLong((String)parameters.get("accountId")),
+				(String)parameters.get("keywords"), filter, pagination, sorts);
+		}
+		else {
+			throw new NotSupportedException(
+				"One of the following parameters must be informed: [accountId]");
+		}
 	}
 
 	@Override
@@ -809,6 +825,9 @@ public abstract class BaseAccountRoleResourceImpl
 			java.util.Collection<AccountRole> accountRoles,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseAccountRoleResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseAccountRoleResourceImpl.java
@@ -723,7 +723,7 @@ public abstract class BaseAccountRoleResourceImpl
 			}
 			else {
 				throw new NotSupportedException(
-					"One of the following parameters must be informed: [accountId]");
+					"One of the following parameters must be specified: [accountId]");
 			}
 		}
 
@@ -794,7 +794,7 @@ public abstract class BaseAccountRoleResourceImpl
 		}
 		else {
 			throw new NotSupportedException(
-				"One of the following parameters must be informed: [accountId]");
+				"One of the following parameters must be specified: [accountId]");
 		}
 	}
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseEmailAddressResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseEmailAddressResourceImpl.java
@@ -175,6 +175,9 @@ public abstract class BaseEmailAddressResourceImpl
 			java.util.Collection<EmailAddress> emailAddresses,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -182,6 +185,9 @@ public abstract class BaseEmailAddressResourceImpl
 			java.util.Collection<EmailAddress> emailAddresses,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -217,7 +223,8 @@ public abstract class BaseEmailAddressResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -247,6 +254,9 @@ public abstract class BaseEmailAddressResourceImpl
 			java.util.Collection<EmailAddress> emailAddresses,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseOrganizationResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseOrganizationResourceImpl.java
@@ -1315,9 +1315,16 @@ public abstract class BaseOrganizationResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return getAccountOrganizationsPage(
-			Long.parseLong((String)parameters.get("accountId")), search, filter,
-			pagination, sorts);
+		if (parameters.containsKey("accountId")) {
+			return getAccountOrganizationsPage(
+				Long.parseLong((String)parameters.get("accountId")), search,
+				filter, pagination, sorts);
+		}
+		else {
+			return getOrganizationsPage(
+				Boolean.parseBoolean((String)parameters.get("flatten")), search,
+				filter, pagination, sorts);
+		}
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BasePhoneResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BasePhoneResourceImpl.java
@@ -56,6 +56,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.UriInfo;
@@ -175,6 +176,9 @@ public abstract class BasePhoneResourceImpl
 			java.util.Collection<Phone> phones,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -182,6 +186,9 @@ public abstract class BasePhoneResourceImpl
 			java.util.Collection<Phone> phones,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -217,8 +224,18 @@ public abstract class BasePhoneResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return getOrganizationPhonesPage(
-			(String)parameters.get("organizationId"));
+		if (parameters.containsKey("organizationId")) {
+			return getOrganizationPhonesPage(
+				(String)parameters.get("organizationId"));
+		}
+		else if (parameters.containsKey("userAccountId")) {
+			return getUserAccountPhonesPage(
+				Long.parseLong((String)parameters.get("userAccountId")));
+		}
+		else {
+			throw new NotSupportedException(
+				"One of the following parameters must be informed: [organizationId, userAccountId]");
+		}
 	}
 
 	@Override
@@ -248,6 +265,9 @@ public abstract class BasePhoneResourceImpl
 			java.util.Collection<Phone> phones,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BasePhoneResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BasePhoneResourceImpl.java
@@ -234,7 +234,7 @@ public abstract class BasePhoneResourceImpl
 		}
 		else {
 			throw new NotSupportedException(
-				"One of the following parameters must be informed: [organizationId, userAccountId]");
+				"One of the following parameters must be specified: [organizationId, userAccountId]");
 		}
 	}
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BasePostalAddressResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BasePostalAddressResourceImpl.java
@@ -181,6 +181,9 @@ public abstract class BasePostalAddressResourceImpl
 			java.util.Collection<PostalAddress> postalAddresses,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -188,6 +191,9 @@ public abstract class BasePostalAddressResourceImpl
 			java.util.Collection<PostalAddress> postalAddresses,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -223,7 +229,8 @@ public abstract class BasePostalAddressResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -253,6 +260,9 @@ public abstract class BasePostalAddressResourceImpl
 			java.util.Collection<PostalAddress> postalAddresses,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseRoleResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseRoleResourceImpl.java
@@ -428,6 +428,9 @@ public abstract class BaseRoleResourceImpl
 			java.util.Collection<Role> roles,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -435,6 +438,9 @@ public abstract class BaseRoleResourceImpl
 			java.util.Collection<Role> roles,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -500,6 +506,9 @@ public abstract class BaseRoleResourceImpl
 			java.util.Collection<Role> roles,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSegmentResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSegmentResourceImpl.java
@@ -56,6 +56,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.UriInfo;
@@ -159,6 +160,9 @@ public abstract class BaseSegmentResourceImpl
 			java.util.Collection<Segment> segments,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -166,6 +170,9 @@ public abstract class BaseSegmentResourceImpl
 			java.util.Collection<Segment> segments,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -206,7 +213,8 @@ public abstract class BaseSegmentResourceImpl
 				(Long)parameters.get("siteId"), pagination);
 		}
 		else {
-			return null;
+			throw new NotSupportedException(
+				"One of the following parameters must be informed: [siteId]");
 		}
 	}
 
@@ -237,6 +245,9 @@ public abstract class BaseSegmentResourceImpl
 			java.util.Collection<Segment> segments,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSegmentResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSegmentResourceImpl.java
@@ -214,7 +214,7 @@ public abstract class BaseSegmentResourceImpl
 		}
 		else {
 			throw new NotSupportedException(
-				"One of the following parameters must be informed: [siteId]");
+				"One of the following parameters must be specified: [siteId]");
 		}
 	}
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSegmentUserResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSegmentUserResourceImpl.java
@@ -118,6 +118,9 @@ public abstract class BaseSegmentUserResourceImpl
 			java.util.Collection<SegmentUser> segmentUsers,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -125,6 +128,9 @@ public abstract class BaseSegmentUserResourceImpl
 			java.util.Collection<SegmentUser> segmentUsers,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -160,7 +166,8 @@ public abstract class BaseSegmentUserResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -190,6 +197,9 @@ public abstract class BaseSegmentUserResourceImpl
 			java.util.Collection<SegmentUser> segmentUsers,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSiteResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSiteResourceImpl.java
@@ -167,6 +167,9 @@ public abstract class BaseSiteResourceImpl
 			java.util.Collection<Site> sites,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -174,6 +177,9 @@ public abstract class BaseSiteResourceImpl
 			java.util.Collection<Site> sites,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -209,7 +215,8 @@ public abstract class BaseSiteResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -239,6 +246,9 @@ public abstract class BaseSiteResourceImpl
 			java.util.Collection<Site> sites,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSubscriptionResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSubscriptionResourceImpl.java
@@ -172,6 +172,9 @@ public abstract class BaseSubscriptionResourceImpl
 			java.util.Collection<Subscription> subscriptions,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -179,6 +182,9 @@ public abstract class BaseSubscriptionResourceImpl
 			java.util.Collection<Subscription> subscriptions,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -214,7 +220,8 @@ public abstract class BaseSubscriptionResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -244,6 +251,9 @@ public abstract class BaseSubscriptionResourceImpl
 			java.util.Collection<Subscription> subscriptions,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseUserAccountResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseUserAccountResourceImpl.java
@@ -1391,9 +1391,15 @@ public abstract class BaseUserAccountResourceImpl
 			"createStrategy", "INSERT");
 
 		if ("INSERT".equalsIgnoreCase(createStrategy)) {
-			userAccountUnsafeConsumer = userAccount -> postAccountUserAccount(
-				Long.parseLong((String)parameters.get("accountId")),
+			userAccountUnsafeConsumer = userAccount -> postUserAccount(
 				userAccount);
+
+			if (parameters.containsKey("accountId")) {
+				userAccountUnsafeConsumer =
+					userAccount -> postAccountUserAccount(
+						Long.parseLong((String)parameters.get("accountId")),
+						userAccount);
+			}
 		}
 
 		if ("UPSERT".equalsIgnoreCase(createStrategy)) {
@@ -1468,10 +1474,18 @@ public abstract class BaseUserAccountResourceImpl
 				(Long)parameters.get("siteId"), search, filter, pagination,
 				sorts);
 		}
-		else {
+		else if (parameters.containsKey("accountId")) {
 			return getAccountUserAccountsPage(
 				Long.parseLong((String)parameters.get("accountId")), search,
 				filter, pagination, sorts);
+		}
+		else if (parameters.containsKey("organizationId")) {
+			return getOrganizationUserAccountsPage(
+				(String)parameters.get("organizationId"), search, filter,
+				pagination, sorts);
+		}
+		else {
+			return getUserAccountsPage(search, filter, pagination, sorts);
 		}
 	}
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseWebUrlResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseWebUrlResourceImpl.java
@@ -56,6 +56,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.UriInfo;
@@ -175,6 +176,9 @@ public abstract class BaseWebUrlResourceImpl
 			java.util.Collection<WebUrl> webUrls,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -182,6 +186,9 @@ public abstract class BaseWebUrlResourceImpl
 			java.util.Collection<WebUrl> webUrls,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -217,8 +224,18 @@ public abstract class BaseWebUrlResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return getOrganizationWebUrlsPage(
-			(String)parameters.get("organizationId"));
+		if (parameters.containsKey("organizationId")) {
+			return getOrganizationWebUrlsPage(
+				(String)parameters.get("organizationId"));
+		}
+		else if (parameters.containsKey("userAccountId")) {
+			return getUserAccountWebUrlsPage(
+				Long.parseLong((String)parameters.get("userAccountId")));
+		}
+		else {
+			throw new NotSupportedException(
+				"One of the following parameters must be informed: [organizationId, userAccountId]");
+		}
 	}
 
 	@Override
@@ -248,6 +265,9 @@ public abstract class BaseWebUrlResourceImpl
 			java.util.Collection<WebUrl> webUrls,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseWebUrlResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseWebUrlResourceImpl.java
@@ -234,7 +234,7 @@ public abstract class BaseWebUrlResourceImpl
 		}
 		else {
 			throw new NotSupportedException(
-				"One of the following parameters must be informed: [organizationId, userAccountId]");
+				"One of the following parameters must be specified: [organizationId, userAccountId]");
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingImageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingImageResourceImpl.java
@@ -364,7 +364,7 @@ public abstract class BaseBlogPostingImageResourceImpl
 			}
 			else {
 				throw new NotSupportedException(
-					"One of the following parameters must be informed: [siteId]");
+					"One of the following parameters must be specified: [siteId]");
 			}
 		}
 
@@ -436,7 +436,7 @@ public abstract class BaseBlogPostingImageResourceImpl
 		}
 		else {
 			throw new NotSupportedException(
-				"One of the following parameters must be informed: [siteId]");
+				"One of the following parameters must be specified: [siteId]");
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingImageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingImageResourceImpl.java
@@ -356,14 +356,15 @@ public abstract class BaseBlogPostingImageResourceImpl
 			"createStrategy", "INSERT");
 
 		if ("INSERT".equalsIgnoreCase(createStrategy)) {
-			blogPostingImageUnsafeConsumer = blogPostingImage -> {
-			};
-
 			if (parameters.containsKey("siteId")) {
 				blogPostingImageUnsafeConsumer =
 					blogPostingImage -> postSiteBlogPostingImage(
 						(Long)parameters.get("siteId"),
 						(MultipartBody)parameters.get("multipartBody"));
+			}
+			else {
+				throw new NotSupportedException(
+					"One of the following parameters must be informed: [siteId]");
 			}
 		}
 
@@ -434,7 +435,8 @@ public abstract class BaseBlogPostingImageResourceImpl
 				pagination, sorts);
 		}
 		else {
-			return null;
+			throw new NotSupportedException(
+				"One of the following parameters must be informed: [siteId]");
 		}
 	}
 
@@ -465,6 +467,9 @@ public abstract class BaseBlogPostingImageResourceImpl
 			java.util.Collection<BlogPostingImage> blogPostingImages,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingResourceImpl.java
@@ -1133,12 +1133,13 @@ public abstract class BaseBlogPostingResourceImpl
 			"createStrategy", "INSERT");
 
 		if ("INSERT".equalsIgnoreCase(createStrategy)) {
-			blogPostingUnsafeConsumer = blogPosting -> {
-			};
-
 			if (parameters.containsKey("siteId")) {
 				blogPostingUnsafeConsumer = blogPosting -> postSiteBlogPosting(
 					(Long)parameters.get("siteId"), blogPosting);
+			}
+			else {
+				throw new NotSupportedException(
+					"One of the following parameters must be informed: [siteId]");
 			}
 		}
 
@@ -1217,7 +1218,8 @@ public abstract class BaseBlogPostingResourceImpl
 				pagination, sorts);
 		}
 		else {
-			return null;
+			throw new NotSupportedException(
+				"One of the following parameters must be informed: [siteId]");
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingResourceImpl.java
@@ -1139,7 +1139,7 @@ public abstract class BaseBlogPostingResourceImpl
 			}
 			else {
 				throw new NotSupportedException(
-					"One of the following parameters must be informed: [siteId]");
+					"One of the following parameters must be specified: [siteId]");
 			}
 		}
 
@@ -1219,7 +1219,7 @@ public abstract class BaseBlogPostingResourceImpl
 		}
 		else {
 			throw new NotSupportedException(
-				"One of the following parameters must be informed: [siteId]");
+				"One of the following parameters must be specified: [siteId]");
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseCommentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseCommentResourceImpl.java
@@ -1456,7 +1456,7 @@ public abstract class BaseCommentResourceImpl
 			}
 			else {
 				throw new NotSupportedException(
-					"One of the following parameters must be informed: [blogPostingId, documentId, structuredContentId]");
+					"One of the following parameters must be specified: [blogPostingId, documentId, structuredContentId]");
 			}
 		}
 
@@ -1537,7 +1537,7 @@ public abstract class BaseCommentResourceImpl
 		}
 		else {
 			throw new NotSupportedException(
-				"One of the following parameters must be informed: [blogPostingId, documentId, structuredContentId]");
+				"One of the following parameters must be specified: [blogPostingId, documentId, structuredContentId]");
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseCommentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseCommentResourceImpl.java
@@ -1438,9 +1438,26 @@ public abstract class BaseCommentResourceImpl
 			"createStrategy", "INSERT");
 
 		if ("INSERT".equalsIgnoreCase(createStrategy)) {
-			commentUnsafeConsumer = comment -> postBlogPostingComment(
-				Long.parseLong((String)parameters.get("blogPostingId")),
-				comment);
+			if (parameters.containsKey("blogPostingId")) {
+				commentUnsafeConsumer = comment -> postBlogPostingComment(
+					Long.parseLong((String)parameters.get("blogPostingId")),
+					comment);
+			}
+			else if (parameters.containsKey("documentId")) {
+				commentUnsafeConsumer = comment -> postDocumentComment(
+					Long.parseLong((String)parameters.get("documentId")),
+					comment);
+			}
+			else if (parameters.containsKey("structuredContentId")) {
+				commentUnsafeConsumer = comment -> postStructuredContentComment(
+					Long.parseLong(
+						(String)parameters.get("structuredContentId")),
+					comment);
+			}
+			else {
+				throw new NotSupportedException(
+					"One of the following parameters must be informed: [blogPostingId, documentId, structuredContentId]");
+			}
 		}
 
 		if (commentUnsafeConsumer == null) {
@@ -1503,9 +1520,25 @@ public abstract class BaseCommentResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return getBlogPostingCommentsPage(
-			Long.parseLong((String)parameters.get("blogPostingId")), search,
-			null, filter, pagination, sorts);
+		if (parameters.containsKey("blogPostingId")) {
+			return getBlogPostingCommentsPage(
+				Long.parseLong((String)parameters.get("blogPostingId")), search,
+				null, filter, pagination, sorts);
+		}
+		else if (parameters.containsKey("documentId")) {
+			return getDocumentCommentsPage(
+				Long.parseLong((String)parameters.get("documentId")), search,
+				null, filter, pagination, sorts);
+		}
+		else if (parameters.containsKey("structuredContentId")) {
+			return getStructuredContentCommentsPage(
+				Long.parseLong((String)parameters.get("structuredContentId")),
+				search, null, filter, pagination, sorts);
+		}
+		else {
+			throw new NotSupportedException(
+				"One of the following parameters must be informed: [blogPostingId, documentId, structuredContentId]");
+		}
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentElementResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentElementResourceImpl.java
@@ -56,6 +56,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.UriInfo;
@@ -196,6 +197,9 @@ public abstract class BaseContentElementResourceImpl
 			java.util.Collection<ContentElement> contentElements,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -203,6 +207,9 @@ public abstract class BaseContentElementResourceImpl
 			java.util.Collection<ContentElement> contentElements,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -249,7 +256,8 @@ public abstract class BaseContentElementResourceImpl
 				pagination, sorts);
 		}
 		else {
-			return null;
+			throw new NotSupportedException(
+				"One of the following parameters must be informed: [assetLibraryId, siteId]");
 		}
 	}
 
@@ -280,6 +288,9 @@ public abstract class BaseContentElementResourceImpl
 			java.util.Collection<ContentElement> contentElements,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentElementResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentElementResourceImpl.java
@@ -257,7 +257,7 @@ public abstract class BaseContentElementResourceImpl
 		}
 		else {
 			throw new NotSupportedException(
-				"One of the following parameters must be informed: [assetLibraryId, siteId]");
+				"One of the following parameters must be specified: [assetLibraryId, siteId]");
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentSetElementResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentSetElementResourceImpl.java
@@ -332,6 +332,9 @@ public abstract class BaseContentSetElementResourceImpl
 			java.util.Collection<ContentSetElement> contentSetElements,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -339,6 +342,9 @@ public abstract class BaseContentSetElementResourceImpl
 			java.util.Collection<ContentSetElement> contentSetElements,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -374,7 +380,8 @@ public abstract class BaseContentSetElementResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -404,6 +411,9 @@ public abstract class BaseContentSetElementResourceImpl
 			java.util.Collection<ContentSetElement> contentSetElements,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentStructureResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentStructureResourceImpl.java
@@ -678,7 +678,7 @@ public abstract class BaseContentStructureResourceImpl
 		}
 		else {
 			throw new NotSupportedException(
-				"One of the following parameters must be informed: [assetLibraryId, siteId]");
+				"One of the following parameters must be specified: [assetLibraryId, siteId]");
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentStructureResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentStructureResourceImpl.java
@@ -64,6 +64,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.UriInfo;
@@ -617,6 +618,9 @@ public abstract class BaseContentStructureResourceImpl
 			java.util.Collection<ContentStructure> contentStructures,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -624,6 +628,9 @@ public abstract class BaseContentStructureResourceImpl
 			java.util.Collection<ContentStructure> contentStructures,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -670,7 +677,8 @@ public abstract class BaseContentStructureResourceImpl
 				pagination, sorts);
 		}
 		else {
-			return null;
+			throw new NotSupportedException(
+				"One of the following parameters must be informed: [assetLibraryId, siteId]");
 		}
 	}
 
@@ -701,6 +709,9 @@ public abstract class BaseContentStructureResourceImpl
 			java.util.Collection<ContentStructure> contentStructures,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected String getPermissionCheckerActionsResourceName(Object id)

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentTemplateResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentTemplateResourceImpl.java
@@ -56,6 +56,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.UriInfo;
@@ -236,6 +237,9 @@ public abstract class BaseContentTemplateResourceImpl
 			java.util.Collection<ContentTemplate> contentTemplates,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -243,6 +247,9 @@ public abstract class BaseContentTemplateResourceImpl
 			java.util.Collection<ContentTemplate> contentTemplates,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -289,7 +296,8 @@ public abstract class BaseContentTemplateResourceImpl
 				pagination, sorts);
 		}
 		else {
-			return null;
+			throw new NotSupportedException(
+				"One of the following parameters must be informed: [assetLibraryId, siteId]");
 		}
 	}
 
@@ -320,6 +328,9 @@ public abstract class BaseContentTemplateResourceImpl
 			java.util.Collection<ContentTemplate> contentTemplates,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentTemplateResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentTemplateResourceImpl.java
@@ -297,7 +297,7 @@ public abstract class BaseContentTemplateResourceImpl
 		}
 		else {
 			throw new NotSupportedException(
-				"One of the following parameters must be informed: [assetLibraryId, siteId]");
+				"One of the following parameters must be specified: [assetLibraryId, siteId]");
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentFolderResourceImpl.java
@@ -1258,7 +1258,7 @@ public abstract class BaseDocumentFolderResourceImpl
 			}
 			else {
 				throw new NotSupportedException(
-					"One of the following parameters must be informed: [assetLibraryId, siteId]");
+					"One of the following parameters must be specified: [assetLibraryId, siteId]");
 			}
 		}
 
@@ -1337,7 +1337,7 @@ public abstract class BaseDocumentFolderResourceImpl
 		}
 		else {
 			throw new NotSupportedException(
-				"One of the following parameters must be informed: [assetLibraryId, siteId]");
+				"One of the following parameters must be specified: [assetLibraryId, siteId]");
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentFolderResourceImpl.java
@@ -1246,9 +1246,6 @@ public abstract class BaseDocumentFolderResourceImpl
 			"createStrategy", "INSERT");
 
 		if ("INSERT".equalsIgnoreCase(createStrategy)) {
-			documentFolderUnsafeConsumer = documentFolder -> {
-			};
-
 			if (parameters.containsKey("assetLibraryId")) {
 				documentFolderUnsafeConsumer =
 					documentFolder -> postAssetLibraryDocumentFolder(
@@ -1258,6 +1255,10 @@ public abstract class BaseDocumentFolderResourceImpl
 				documentFolderUnsafeConsumer =
 					documentFolder -> postSiteDocumentFolder(
 						(Long)parameters.get("siteId"), documentFolder);
+			}
+			else {
+				throw new NotSupportedException(
+					"One of the following parameters must be informed: [assetLibraryId, siteId]");
 			}
 		}
 
@@ -1335,7 +1336,8 @@ public abstract class BaseDocumentFolderResourceImpl
 				null, filter, pagination, sorts);
 		}
 		else {
-			return null;
+			throw new NotSupportedException(
+				"One of the following parameters must be informed: [assetLibraryId, siteId]");
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentResourceImpl.java
@@ -1565,11 +1565,12 @@ public abstract class BaseDocumentResourceImpl
 			"createStrategy", "INSERT");
 
 		if ("INSERT".equalsIgnoreCase(createStrategy)) {
-			documentUnsafeConsumer = document -> postDocumentFolderDocument(
-				Long.parseLong((String)parameters.get("documentFolderId")),
-				(MultipartBody)parameters.get("multipartBody"));
-
-			if (parameters.containsKey("assetLibraryId")) {
+			if (parameters.containsKey("documentFolderId")) {
+				documentUnsafeConsumer = document -> postDocumentFolderDocument(
+					Long.parseLong((String)parameters.get("documentFolderId")),
+					(MultipartBody)parameters.get("multipartBody"));
+			}
+			else if (parameters.containsKey("assetLibraryId")) {
 				documentUnsafeConsumer = document -> postAssetLibraryDocument(
 					(Long)parameters.get("assetLibraryId"),
 					(MultipartBody)parameters.get("multipartBody"));
@@ -1578,6 +1579,10 @@ public abstract class BaseDocumentResourceImpl
 				documentUnsafeConsumer = document -> postSiteDocument(
 					(Long)parameters.get("siteId"),
 					(MultipartBody)parameters.get("multipartBody"));
+			}
+			else {
+				throw new NotSupportedException(
+					"One of the following parameters must be informed: [documentFolderId, assetLibraryId, siteId]");
 			}
 		}
 
@@ -1662,11 +1667,15 @@ public abstract class BaseDocumentResourceImpl
 				Boolean.parseBoolean((String)parameters.get("flatten")), search,
 				null, filter, pagination, sorts);
 		}
-		else {
+		else if (parameters.containsKey("documentFolderId")) {
 			return getDocumentFolderDocumentsPage(
 				Long.parseLong((String)parameters.get("documentFolderId")),
 				Boolean.parseBoolean((String)parameters.get("flatten")), search,
 				null, filter, pagination, sorts);
+		}
+		else {
+			throw new NotSupportedException(
+				"One of the following parameters must be informed: [assetLibraryId, siteId, documentFolderId]");
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentResourceImpl.java
@@ -1582,7 +1582,7 @@ public abstract class BaseDocumentResourceImpl
 			}
 			else {
 				throw new NotSupportedException(
-					"One of the following parameters must be informed: [documentFolderId, assetLibraryId, siteId]");
+					"One of the following parameters must be specified: [documentFolderId, assetLibraryId, siteId]");
 			}
 		}
 
@@ -1675,7 +1675,7 @@ public abstract class BaseDocumentResourceImpl
 		}
 		else {
 			throw new NotSupportedException(
-				"One of the following parameters must be informed: [assetLibraryId, siteId, documentFolderId]");
+				"One of the following parameters must be specified: [assetLibraryId, siteId, documentFolderId]");
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseArticleResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseArticleResourceImpl.java
@@ -1606,7 +1606,7 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 			}
 			else {
 				throw new NotSupportedException(
-					"One of the following parameters must be informed: [knowledgeBaseFolderId, siteId]");
+					"One of the following parameters must be specified: [knowledgeBaseFolderId, siteId]");
 			}
 		}
 
@@ -1699,7 +1699,7 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 		}
 		else {
 			throw new NotSupportedException(
-				"One of the following parameters must be informed: [siteId, knowledgeBaseFolderId]");
+				"One of the following parameters must be specified: [siteId, knowledgeBaseFolderId]");
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseArticleResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseArticleResourceImpl.java
@@ -1592,17 +1592,21 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 			"createStrategy", "INSERT");
 
 		if ("INSERT".equalsIgnoreCase(createStrategy)) {
-			knowledgeBaseArticleUnsafeConsumer =
-				knowledgeBaseArticle ->
+			if (parameters.containsKey("knowledgeBaseFolderId")) {
+				knowledgeBaseArticleUnsafeConsumer = knowledgeBaseArticle ->
 					postKnowledgeBaseFolderKnowledgeBaseArticle(
 						Long.parseLong(
 							(String)parameters.get("knowledgeBaseFolderId")),
 						knowledgeBaseArticle);
-
-			if (parameters.containsKey("siteId")) {
+			}
+			else if (parameters.containsKey("siteId")) {
 				knowledgeBaseArticleUnsafeConsumer =
 					knowledgeBaseArticle -> postSiteKnowledgeBaseArticle(
 						(Long)parameters.get("siteId"), knowledgeBaseArticle);
+			}
+			else {
+				throw new NotSupportedException(
+					"One of the following parameters must be informed: [knowledgeBaseFolderId, siteId]");
 			}
 		}
 
@@ -1687,11 +1691,15 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 				Boolean.parseBoolean((String)parameters.get("flatten")), search,
 				null, filter, pagination, sorts);
 		}
-		else {
+		else if (parameters.containsKey("knowledgeBaseFolderId")) {
 			return getKnowledgeBaseFolderKnowledgeBaseArticlesPage(
 				Long.parseLong((String)parameters.get("knowledgeBaseFolderId")),
 				Boolean.parseBoolean((String)parameters.get("flatten")), search,
 				null, filter, pagination, sorts);
+		}
+		else {
+			throw new NotSupportedException(
+				"One of the following parameters must be informed: [siteId, knowledgeBaseFolderId]");
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseAttachmentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseAttachmentResourceImpl.java
@@ -361,7 +361,7 @@ public abstract class BaseKnowledgeBaseAttachmentResourceImpl
 			}
 			else {
 				throw new NotSupportedException(
-					"One of the following parameters must be informed: [knowledgeBaseArticleId]");
+					"One of the following parameters must be specified: [knowledgeBaseArticleId]");
 			}
 		}
 
@@ -440,7 +440,7 @@ public abstract class BaseKnowledgeBaseAttachmentResourceImpl
 		}
 		else {
 			throw new NotSupportedException(
-				"One of the following parameters must be informed: [knowledgeBaseArticleId]");
+				"One of the following parameters must be specified: [knowledgeBaseArticleId]");
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseAttachmentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseAttachmentResourceImpl.java
@@ -350,11 +350,19 @@ public abstract class BaseKnowledgeBaseAttachmentResourceImpl
 			"createStrategy", "INSERT");
 
 		if ("INSERT".equalsIgnoreCase(createStrategy)) {
-			knowledgeBaseAttachmentUnsafeConsumer = knowledgeBaseAttachment ->
-				postKnowledgeBaseArticleKnowledgeBaseAttachment(
-					Long.parseLong(
-						(String)parameters.get("knowledgeBaseArticleId")),
-					(MultipartBody)parameters.get("multipartBody"));
+			if (parameters.containsKey("knowledgeBaseArticleId")) {
+				knowledgeBaseAttachmentUnsafeConsumer =
+					knowledgeBaseAttachment ->
+						postKnowledgeBaseArticleKnowledgeBaseAttachment(
+							Long.parseLong(
+								(String)parameters.get(
+									"knowledgeBaseArticleId")),
+							(MultipartBody)parameters.get("multipartBody"));
+			}
+			else {
+				throw new NotSupportedException(
+					"One of the following parameters must be informed: [knowledgeBaseArticleId]");
+			}
 		}
 
 		if (knowledgeBaseAttachmentUnsafeConsumer == null) {
@@ -425,8 +433,15 @@ public abstract class BaseKnowledgeBaseAttachmentResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return getKnowledgeBaseArticleKnowledgeBaseAttachmentsPage(
-			Long.parseLong((String)parameters.get("knowledgeBaseArticleId")));
+		if (parameters.containsKey("knowledgeBaseArticleId")) {
+			return getKnowledgeBaseArticleKnowledgeBaseAttachmentsPage(
+				Long.parseLong(
+					(String)parameters.get("knowledgeBaseArticleId")));
+		}
+		else {
+			throw new NotSupportedException(
+				"One of the following parameters must be informed: [knowledgeBaseArticleId]");
+		}
 	}
 
 	@Override
@@ -457,6 +472,9 @@ public abstract class BaseKnowledgeBaseAttachmentResourceImpl
 				knowledgeBaseAttachments,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseFolderResourceImpl.java
@@ -1042,7 +1042,7 @@ public abstract class BaseKnowledgeBaseFolderResourceImpl
 			}
 			else {
 				throw new NotSupportedException(
-					"One of the following parameters must be informed: [siteId]");
+					"One of the following parameters must be specified: [siteId]");
 			}
 		}
 
@@ -1125,7 +1125,7 @@ public abstract class BaseKnowledgeBaseFolderResourceImpl
 		}
 		else {
 			throw new NotSupportedException(
-				"One of the following parameters must be informed: [siteId]");
+				"One of the following parameters must be specified: [siteId]");
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseFolderResourceImpl.java
@@ -1035,13 +1035,14 @@ public abstract class BaseKnowledgeBaseFolderResourceImpl
 			"createStrategy", "INSERT");
 
 		if ("INSERT".equalsIgnoreCase(createStrategy)) {
-			knowledgeBaseFolderUnsafeConsumer = knowledgeBaseFolder -> {
-			};
-
 			if (parameters.containsKey("siteId")) {
 				knowledgeBaseFolderUnsafeConsumer =
 					knowledgeBaseFolder -> postSiteKnowledgeBaseFolder(
 						(Long)parameters.get("siteId"), knowledgeBaseFolder);
+			}
+			else {
+				throw new NotSupportedException(
+					"One of the following parameters must be informed: [siteId]");
 			}
 		}
 
@@ -1123,7 +1124,8 @@ public abstract class BaseKnowledgeBaseFolderResourceImpl
 				(Long)parameters.get("siteId"), pagination);
 		}
 		else {
-			return null;
+			throw new NotSupportedException(
+				"One of the following parameters must be informed: [siteId]");
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseLanguageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseLanguageResourceImpl.java
@@ -200,7 +200,7 @@ public abstract class BaseLanguageResourceImpl
 		}
 		else {
 			throw new NotSupportedException(
-				"One of the following parameters must be informed: [assetLibraryId, siteId]");
+				"One of the following parameters must be specified: [assetLibraryId, siteId]");
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseLanguageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseLanguageResourceImpl.java
@@ -56,6 +56,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.UriInfo;
@@ -142,6 +143,9 @@ public abstract class BaseLanguageResourceImpl
 			java.util.Collection<Language> languages,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -149,6 +153,9 @@ public abstract class BaseLanguageResourceImpl
 			java.util.Collection<Language> languages,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -192,7 +199,8 @@ public abstract class BaseLanguageResourceImpl
 			return getSiteLanguagesPage((Long)parameters.get("siteId"));
 		}
 		else {
-			return null;
+			throw new NotSupportedException(
+				"One of the following parameters must be informed: [assetLibraryId, siteId]");
 		}
 	}
 
@@ -223,6 +231,9 @@ public abstract class BaseLanguageResourceImpl
 			java.util.Collection<Language> languages,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardAttachmentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardAttachmentResourceImpl.java
@@ -490,11 +490,24 @@ public abstract class BaseMessageBoardAttachmentResourceImpl
 			"createStrategy", "INSERT");
 
 		if ("INSERT".equalsIgnoreCase(createStrategy)) {
-			messageBoardAttachmentUnsafeConsumer = messageBoardAttachment ->
-				postMessageBoardMessageMessageBoardAttachment(
-					Long.parseLong(
-						(String)parameters.get("messageBoardMessageId")),
-					(MultipartBody)parameters.get("multipartBody"));
+			if (parameters.containsKey("messageBoardMessageId")) {
+				messageBoardAttachmentUnsafeConsumer = messageBoardAttachment ->
+					postMessageBoardMessageMessageBoardAttachment(
+						Long.parseLong(
+							(String)parameters.get("messageBoardMessageId")),
+						(MultipartBody)parameters.get("multipartBody"));
+			}
+			else if (parameters.containsKey("messageBoardThreadId")) {
+				messageBoardAttachmentUnsafeConsumer = messageBoardAttachment ->
+					postMessageBoardThreadMessageBoardAttachment(
+						Long.parseLong(
+							(String)parameters.get("messageBoardThreadId")),
+						(MultipartBody)parameters.get("multipartBody"));
+			}
+			else {
+				throw new NotSupportedException(
+					"One of the following parameters must be informed: [messageBoardMessageId, messageBoardThreadId]");
+			}
 		}
 
 		if (messageBoardAttachmentUnsafeConsumer == null) {
@@ -564,8 +577,19 @@ public abstract class BaseMessageBoardAttachmentResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return getMessageBoardMessageMessageBoardAttachmentsPage(
-			Long.parseLong((String)parameters.get("messageBoardMessageId")));
+		if (parameters.containsKey("messageBoardMessageId")) {
+			return getMessageBoardMessageMessageBoardAttachmentsPage(
+				Long.parseLong(
+					(String)parameters.get("messageBoardMessageId")));
+		}
+		else if (parameters.containsKey("messageBoardThreadId")) {
+			return getMessageBoardThreadMessageBoardAttachmentsPage(
+				Long.parseLong((String)parameters.get("messageBoardThreadId")));
+		}
+		else {
+			throw new NotSupportedException(
+				"One of the following parameters must be informed: [messageBoardMessageId, messageBoardThreadId]");
+		}
 	}
 
 	@Override
@@ -596,6 +620,9 @@ public abstract class BaseMessageBoardAttachmentResourceImpl
 				messageBoardAttachments,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardAttachmentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardAttachmentResourceImpl.java
@@ -506,7 +506,7 @@ public abstract class BaseMessageBoardAttachmentResourceImpl
 			}
 			else {
 				throw new NotSupportedException(
-					"One of the following parameters must be informed: [messageBoardMessageId, messageBoardThreadId]");
+					"One of the following parameters must be specified: [messageBoardMessageId, messageBoardThreadId]");
 			}
 		}
 
@@ -588,7 +588,7 @@ public abstract class BaseMessageBoardAttachmentResourceImpl
 		}
 		else {
 			throw new NotSupportedException(
-				"One of the following parameters must be informed: [messageBoardMessageId, messageBoardThreadId]");
+				"One of the following parameters must be specified: [messageBoardMessageId, messageBoardThreadId]");
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardMessageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardMessageResourceImpl.java
@@ -1478,12 +1478,17 @@ public abstract class BaseMessageBoardMessageResourceImpl
 			"createStrategy", "INSERT");
 
 		if ("INSERT".equalsIgnoreCase(createStrategy)) {
-			messageBoardMessageUnsafeConsumer =
-				messageBoardMessage ->
+			if (parameters.containsKey("messageBoardThreadId")) {
+				messageBoardMessageUnsafeConsumer = messageBoardMessage ->
 					postMessageBoardThreadMessageBoardMessage(
 						Long.parseLong(
 							(String)parameters.get("messageBoardThreadId")),
 						messageBoardMessage);
+			}
+			else {
+				throw new NotSupportedException(
+					"One of the following parameters must be informed: [messageBoardThreadId]");
+			}
 		}
 
 		if ("UPSERT".equalsIgnoreCase(createStrategy)) {
@@ -1565,10 +1570,14 @@ public abstract class BaseMessageBoardMessageResourceImpl
 				Boolean.parseBoolean((String)parameters.get("flatten")), search,
 				null, filter, pagination, sorts);
 		}
-		else {
+		else if (parameters.containsKey("messageBoardThreadId")) {
 			return getMessageBoardThreadMessageBoardMessagesPage(
 				Long.parseLong((String)parameters.get("messageBoardThreadId")),
 				search, null, filter, pagination, sorts);
+		}
+		else {
+			throw new NotSupportedException(
+				"One of the following parameters must be informed: [siteId, messageBoardThreadId]");
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardMessageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardMessageResourceImpl.java
@@ -1487,7 +1487,7 @@ public abstract class BaseMessageBoardMessageResourceImpl
 			}
 			else {
 				throw new NotSupportedException(
-					"One of the following parameters must be informed: [messageBoardThreadId]");
+					"One of the following parameters must be specified: [messageBoardThreadId]");
 			}
 		}
 
@@ -1577,7 +1577,7 @@ public abstract class BaseMessageBoardMessageResourceImpl
 		}
 		else {
 			throw new NotSupportedException(
-				"One of the following parameters must be informed: [siteId, messageBoardThreadId]");
+				"One of the following parameters must be specified: [siteId, messageBoardThreadId]");
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardSectionResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardSectionResourceImpl.java
@@ -1007,13 +1007,14 @@ public abstract class BaseMessageBoardSectionResourceImpl
 			"createStrategy", "INSERT");
 
 		if ("INSERT".equalsIgnoreCase(createStrategy)) {
-			messageBoardSectionUnsafeConsumer = messageBoardSection -> {
-			};
-
 			if (parameters.containsKey("siteId")) {
 				messageBoardSectionUnsafeConsumer =
 					messageBoardSection -> postSiteMessageBoardSection(
 						(Long)parameters.get("siteId"), messageBoardSection);
+			}
+			else {
+				throw new NotSupportedException(
+					"One of the following parameters must be informed: [siteId]");
 			}
 		}
 
@@ -1087,7 +1088,8 @@ public abstract class BaseMessageBoardSectionResourceImpl
 				null, filter, pagination, sorts);
 		}
 		else {
-			return null;
+			throw new NotSupportedException(
+				"One of the following parameters must be informed: [siteId]");
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardSectionResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardSectionResourceImpl.java
@@ -1014,7 +1014,7 @@ public abstract class BaseMessageBoardSectionResourceImpl
 			}
 			else {
 				throw new NotSupportedException(
-					"One of the following parameters must be informed: [siteId]");
+					"One of the following parameters must be specified: [siteId]");
 			}
 		}
 
@@ -1089,7 +1089,7 @@ public abstract class BaseMessageBoardSectionResourceImpl
 		}
 		else {
 			throw new NotSupportedException(
-				"One of the following parameters must be informed: [siteId]");
+				"One of the following parameters must be specified: [siteId]");
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardThreadResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardThreadResourceImpl.java
@@ -1341,7 +1341,7 @@ public abstract class BaseMessageBoardThreadResourceImpl
 			}
 			else {
 				throw new NotSupportedException(
-					"One of the following parameters must be informed: [messageBoardSectionId, siteId]");
+					"One of the following parameters must be specified: [messageBoardSectionId, siteId]");
 			}
 		}
 
@@ -1419,7 +1419,7 @@ public abstract class BaseMessageBoardThreadResourceImpl
 		}
 		else {
 			throw new NotSupportedException(
-				"One of the following parameters must be informed: [siteId, messageBoardSectionId]");
+				"One of the following parameters must be specified: [siteId, messageBoardSectionId]");
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardThreadResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardThreadResourceImpl.java
@@ -1325,16 +1325,23 @@ public abstract class BaseMessageBoardThreadResourceImpl
 			"createStrategy", "INSERT");
 
 		if ("INSERT".equalsIgnoreCase(createStrategy)) {
-			messageBoardThreadUnsafeConsumer =
-				messageBoardThread -> postMessageBoardSectionMessageBoardThread(
-					Long.parseLong(
-						(String)parameters.get("messageBoardSectionId")),
-					messageBoardThread);
-
-			if (parameters.containsKey("siteId")) {
+			if (parameters.containsKey("messageBoardSectionId")) {
+				messageBoardThreadUnsafeConsumer =
+					messageBoardThread ->
+						postMessageBoardSectionMessageBoardThread(
+							Long.parseLong(
+								(String)parameters.get(
+									"messageBoardSectionId")),
+							messageBoardThread);
+			}
+			else if (parameters.containsKey("siteId")) {
 				messageBoardThreadUnsafeConsumer =
 					messageBoardThread -> postSiteMessageBoardThread(
 						(Long)parameters.get("siteId"), messageBoardThread);
+			}
+			else {
+				throw new NotSupportedException(
+					"One of the following parameters must be informed: [messageBoardSectionId, siteId]");
 			}
 		}
 
@@ -1405,10 +1412,14 @@ public abstract class BaseMessageBoardThreadResourceImpl
 				Boolean.parseBoolean((String)parameters.get("flatten")), search,
 				null, filter, pagination, sorts);
 		}
-		else {
+		else if (parameters.containsKey("messageBoardSectionId")) {
 			return getMessageBoardSectionMessageBoardThreadsPage(
 				Long.parseLong((String)parameters.get("messageBoardSectionId")),
 				search, null, filter, pagination, sorts);
+		}
+		else {
+			throw new NotSupportedException(
+				"One of the following parameters must be informed: [siteId, messageBoardSectionId]");
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseNavigationMenuResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseNavigationMenuResourceImpl.java
@@ -668,7 +668,7 @@ public abstract class BaseNavigationMenuResourceImpl
 			}
 			else {
 				throw new NotSupportedException(
-					"One of the following parameters must be informed: [siteId]");
+					"One of the following parameters must be specified: [siteId]");
 			}
 		}
 
@@ -739,7 +739,7 @@ public abstract class BaseNavigationMenuResourceImpl
 		}
 		else {
 			throw new NotSupportedException(
-				"One of the following parameters must be informed: [siteId]");
+				"One of the following parameters must be specified: [siteId]");
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseNavigationMenuResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseNavigationMenuResourceImpl.java
@@ -661,13 +661,14 @@ public abstract class BaseNavigationMenuResourceImpl
 			"createStrategy", "INSERT");
 
 		if ("INSERT".equalsIgnoreCase(createStrategy)) {
-			navigationMenuUnsafeConsumer = navigationMenu -> {
-			};
-
 			if (parameters.containsKey("siteId")) {
 				navigationMenuUnsafeConsumer =
 					navigationMenu -> postSiteNavigationMenu(
 						(Long)parameters.get("siteId"), navigationMenu);
+			}
+			else {
+				throw new NotSupportedException(
+					"One of the following parameters must be informed: [siteId]");
 			}
 		}
 
@@ -737,7 +738,8 @@ public abstract class BaseNavigationMenuResourceImpl
 				(Long)parameters.get("siteId"), pagination);
 		}
 		else {
-			return null;
+			throw new NotSupportedException(
+				"One of the following parameters must be informed: [siteId]");
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseSitePageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseSitePageResourceImpl.java
@@ -57,6 +57,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.UriInfo;
@@ -367,6 +368,9 @@ public abstract class BaseSitePageResourceImpl
 			java.util.Collection<SitePage> sitePages,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -374,6 +378,9 @@ public abstract class BaseSitePageResourceImpl
 			java.util.Collection<SitePage> sitePages,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -415,7 +422,8 @@ public abstract class BaseSitePageResourceImpl
 				pagination, sorts);
 		}
 		else {
-			return null;
+			throw new NotSupportedException(
+				"One of the following parameters must be informed: [siteId]");
 		}
 	}
 
@@ -446,6 +454,9 @@ public abstract class BaseSitePageResourceImpl
 			java.util.Collection<SitePage> sitePages,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseSitePageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseSitePageResourceImpl.java
@@ -423,7 +423,7 @@ public abstract class BaseSitePageResourceImpl
 		}
 		else {
 			throw new NotSupportedException(
-				"One of the following parameters must be informed: [siteId]");
+				"One of the following parameters must be specified: [siteId]");
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentFolderResourceImpl.java
@@ -1336,7 +1336,7 @@ public abstract class BaseStructuredContentFolderResourceImpl
 			}
 			else {
 				throw new NotSupportedException(
-					"One of the following parameters must be informed: [assetLibraryId, siteId]");
+					"One of the following parameters must be specified: [assetLibraryId, siteId]");
 			}
 		}
 
@@ -1422,7 +1422,7 @@ public abstract class BaseStructuredContentFolderResourceImpl
 		}
 		else {
 			throw new NotSupportedException(
-				"One of the following parameters must be informed: [assetLibraryId, siteId]");
+				"One of the following parameters must be specified: [assetLibraryId, siteId]");
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentFolderResourceImpl.java
@@ -1321,9 +1321,6 @@ public abstract class BaseStructuredContentFolderResourceImpl
 			"createStrategy", "INSERT");
 
 		if ("INSERT".equalsIgnoreCase(createStrategy)) {
-			structuredContentFolderUnsafeConsumer = structuredContentFolder -> {
-			};
-
 			if (parameters.containsKey("assetLibraryId")) {
 				structuredContentFolderUnsafeConsumer =
 					structuredContentFolder ->
@@ -1336,6 +1333,10 @@ public abstract class BaseStructuredContentFolderResourceImpl
 					structuredContentFolder -> postSiteStructuredContentFolder(
 						(Long)parameters.get("siteId"),
 						structuredContentFolder);
+			}
+			else {
+				throw new NotSupportedException(
+					"One of the following parameters must be informed: [assetLibraryId, siteId]");
 			}
 		}
 
@@ -1420,7 +1421,8 @@ public abstract class BaseStructuredContentFolderResourceImpl
 				null, filter, pagination, sorts);
 		}
 		else {
-			return null;
+			throw new NotSupportedException(
+				"One of the following parameters must be informed: [assetLibraryId, siteId]");
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentResourceImpl.java
@@ -2020,15 +2020,15 @@ public abstract class BaseStructuredContentResourceImpl
 			"createStrategy", "INSERT");
 
 		if ("INSERT".equalsIgnoreCase(createStrategy)) {
-			structuredContentUnsafeConsumer =
-				structuredContent ->
+			if (parameters.containsKey("structuredContentFolderId")) {
+				structuredContentUnsafeConsumer = structuredContent ->
 					postStructuredContentFolderStructuredContent(
 						Long.parseLong(
 							(String)parameters.get(
 								"structuredContentFolderId")),
 						structuredContent);
-
-			if (parameters.containsKey("assetLibraryId")) {
+			}
+			else if (parameters.containsKey("assetLibraryId")) {
 				structuredContentUnsafeConsumer =
 					structuredContent -> postAssetLibraryStructuredContent(
 						(Long)parameters.get("assetLibraryId"),
@@ -2038,6 +2038,10 @@ public abstract class BaseStructuredContentResourceImpl
 				structuredContentUnsafeConsumer =
 					structuredContent -> postSiteStructuredContent(
 						(Long)parameters.get("siteId"), structuredContent);
+			}
+			else {
+				throw new NotSupportedException(
+					"One of the following parameters must be informed: [structuredContentFolderId, assetLibraryId, siteId]");
 			}
 		}
 
@@ -2124,10 +2128,21 @@ public abstract class BaseStructuredContentResourceImpl
 				Boolean.parseBoolean((String)parameters.get("flatten")), search,
 				null, filter, pagination, sorts);
 		}
-		else {
+		else if (parameters.containsKey("contentStructureId")) {
 			return getContentStructureStructuredContentsPage(
 				Long.parseLong((String)parameters.get("contentStructureId")),
 				search, null, filter, pagination, sorts);
+		}
+		else if (parameters.containsKey("structuredContentFolderId")) {
+			return getStructuredContentFolderStructuredContentsPage(
+				Long.parseLong(
+					(String)parameters.get("structuredContentFolderId")),
+				Boolean.parseBoolean((String)parameters.get("flatten")), search,
+				null, filter, pagination, sorts);
+		}
+		else {
+			throw new NotSupportedException(
+				"One of the following parameters must be informed: [assetLibraryId, siteId, contentStructureId, structuredContentFolderId]");
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentResourceImpl.java
@@ -2041,7 +2041,7 @@ public abstract class BaseStructuredContentResourceImpl
 			}
 			else {
 				throw new NotSupportedException(
-					"One of the following parameters must be informed: [structuredContentFolderId, assetLibraryId, siteId]");
+					"One of the following parameters must be specified: [structuredContentFolderId, assetLibraryId, siteId]");
 			}
 		}
 
@@ -2142,7 +2142,7 @@ public abstract class BaseStructuredContentResourceImpl
 		}
 		else {
 			throw new NotSupportedException(
-				"One of the following parameters must be informed: [assetLibraryId, siteId, contentStructureId, structuredContentFolderId]");
+				"One of the following parameters must be specified: [assetLibraryId, siteId, contentStructureId, structuredContentFolderId]");
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiNodeResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiNodeResourceImpl.java
@@ -850,7 +850,7 @@ public abstract class BaseWikiNodeResourceImpl
 			}
 			else {
 				throw new NotSupportedException(
-					"One of the following parameters must be informed: [siteId]");
+					"One of the following parameters must be specified: [siteId]");
 			}
 		}
 
@@ -930,7 +930,7 @@ public abstract class BaseWikiNodeResourceImpl
 		}
 		else {
 			throw new NotSupportedException(
-				"One of the following parameters must be informed: [siteId]");
+				"One of the following parameters must be specified: [siteId]");
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiNodeResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiNodeResourceImpl.java
@@ -844,12 +844,13 @@ public abstract class BaseWikiNodeResourceImpl
 			"createStrategy", "INSERT");
 
 		if ("INSERT".equalsIgnoreCase(createStrategy)) {
-			wikiNodeUnsafeConsumer = wikiNode -> {
-			};
-
 			if (parameters.containsKey("siteId")) {
 				wikiNodeUnsafeConsumer = wikiNode -> postSiteWikiNode(
 					(Long)parameters.get("siteId"), wikiNode);
+			}
+			else {
+				throw new NotSupportedException(
+					"One of the following parameters must be informed: [siteId]");
 			}
 		}
 
@@ -928,7 +929,8 @@ public abstract class BaseWikiNodeResourceImpl
 				pagination, sorts);
 		}
 		else {
-			return null;
+			throw new NotSupportedException(
+				"One of the following parameters must be informed: [siteId]");
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiPageAttachmentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiPageAttachmentResourceImpl.java
@@ -337,7 +337,7 @@ public abstract class BaseWikiPageAttachmentResourceImpl
 			}
 			else {
 				throw new NotSupportedException(
-					"One of the following parameters must be informed: [wikiPageId]");
+					"One of the following parameters must be specified: [wikiPageId]");
 			}
 		}
 
@@ -408,7 +408,7 @@ public abstract class BaseWikiPageAttachmentResourceImpl
 		}
 		else {
 			throw new NotSupportedException(
-				"One of the following parameters must be informed: [wikiPageId]");
+				"One of the following parameters must be specified: [wikiPageId]");
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiPageAttachmentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiPageAttachmentResourceImpl.java
@@ -329,10 +329,16 @@ public abstract class BaseWikiPageAttachmentResourceImpl
 			"createStrategy", "INSERT");
 
 		if ("INSERT".equalsIgnoreCase(createStrategy)) {
-			wikiPageAttachmentUnsafeConsumer =
-				wikiPageAttachment -> postWikiPageWikiPageAttachment(
-					Long.parseLong((String)parameters.get("wikiPageId")),
-					(MultipartBody)parameters.get("multipartBody"));
+			if (parameters.containsKey("wikiPageId")) {
+				wikiPageAttachmentUnsafeConsumer =
+					wikiPageAttachment -> postWikiPageWikiPageAttachment(
+						Long.parseLong((String)parameters.get("wikiPageId")),
+						(MultipartBody)parameters.get("multipartBody"));
+			}
+			else {
+				throw new NotSupportedException(
+					"One of the following parameters must be informed: [wikiPageId]");
+			}
 		}
 
 		if (wikiPageAttachmentUnsafeConsumer == null) {
@@ -396,8 +402,14 @@ public abstract class BaseWikiPageAttachmentResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return getWikiPageWikiPageAttachmentsPage(
-			Long.parseLong((String)parameters.get("wikiPageId")));
+		if (parameters.containsKey("wikiPageId")) {
+			return getWikiPageWikiPageAttachmentsPage(
+				Long.parseLong((String)parameters.get("wikiPageId")));
+		}
+		else {
+			throw new NotSupportedException(
+				"One of the following parameters must be informed: [wikiPageId]");
+		}
 	}
 
 	@Override
@@ -427,6 +439,9 @@ public abstract class BaseWikiPageAttachmentResourceImpl
 			java.util.Collection<WikiPageAttachment> wikiPageAttachments,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiPageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiPageResourceImpl.java
@@ -805,7 +805,7 @@ public abstract class BaseWikiPageResourceImpl
 			}
 			else {
 				throw new NotSupportedException(
-					"One of the following parameters must be informed: [wikiNodeId]");
+					"One of the following parameters must be specified: [wikiNodeId]");
 			}
 		}
 
@@ -885,7 +885,7 @@ public abstract class BaseWikiPageResourceImpl
 		}
 		else {
 			throw new NotSupportedException(
-				"One of the following parameters must be informed: [wikiNodeId]");
+				"One of the following parameters must be specified: [wikiNodeId]");
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiPageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiPageResourceImpl.java
@@ -798,8 +798,15 @@ public abstract class BaseWikiPageResourceImpl
 			"createStrategy", "INSERT");
 
 		if ("INSERT".equalsIgnoreCase(createStrategy)) {
-			wikiPageUnsafeConsumer = wikiPage -> postWikiNodeWikiPage(
-				Long.parseLong((String)parameters.get("wikiNodeId")), wikiPage);
+			if (parameters.containsKey("wikiNodeId")) {
+				wikiPageUnsafeConsumer = wikiPage -> postWikiNodeWikiPage(
+					Long.parseLong((String)parameters.get("wikiNodeId")),
+					wikiPage);
+			}
+			else {
+				throw new NotSupportedException(
+					"One of the following parameters must be informed: [wikiNodeId]");
+			}
 		}
 
 		if ("UPSERT".equalsIgnoreCase(createStrategy)) {
@@ -871,9 +878,15 @@ public abstract class BaseWikiPageResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return getWikiNodeWikiPagesPage(
-			Long.parseLong((String)parameters.get("wikiNodeId")), search, null,
-			filter, pagination, sorts);
+		if (parameters.containsKey("wikiNodeId")) {
+			return getWikiNodeWikiPagesPage(
+				Long.parseLong((String)parameters.get("wikiNodeId")), search,
+				null, filter, pagination, sorts);
+		}
+		else {
+			throw new NotSupportedException(
+				"One of the following parameters must be informed: [wikiNodeId]");
+		}
 	}
 
 	@Override

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormDocumentResourceImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormDocumentResourceImpl.java
@@ -182,6 +182,9 @@ public abstract class BaseFormDocumentResourceImpl
 			java.util.Collection<FormDocument> formDocuments,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -228,7 +231,8 @@ public abstract class BaseFormDocumentResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -258,6 +262,9 @@ public abstract class BaseFormDocumentResourceImpl
 			java.util.Collection<FormDocument> formDocuments,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormRecordResourceImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormRecordResourceImpl.java
@@ -361,7 +361,7 @@ public abstract class BaseFormRecordResourceImpl
 			}
 			else {
 				throw new NotSupportedException(
-					"One of the following parameters must be informed: [formId]");
+					"One of the following parameters must be specified: [formId]");
 			}
 		}
 
@@ -431,7 +431,7 @@ public abstract class BaseFormRecordResourceImpl
 		}
 		else {
 			throw new NotSupportedException(
-				"One of the following parameters must be informed: [formId]");
+				"One of the following parameters must be specified: [formId]");
 		}
 	}
 

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormRecordResourceImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormRecordResourceImpl.java
@@ -354,8 +354,15 @@ public abstract class BaseFormRecordResourceImpl
 			"createStrategy", "INSERT");
 
 		if ("INSERT".equalsIgnoreCase(createStrategy)) {
-			formRecordUnsafeConsumer = formRecord -> postFormFormRecord(
-				Long.parseLong((String)parameters.get("formId")), formRecord);
+			if (parameters.containsKey("formId")) {
+				formRecordUnsafeConsumer = formRecord -> postFormFormRecord(
+					Long.parseLong((String)parameters.get("formId")),
+					formRecord);
+			}
+			else {
+				throw new NotSupportedException(
+					"One of the following parameters must be informed: [formId]");
+			}
 		}
 
 		if (formRecordUnsafeConsumer == null) {
@@ -380,6 +387,9 @@ public abstract class BaseFormRecordResourceImpl
 			java.util.Collection<FormRecord> formRecords,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -415,8 +425,14 @@ public abstract class BaseFormRecordResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return getFormFormRecordsPage(
-			Long.parseLong((String)parameters.get("formId")), pagination);
+		if (parameters.containsKey("formId")) {
+			return getFormFormRecordsPage(
+				Long.parseLong((String)parameters.get("formId")), pagination);
+		}
+		else {
+			throw new NotSupportedException(
+				"One of the following parameters must be informed: [formId]");
+		}
 	}
 
 	@Override

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormResourceImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormResourceImpl.java
@@ -59,6 +59,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.UriInfo;
@@ -220,6 +221,9 @@ public abstract class BaseFormResourceImpl
 			java.util.Collection<Form> forms,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -227,6 +231,9 @@ public abstract class BaseFormResourceImpl
 			java.util.Collection<Form> forms,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -266,7 +273,8 @@ public abstract class BaseFormResourceImpl
 			return getSiteFormsPage((Long)parameters.get("siteId"), pagination);
 		}
 		else {
-			return null;
+			throw new NotSupportedException(
+				"One of the following parameters must be informed: [siteId]");
 		}
 	}
 
@@ -297,6 +305,9 @@ public abstract class BaseFormResourceImpl
 			java.util.Collection<Form> forms,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormResourceImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormResourceImpl.java
@@ -274,7 +274,7 @@ public abstract class BaseFormResourceImpl
 		}
 		else {
 			throw new NotSupportedException(
-				"One of the following parameters must be informed: [siteId]");
+				"One of the following parameters must be specified: [siteId]");
 		}
 	}
 

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormStructureResourceImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormStructureResourceImpl.java
@@ -208,7 +208,7 @@ public abstract class BaseFormStructureResourceImpl
 		}
 		else {
 			throw new NotSupportedException(
-				"One of the following parameters must be informed: [siteId]");
+				"One of the following parameters must be specified: [siteId]");
 		}
 	}
 

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormStructureResourceImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormStructureResourceImpl.java
@@ -56,6 +56,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.UriInfo;
@@ -153,6 +154,9 @@ public abstract class BaseFormStructureResourceImpl
 			java.util.Collection<FormStructure> formStructures,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -160,6 +164,9 @@ public abstract class BaseFormStructureResourceImpl
 			java.util.Collection<FormStructure> formStructures,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -200,7 +207,8 @@ public abstract class BaseFormStructureResourceImpl
 				(Long)parameters.get("siteId"), pagination);
 		}
 		else {
-			return null;
+			throw new NotSupportedException(
+				"One of the following parameters must be informed: [siteId]");
 		}
 	}
 
@@ -231,6 +239,9 @@ public abstract class BaseFormStructureResourceImpl
 			java.util.Collection<FormStructure> formStructures,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/headless/user-account-extension/.gitignore
+++ b/modules/apps/headless/user-account-extension/.gitignore
@@ -1,0 +1,3 @@
+.gradle/
+build/
+target/

--- a/modules/apps/headless/user-account-extension/bnd.bnd
+++ b/modules/apps/headless/user-account-extension/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: User Account Extension
+Bundle-SymbolicName: com.liferay.useraccount.extension
+Bundle-Version: 1.0.0

--- a/modules/apps/headless/user-account-extension/build.gradle
+++ b/modules/apps/headless/user-account-extension/build.gradle
@@ -1,0 +1,20 @@
+dependencies {
+	compileOnly project(":apps:headless:headless-admin-user:headless-admin-user-api")
+
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+
+	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.13.2"
+	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-core", version: "2.13.2"
+	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.13.2.2"
+
+	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
+
+	compileOnly group: "org.osgi", name: "org.osgi.service.component", version: "1.4.0"
+	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
+	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
+
+	compileOnly group: "com.fasterxml.jackson.jaxrs", name: "jackson-jaxrs-json-provider", version: "2.9.8"
+	compileOnly group: "org.osgi", name: "org.osgi.service.jaxrs", version: "1.0.0"
+	compileOnly group: "javax.ws.rs", name: "javax.ws.rs-api", version: "2.1"
+
+}

--- a/modules/apps/headless/user-account-extension/src/main/java/com/liferay/useraccount/extension/BiographyService.java
+++ b/modules/apps/headless/user-account-extension/src/main/java/com/liferay/useraccount/extension/BiographyService.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.useraccount.extension;
+
+/**
+ * @author Javier de Arcos
+ */
+public interface BiographyService {
+    String getBiography(String userId);
+}

--- a/modules/apps/headless/user-account-extension/src/main/java/com/liferay/useraccount/extension/GithubBiographyService.java
+++ b/modules/apps/headless/user-account-extension/src/main/java/com/liferay/useraccount/extension/GithubBiographyService.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.useraccount.extension;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.osgi.service.component.annotations.Component;
+
+import java.io.IOException;
+import java.net.URL;
+
+/**
+ * @author Javier de Arcos
+ */
+@Component(
+        immediate = true,
+        service = BiographyService.class
+)
+public class GithubBiographyService implements BiographyService {
+
+    private static final String GITHUB_USERS_ENDPOINT = "https://api.github.com/users/";
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    {
+        OBJECT_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    }
+
+    @Override
+    public String getBiography(String userId) {
+        try {
+            if (userId != null) {
+                URL url = new URL(GITHUB_USERS_ENDPOINT + userId);
+                GithubUser githubUser = OBJECT_MAPPER.readValue(url, GithubUser.class);
+                return githubUser.getBio();
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        return null;
+    }
+
+    private static class GithubUser {
+        private String login;
+        private String bio;
+
+        public String getLogin() {
+            return login;
+        }
+
+        public void setLogin(String login) {
+            this.login = login;
+        }
+
+        public String getBio() {
+            return bio;
+        }
+
+        public void setBio(String bio) {
+            this.bio = bio;
+        }
+    }
+}

--- a/modules/apps/headless/user-account-extension/src/main/java/com/liferay/useraccount/extension/UserAccountExtensionContext.java
+++ b/modules/apps/headless/user-account-extension/src/main/java/com/liferay/useraccount/extension/UserAccountExtensionContext.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.useraccount.extension;
+
+import com.liferay.headless.admin.user.dto.v1_0.UserAccount;
+import com.liferay.portal.vulcan.jaxrs.context.EntityExtensionContext;
+import com.liferay.portal.vulcan.jaxrs.context.ExtensionContext;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+import javax.ws.rs.ext.ContextResolver;
+import java.util.*;
+
+/**
+ * @author Javier de Arcos
+ */
+@Component(
+        property = {
+                "osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Admin.User)",
+                "osgi.jaxrs.extension=true",
+                "osgi.jaxrs.name=Liferay.Headless.Admin.UserAccount.BiographyExtension"
+        },
+        service = ContextResolver.class
+)
+public class UserAccountExtensionContext implements ContextResolver<ExtensionContext> {
+    @Override
+    public ExtensionContext getContext(Class<?> type) {
+        if (type.isAssignableFrom(UserAccount.class)) {
+            return new EntityExtensionContext<UserAccount>() {
+                @Override
+                public Map<String, Object> getEntityExtendedProperties(UserAccount userAccount) {
+                    return Collections.singletonMap("biography", getGithubName(userAccount));
+                }
+
+                @Override
+                public Set<String> getEntityFilteredPropertyKeys(UserAccount entity) {
+                    return null;
+                }
+            };
+        }
+
+        return null;
+    }
+
+    private String getGithubName(UserAccount userAccount) {
+        return biographyService.getBiography(userAccount.getAlternateName());
+    }
+
+    @Reference
+    private BiographyService biographyService;
+
+}

--- a/modules/apps/headless/user-account-extension/src/main/java/com/liferay/useraccount/extension/UserAccountGraphQLContributor.java
+++ b/modules/apps/headless/user-account-extension/src/main/java/com/liferay/useraccount/extension/UserAccountGraphQLContributor.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.useraccount.extension;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import com.liferay.headless.admin.user.dto.v1_0.UserAccount;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLTypeExtension;
+import com.liferay.portal.vulcan.graphql.contributor.GraphQLContributor;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+import java.util.Map;
+
+/**
+ * @author Javier de Arcos
+ */
+@Component(
+		immediate = true,
+		service = GraphQLContributor.class
+)
+public class UserAccountGraphQLContributor implements GraphQLContributor {
+
+	@Activate
+	public void activate() {
+		UserAccountQueryContributor.setBiographyService(biographyService);
+		UserAccountQueryContributor.setDtoConverterRegistry(_dtoConverterRegistry);
+	}
+
+	@Override
+	public String getPath() {
+		return "/headless-admin-user-graphql/v1_0";
+	}
+
+	@Override
+	public UserAccountQueryContributor getQuery() {
+		return new UserAccountQueryContributor();
+	}
+
+	public static class UserAccountQueryContributor {
+
+		@GraphQLTypeExtension(UserAccount.class)
+		public class UserAccountBiographyTypeExtension {
+
+			public UserAccountBiographyTypeExtension(UserAccount userAccount) {
+				this.userAccount = userAccount;
+			}
+
+			@GraphQLField
+			public String biography() {
+				return getGithubName(userAccount);
+			}
+
+			private final UserAccount userAccount;
+		}
+
+		@GraphQLTypeExtension(Object.class)
+		public class UserAccountBiographyTypeExtension2<T> {
+
+			public UserAccountBiographyTypeExtension2(T object) {
+				this.object = object;
+			}
+
+			@GraphQLField
+			public Map<String, Object> thisIsTheMap() {
+
+//					for (String className : dtoConverter.getDTOClassNames()) {
+//						try {
+//							if (Class.forName(className).isInstance(object)) {
+//								System.out.println("yes");
+//							}
+//						} catch (Exception exception) {
+//							System.out.println(exception.getStackTrace());
+//						}
+//					}
+
+				return HashMapBuilder
+					.<String, Object>put("key1", "valueString")
+					.<String, Object>put("key2", 2L)
+					.<String, Object>put("key3", true)
+					.build();
+			}
+
+			private final Object object;
+		}
+
+		private String getGithubName(UserAccount userAccount) {
+			return biographyService.getBiography(userAccount.getAlternateName());
+		}
+
+		public static void setBiographyService(BiographyService service) {
+			biographyService = service;
+		}
+
+		public static void setDtoConverterRegistry(DTOConverterRegistry dtoConverterRegistry) {
+			dtoConverter = dtoConverterRegistry;
+		}
+
+		private static BiographyService biographyService;
+		private static DTOConverterRegistry dtoConverter;
+	}
+
+	@Reference
+	private BiographyService biographyService;
+
+	@Reference
+	private DTOConverterRegistry _dtoConverterRegistry;
+}

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectActionResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectActionResourceImpl.java
@@ -485,7 +485,7 @@ public abstract class BaseObjectActionResourceImpl
 			}
 			else {
 				throw new NotSupportedException(
-					"One of the following parameters must be informed: [objectDefinitionId]");
+					"One of the following parameters must be specified: [objectDefinitionId]");
 			}
 		}
 
@@ -557,7 +557,7 @@ public abstract class BaseObjectActionResourceImpl
 		}
 		else {
 			throw new NotSupportedException(
-				"One of the following parameters must be informed: [objectDefinitionId]");
+				"One of the following parameters must be specified: [objectDefinitionId]");
 		}
 	}
 

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectActionResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectActionResourceImpl.java
@@ -476,11 +476,17 @@ public abstract class BaseObjectActionResourceImpl
 			"createStrategy", "INSERT");
 
 		if ("INSERT".equalsIgnoreCase(createStrategy)) {
-			objectActionUnsafeConsumer =
-				objectAction -> postObjectDefinitionObjectAction(
-					Long.parseLong(
-						(String)parameters.get("objectDefinitionId")),
-					objectAction);
+			if (parameters.containsKey("objectDefinitionId")) {
+				objectActionUnsafeConsumer =
+					objectAction -> postObjectDefinitionObjectAction(
+						Long.parseLong(
+							(String)parameters.get("objectDefinitionId")),
+						objectAction);
+			}
+			else {
+				throw new NotSupportedException(
+					"One of the following parameters must be informed: [objectDefinitionId]");
+			}
 		}
 
 		if (objectActionUnsafeConsumer == null) {
@@ -544,9 +550,15 @@ public abstract class BaseObjectActionResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return getObjectDefinitionObjectActionsPage(
-			Long.parseLong((String)parameters.get("objectDefinitionId")),
-			search, pagination);
+		if (parameters.containsKey("objectDefinitionId")) {
+			return getObjectDefinitionObjectActionsPage(
+				Long.parseLong((String)parameters.get("objectDefinitionId")),
+				search, pagination);
+		}
+		else {
+			throw new NotSupportedException(
+				"One of the following parameters must be informed: [objectDefinitionId]");
+		}
 	}
 
 	@Override

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectFieldResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectFieldResourceImpl.java
@@ -492,7 +492,7 @@ public abstract class BaseObjectFieldResourceImpl
 			}
 			else {
 				throw new NotSupportedException(
-					"One of the following parameters must be informed: [objectDefinitionId]");
+					"One of the following parameters must be specified: [objectDefinitionId]");
 			}
 		}
 
@@ -564,7 +564,7 @@ public abstract class BaseObjectFieldResourceImpl
 		}
 		else {
 			throw new NotSupportedException(
-				"One of the following parameters must be informed: [objectDefinitionId]");
+				"One of the following parameters must be specified: [objectDefinitionId]");
 		}
 	}
 

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectFieldResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectFieldResourceImpl.java
@@ -483,11 +483,17 @@ public abstract class BaseObjectFieldResourceImpl
 			"createStrategy", "INSERT");
 
 		if ("INSERT".equalsIgnoreCase(createStrategy)) {
-			objectFieldUnsafeConsumer =
-				objectField -> postObjectDefinitionObjectField(
-					Long.parseLong(
-						(String)parameters.get("objectDefinitionId")),
-					objectField);
+			if (parameters.containsKey("objectDefinitionId")) {
+				objectFieldUnsafeConsumer =
+					objectField -> postObjectDefinitionObjectField(
+						Long.parseLong(
+							(String)parameters.get("objectDefinitionId")),
+						objectField);
+			}
+			else {
+				throw new NotSupportedException(
+					"One of the following parameters must be informed: [objectDefinitionId]");
+			}
 		}
 
 		if (objectFieldUnsafeConsumer == null) {
@@ -551,9 +557,15 @@ public abstract class BaseObjectFieldResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return getObjectDefinitionObjectFieldsPage(
-			Long.parseLong((String)parameters.get("objectDefinitionId")),
-			search, pagination);
+		if (parameters.containsKey("objectDefinitionId")) {
+			return getObjectDefinitionObjectFieldsPage(
+				Long.parseLong((String)parameters.get("objectDefinitionId")),
+				search, pagination);
+		}
+		else {
+			throw new NotSupportedException(
+				"One of the following parameters must be informed: [objectDefinitionId]");
+		}
 	}
 
 	@Override

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectLayoutResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectLayoutResourceImpl.java
@@ -396,11 +396,17 @@ public abstract class BaseObjectLayoutResourceImpl
 			"createStrategy", "INSERT");
 
 		if ("INSERT".equalsIgnoreCase(createStrategy)) {
-			objectLayoutUnsafeConsumer =
-				objectLayout -> postObjectDefinitionObjectLayout(
-					Long.parseLong(
-						(String)parameters.get("objectDefinitionId")),
-					objectLayout);
+			if (parameters.containsKey("objectDefinitionId")) {
+				objectLayoutUnsafeConsumer =
+					objectLayout -> postObjectDefinitionObjectLayout(
+						Long.parseLong(
+							(String)parameters.get("objectDefinitionId")),
+						objectLayout);
+			}
+			else {
+				throw new NotSupportedException(
+					"One of the following parameters must be informed: [objectDefinitionId]");
+			}
 		}
 
 		if (objectLayoutUnsafeConsumer == null) {
@@ -464,9 +470,15 @@ public abstract class BaseObjectLayoutResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return getObjectDefinitionObjectLayoutsPage(
-			Long.parseLong((String)parameters.get("objectDefinitionId")),
-			search, pagination);
+		if (parameters.containsKey("objectDefinitionId")) {
+			return getObjectDefinitionObjectLayoutsPage(
+				Long.parseLong((String)parameters.get("objectDefinitionId")),
+				search, pagination);
+		}
+		else {
+			throw new NotSupportedException(
+				"One of the following parameters must be informed: [objectDefinitionId]");
+		}
 	}
 
 	@Override

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectLayoutResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectLayoutResourceImpl.java
@@ -405,7 +405,7 @@ public abstract class BaseObjectLayoutResourceImpl
 			}
 			else {
 				throw new NotSupportedException(
-					"One of the following parameters must be informed: [objectDefinitionId]");
+					"One of the following parameters must be specified: [objectDefinitionId]");
 			}
 		}
 
@@ -477,7 +477,7 @@ public abstract class BaseObjectLayoutResourceImpl
 		}
 		else {
 			throw new NotSupportedException(
-				"One of the following parameters must be informed: [objectDefinitionId]");
+				"One of the following parameters must be specified: [objectDefinitionId]");
 		}
 	}
 

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectRelationshipResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectRelationshipResourceImpl.java
@@ -421,11 +421,18 @@ public abstract class BaseObjectRelationshipResourceImpl
 			"createStrategy", "INSERT");
 
 		if ("INSERT".equalsIgnoreCase(createStrategy)) {
-			objectRelationshipUnsafeConsumer =
-				objectRelationship -> postObjectDefinitionObjectRelationship(
-					Long.parseLong(
-						(String)parameters.get("objectDefinitionId")),
-					objectRelationship);
+			if (parameters.containsKey("objectDefinitionId")) {
+				objectRelationshipUnsafeConsumer =
+					objectRelationship ->
+						postObjectDefinitionObjectRelationship(
+							Long.parseLong(
+								(String)parameters.get("objectDefinitionId")),
+							objectRelationship);
+			}
+			else {
+				throw new NotSupportedException(
+					"One of the following parameters must be informed: [objectDefinitionId]");
+			}
 		}
 
 		if (objectRelationshipUnsafeConsumer == null) {
@@ -489,9 +496,15 @@ public abstract class BaseObjectRelationshipResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return getObjectDefinitionObjectRelationshipsPage(
-			Long.parseLong((String)parameters.get("objectDefinitionId")),
-			search, filter, pagination);
+		if (parameters.containsKey("objectDefinitionId")) {
+			return getObjectDefinitionObjectRelationshipsPage(
+				Long.parseLong((String)parameters.get("objectDefinitionId")),
+				search, filter, pagination);
+		}
+		else {
+			throw new NotSupportedException(
+				"One of the following parameters must be informed: [objectDefinitionId]");
+		}
 	}
 
 	@Override

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectRelationshipResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectRelationshipResourceImpl.java
@@ -431,7 +431,7 @@ public abstract class BaseObjectRelationshipResourceImpl
 			}
 			else {
 				throw new NotSupportedException(
-					"One of the following parameters must be informed: [objectDefinitionId]");
+					"One of the following parameters must be specified: [objectDefinitionId]");
 			}
 		}
 
@@ -503,7 +503,7 @@ public abstract class BaseObjectRelationshipResourceImpl
 		}
 		else {
 			throw new NotSupportedException(
-				"One of the following parameters must be informed: [objectDefinitionId]");
+				"One of the following parameters must be specified: [objectDefinitionId]");
 		}
 	}
 

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectValidationRuleResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectValidationRuleResourceImpl.java
@@ -525,12 +525,17 @@ public abstract class BaseObjectValidationRuleResourceImpl
 			"createStrategy", "INSERT");
 
 		if ("INSERT".equalsIgnoreCase(createStrategy)) {
-			objectValidationRuleUnsafeConsumer =
-				objectValidationRule ->
+			if (parameters.containsKey("objectDefinitionId")) {
+				objectValidationRuleUnsafeConsumer = objectValidationRule ->
 					postObjectDefinitionObjectValidationRule(
 						Long.parseLong(
 							(String)parameters.get("objectDefinitionId")),
 						objectValidationRule);
+			}
+			else {
+				throw new NotSupportedException(
+					"One of the following parameters must be informed: [objectDefinitionId]");
+			}
 		}
 
 		if (objectValidationRuleUnsafeConsumer == null) {
@@ -598,9 +603,15 @@ public abstract class BaseObjectValidationRuleResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return getObjectDefinitionObjectValidationRulesPage(
-			Long.parseLong((String)parameters.get("objectDefinitionId")),
-			search, pagination);
+		if (parameters.containsKey("objectDefinitionId")) {
+			return getObjectDefinitionObjectValidationRulesPage(
+				Long.parseLong((String)parameters.get("objectDefinitionId")),
+				search, pagination);
+		}
+		else {
+			throw new NotSupportedException(
+				"One of the following parameters must be informed: [objectDefinitionId]");
+		}
 	}
 
 	@Override

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectValidationRuleResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectValidationRuleResourceImpl.java
@@ -534,7 +534,7 @@ public abstract class BaseObjectValidationRuleResourceImpl
 			}
 			else {
 				throw new NotSupportedException(
-					"One of the following parameters must be informed: [objectDefinitionId]");
+					"One of the following parameters must be specified: [objectDefinitionId]");
 			}
 		}
 
@@ -610,7 +610,7 @@ public abstract class BaseObjectValidationRuleResourceImpl
 		}
 		else {
 			throw new NotSupportedException(
-				"One of the following parameters must be informed: [objectDefinitionId]");
+				"One of the following parameters must be specified: [objectDefinitionId]");
 		}
 	}
 

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectViewResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectViewResourceImpl.java
@@ -425,11 +425,17 @@ public abstract class BaseObjectViewResourceImpl
 			"createStrategy", "INSERT");
 
 		if ("INSERT".equalsIgnoreCase(createStrategy)) {
-			objectViewUnsafeConsumer =
-				objectView -> postObjectDefinitionObjectView(
-					Long.parseLong(
-						(String)parameters.get("objectDefinitionId")),
-					objectView);
+			if (parameters.containsKey("objectDefinitionId")) {
+				objectViewUnsafeConsumer =
+					objectView -> postObjectDefinitionObjectView(
+						Long.parseLong(
+							(String)parameters.get("objectDefinitionId")),
+						objectView);
+			}
+			else {
+				throw new NotSupportedException(
+					"One of the following parameters must be informed: [objectDefinitionId]");
+			}
 		}
 
 		if (objectViewUnsafeConsumer == null) {
@@ -493,9 +499,15 @@ public abstract class BaseObjectViewResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return getObjectDefinitionObjectViewsPage(
-			Long.parseLong((String)parameters.get("objectDefinitionId")),
-			search, pagination);
+		if (parameters.containsKey("objectDefinitionId")) {
+			return getObjectDefinitionObjectViewsPage(
+				Long.parseLong((String)parameters.get("objectDefinitionId")),
+				search, pagination);
+		}
+		else {
+			throw new NotSupportedException(
+				"One of the following parameters must be informed: [objectDefinitionId]");
+		}
 	}
 
 	@Override

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectViewResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectViewResourceImpl.java
@@ -434,7 +434,7 @@ public abstract class BaseObjectViewResourceImpl
 			}
 			else {
 				throw new NotSupportedException(
-					"One of the following parameters must be informed: [objectDefinitionId]");
+					"One of the following parameters must be specified: [objectDefinitionId]");
 			}
 		}
 
@@ -506,7 +506,7 @@ public abstract class BaseObjectViewResourceImpl
 		}
 		else {
 			throw new NotSupportedException(
-				"One of the following parameters must be informed: [objectDefinitionId]");
+				"One of the following parameters must be specified: [objectDefinitionId]");
 		}
 	}
 

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseObjectEntryResourceImpl.java
@@ -819,7 +819,8 @@ public abstract class BaseObjectEntryResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/BaseAccountCategoryForecastResourceImpl.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/BaseAccountCategoryForecastResourceImpl.java
@@ -151,6 +151,9 @@ public abstract class BaseAccountCategoryForecastResourceImpl
 				accountCategoryForecasts,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -159,6 +162,9 @@ public abstract class BaseAccountCategoryForecastResourceImpl
 				accountCategoryForecasts,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -194,7 +200,8 @@ public abstract class BaseAccountCategoryForecastResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -225,6 +232,9 @@ public abstract class BaseAccountCategoryForecastResourceImpl
 				accountCategoryForecasts,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/BaseAccountForecastResourceImpl.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/BaseAccountForecastResourceImpl.java
@@ -140,6 +140,9 @@ public abstract class BaseAccountForecastResourceImpl
 			java.util.Collection<AccountForecast> accountForecasts,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -147,6 +150,9 @@ public abstract class BaseAccountForecastResourceImpl
 			java.util.Collection<AccountForecast> accountForecasts,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -182,7 +188,8 @@ public abstract class BaseAccountForecastResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -212,6 +219,9 @@ public abstract class BaseAccountForecastResourceImpl
 			java.util.Collection<AccountForecast> accountForecasts,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/BaseSkuForecastResourceImpl.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/BaseSkuForecastResourceImpl.java
@@ -138,6 +138,9 @@ public abstract class BaseSkuForecastResourceImpl
 			java.util.Collection<SkuForecast> skuForecasts,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -145,6 +148,9 @@ public abstract class BaseSkuForecastResourceImpl
 			java.util.Collection<SkuForecast> skuForecasts,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -180,7 +186,8 @@ public abstract class BaseSkuForecastResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -210,6 +217,9 @@ public abstract class BaseSkuForecastResourceImpl
 			java.util.Collection<SkuForecast> skuForecasts,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseAssigneeMetricResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseAssigneeMetricResourceImpl.java
@@ -125,6 +125,9 @@ public abstract class BaseAssigneeMetricResourceImpl
 			java.util.Collection<AssigneeMetric> assigneeMetrics,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -132,6 +135,9 @@ public abstract class BaseAssigneeMetricResourceImpl
 			java.util.Collection<AssigneeMetric> assigneeMetrics,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -167,7 +173,8 @@ public abstract class BaseAssigneeMetricResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -197,6 +204,9 @@ public abstract class BaseAssigneeMetricResourceImpl
 			java.util.Collection<AssigneeMetric> assigneeMetrics,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseAssigneeResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseAssigneeResourceImpl.java
@@ -109,6 +109,9 @@ public abstract class BaseAssigneeResourceImpl
 			java.util.Collection<Assignee> assignees,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -116,6 +119,9 @@ public abstract class BaseAssigneeResourceImpl
 			java.util.Collection<Assignee> assignees,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -151,7 +157,8 @@ public abstract class BaseAssigneeResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -181,6 +188,9 @@ public abstract class BaseAssigneeResourceImpl
 			java.util.Collection<Assignee> assignees,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseCalendarResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseCalendarResourceImpl.java
@@ -92,6 +92,9 @@ public abstract class BaseCalendarResourceImpl
 			java.util.Collection<Calendar> calendars,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -99,6 +102,9 @@ public abstract class BaseCalendarResourceImpl
 			java.util.Collection<Calendar> calendars,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -164,6 +170,9 @@ public abstract class BaseCalendarResourceImpl
 			java.util.Collection<Calendar> calendars,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseIndexResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseIndexResourceImpl.java
@@ -124,6 +124,9 @@ public abstract class BaseIndexResourceImpl
 			java.util.Collection<Index> indexes,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -131,6 +134,9 @@ public abstract class BaseIndexResourceImpl
 			java.util.Collection<Index> indexes,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -166,7 +172,8 @@ public abstract class BaseIndexResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -196,6 +203,9 @@ public abstract class BaseIndexResourceImpl
 			java.util.Collection<Index> indexes,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseInstanceResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseInstanceResourceImpl.java
@@ -419,7 +419,7 @@ public abstract class BaseInstanceResourceImpl
 			}
 			else {
 				throw new NotSupportedException(
-					"One of the following parameters must be informed: [processId]");
+					"One of the following parameters must be specified: [processId]");
 			}
 		}
 
@@ -496,7 +496,7 @@ public abstract class BaseInstanceResourceImpl
 		}
 		else {
 			throw new NotSupportedException(
-				"One of the following parameters must be informed: [processId]");
+				"One of the following parameters must be specified: [processId]");
 		}
 	}
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseInstanceResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseInstanceResourceImpl.java
@@ -412,8 +412,15 @@ public abstract class BaseInstanceResourceImpl
 			"createStrategy", "INSERT");
 
 		if ("INSERT".equalsIgnoreCase(createStrategy)) {
-			instanceUnsafeConsumer = instance -> postProcessInstance(
-				Long.parseLong((String)parameters.get("processId")), instance);
+			if (parameters.containsKey("processId")) {
+				instanceUnsafeConsumer = instance -> postProcessInstance(
+					Long.parseLong((String)parameters.get("processId")),
+					instance);
+			}
+			else {
+				throw new NotSupportedException(
+					"One of the following parameters must be informed: [processId]");
+			}
 		}
 
 		if (instanceUnsafeConsumer == null) {
@@ -438,6 +445,9 @@ public abstract class BaseInstanceResourceImpl
 			java.util.Collection<Instance> instances,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -473,15 +483,21 @@ public abstract class BaseInstanceResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return getProcessInstancesPage(
-			Long.parseLong((String)parameters.get("processId")),
-			(Long[])parameters.get("assigneeIds"),
-			(Long[])parameters.get("classPKs"),
-			new java.util.Date((String)parameters.get("dateEnd")),
-			new java.util.Date((String)parameters.get("dateStart")),
-			(String[])parameters.get("slaStatuses"),
-			(String[])parameters.get("statuses"),
-			(String[])parameters.get("taskNames"), pagination, sorts);
+		if (parameters.containsKey("processId")) {
+			return getProcessInstancesPage(
+				Long.parseLong((String)parameters.get("processId")),
+				(Long[])parameters.get("assigneeIds"),
+				(Long[])parameters.get("classPKs"),
+				new java.util.Date((String)parameters.get("dateEnd")),
+				new java.util.Date((String)parameters.get("dateStart")),
+				(String[])parameters.get("slaStatuses"),
+				(String[])parameters.get("statuses"),
+				(String[])parameters.get("taskNames"), pagination, sorts);
+		}
+		else {
+			throw new NotSupportedException(
+				"One of the following parameters must be informed: [processId]");
+		}
 	}
 
 	@Override
@@ -511,6 +527,9 @@ public abstract class BaseInstanceResourceImpl
 			java.util.Collection<Instance> instances,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseNodeMetricResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseNodeMetricResourceImpl.java
@@ -155,6 +155,9 @@ public abstract class BaseNodeMetricResourceImpl
 			java.util.Collection<NodeMetric> nodeMetrics,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -162,6 +165,9 @@ public abstract class BaseNodeMetricResourceImpl
 			java.util.Collection<NodeMetric> nodeMetrics,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -197,7 +203,8 @@ public abstract class BaseNodeMetricResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -227,6 +234,9 @@ public abstract class BaseNodeMetricResourceImpl
 			java.util.Collection<NodeMetric> nodeMetrics,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseNodeResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseNodeResourceImpl.java
@@ -241,7 +241,7 @@ public abstract class BaseNodeResourceImpl
 			}
 			else {
 				throw new NotSupportedException(
-					"One of the following parameters must be informed: [processId]");
+					"One of the following parameters must be specified: [processId]");
 			}
 		}
 
@@ -310,7 +310,7 @@ public abstract class BaseNodeResourceImpl
 		}
 		else {
 			throw new NotSupportedException(
-				"One of the following parameters must be informed: [processId]");
+				"One of the following parameters must be specified: [processId]");
 		}
 	}
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseNodeResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseNodeResourceImpl.java
@@ -235,8 +235,14 @@ public abstract class BaseNodeResourceImpl
 			"createStrategy", "INSERT");
 
 		if ("INSERT".equalsIgnoreCase(createStrategy)) {
-			nodeUnsafeConsumer = node -> postProcessNode(
-				Long.parseLong((String)parameters.get("processId")), node);
+			if (parameters.containsKey("processId")) {
+				nodeUnsafeConsumer = node -> postProcessNode(
+					Long.parseLong((String)parameters.get("processId")), node);
+			}
+			else {
+				throw new NotSupportedException(
+					"One of the following parameters must be informed: [processId]");
+			}
 		}
 
 		if (nodeUnsafeConsumer == null) {
@@ -260,6 +266,9 @@ public abstract class BaseNodeResourceImpl
 			java.util.Collection<Node> nodes,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -295,8 +304,14 @@ public abstract class BaseNodeResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return getProcessNodesPage(
-			Long.parseLong((String)parameters.get("processId")));
+		if (parameters.containsKey("processId")) {
+			return getProcessNodesPage(
+				Long.parseLong((String)parameters.get("processId")));
+		}
+		else {
+			throw new NotSupportedException(
+				"One of the following parameters must be informed: [processId]");
+		}
 	}
 
 	@Override
@@ -326,6 +341,9 @@ public abstract class BaseNodeResourceImpl
 			java.util.Collection<Node> nodes,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseProcessMetricResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseProcessMetricResourceImpl.java
@@ -174,6 +174,9 @@ public abstract class BaseProcessMetricResourceImpl
 			java.util.Collection<ProcessMetric> processMetrics,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -181,6 +184,9 @@ public abstract class BaseProcessMetricResourceImpl
 			java.util.Collection<ProcessMetric> processMetrics,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -247,6 +253,9 @@ public abstract class BaseProcessMetricResourceImpl
 			java.util.Collection<ProcessMetric> processMetrics,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseProcessResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseProcessResourceImpl.java
@@ -415,7 +415,8 @@ public abstract class BaseProcessResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseProcessVersionResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseProcessVersionResourceImpl.java
@@ -163,7 +163,7 @@ public abstract class BaseProcessVersionResourceImpl
 		}
 		else {
 			throw new NotSupportedException(
-				"One of the following parameters must be informed: [processId]");
+				"One of the following parameters must be specified: [processId]");
 		}
 	}
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseProcessVersionResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseProcessVersionResourceImpl.java
@@ -56,6 +56,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.UriInfo;
@@ -108,6 +109,9 @@ public abstract class BaseProcessVersionResourceImpl
 			java.util.Collection<ProcessVersion> processVersions,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -115,6 +119,9 @@ public abstract class BaseProcessVersionResourceImpl
 			java.util.Collection<ProcessVersion> processVersions,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -150,8 +157,14 @@ public abstract class BaseProcessVersionResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return getProcessProcessVersionsPage(
-			Long.parseLong((String)parameters.get("processId")));
+		if (parameters.containsKey("processId")) {
+			return getProcessProcessVersionsPage(
+				Long.parseLong((String)parameters.get("processId")));
+		}
+		else {
+			throw new NotSupportedException(
+				"One of the following parameters must be informed: [processId]");
+		}
 	}
 
 	@Override
@@ -181,6 +194,9 @@ public abstract class BaseProcessVersionResourceImpl
 			java.util.Collection<ProcessVersion> processVersions,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseReindexStatusResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseReindexStatusResourceImpl.java
@@ -94,6 +94,9 @@ public abstract class BaseReindexStatusResourceImpl
 			java.util.Collection<ReindexStatus> reindexStatuses,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -101,6 +104,9 @@ public abstract class BaseReindexStatusResourceImpl
 			java.util.Collection<ReindexStatus> reindexStatuses,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -136,7 +142,8 @@ public abstract class BaseReindexStatusResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -166,6 +173,9 @@ public abstract class BaseReindexStatusResourceImpl
 			java.util.Collection<ReindexStatus> reindexStatuses,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseRoleResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseRoleResourceImpl.java
@@ -169,7 +169,7 @@ public abstract class BaseRoleResourceImpl
 		}
 		else {
 			throw new NotSupportedException(
-				"One of the following parameters must be informed: [processId]");
+				"One of the following parameters must be specified: [processId]");
 		}
 	}
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseRoleResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseRoleResourceImpl.java
@@ -56,6 +56,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.UriInfo;
@@ -113,6 +114,9 @@ public abstract class BaseRoleResourceImpl
 			java.util.Collection<Role> roles,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -120,6 +124,9 @@ public abstract class BaseRoleResourceImpl
 			java.util.Collection<Role> roles,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -155,9 +162,15 @@ public abstract class BaseRoleResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return getProcessRolesPage(
-			Long.parseLong((String)parameters.get("processId")),
-			Boolean.parseBoolean((String)parameters.get("completed")));
+		if (parameters.containsKey("processId")) {
+			return getProcessRolesPage(
+				Long.parseLong((String)parameters.get("processId")),
+				Boolean.parseBoolean((String)parameters.get("completed")));
+		}
+		else {
+			throw new NotSupportedException(
+				"One of the following parameters must be informed: [processId]");
+		}
 	}
 
 	@Override
@@ -187,6 +200,9 @@ public abstract class BaseRoleResourceImpl
 			java.util.Collection<Role> roles,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseSLAResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseSLAResourceImpl.java
@@ -411,8 +411,14 @@ public abstract class BaseSLAResourceImpl
 			"createStrategy", "INSERT");
 
 		if ("INSERT".equalsIgnoreCase(createStrategy)) {
-			slaUnsafeConsumer = sla -> postProcessSLA(
-				Long.parseLong((String)parameters.get("processId")), sla);
+			if (parameters.containsKey("processId")) {
+				slaUnsafeConsumer = sla -> postProcessSLA(
+					Long.parseLong((String)parameters.get("processId")), sla);
+			}
+			else {
+				throw new NotSupportedException(
+					"One of the following parameters must be informed: [processId]");
+			}
 		}
 
 		if (slaUnsafeConsumer == null) {
@@ -475,9 +481,15 @@ public abstract class BaseSLAResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return getProcessSLAsPage(
-			Long.parseLong((String)parameters.get("processId")),
-			Integer.parseInt((String)parameters.get("status")), pagination);
+		if (parameters.containsKey("processId")) {
+			return getProcessSLAsPage(
+				Long.parseLong((String)parameters.get("processId")),
+				Integer.parseInt((String)parameters.get("status")), pagination);
+		}
+		else {
+			throw new NotSupportedException(
+				"One of the following parameters must be informed: [processId]");
+		}
 	}
 
 	@Override

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseSLAResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseSLAResourceImpl.java
@@ -417,7 +417,7 @@ public abstract class BaseSLAResourceImpl
 			}
 			else {
 				throw new NotSupportedException(
-					"One of the following parameters must be informed: [processId]");
+					"One of the following parameters must be specified: [processId]");
 			}
 		}
 
@@ -488,7 +488,7 @@ public abstract class BaseSLAResourceImpl
 		}
 		else {
 			throw new NotSupportedException(
-				"One of the following parameters must be informed: [processId]");
+				"One of the following parameters must be specified: [processId]");
 		}
 	}
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseTaskResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseTaskResourceImpl.java
@@ -389,7 +389,7 @@ public abstract class BaseTaskResourceImpl
 			}
 			else {
 				throw new NotSupportedException(
-					"One of the following parameters must be informed: [processId]");
+					"One of the following parameters must be specified: [processId]");
 			}
 		}
 
@@ -458,7 +458,7 @@ public abstract class BaseTaskResourceImpl
 		}
 		else {
 			throw new NotSupportedException(
-				"One of the following parameters must be informed: [processId]");
+				"One of the following parameters must be specified: [processId]");
 		}
 	}
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseTaskResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseTaskResourceImpl.java
@@ -383,8 +383,14 @@ public abstract class BaseTaskResourceImpl
 			"createStrategy", "INSERT");
 
 		if ("INSERT".equalsIgnoreCase(createStrategy)) {
-			taskUnsafeConsumer = task -> postProcessTask(
-				Long.parseLong((String)parameters.get("processId")), task);
+			if (parameters.containsKey("processId")) {
+				taskUnsafeConsumer = task -> postProcessTask(
+					Long.parseLong((String)parameters.get("processId")), task);
+			}
+			else {
+				throw new NotSupportedException(
+					"One of the following parameters must be informed: [processId]");
+			}
 		}
 
 		if (taskUnsafeConsumer == null) {
@@ -408,6 +414,9 @@ public abstract class BaseTaskResourceImpl
 			java.util.Collection<Task> tasks,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -443,8 +452,14 @@ public abstract class BaseTaskResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return getProcessTasksPage(
-			Long.parseLong((String)parameters.get("processId")));
+		if (parameters.containsKey("processId")) {
+			return getProcessTasksPage(
+				Long.parseLong((String)parameters.get("processId")));
+		}
+		else {
+			throw new NotSupportedException(
+				"One of the following parameters must be informed: [processId]");
+		}
 	}
 
 	@Override
@@ -474,6 +489,9 @@ public abstract class BaseTaskResourceImpl
 			java.util.Collection<Task> tasks,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseTimeRangeResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseTimeRangeResourceImpl.java
@@ -92,6 +92,9 @@ public abstract class BaseTimeRangeResourceImpl
 			java.util.Collection<TimeRange> timeRanges,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -99,6 +102,9 @@ public abstract class BaseTimeRangeResourceImpl
 			java.util.Collection<TimeRange> timeRanges,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -164,6 +170,9 @@ public abstract class BaseTimeRangeResourceImpl
 			java.util.Collection<TimeRange> timeRanges,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseFieldMappingInfoResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseFieldMappingInfoResourceImpl.java
@@ -108,6 +108,9 @@ public abstract class BaseFieldMappingInfoResourceImpl
 			java.util.Collection<FieldMappingInfo> fieldMappingInfos,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -115,6 +118,9 @@ public abstract class BaseFieldMappingInfoResourceImpl
 			java.util.Collection<FieldMappingInfo> fieldMappingInfos,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -180,6 +186,9 @@ public abstract class BaseFieldMappingInfoResourceImpl
 			java.util.Collection<FieldMappingInfo> fieldMappingInfos,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseKeywordQueryContributorResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseKeywordQueryContributorResourceImpl.java
@@ -99,6 +99,9 @@ public abstract class BaseKeywordQueryContributorResourceImpl
 				keywordQueryContributors,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -107,6 +110,9 @@ public abstract class BaseKeywordQueryContributorResourceImpl
 				keywordQueryContributors,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -173,6 +179,9 @@ public abstract class BaseKeywordQueryContributorResourceImpl
 				keywordQueryContributors,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseModelPrefilterContributorResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseModelPrefilterContributorResourceImpl.java
@@ -99,6 +99,9 @@ public abstract class BaseModelPrefilterContributorResourceImpl
 				modelPrefilterContributors,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -107,6 +110,9 @@ public abstract class BaseModelPrefilterContributorResourceImpl
 				modelPrefilterContributors,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -173,6 +179,9 @@ public abstract class BaseModelPrefilterContributorResourceImpl
 				modelPrefilterContributors,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseQueryPrefilterContributorResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseQueryPrefilterContributorResourceImpl.java
@@ -99,6 +99,9 @@ public abstract class BaseQueryPrefilterContributorResourceImpl
 				queryPrefilterContributors,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -107,6 +110,9 @@ public abstract class BaseQueryPrefilterContributorResourceImpl
 				queryPrefilterContributors,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -173,6 +179,9 @@ public abstract class BaseQueryPrefilterContributorResourceImpl
 				queryPrefilterContributors,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSXPParameterContributorDefinitionResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSXPParameterContributorDefinitionResourceImpl.java
@@ -101,6 +101,9 @@ public abstract class BaseSXPParameterContributorDefinitionResourceImpl
 				sxpParameterContributorDefinitions,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -109,6 +112,9 @@ public abstract class BaseSXPParameterContributorDefinitionResourceImpl
 				sxpParameterContributorDefinitions,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -175,6 +181,9 @@ public abstract class BaseSXPParameterContributorDefinitionResourceImpl
 				sxpParameterContributorDefinitions,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSearchableAssetNameDisplayResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSearchableAssetNameDisplayResourceImpl.java
@@ -112,6 +112,9 @@ public abstract class BaseSearchableAssetNameDisplayResourceImpl
 				searchableAssetNameDisplays,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -120,6 +123,9 @@ public abstract class BaseSearchableAssetNameDisplayResourceImpl
 				searchableAssetNameDisplays,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -155,7 +161,8 @@ public abstract class BaseSearchableAssetNameDisplayResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -186,6 +193,9 @@ public abstract class BaseSearchableAssetNameDisplayResourceImpl
 				searchableAssetNameDisplays,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSearchableAssetNameResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSearchableAssetNameResourceImpl.java
@@ -98,6 +98,9 @@ public abstract class BaseSearchableAssetNameResourceImpl
 			java.util.Collection<SearchableAssetName> searchableAssetNames,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -105,6 +108,9 @@ public abstract class BaseSearchableAssetNameResourceImpl
 			java.util.Collection<SearchableAssetName> searchableAssetNames,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -170,6 +176,9 @@ public abstract class BaseSearchableAssetNameResourceImpl
 			java.util.Collection<SearchableAssetName> searchableAssetNames,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/BaseExperimentResourceImpl.java
+++ b/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/BaseExperimentResourceImpl.java
@@ -178,6 +178,9 @@ public abstract class BaseExperimentResourceImpl
 			java.util.Collection<Experiment> experiments,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -224,7 +227,8 @@ public abstract class BaseExperimentResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -254,6 +258,9 @@ public abstract class BaseExperimentResourceImpl
 			java.util.Collection<Experiment> experiments,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/BaseStatusResourceImpl.java
+++ b/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/BaseStatusResourceImpl.java
@@ -176,7 +176,7 @@ public abstract class BaseStatusResourceImpl
 			}
 			else {
 				throw new NotSupportedException(
-					"One of the following parameters must be informed: [experimentId]");
+					"One of the following parameters must be specified: [experimentId]");
 			}
 		}
 

--- a/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/BaseStatusResourceImpl.java
+++ b/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/BaseStatusResourceImpl.java
@@ -169,8 +169,15 @@ public abstract class BaseStatusResourceImpl
 			"createStrategy", "INSERT");
 
 		if ("INSERT".equalsIgnoreCase(createStrategy)) {
-			statusUnsafeConsumer = status -> postExperimentStatus(
-				Long.parseLong((String)parameters.get("experimentId")), status);
+			if (parameters.containsKey("experimentId")) {
+				statusUnsafeConsumer = status -> postExperimentStatus(
+					Long.parseLong((String)parameters.get("experimentId")),
+					status);
+			}
+			else {
+				throw new NotSupportedException(
+					"One of the following parameters must be informed: [experimentId]");
+			}
 		}
 
 		if (statusUnsafeConsumer == null) {
@@ -194,6 +201,9 @@ public abstract class BaseStatusResourceImpl
 			java.util.Collection<Status> statuses,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -229,7 +239,8 @@ public abstract class BaseStatusResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override
@@ -259,6 +270,9 @@ public abstract class BaseStatusResourceImpl
 			java.util.Collection<Status> statuses,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
@@ -552,6 +552,7 @@ public abstract class Base${schemaName}ResourceImpl
 						<#assign
 							scopeParameters = scopeParameters + [parentBatchJavaMethodSignature.parentSchemaName!?uncap_first + "Id"]
 						/>
+
 						if (parameters.containsKey("${parentBatchJavaMethodSignature.parentSchemaName!?uncap_first + "Id"}")) {
 							return ${parentBatchJavaMethodSignature.methodName}(
 								<@getGETBatchJavaMethodParameters javaMethodParameters=parentBatchJavaMethodSignature.javaMethodParameters />

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
@@ -360,7 +360,7 @@ public abstract class Base${schemaName}ResourceImpl
 			</#if>
 
 			<#if createStrategies?seq_contains("INSERT")>
-				<#assign scopeParameters = []/>
+				<#assign parentParameterNames = []/>
 
 				if ("INSERT".equalsIgnoreCase(createStrategy)) {
 
@@ -375,7 +375,7 @@ public abstract class Base${schemaName}ResourceImpl
 
 					<#if postParentBatchJavaMethodSignatures?has_content>
 						<#list postParentBatchJavaMethodSignatures as parentBatchJavaMethodSignature>
-							<#assign scopeParameters = scopeParameters + [parentBatchJavaMethodSignature.parentSchemaName!?uncap_first + "Id"]/>
+							<#assign parentParameterNames = parentParameterNames + [parentBatchJavaMethodSignature.parentSchemaName!?uncap_first + "Id"]/>
 
 							if (parameters.containsKey("${parentBatchJavaMethodSignature.parentSchemaName?uncap_first}Id")) {
 								${schemaVarName}UnsafeConsumer = ${schemaVarName} -> ${parentBatchJavaMethodSignature.methodName}(
@@ -393,7 +393,7 @@ public abstract class Base${schemaName}ResourceImpl
 					</#if>
 
 					<#if postAssetLibraryBatchJavaMethodSignature??>
-						<#assign scopeParameters = scopeParameters + ["assetLibraryId"]/>
+						<#assign parentParameterNames = parentParameterNames + ["assetLibraryId"]/>
 
 						<#if postParentBatchJavaMethodSignatures?has_content>
 							else
@@ -410,7 +410,7 @@ public abstract class Base${schemaName}ResourceImpl
 					</#if>
 
 					<#if postSiteBatchJavaMethodSignature??>
-						<#assign scopeParameters = scopeParameters + ["siteId"]/>
+						<#assign parentParameterNames = parentParameterNames + ["siteId"]/>
 
 						<#if postParentBatchJavaMethodSignatures?has_content || postAssetLibraryBatchJavaMethodSignature??>
 							else
@@ -426,9 +426,9 @@ public abstract class Base${schemaName}ResourceImpl
 						}
 					</#if>
 
-					<#if !postBatchJavaMethodSignature?? && scopeParameters?has_content>
+					<#if !postBatchJavaMethodSignature?? && parentParameterNames?has_content>
 						else {
-							throw new NotSupportedException("One of the following parameters must be specified: [${scopeParameters?join(", ")}]");
+							throw new NotSupportedException("One of the following parameters must be specified: [${parentParameterNames?join(", ")}]");
 						}
 					</#if>
 				}
@@ -530,10 +530,10 @@ public abstract class Base${schemaName}ResourceImpl
 		@Override
 		public Page<${javaDataType}> read(Filter filter, Pagination pagination, Sort[] sorts, Map<String, Serializable> parameters, String search) throws Exception {
 			<#if freeMarkerTool.hasReadVulcanBatchImplementation(javaMethodSignatures)>
-				<#assign scopeParameters = []/>
+				<#assign parentParameterNames = []/>
 
 				<#if getAssetLibraryBatchJavaMethodSignature??>
-					<#assign scopeParameters = scopeParameters + ["assetLibraryId"]/>
+					<#assign parentParameterNames = parentParameterNames + ["assetLibraryId"]/>
 
 					if (parameters.containsKey("assetLibraryId")) {
 						return ${getAssetLibraryBatchJavaMethodSignature.methodName}(
@@ -543,7 +543,7 @@ public abstract class Base${schemaName}ResourceImpl
 					else
 				</#if>
 				<#if getSiteBatchJavaMethodSignature??>
-					<#assign scopeParameters = scopeParameters + ["siteId"]/>
+					<#assign parentParameterNames = parentParameterNames + ["siteId"]/>
 
 					if (parameters.containsKey("siteId")) {
 						return ${getSiteBatchJavaMethodSignature.methodName}(
@@ -556,7 +556,7 @@ public abstract class Base${schemaName}ResourceImpl
 				<#if getParentBatchJavaMethodSignatures?has_content>
 					<#list getParentBatchJavaMethodSignatures as parentBatchJavaMethodSignature>
 						<#assign
-							scopeParameters = scopeParameters + [parentBatchJavaMethodSignature.parentSchemaName!?uncap_first + "Id"]
+							parentParameterNames = parentParameterNames + [parentBatchJavaMethodSignature.parentSchemaName!?uncap_first + "Id"]
 						/>
 
 						if (parameters.containsKey("${parentBatchJavaMethodSignature.parentSchemaName!?uncap_first + "Id"}")) {
@@ -582,7 +582,7 @@ public abstract class Base${schemaName}ResourceImpl
 					</#if>
 				<#else>
 					{
-						throw new NotSupportedException("One of the following parameters must be specified: [${scopeParameters?join(", ")}]");
+						throw new NotSupportedException("One of the following parameters must be specified: [${parentParameterNames?join(", ")}]");
 					}
 				</#if>
 			<#else>

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
@@ -107,10 +107,10 @@ public abstract class Base${schemaName}ResourceImpl
 				<#assign getAssetLibraryBatchJavaMethodSignature = javaMethodSignature />
 			<#elseif stringUtil.equals(javaMethodSignature.methodName, "getSite" + schemaName + "sPage")>
 				<#assign getSiteBatchJavaMethodSignature = javaMethodSignature />
-			<#elseif stringUtil.equals(javaMethodSignature.methodName, "get" + schemaName + "sPage")>
-				<#assign getBatchJavaMethodSignature = javaMethodSignature />
 			<#elseif stringUtil.equals(javaMethodSignature.methodName, "get" + parentSchemaName + schemaName + "sPage")>
 				<#assign getParentBatchJavaMethodSignatures = getParentBatchJavaMethodSignatures + [javaMethodSignature] />
+			<#elseif stringUtil.equals(javaMethodSignature.methodName, "get" + schemaName + "sPage")>
+				<#assign getBatchJavaMethodSignature = javaMethodSignature />
 			</#if>
 		<#elseif stringUtil.equals(javaMethodSignature.methodName, "patch" + schemaName)>
 			<#assign patchBatchJavaMethodSignature = javaMethodSignature />
@@ -119,10 +119,10 @@ public abstract class Base${schemaName}ResourceImpl
 				<#assign postAssetLibraryBatchJavaMethodSignature = javaMethodSignature />
 			<#elseif stringUtil.equals(javaMethodSignature.methodName, "postSite" + schemaName)>
 				<#assign postSiteBatchJavaMethodSignature = javaMethodSignature />
-			<#elseif stringUtil.equals(javaMethodSignature.methodName, "post" + schemaName)>
-				<#assign postBatchJavaMethodSignature = javaMethodSignature />
 			<#elseif stringUtil.equals(javaMethodSignature.methodName, "post" + parentSchemaName + schemaName)>
 				<#assign postParentBatchJavaMethodSignatures = postParentBatchJavaMethodSignatures + [javaMethodSignature] />
+			<#elseif stringUtil.equals(javaMethodSignature.methodName, "post" + schemaName)>
+				<#assign postBatchJavaMethodSignature = javaMethodSignature />
 			</#if>
 		<#elseif stringUtil.equals(javaMethodSignature.methodName, "put" + schemaName)>
 			<#assign putBatchJavaMethodSignature = javaMethodSignature />
@@ -381,6 +381,7 @@ public abstract class Base${schemaName}ResourceImpl
 									/>
 								);
 							}
+
 							<#if parentBatchJavaMethodSignature?has_next>
 								else
 							</#if>
@@ -423,7 +424,7 @@ public abstract class Base${schemaName}ResourceImpl
 
 					<#if !postBatchJavaMethodSignature?? && scopeParameters?has_content>
 						else {
-							throw new NotSupportedException("One of the following parameters must be informed: [${scopeParameters?join(", ")}]");
+							throw new NotSupportedException("One of the following parameters must be specified: [${scopeParameters?join(", ")}]");
 						}
 					</#if>
 				}
@@ -547,6 +548,7 @@ public abstract class Base${schemaName}ResourceImpl
 					}
 					else
 				</#if>
+
 				<#if getParentBatchJavaMethodSignatures?has_content>
 					<#list getParentBatchJavaMethodSignatures as parentBatchJavaMethodSignature>
 						<#assign
@@ -576,7 +578,7 @@ public abstract class Base${schemaName}ResourceImpl
 					</#if>
 				<#else>
 					{
-						throw new NotSupportedException("One of the following parameters must be informed: [${scopeParameters?join(", ")}]");
+						throw new NotSupportedException("One of the following parameters must be specified: [${scopeParameters?join(", ")}]");
 					}
 				</#if>
 			<#else>

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
@@ -108,9 +108,11 @@ public abstract class Base${schemaName}ResourceImpl
 			<#elseif stringUtil.equals(javaMethodSignature.methodName, "getSite" + schemaName + "sPage")>
 				<#assign getSiteBatchJavaMethodSignature = javaMethodSignature />
 			<#elseif stringUtil.equals(javaMethodSignature.methodName, "get" + parentSchemaName + schemaName + "sPage")>
-				<#assign getParentBatchJavaMethodSignatures = getParentBatchJavaMethodSignatures + [javaMethodSignature] />
-			<#elseif stringUtil.equals(javaMethodSignature.methodName, "get" + schemaName + "sPage")>
-				<#assign getBatchJavaMethodSignature = javaMethodSignature />
+				<#if parentSchemaName?has_content>
+					<#assign getParentBatchJavaMethodSignatures = getParentBatchJavaMethodSignatures + [javaMethodSignature] />
+				<#else>
+					<#assign getBatchJavaMethodSignature = javaMethodSignature />
+				</#if>
 			</#if>
 		<#elseif stringUtil.equals(javaMethodSignature.methodName, "patch" + schemaName)>
 			<#assign patchBatchJavaMethodSignature = javaMethodSignature />
@@ -120,9 +122,11 @@ public abstract class Base${schemaName}ResourceImpl
 			<#elseif stringUtil.equals(javaMethodSignature.methodName, "postSite" + schemaName)>
 				<#assign postSiteBatchJavaMethodSignature = javaMethodSignature />
 			<#elseif stringUtil.equals(javaMethodSignature.methodName, "post" + parentSchemaName + schemaName)>
-				<#assign postParentBatchJavaMethodSignatures = postParentBatchJavaMethodSignatures + [javaMethodSignature] />
-			<#elseif stringUtil.equals(javaMethodSignature.methodName, "post" + schemaName)>
-				<#assign postBatchJavaMethodSignature = javaMethodSignature />
+				<#if parentSchemaName?has_content>
+					<#assign postParentBatchJavaMethodSignatures = postParentBatchJavaMethodSignatures + [javaMethodSignature] />
+				<#else>
+					<#assign postBatchJavaMethodSignature = javaMethodSignature />
+				</#if>
 			</#if>
 		<#elseif stringUtil.equals(javaMethodSignature.methodName, "put" + schemaName)>
 			<#assign putBatchJavaMethodSignature = javaMethodSignature />


### PR DESCRIPTION
This PR is a follow-up of [brianchandotcom#115531](https://github.com/brianchandotcom/liferay-portal/pull/118868) and [ccorreagg#9](https://github.com/ccorreagg/liferay-portal/pull/11) with the changes requested.

---

This PR contains the code in the REST Builder to modify the methods of the VulcanBatchEngineTaskItemDelegate interface.

The purposes of the modifications are the following:

- Throw an exception if there is not any default implementation of any of the methods.
- Throw an exception in execution time if it is not possible any of the available implementation of the methods because of a missing parameter.

**Before the PR:**

It was possible to call those methods and get a valid response without getting an error even though there was nothing to do (as in the `update` method).

**After the PR:**

For those methods that did not have a default implementation, an exception is thrown to indicate that the method is not available and should be overriden:

```
@Override
public void delete(
		java.util.Collection<AccountRole> accountRoles,
		Map<String, Serializable> parameters)
	throws Exception {

	throw new UnsupportedOperationException(
		"This method needs to be implemented");
}
```
For those methods that were already implemented, a more complete error flow has been added by validating the required parameters:

```
@Override
public Page<AccountRole> read(
		Filter filter, Pagination pagination, Sort[] sorts,
		Map<String, Serializable> parameters, String search)
	throws Exception {

	if (parameters.containsKey("accountId")) {
		return getAccountAccountRolesPage(
			Long.parseLong((String)parameters.get("accountId")),
			(String)parameters.get("keywords"), filter, pagination, sorts);
	}
	else {
		throw new NotSupportedException(
			"One of the following parameters must be informed: [accountId]");
	}
}
```

For those entities that have more than one possible parent, all the implementations have been included:
```
@Override
@SuppressWarnings("PMD.UnusedLocalVariable")
public void create(
		java.util.Collection<Comment> comments,
		Map<String, Serializable> parameters)
	throws Exception {

	[...]

		if (parameters.containsKey("blogPostingId")) {
			commentUnsafeConsumer = comment -> postBlogPostingComment(
				Long.parseLong((String)parameters.get("blogPostingId")),
				comment);
		}
		else if (parameters.containsKey("documentId")) {
			commentUnsafeConsumer = comment -> postDocumentComment(
				Long.parseLong((String)parameters.get("documentId")),
				comment);
		}
		else if (parameters.containsKey("structuredContentId")) {
			commentUnsafeConsumer = comment -> postStructuredContentComment(
				Long.parseLong(
					(String)parameters.get("structuredContentId")),
				comment);
		}
		else {
			throw new NotSupportedException(
				"One of the following parameters must be informed: [blogPostingId, documentId, structuredContentId]");
		}
	}

	[...]
}
```
