### PR TITLE
LPS-155466, LPS-155457 | master

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FDSQuickActions.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FDSQuickActions.macro
@@ -1,0 +1,17 @@
+definition {
+
+	macro viewQuickActionMenuNotPresent {
+		AssertNotVisible(
+			key_title = "${title}",
+			locator1 = "FrontendDataSet#VIEW_ACTION_BUTTON");
+
+		AssertNotVisible(
+			key_title = "${title}",
+			locator1 = "FrontendDataSet#EDIT_ACTION_BUTTON");
+
+		AssertNotVisible(
+			key_title = "${title}",
+			locator1 = "FrontendDataSet#DELETE_ACTION_BUTTON");
+	}
+
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSQuickActions.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSQuickActions.testcase
@@ -49,7 +49,7 @@ definition {
 		}
 	}
 
-	@description = "155457. Assert that over mouse off of the table body quick action menu is not visible."
+	@description = "LPS-155457. Assert that over mouse off of the table body quick action menu is not visible."
 	@priority = "5"
 	test CanDisappearWhenNotHovered {
 		task ("When hover mouse off of the table body") {
@@ -63,7 +63,7 @@ definition {
 		}
 	}
 
-	@description = "155466. Assert that test-pencil is appended to browser URL after clicking."
+	@description = "LPS-155466. Assert that test-pencil is appended to browser URL after clicking."
 	@priority = "5"
 	test CanExecuteAnAction {
 		var portalURL = PropsUtil.get("portal.url");

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSQuickActions.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSQuickActions.testcase
@@ -49,6 +49,20 @@ definition {
 		}
 	}
 
+	@description = "155457. Assert that over mouse off of the table body quick action menu is not visible."
+	@priority = "5"
+	test CanDisappearWhenNotHovered {
+		task ("When hover mouse off of the table body") {
+			MouseOver(
+				key_portletTitleName = "FDSSamplePortlet",
+				locator1 = "Home#PORTLET_HEADER");
+		}
+
+		task ("Then quick action menu is not visible") {
+			FDSQuickActions.viewQuickActionMenuNotPresent(title = "Sample1");
+		}
+	}
+
 	@description = "155466. Assert that test-pencil is appended to browser URL after clicking."
 	@priority = "5"
 	test CanExecuteAnAction {

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSQuickActions.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSQuickActions.testcase
@@ -30,9 +30,13 @@ definition {
 
 			Navigator.gotoPage(pageName = "Frontend Data Set Test Page");
 
+			WaitForElementPresent(
+				key_itemName = "Sample1",
+				locator1 = "FrontendDataSet#TABLE_ITEM_ROW");
+
 			MouseOver(
-				key_title = "Sample1",
-				locator1 = "FrontendDataSet#ENTRY_TITLE");
+				key_itemName = "Sample1",
+				locator1 = "FrontendDataSet#TABLE_ITEM_ROW");
 		}
 	}
 

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSQuickActions.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSQuickActions.testcase
@@ -1,0 +1,68 @@
+@component-name = "portal-frontend-infrastructure"
+definition {
+
+	property osgi.modules.includes = "frontend-data-set-sample-web";
+	property portal.acceptance = "true";
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.component.names = "Frontend Dataset";
+	property testray.main.component.name = "Frontend Dataset";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginPG();
+
+		task ("Given Frontend Dataset sample portlet") {
+			JSONLayout.addPublicLayout(
+				groupName = "Guest",
+				layoutName = "Frontend Data Set Test Page");
+
+			JSONLayout.addWidgetToPublicLayout(
+				groupName = "Guest",
+				layoutName = "Frontend Data Set Test Page",
+				widgetName = "Frontend Data Set Sample");
+
+			JSONLayout.updateLayoutTemplateOfPublicLayout(
+				groupName = "Guest",
+				layoutName = "Frontend Data Set Test Page",
+				layoutTemplate = "1 Column");
+
+			Navigator.gotoPage(pageName = "Frontend Data Set Test Page");
+
+			MouseOver(
+				key_title = "Sample1",
+				locator1 = "FrontendDataSet#ENTRY_TITLE");
+		}
+	}
+
+	tearDown {
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
+
+		if ("${testPortalInstance}" == "true") {
+			PortalInstances.tearDownCP();
+		}
+		else {
+			JSONLayout.deletePublicLayout(
+				groupName = "Guest",
+				layoutName = "Frontend Data Set Test Page");
+		}
+	}
+
+	@description = "155466. Assert that test-pencil is appended to browser URL after clicking."
+	@priority = "5"
+	test CanExecuteAnAction {
+		var portalURL = PropsUtil.get("portal.url");
+
+		task ("When click on Pencil Icon ") {
+			ClickNoError(
+				key_title = "Sample1",
+				locator1 = "FrontendDataSet#EDIT_ACTION_BUTTON");
+		}
+
+		task ("Then #test-pencil is appended to browser URL") {
+			AssertLocation(value1 = "${portalURL}/frontend-data-set-test-page#test-pencil");
+		}
+	}
+
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSQuickActions.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSQuickActions.testcase
@@ -2,9 +2,9 @@
 definition {
 
 	property osgi.modules.includes = "frontend-data-set-sample-web";
-	property portal.acceptance = "true";
-	property portal.release = "true";
-	property portal.upstream = "true";
+	property portal.acceptance = "false";
+	property portal.release = "false";
+	property portal.upstream = "quarantine";
 	property testray.component.names = "Frontend Dataset";
 	property testray.main.component.name = "Frontend Dataset";
 
@@ -53,13 +53,11 @@ definition {
 		}
 	}
 
