### PR TITLE
LPS-154649 Add test CanReturnToPreviousStepIfElementDoesNotExist

### DIFF
--- a/modules/apps/frontend-js/frontend-js-components-sample-web/src/main/resources/META-INF/resources/js/TestSampleWalkthrough.js
+++ b/modules/apps/frontend-js/frontend-js-components-sample-web/src/main/resources/META-INF/resources/js/TestSampleWalkthrough.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {Walkthrough} from 'frontend-js-components-web';
+import React from 'react';
+
+const TEST_WALKTHROUGH_CONFIG = {
+	closeOnClickOutside: false,
+	closeable: true,
+	skippable: true,
+	steps: [
+		{
+			content: '<span>Content 1</span><br/><code>Hello1</code>',
+			darkbg: true,
+			nodeToHighlight: '#teststep1',
+			title: 'Title 1',
+		},
+		{
+			content: '<span>Content 2</span><br/><code>Hello2</code>',
+			nodeToHighlight: '#teststep2',
+			title: 'Title 2',
+		},
+	],
+};
+
+export default function TestSampleWalkthrough(...props) {
+	return <Walkthrough {...TEST_WALKTHROUGH_CONFIG} {...props} />;
+}

--- a/modules/apps/frontend-js/frontend-js-components-sample-web/src/main/resources/META-INF/resources/partials/test_walkable.jsp
+++ b/modules/apps/frontend-js/frontend-js-components-sample-web/src/main/resources/META-INF/resources/partials/test_walkable.jsp
@@ -1,0 +1,39 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ include file="/init.jsp" %>
+
+<clay:container-fluid>
+	<clay:row>
+		<h2>Test Walkable Sample</h2>
+
+		<div class="btn-group">
+			<div class="btn-group-item">
+				<clay:button displayType="primary" id="teststep1" label="Step 1"></clay:button>
+			</div>
+		</div>
+	</clay:row>
+
+	<clay:row>
+		<p>Walkable sample to test walkthrough behavior with no element on page.</p>
+	</clay:row>
+
+	<div>
+		<react:component
+			module="js/TestSampleWalkthrough"
+		/>
+	</div>
+</clay:container-fluid>

--- a/modules/apps/frontend-js/frontend-js-components-sample-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/frontend-js/frontend-js-components-sample-web/src/main/resources/META-INF/resources/view.jsp
@@ -18,7 +18,7 @@
 
 <div class="frontend-js-components-sample-web">
 	<liferay-ui:tabs
-		names="Translation Manager, Management Toolbar, Walkable"
+		names="Translation Manager, Management Toolbar, Walkable, Test Walkable"
 		refresh="<%= false %>"
 	>
 		<liferay-ui:section>
@@ -31,6 +31,10 @@
 
 		<liferay-ui:section>
 			<liferay-util:include page="/partials/walkable.jsp" servletContext="<%= application %>" />
+		</liferay-ui:section>
+
+		<liferay-ui:section>
+			<liferay-util:include page="/partials/test_walkable.jsp" servletContext="<%= application %>" />
 		</liferay-ui:section>
 	</liferay-ui:tabs>
 </div>

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/macros/WalkthroughPopover.macro
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/macros/WalkthroughPopover.macro
@@ -4,7 +4,7 @@ definition {
 		WaitForSPARefresh();
 
 		var javascript = '''
-		let elem = document.querySelector('*.${elementClass}');
+		let elem = document.querySelectorAll('*.${elementClass}')[${childIndex}];
 
 		let elementCoordinates = elem.getBoundingClientRect();
 
@@ -24,7 +24,7 @@ definition {
 		WaitForSPARefresh();
 
 		var javascript = '''
-		let elem = document.querySelector('*.${elementClass}');
+		let elem = document.querySelectorAll('*.${elementClass}')[${childIndex}];
 
 		let elementCoordinates = elem.getBoundingClientRect();
 
@@ -79,8 +79,18 @@ definition {
 	macro viewCoordinatePositionMatchesElementStep {
 		var step_x = WalkthroughPopover.getElementRectanglePositionX(elementId = "${stepElementId}");
 		var step_y = WalkthroughPopover.getElementRectanglePositionY(elementId = "${stepElementId}");
-		var hotspot_x = WalkthroughPopover.getElementCirclePositionX(elementClass = "${hotspotElementClass}");
-		var hotspot_y = WalkthroughPopover.getElementCirclePositionY(elementClass = "${hotspotElementClass}");
+		var hotspotChildIndex = "0";
+
+		if (contains("${stepElementId}", "teststep")) {
+			var hotspotChildIndex = "1";
+		}
+
+		var hotspot_x = WalkthroughPopover.getElementCirclePositionX(
+			childIndex = "${hotspotChildIndex}",
+			elementClass = "${hotspotElementClass}");
+		var hotspot_y = WalkthroughPopover.getElementCirclePositionY(
+			childIndex = "${hotspotChildIndex}",
+			elementClass = "${hotspotElementClass}");
 
 		echo("position step (x,y): ${step_x},${step_y}");
 

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/paths/Walkthrough.path
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/paths/Walkthrough.path
@@ -17,7 +17,7 @@
 </tr>
 <tr>
 	<td>HOTSPOT</td>
-	<td>//*[@class='lfr-walkthrough-hotspot']</td>
+	<td>//div[not(contains(@class,'hide')) and contains(@id, 'tabs')]//*[@class='lfr-walkthrough-hotspot']</td>
 	<td></td>
 </tr>
 <tr>

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/WalkthroughPopover.testcase
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/WalkthroughPopover.testcase
@@ -182,6 +182,26 @@ definition {
 		}
 	}
 
+	@description = "LPS-154649. Assert hotspot can transition back to previous step if next element doesn't exist on the page."
+	@priority = "3"
+	test CanReturnToPreviousStepIfElementDoesNotExist {
+		task ("Given JSON file includes an element that does not exist on the page/sample portlet") {
+			Navigator.gotoNavTab(navTab = "Test Walkable");
+		}
+
+		task ("When popover mode transistions to the step that has no element") {
+			Walkthrough.enablePopoverMode();
+
+			Click(locator1 = "Button#OK");
+		}
+
+		task ("Then hotspot returns to last element") {
+			WalkthroughPopover.viewCoordinatePositionMatchesElementStep(
+				hotspotElementClass = "lfr-walkthrough-hotspot-inner",
+				stepElementId = "teststep1");
+		}
+	}
+
 	@description = "LPS-154648. Assert final step can transition to hotspot mode."
 	@priority = "5"
 	test FinalStepCanTransitionToHotSpotMode {


### PR DESCRIPTION
Manually forwarding due to [GitHub issue with Webhooks](https://liferay.slack.com/archives/C19PWQ74J/p1655763502752029?thread_ts=1655763326.036609&cid=C19PWQ74J) preveting `ci:forward` attempts. Test failures are not related to PR.

cc/ @susanchen3

----

**Background**
Create automated tests for Walkthrough component. 
Renamed test to CanReturnToPreviousStepIfElementDoesNotExist because no error message is displayed. 

**Test Plan**
Given: JSON file includes an element that does not exist on the page/sample portlet
And Given: frontend-js-components-sample-web deployed to test page
And Given: Navigate to Test Walkable tab on sample portlet
When: popover mode transitions to the step that has no element
Then: ~error message is displayed~ hotspot returns to last element

**JIRA Ticket:**
https://issues.liferay.com/browse/LPS-154649