### PR TITLE
LPS-154538 Export PortletURL utils and import them throughout the codebase (with sorting)

### DIFF
--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/js/DefaultAddresses.js
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/js/DefaultAddresses.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {delegate} from 'frontend-js-web';
+import {createPortletURL, delegate} from 'frontend-js-web';
 
 export default function ({
 	baseSelectDefaultAddressURL,
@@ -49,7 +49,7 @@ export default function ({
 					return;
 				}
 
-				const updateAccountEntryDefaultAddressesURL = Liferay.Util.PortletURL.createPortletURL(
+				const updateAccountEntryDefaultAddressesURL = createPortletURL(
 					baseUpdateAccountEntryDefaultAddressesURL,
 					{addressId: selectedItem.entityid, type}
 				);
@@ -61,10 +61,7 @@ export default function ({
 			},
 			selectEventName: '<portlet:namespace />selectDefaultAddress',
 			title,
-			url: Liferay.Util.PortletURL.createPortletURL(
-				baseSelectDefaultAddressURL,
-				{type}
-			),
+			url: createPortletURL(baseSelectDefaultAddressURL, {type}),
 		});
 	};
 

--- a/modules/apps/commerce/commerce-payment-web/src/main/resources/META-INF/resources/js/DefaultCommercePaymentMethod.js
+++ b/modules/apps/commerce/commerce-payment-web/src/main/resources/META-INF/resources/js/DefaultCommercePaymentMethod.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {delegate} from 'frontend-js-web';
+import {createPortletURL, delegate} from 'frontend-js-web';
 
 export default function ({
 	baseSelectDefaultCommercePaymentMethodURL,
@@ -37,7 +37,7 @@ export default function ({
 					return;
 				}
 
-				const updateAccountEntryDefaultCommercePaymentMethodURL = Liferay.Util.PortletURL.createPortletURL(
+				const updateAccountEntryDefaultCommercePaymentMethodURL = createPortletURL(
 					baseUpdateAccountEntryDefaultCommercePaymentMethodURL,
 					{commercePaymentMethodKey: selectedItem.entityid}
 				);
@@ -50,9 +50,7 @@ export default function ({
 			selectEventName:
 				'<portlet:namespace />selectDefaultCommercePaymentMethod',
 			title,
-			url: Liferay.Util.PortletURL.createPortletURL(
-				baseSelectDefaultCommercePaymentMethodURL
-			),
+			url: createPortletURL(baseSelectDefaultCommercePaymentMethodURL),
 		});
 	};
 

--- a/modules/apps/commerce/commerce-term-web/src/main/resources/META-INF/resources/js/DefaultCommerceTermEntries.js
+++ b/modules/apps/commerce/commerce-term-web/src/main/resources/META-INF/resources/js/DefaultCommerceTermEntries.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {delegate} from 'frontend-js-web';
+import {createPortletURL, delegate} from 'frontend-js-web';
 
 export default function ({
 	baseSelectDefaultCommerceTermEntryURL,
@@ -49,7 +49,7 @@ export default function ({
 					return;
 				}
 
-				const updateAccountEntryDefaultCommerceTermEntryURL = Liferay.Util.PortletURL.createPortletURL(
+				const updateAccountEntryDefaultCommerceTermEntryURL = createPortletURL(
 					baseUpdateAccountEntryDefaultCommerceTermEntryURL,
 					{commerceTermEntryId: selectedItem.entityid, type}
 				);
@@ -62,10 +62,9 @@ export default function ({
 			selectEventName:
 				'<portlet:namespace />selectDefaultCommerceTermEntry',
 			title,
-			url: Liferay.Util.PortletURL.createPortletURL(
-				baseSelectDefaultCommerceTermEntryURL,
-				{type}
-			),
+			url: createPortletURL(baseSelectDefaultCommerceTermEntryURL, {
+				type,
+			}),
 		});
 	};
 

--- a/modules/apps/digital-signature/digital-signature-web/src/main/resources/META-INF/resources/js/components/digital-signature-form/FileSelector.js
+++ b/modules/apps/digital-signature/digital-signature-web/src/main/resources/META-INF/resources/js/components/digital-signature-form/FileSelector.js
@@ -13,6 +13,7 @@
  */
 
 import ClayButton from '@clayui/button';
+import {createPortletURL} from 'frontend-js-web';
 import React, {useContext} from 'react';
 
 import {AppContext} from '../../AppContext';
@@ -33,7 +34,7 @@ const getDocumentLibrarySelectorURL = (portletNamespace) => {
 		'refererGroupId': Liferay.ThemeDisplay.getSiteGroupId(),
 	};
 
-	const documentLibrarySelectorURL = Liferay.Util.PortletURL.createPortletURL(
+	const documentLibrarySelectorURL = createPortletURL(
 		themeDisplay.getLayoutRelativeControlPanelURL(),
 		documentLibrarySelectorParameters
 	);

--- a/modules/apps/digital-signature/digital-signature-web/src/main/resources/META-INF/resources/js/pages/envelope/EnvelopeView.js
+++ b/modules/apps/digital-signature/digital-signature-web/src/main/resources/META-INF/resources/js/pages/envelope/EnvelopeView.js
@@ -16,7 +16,12 @@ import ClayButton from '@clayui/button';
 import ClayIcon from '@clayui/icon';
 import ClayLabel from '@clayui/label';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
-import {createActionURL, fetch, openToast} from 'frontend-js-web';
+import {
+	createActionURL,
+	createResourceURL,
+	fetch,
+	openToast,
+} from 'frontend-js-web';
 import React, {useContext, useEffect, useState} from 'react';
 
 import {AppContext} from '../../AppContext';
@@ -94,14 +99,11 @@ const EnvelopeHeader = ({docusignStatus, emailSubject, envelopeId}) => {
 			<ClayButton
 				onClick={() =>
 					window.open(
-						Liferay.Util.PortletURL.createResourceURL(
-							baseResourceURL,
-							{
-								dsEnvelopeId: envelopeId,
-								p_p_resource_id:
-									'/digital_signature/get_ds_documents_as_bytes',
-							}
-						),
+						createResourceURL(baseResourceURL, {
+							dsEnvelopeId: envelopeId,
+							p_p_resource_id:
+								'/digital_signature/get_ds_documents_as_bytes',
+						}),
 						'_blank'
 					)
 				}
@@ -134,7 +136,7 @@ function EnvelopeView({
 	const getEnvelope = async () => {
 		try {
 			const response = await fetch(
-				Liferay.Util.PortletURL.createResourceURL(baseResourceURL, {
+				createResourceURL(baseResourceURL, {
 					dsEnvelopeId: envelopeId,
 					p_p_resource_id: '/digital_signature/get_ds_envelope',
 				})

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts
@@ -736,6 +736,21 @@ export function toggleSelectBox(
 	toggleBoxId: string
 ): void;
 
+export function createActionURL(
+	basePortletURL: string,
+	parameters?: Object
+): URL;
+
+export function createPortletURL(
+	basePortletURL: string,
+	parameters?: Object
+): URL;
+
+export function createRenderURL(
+	basePortletURL: string,
+	parameters?: Object
+): URL;
+
 export function createResourceURL(
 	basePortletURL: string,
 	parameters?: Object

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts
@@ -12,11 +12,64 @@
  * details.
  */
 
-/* Debounces function execution. */
-export function debounce(fn: () => void, delay: number): () => void;
+interface Region {
+	bottom: number;
+	height: number;
+	left: number;
+	right: number;
+	top: number;
+	width: number;
+}
+
+/**
+ * Aligns the element with the best region around alignElement. The best
+ * region is defined by clockwise rotation starting from the specified
+ * `position`. The element is always aligned in the middle of alignElement
+ * axis.
+ */
+export function align(
+	element: HTMLElement,
+	alignElement: HTMLElement,
+	position: number,
+	autoBestAlign: boolean
+): string;
 
 /* Cancels the scheduled debounced function. */
 export function cancelDebounce(debounced: () => void): void;
+
+export function createActionURL(
+	basePortletURL: string,
+	parameters?: Object
+): URL;
+
+export function createPortletURL(
+	basePortletURL: string,
+	parameters?: Object
+): URL;
+
+export function createRenderURL(
+	basePortletURL: string,
+	parameters?: Object
+): URL;
+
+export function createResourceURL(
+	basePortletURL: string,
+	parameters?: Object
+): URL;
+
+/* Debounces function execution. */
+export function debounce(fn: () => void, delay: number): () => void;
+
+/**
+ * Decodes the update strings.
+ * The update string is a JSON object containing the entire page state.
+ * This decoder returns an object containing the portlet data for portlets whose
+ * state has changed as compared to the current page state.
+ */
+export function decodeUpdateString(
+	pageRenderState: object,
+	updateString: string
+): object;
 
 /**
  * Listens to the specified event on the given DOM element, but only calls the
@@ -29,6 +82,256 @@ export function delegate(
 	selector: string,
 	callback: (event: any) => void
 ): {dispose: () => void};
+
+/**
+ * Function to extract data from form and encode
+ * it as an 'application/x-www-form-urlencoded' string.
+ */
+export function encodeFormAsString(
+	portletId: string,
+	form: HTMLFormElement
+): string;
+
+/**
+ * Fetches a resource. A thin wrapper around ES6 Fetch API, with standardized
+ * default configuration.
+ */
+export function fetch(
+	input: RequestInfo,
+	init?: RequestInit
+): Promise<Response>;
+
+/**
+ * Generates the required options for an action URL request
+ * according to the portletId, action URL and optional form element.
+ */
+export function generateActionUrl(
+	portletId: string,
+	url: string,
+	form: HTMLFormElement
+): object;
+
+/**
+ * Helper for generating portlet mode & window state strings for the URL.
+ */
+export function generatePortletModeAndWindowStateString(
+	pageRenderState: object,
+	portletId: string
+): string;
+
+/**
+ * Returns the best region to align element with alignElement. This is similar
+ * to `suggestAlignBestRegion`, but it only returns the region information,
+ * while `suggestAlignBestRegion` also returns the chosen position.
+ */
+export function getAlignBestRegion(
+	element: HTMLElement,
+	alignElement: HTMLElement,
+	position: number
+): {
+	position: number;
+	region: Region;
+};
+
+/**
+ * Returns the region to align element with alignElement. The element is
+ * always aligned in the middle of alignElement axis.
+ */
+export function getAlignRegion(
+	element: HTMLElement,
+	alignElement: HTMLElement,
+	position: number
+): Region;
+
+export function getCheckedCheckboxes(
+	form: HTMLFormElement,
+	except: string,
+	name?: string
+): Array<number> | '';
+
+export function getUncheckedCheckboxes(
+	form: HTMLFormElement,
+	except: string,
+	name?: string
+): Array<number> | '';
+
+/**
+ * Gets the updated public parameters for the given portlet ID and new render state.
+ * Returns an object whose properties are the group indexes of the
+ * updated public parameters. The values are the new public parameter values.
+ */
+export function getUpdatedPublicRenderParameters(
+	pageRenderState: object,
+	portletId: string,
+	state: RenderState
+): object;
+
+/**
+ * Returns a URL of the specified type.
+ */
+export function getUrl(
+	pageRenderState: object,
+	type: string,
+	portletId: string,
+	parameters: object,
+	cache: string,
+	resourceId: string
+): Promise<string>;
+
+/**
+ * Minimizes portlet
+ */
+export function minimizePortlet(
+	portletSelector: string,
+	trigger: HTMLElement,
+	options?: object
+): void;
+
+export function openSelectionModal<T>(init: {
+	buttonAddLabel?: string;
+	buttonCancelLabel?: string;
+	containerProps?: Object;
+	customSelectEvent?: boolean;
+	height?: string;
+	id?: string;
+	iframeBodyCssClass?: string;
+	multiple?: boolean;
+	onClose?: () => void;
+	onSelect?: (item: T) => void;
+	selectEventName?: string;
+	selectedData?: any;
+	size?: 'full-screen' | 'lg' | 'md' | 'sm';
+	title?: string;
+	url?: string;
+	zIndex?: number;
+}): void;
+
+export function openToast({
+	autoClose,
+	container,
+	containerId,
+	message,
+	onClick,
+	onClose,
+	renderData,
+	title,
+	toastProps,
+	type,
+	variant,
+}: {
+	autoClose?: number | boolean;
+	container?: HTMLElement;
+	containerId?: string;
+	message?: string;
+	onClick?: () => void;
+	onClose?: () => void;
+	renderData?: {portletId: string};
+	title?: string;
+	toastProps?: Object;
+	type?: string;
+	variant?: string;
+}): void;
+
+export function openWindow(config: object, callback?: Function): void;
+
+/**
+ * Registers a portlet client with the portlet hub.
+ */
+export function register(portletId: string): Promise<void>;
+
+export function sub(
+	string: string,
+	data: string | number | string[] | number[] | Array<string> | Array<number>,
+	...args: string[] | number[]
+): string;
+
+/**
+ * Looks for the best region for aligning the given element. The best
+ * region is defined by clockwise rotation starting from the specified
+ * `position`. The element is always aligned in the middle of alignElement
+ * axis.
+ */
+export function suggestAlignBestRegion(
+	element: HTMLElement,
+	alignElement: HTMLElement,
+	position: number
+): {
+	position: number;
+	region: Region;
+};
+
+/**
+ * Throttle implementation that fires on the leading and trailing edges.
+ * If multiple calls come in during the throttle interval, the last call's
+ * arguments and context are used, replacing those of any previously pending
+ * calls.
+ */
+export function throttle(fn: () => void, interval: number): () => void;
+
+export function toggleBoxes(
+	checkBoxId: string,
+	toggleBoxId: string,
+	displayWhenUnchecked?: boolean,
+	toggleChildCheckboxes?: boolean
+): void;
+
+export function toggleRadio(
+	radioId: string,
+	showBoxIds: string | string[],
+	hideBoxIds?: string | string[]
+): void;
+
+export function toggleSelectBox(
+	selectBoxId: string,
+	value: any,
+	toggleBoxId: string
+): void;
+
+/**
+ * Used by the portlet hub methods to check the number and types of the
+ * arguments.
+ */
+export function validateArguments(
+	args: string[],
+	min: number,
+	max: number,
+	types: string[]
+): void;
+
+/**
+ * Validates an HTMLFormElement
+ */
+export function validateForm(form: HTMLFormElement): void;
+
+/**
+ * Verifies that the input parameters are in valid format.
+ *
+ * Parameters must be an object containing parameter names. It may also
+ * contain no property names which represents the case of having no
+ * parameters.
+ *
+ * If properties are present, each property must refer to an array of string
+ * values. The array length must be at least 1, because each parameter must
+ * have a value. However, a value of 'null' may appear in any array entry.
+ *
+ * To represent a <code>null</code> value, the property value must equal [null].
+ */
+export function validateParameters(parameters: object): void;
+
+/**
+ * Validates the specificed portletId against the list
+ * of current portlet in the pageRenderState.
+ */
+export function validatePortletId(
+	portletId: string,
+	pageRenderState: object
+): boolean;
+
+/**
+ * Verifies that the input parameters are in valid format, that the portlet
+ * mode and window state values are allowed for the portlet.
+ */
+export function validateState(state: RenderState, portletData: object): void;
 
 export class AOP {
 
@@ -141,6 +444,19 @@ export class AutoSize {
 	handleInput(event: string): void;
 }
 
+/**
+ * Adds compatibility for YUI events, re-emitting events according to YUI naming
+ * and adding the capability of adding targets to bubble events to them.
+ */
+export class CompatibilityEventProxy {
+	constructor(config: object, element: HTMLElement);
+
+	/**
+	 * Registers another event target as a bubble target.
+	 */
+	addTarget(target: object): void;
+}
+
 export class Disposable {
 
 	/**
@@ -152,6 +468,22 @@ export class Disposable {
 	 * Checks if this instance has already been disposed.
 	 */
 	isDisposed(): boolean;
+}
+
+/**
+ * Appends list item elements to dropdown menus with inline-scrollers on scroll
+ * events to improve page loading performance.
+ */
+export class DynamicInlineScroll {
+	attached(): void;
+
+	created(): void;
+
+	detached(): void;
+}
+
+export class DynamicSelect {
+	constructor(array: object[]);
 }
 
 export class EventEmitter {
@@ -276,182 +608,6 @@ export class EventHandler {
 	setShouldUseFacade(shouldUseFacade: boolean): EventEmitter;
 }
 
-/**
- * Decodes the update strings.
- * The update string is a JSON object containing the entire page state.
- * This decoder returns an object containing the portlet data for portlets whose
- * state has changed as compared to the current page state.
- */
-export function decodeUpdateString(
-	pageRenderState: object,
-	updateString: string
-): object;
-
-/**
- * Function to extract data from form and encode
- * it as an 'application/x-www-form-urlencoded' string.
- */
-export function encodeFormAsString(
-	portletId: string,
-	form: HTMLFormElement
-): string;
-
-/**
- * Generates the required options for an action URL request
- * according to the portletId, action URL and optional form element.
- */
-export function generateActionUrl(
-	portletId: string,
-	url: string,
-	form: HTMLFormElement
-): object;
-
-/**
- * Helper for generating portlet mode & window state strings for the URL.
- */
-export function generatePortletModeAndWindowStateString(
-	pageRenderState: object,
-	portletId: string
-): string;
-
-/**
- * Gets the updated public parameters for the given portlet ID and new render state.
- * Returns an object whose properties are the group indexes of the
- * updated public parameters. The values are the new public parameter values.
- */
-export function getUpdatedPublicRenderParameters(
-	pageRenderState: object,
-	portletId: string,
-	state: RenderState
-): object;
-
-/**
- * Returns a URL of the specified type.
- */
-export function getUrl(
-	pageRenderState: object,
-	type: string,
-	portletId: string,
-	parameters: object,
-	cache: string,
-	resourceId: string
-): Promise<string>;
-
-/**
- * Used by the portlet hub methods to check the number and types of the
- * arguments.
- */
-export function validateArguments(
-	args: string[],
-	min: number,
-	max: number,
-	types: string[]
-): void;
-
-/**
- * Validates an HTMLFormElement
- */
-export function validateForm(form: HTMLFormElement): void;
-
-/**
- * Verifies that the input parameters are in valid format.
- *
- * Parameters must be an object containing parameter names. It may also
- * contain no property names which represents the case of having no
- * parameters.
- *
- * If properties are present, each property must refer to an array of string
- * values. The array length must be at least 1, because each parameter must
- * have a value. However, a value of 'null' may appear in any array entry.
- *
- * To represent a <code>null</code> value, the property value must equal [null].
- */
-export function validateParameters(parameters: object): void;
-
-/**
- * Validates the specificed portletId against the list
- * of current portlet in the pageRenderState.
- */
-export function validatePortletId(
-	portletId: string,
-	pageRenderState: object
-): boolean;
-
-/**
- * Verifies that the input parameters are in valid format, that the portlet
- * mode and window state values are allowed for the portlet.
- */
-export function validateState(state: RenderState, portletData: object): void;
-
-export class RenderState {
-	constructor(state: any);
-
-	/**
-	 * Clone returns a copy of this RenderState instance.
-	 */
-	clone(): RenderState;
-
-	/**
-	 * Set the properties of a RenderState instance based on another RenderState
-	 */
-	from(renderState: RenderState): void;
-
-	/**
-	 * Returns the portletMode for this RenderState.
-	 */
-	getPortletMode(): string;
-
-	/**
-	 * Returns the string parameter value for the given name.
-	 * If name designates a multi-valued parameter this function returns
-	 * the first value in the values array. If the parameter is undefined
-	 * this function returns the optional default parameter <code>defaultValue</code>.
-	 */
-	getValue(name: string, defaultValue?: string): string;
-
-	/**
-	 * Gets the string array parameter value for the given <code>name</code>.
-	 * If the parameter for the given name is undefined, this function
-	 * returns the optional default value array <code>def</code>.
-	 */
-	getValues(name: string, defaultValue?: string[]): string[];
-
-	/**
-	 * Returns the windowState for this RenderState.
-	 */
-	getWindowState(): string;
-
-	/**
-	 * Removes the parameter with the given name.
-	 */
-	remove(name: string): void;
-
-	/**
-	 * Sets the portletMode to the specified value.
-	 */
-	setPortletMode(portletMode: string): void;
-
-	/**
-	 * Sets a parameter with a given name and value.
-	 * The value may be a string or an array.
-	 */
-	setValue(name: string, value: string | string[]): void;
-
-	/**
-	 * Sets the windowState to the specified value.
-	 */
-	setWindowState(windowState: string): void;
-}
-
-/**
- * Minimizes portlet
- */
-export function minimizePortlet(
-	portletSelector: string,
-	trigger: HTMLElement,
-	options?: object
-): void;
-
 export class PortletInit {
 	constructor(portletId: string);
 
@@ -517,101 +673,6 @@ export class PortletInit {
 	startPartialAction(actionParameters: object): Promise<void>;
 }
 
-/**
- * Registers a portlet client with the portlet hub.
- */
-export function register(portletId: string): Promise<void>;
-
-/**
- * Aligns the element with the best region around alignElement. The best
- * region is defined by clockwise rotation starting from the specified
- * `position`. The element is always aligned in the middle of alignElement
- * axis.
- */
-export function align(
-	element: HTMLElement,
-	alignElement: HTMLElement,
-	position: number,
-	autoBestAlign: boolean
-): string;
-
-interface Region {
-	bottom: number;
-	height: number;
-	left: number;
-	right: number;
-	top: number;
-	width: number;
-}
-
-/**
- * Returns the best region to align element with alignElement. This is similar
- * to `suggestAlignBestRegion`, but it only returns the region information,
- * while `suggestAlignBestRegion` also returns the chosen position.
- */
-export function getAlignBestRegion(
-	element: HTMLElement,
-	alignElement: HTMLElement,
-	position: number
-): {
-	position: number;
-	region: Region;
-};
-
-/**
- * Returns the region to align element with alignElement. The element is
- * always aligned in the middle of alignElement axis.
- */
-export function getAlignRegion(
-	element: HTMLElement,
-	alignElement: HTMLElement,
-	position: number
-): Region;
-
-/**
- * Looks for the best region for aligning the given element. The best
- * region is defined by clockwise rotation starting from the specified
- * `position`. The element is always aligned in the middle of alignElement
- * axis.
- */
-export function suggestAlignBestRegion(
-	element: HTMLElement,
-	alignElement: HTMLElement,
-	position: number
-): {
-	position: number;
-	region: Region;
-};
-
-/**
- * Adds compatibility for YUI events, re-emitting events according to YUI naming
- * and adding the capability of adding targets to bubble events to them.
- */
-export class CompatibilityEventProxy {
-	constructor(config: object, element: HTMLElement);
-
-	/**
-	 * Registers another event target as a bubble target.
-	 */
-	addTarget(target: object): void;
-}
-
-/**
- * Appends list item elements to dropdown menus with inline-scrollers on scroll
- * events to improve page loading performance.
- */
-export class DynamicInlineScroll {
-	attached(): void;
-
-	created(): void;
-
-	detached(): void;
-}
-
-export class DynamicSelect {
-	constructor(array: object[]);
-}
-
 export class PortletBase {
 
 	/**
@@ -633,131 +694,62 @@ export class PortletBase {
 	one(selectors: string, root?: string | HTMLElement): HTMLElement | null;
 }
 
-/**
- * Throttle implementation that fires on the leading and trailing edges.
- * If multiple calls come in during the throttle interval, the last call's
- * arguments and context are used, replacing those of any previously pending
- * calls.
- */
-export function throttle(fn: () => void, interval: number): () => void;
+export class RenderState {
+	constructor(state: any);
 
-/**
- * Returns a resource portlet URL in form of a URL object by setting the lifecycle parameter
- **/
-export function createResourceURL(
-	basePortletURL: string,
-	parameters?: Object
-): URL;
+	/**
+	 * Clone returns a copy of this RenderState instance.
+	 */
+	clone(): RenderState;
 
-export function openSelectionModal<T>(init: {
-	buttonAddLabel?: string;
-	buttonCancelLabel?: string;
-	containerProps?: Object;
-	customSelectEvent?: boolean;
-	height?: string;
-	id?: string;
-	iframeBodyCssClass?: string;
-	multiple?: boolean;
-	onClose?: () => void;
-	onSelect?: (item: T) => void;
-	selectEventName?: string;
-	selectedData?: any;
-	size?: 'full-screen' | 'lg' | 'md' | 'sm';
-	title?: string;
-	url?: string;
-	zIndex?: number;
-}): void;
+	/**
+	 * Set the properties of a RenderState instance based on another RenderState
+	 */
+	from(renderState: RenderState): void;
 
-export function openToast({
-	autoClose,
-	container,
-	containerId,
-	message,
-	onClick,
-	onClose,
-	renderData,
-	title,
-	toastProps,
-	type,
-	variant,
-}: {
-	autoClose?: number | boolean;
-	container?: HTMLElement;
-	containerId?: string;
-	message?: string;
-	onClick?: () => void;
-	onClose?: () => void;
-	renderData?: {portletId: string};
-	title?: string;
-	toastProps?: Object;
-	type?: string;
-	variant?: string;
-}): void;
+	/**
+	 * Returns the portletMode for this RenderState.
+	 */
+	getPortletMode(): string;
 
-export function openWindow(config: object, callback?: Function): void;
+	/**
+	 * Returns the string parameter value for the given name.
+	 * If name designates a multi-valued parameter this function returns
+	 * the first value in the values array. If the parameter is undefined
+	 * this function returns the optional default parameter <code>defaultValue</code>.
+	 */
+	getValue(name: string, defaultValue?: string): string;
 
-/**
- * Fetches a resource. A thin wrapper around ES6 Fetch API, with standardized
- * default configuration.
- */
-export function fetch(
-	input: RequestInfo,
-	init?: RequestInit
-): Promise<Response>;
+	/**
+	 * Gets the string array parameter value for the given <code>name</code>.
+	 * If the parameter for the given name is undefined, this function
+	 * returns the optional default value array <code>def</code>.
+	 */
+	getValues(name: string, defaultValue?: string[]): string[];
 
-export function getCheckedCheckboxes(
-	form: HTMLFormElement,
-	except: string,
-	name?: string
-): Array<number> | '';
+	/**
+	 * Returns the windowState for this RenderState.
+	 */
+	getWindowState(): string;
 
-export function getUncheckedCheckboxes(
-	form: HTMLFormElement,
-	except: string,
-	name?: string
-): Array<number> | '';
+	/**
+	 * Removes the parameter with the given name.
+	 */
+	remove(name: string): void;
 
-export function toggleBoxes(
-	checkBoxId: string,
-	toggleBoxId: string,
-	displayWhenUnchecked?: boolean,
-	toggleChildCheckboxes?: boolean
-): void;
+	/**
+	 * Sets the portletMode to the specified value.
+	 */
+	setPortletMode(portletMode: string): void;
 
-export function toggleRadio(
-	radioId: string,
-	showBoxIds: string | string[],
-	hideBoxIds?: string | string[]
-): void;
+	/**
+	 * Sets a parameter with a given name and value.
+	 * The value may be a string or an array.
+	 */
+	setValue(name: string, value: string | string[]): void;
 
-export function toggleSelectBox(
-	selectBoxId: string,
-	value: any,
-	toggleBoxId: string
-): void;
-
-export function createActionURL(
-	basePortletURL: string,
-	parameters?: Object
-): URL;
-
-export function createPortletURL(
-	basePortletURL: string,
-	parameters?: Object
-): URL;
-
-export function createRenderURL(
-	basePortletURL: string,
-	parameters?: Object
-): URL;
-
-export function createResourceURL(
-	basePortletURL: string,
-	parameters?: Object
-): URL;
-
-export function sub(
-	string: string,
-	data: string | number | string[] | number[] | Array<string> | Array<number>,
-	...args: string[] | number[]
-): string;
+	/**
+	 * Sets the windowState to the specified value.
+	 */
+	setWindowState(windowState: string): void;
+}

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
@@ -64,11 +64,8 @@ export {default as openSimpleInputModal} from './liferay/modal/commands/OpenSimp
 // PortletURL API
 
 export {default as createActionURL} from './liferay/util/portlet_url/create_action_url.es';
-
 export {default as createPortletURL} from './liferay/util/portlet_url/create_portlet_url.es';
-
 export {default as createRenderURL} from './liferay/util/portlet_url/create_render_url.es';
-
 export {default as createResourceURL} from './liferay/util/portlet_url/create_resource_url.es';
 
 // Align API

--- a/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/js/editRedirectEntry.js
+++ b/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/js/editRedirectEntry.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {openToast} from 'frontend-js-web';
+import {createResourceURL, openToast} from 'frontend-js-web';
 
 export default function ({
 	getRedirectEntryChainCauseURL,
@@ -59,13 +59,10 @@ export default function ({
 		}
 		else {
 			Liferay.Util.fetch(
-				Liferay.Util.PortletURL.createResourceURL(
-					getRedirectEntryChainCauseURL,
-					{
-						destinationURL: destinationURL.value,
-						sourceURL: sourceURL.value,
-					}
-				)
+				createResourceURL(getRedirectEntryChainCauseURL, {
+					destinationURL: destinationURL.value,
+					sourceURL: sourceURL.value,
+				})
 			)
 				.then((response) => {
 					return response.json();


### PR DESCRIPTION
Original PR => https://github.com/liferay-frontend/liferay-portal/pull/2355

PR after sorting => https://github.com/liferay-frontend/liferay-portal/pull/2397

Manually forwarding because of a stuck CI process.

----

## Original description

Pretty self-explanatory. This PR exports the remaining utils living under the Liferay.Util.PortletURL namespace, and replaced their usages to importing instead of using the global namespace.