-	@description = "LPS-155457. Assert that over mouse off of the table body quick action menu is not visible."
+	@description = "LPS-155457. Assert that hover over mouse off of the table body quick action menu is not visible."
 	@priority = "5"
 	test CanDisappearWhenNotHovered {
 		task ("When hover mouse off of the table body") {
-			MouseOver(
-				key_portletTitleName = "FDSSamplePortlet",
-				locator1 = "Home#PORTLET_HEADER");
+			MouseOver(locator1 = "FrontendDataSet#TABLE_BODY");
 		}
 
 		task ("Then quick action menu is not visible") {

--- a/portal-web/poshi.properties
+++ b/portal-web/poshi.properties
@@ -15,6 +15,7 @@ test.dirs=\
     ../modules/apps/dispatch/dispatch-test/src/testFunctional,\
     ../modules/apps/document-library-opener/document-library-opener-google-drive-test/src/testFunctional,\
     ../modules/apps/frontend-css/frontend-css-test/src/testFunctional,\
+    ../modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional,\
     ../modules/apps/frontend-js/frontend-js-test/src/testFunctional,\
     ../modules/apps/item-selector/item-selector-test/src/testFunctional,\
     ../modules/apps/layout/layout-admin-web-test/src/testFunctional,\

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
@@ -11,6 +11,16 @@
 
 <tbody>
 <tr>
+	<td>EDIT_ACTION_BUTTON</td>
+	<td>//div[contains(@class,'dnd-td') and text()='${key_title}']//..//*[*[name()='svg'][contains(@class,'lexicon-icon-pencil')]]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>ENTRY_TITLE</td>
+	<td>//div[contains(@class,'dnd-td') and text()='${key_title}']</td>
+	<td></td>
+</tr>
+<tr>
 	<td>VIEW_ACTION_BUTTON</td>
 	<td>//div[contains(@class,'dnd-td') and text()='${key_title}']//..//*[*[name()='svg'][contains(@class,'lexicon-icon-view')]]</td>
 	<td></td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
@@ -11,6 +11,11 @@
 
 <tbody>
 <tr>
+	<td>DELETE_ACTION_BUTTON</td>
+	<td>//div[contains(@class,'dnd-td') and text()='${key_title}']//..//*[*[name()='svg'][contains(@class,'lexicon-icon-times-circle')]]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>EDIT_ACTION_BUTTON</td>
 	<td>//div[contains(@class,'dnd-td') and text()='${key_title}']//..//*[*[name()='svg'][contains(@class,'lexicon-icon-pencil')]]</td>
 	<td></td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
@@ -21,11 +21,6 @@
 	<td></td>
 </tr>
 <tr>
-	<td>ENTRY_TITLE</td>
-	<td>//div[contains(@class,'dnd-td') and text()='${key_title}']</td>
-	<td></td>
-</tr>
-<tr>
 	<td>VIEW_ACTION_BUTTON</td>
 	<td>//div[contains(@class,'dnd-td') and text()='${key_title}']//..//*[*[name()='svg'][contains(@class,'lexicon-icon-view')]]</td>
 	<td></td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
@@ -31,6 +31,11 @@
 	<td></td>
 </tr>
 <tr>
+	<td>TABLE_BODY</td>
+	<td>//*[contains(@class,'fds')]//*[@class='dnd-tbody']</td>
+	<td></td>
+</tr>
+<tr>
 	<td>TABLE_ITEM_ROW</td>
 	<td>//*[normalize-space(text())='${key_itemName}']/parent::*[contains(@class,'dnd-tr')]</td>
 	<td></td>


### PR DESCRIPTION
Manually forwarded due to [unrelated test failures](https://github.com/liferay-frontend/liferay-portal/pull/2405#issuecomment-1163797535)

----

**Background**
Create automated tests for the Frontend Dataset component.

**Test Plan**
**FDSQuickActions#CanExecuteAnAction**
Given: frontend-data-set-sample-web deployed
And Given: FDS Sample Portlet added to page
When: Hover over 1st row item (Sample 1)
And When: click on Pencil Icon 
Then: #test-pencil is appended to browser URL

**FDSQuickActions#CanDisappearWhenNotHovered**
Given: frontend-data-set-sample-web deployed
And Given: FDS Sample Portlet added to page
When: Hover over 1st row item (Sample 1)
And When: hover mouse off of the table body (can hover mouse on table header)
Then: quick action menu is not visible

**JIRA Ticket**:
https://issues.liferay.com/browse/LPS-155466
https://issues.liferay.com/browse/LPS-155457