### PR TITLE
LPS-154839 Add/remove consent cookies to request depending on config 

### DIFF
--- a/modules/apps/cookies/cookies-banner-web/src/main/java/com/liferay/cookies/banner/web/internal/servlet/taglib/CookiesBannerBottomJSPDynamicInclude.java
+++ b/modules/apps/cookies/cookies-banner-web/src/main/java/com/liferay/cookies/banner/web/internal/servlet/taglib/CookiesBannerBottomJSPDynamicInclude.java
@@ -70,7 +70,9 @@ public class CookiesBannerBottomJSPDynamicInclude
 						CookiesPreferenceHandlingConfiguration.class,
 						group.getGroupId());
 
-			if (!cookiesPreferenceHandlingConfiguration.enabled()) {
+			if (!cookiesPreferenceHandlingConfiguration.enabled() ||
+				!cookiesPreferenceHandlingConfiguration.explicitConsentMode()) {
+
 				return;
 			}
 		}

--- a/modules/apps/cookies/cookies-impl/src/main/java/com/liferay/cookies/internal/events/CookiesPreAction.java
+++ b/modules/apps/cookies/cookies-impl/src/main/java/com/liferay/cookies/internal/events/CookiesPreAction.java
@@ -1,0 +1,274 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.cookies.internal.events;
+
+import com.liferay.cookies.configuration.CookiesPreferenceHandlingConfiguration;
+import com.liferay.portal.kernel.cookies.CookiesManagerUtil;
+import com.liferay.portal.kernel.cookies.constants.CookiesConstants;
+import com.liferay.portal.kernel.events.Action;
+import com.liferay.portal.kernel.events.LifecycleAction;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.module.configuration.ConfigurationException;
+import com.liferay.portal.kernel.module.configuration.ConfigurationProvider;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Carol Alonso
+ */
+@Component(
+	property = "key=servlet.service.events.pre", service = LifecycleAction.class
+)
+public class CookiesPreAction extends Action {
+
+	@Override
+	public void run(
+		HttpServletRequest httpServletRequest,
+		HttpServletResponse httpServletResponse) {
+
+		try {
+			_run(httpServletRequest, httpServletResponse);
+		}
+		catch (Exception exception) {
+			_log.error(exception);
+		}
+	}
+
+	private void _addCookie(
+		HttpServletRequest httpServletRequest,
+		HttpServletResponse httpServletResponse, Cookie cookie) {
+
+		cookie.setPath("/");
+		cookie.setVersion(0);
+
+		if (cookie.getMaxAge() != 0) {
+			cookie.setMaxAge(365 * 24 * 60 * 60);
+		}
+
+		CookiesManagerUtil.addCookie(
+			CookiesConstants.CONSENT_TYPE_NECESSARY, cookie, httpServletRequest,
+			httpServletResponse);
+	}
+
+	private void _expireCookie(
+		HttpServletRequest httpServletRequest,
+		HttpServletResponse httpServletResponse, String name) {
+
+		Cookie cookie = new Cookie(name, null);
+
+		cookie.setMaxAge(0);
+
+		_addCookie(httpServletRequest, httpServletResponse, cookie);
+	}
+
+	private void _expireNecessaryCookies(
+		HttpServletRequest httpServletRequest,
+		HttpServletResponse httpServletResponse) {
+
+		for (String necessaryCookieName : CookiesPreAction._NECESSARY_COOKIES) {
+			_expireCookie(
+				httpServletRequest, httpServletResponse, necessaryCookieName);
+		}
+	}
+
+	private void _expireOptionalCookies(
+		HttpServletRequest httpServletRequest,
+		HttpServletResponse httpServletResponse) {
+
+		for (String optionalCookieName : CookiesPreAction._OPTIONAL_COOKIES) {
+			_expireCookie(
+				httpServletRequest, httpServletResponse, optionalCookieName);
+		}
+	}
+
+	private void _expireUserConsentConfiguredCookie(
+		HttpServletRequest httpServletRequest,
+		HttpServletResponse httpServletResponse) {
+
+		_expireCookie(
+			httpServletRequest, httpServletResponse,
+			CookiesConstants.NAME_USER_CONSENT_CONFIGURED);
+	}
+
+	private Map<String, String> _parseCookieMap(Cookie[] cookies) {
+		Map<String, String> cookieMap = new HashMap<>();
+
+		if (cookies != null) {
+			for (Cookie cookie : cookies) {
+				String cookieName = cookie.getName();
+
+				if (cookieName.startsWith("CONSENT_TYPE_") ||
+					cookieName.equals(
+						CookiesConstants.NAME_USER_CONSENT_CONFIGURED)) {
+
+					cookieMap.put(cookieName, cookie.getValue());
+				}
+			}
+		}
+
+		return cookieMap;
+	}
+
+	private void _run(
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse)
+		throws ConfigurationException {
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		CookiesPreferenceHandlingConfiguration
+			cookiesPreferenceHandlingConfiguration =
+				_configurationProvider.getGroupConfiguration(
+					CookiesPreferenceHandlingConfiguration.class,
+					themeDisplay.getScopeGroupId());
+
+		Map<String, String> requestCookies = _parseCookieMap(
+			httpServletRequest.getCookies());
+
+		String necessaryConsentCookie = requestCookies.get(
+			CookiesConstants.NAME_CONSENT_TYPE_NECESSARY);
+		String performanceConsentCookie = requestCookies.get(
+			CookiesConstants.NAME_CONSENT_TYPE_PERFORMANCE);
+		String functionalConsentCookie = requestCookies.get(
+			CookiesConstants.NAME_CONSENT_TYPE_FUNCTIONAL);
+		String personalizationConsentCookie = requestCookies.get(
+			CookiesConstants.NAME_CONSENT_TYPE_PERSONALIZATION);
+		String userConsentCookie = requestCookies.get(
+			CookiesConstants.NAME_USER_CONSENT_CONFIGURED);
+
+		boolean optionalCookiesSet = false;
+
+		if ((performanceConsentCookie != null) &&
+			(functionalConsentCookie != null) &&
+			(personalizationConsentCookie != null)) {
+
+			optionalCookiesSet = true;
+		}
+
+		boolean allConsentCookiesSet = false;
+
+		if ((necessaryConsentCookie != null) && optionalCookiesSet) {
+			allConsentCookiesSet = true;
+		}
+
+		if (!cookiesPreferenceHandlingConfiguration.enabled()) {
+			if (userConsentCookie != null) {
+				_expireUserConsentConfiguredCookie(
+					httpServletRequest, httpServletResponse);
+			}
+
+			if (necessaryConsentCookie != null) {
+				_expireNecessaryCookies(
+					httpServletRequest, httpServletResponse);
+			}
+
+			if (optionalCookiesSet) {
+				_expireOptionalCookies(httpServletRequest, httpServletResponse);
+			}
+		}
+		else {
+			if (cookiesPreferenceHandlingConfiguration.explicitConsentMode()) {
+				if (!(optionalCookiesSet && (necessaryConsentCookie != null) &&
+					  (userConsentCookie != null))) {
+
+					if (userConsentCookie != null) {
+						_expireUserConsentConfiguredCookie(
+							httpServletRequest, httpServletResponse);
+					}
+
+					if (necessaryConsentCookie == null) {
+						_setNecessaryCookies(
+							httpServletRequest, httpServletResponse);
+					}
+
+					if ((userConsentCookie == null) || !optionalCookiesSet) {
+						_setOptionalCookies(
+							httpServletRequest, httpServletResponse, "false");
+					}
+				}
+			}
+			else {
+				if (!allConsentCookiesSet) {
+					if (userConsentCookie != null) {
+						_expireUserConsentConfiguredCookie(
+							httpServletRequest, httpServletResponse);
+					}
+
+					if (necessaryConsentCookie == null) {
+						_setNecessaryCookies(
+							httpServletRequest, httpServletResponse);
+					}
+
+					if (!optionalCookiesSet) {
+						_setOptionalCookies(
+							httpServletRequest, httpServletResponse, "true");
+					}
+				}
+			}
+		}
+	}
+
+	private void _setNecessaryCookies(
+		HttpServletRequest httpServletRequest,
+		HttpServletResponse httpServletResponse) {
+
+		for (String necessaryCookieName : CookiesPreAction._NECESSARY_COOKIES) {
+			Cookie cookie = new Cookie(necessaryCookieName, "true");
+
+			_addCookie(httpServletRequest, httpServletResponse, cookie);
+		}
+	}
+
+	private void _setOptionalCookies(
+		HttpServletRequest httpServletRequest,
+		HttpServletResponse httpServletResponse, String value) {
+
+		for (String optionalCookieName : CookiesPreAction._OPTIONAL_COOKIES) {
+			Cookie cookie = new Cookie(optionalCookieName, value);
+
+			_addCookie(httpServletRequest, httpServletResponse, cookie);
+		}
+	}
+
+	private static final String[] _NECESSARY_COOKIES = {
+		CookiesConstants.NAME_CONSENT_TYPE_NECESSARY
+	};
+
+	private static final String[] _OPTIONAL_COOKIES = {
+		CookiesConstants.NAME_CONSENT_TYPE_FUNCTIONAL,
+		CookiesConstants.NAME_CONSENT_TYPE_PERFORMANCE,
+		CookiesConstants.NAME_CONSENT_TYPE_PERSONALIZATION
+	};
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		CookiesPreAction.class);
+
+	@Reference
+	private ConfigurationProvider _configurationProvider;
+
+}

--- a/modules/apps/cookies/cookies-test/build.gradle
+++ b/modules/apps/cookies/cookies-test/build.gradle
@@ -1,3 +1,13 @@
 dependencies {
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.1"
+	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
+	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
+	compileOnly project(":apps:configuration-admin:configuration-admin-api")
+	compileOnly project(":apps:cookies:cookies-api")
+	compileOnly project(":apps:cookies:cookies-impl")
+	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
+	compileOnly project(":core:petra:petra-string")
+
 	testIntegrationCompile project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/cookies/cookies-test/src/test/java/com/liferay/cookies/internal/events/CookiesPreActionTest.java
+++ b/modules/apps/cookies/cookies-test/src/test/java/com/liferay/cookies/internal/events/CookiesPreActionTest.java
@@ -1,0 +1,447 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.cookies.internal.events;
+
+import com.liferay.cookies.configuration.CookiesPreferenceHandlingConfiguration;
+import com.liferay.cookies.internal.manager.CookiesManagerImpl;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.cookies.CookiesManager;
+import com.liferay.portal.kernel.cookies.CookiesManagerUtil;
+import com.liferay.portal.kernel.cookies.constants.CookiesConstants;
+import com.liferay.portal.kernel.module.configuration.ConfigurationException;
+import com.liferay.portal.kernel.module.configuration.ConfigurationProvider;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * @author Carol Alonso
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class CookiesPreActionTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	public void setCookieManagementConfiguration(
+			Boolean enabled, Boolean explicitConsentMode)
+		throws ConfigurationException {
+
+		ReflectionTestUtil.setFieldValue(_cookiesManager, "_portal", _portal);
+
+		ReflectionTestUtil.setFieldValue(
+			CookiesManagerUtil.class, "_cookiesManager", _cookiesManager);
+
+		Mockito.when(
+			_portal.isSecure(Mockito.any())
+		).thenReturn(
+			false
+		);
+
+		Mockito.when(
+			_configurationProvider.getGroupConfiguration(
+				CookiesPreferenceHandlingConfiguration.class, 0)
+		).thenReturn(
+			new CookiesPreferenceHandlingConfiguration() {
+
+				@Override
+				public boolean enabled() {
+					return enabled;
+				}
+
+				@Override
+				public boolean explicitConsentMode() {
+					return explicitConsentMode;
+				}
+
+			}
+		);
+
+		ReflectionTestUtil.setFieldValue(
+			_cookiesPreAction, "_configurationProvider",
+			_configurationProvider);
+	}
+
+	@Test
+	public void testCookieManagementDisabledWithAllCookies() throws Exception {
+		setCookieManagementConfiguration(false, false);
+
+		HttpServletRequest httpServletRequest = _getHttpServletRequest(
+			true, true, true);
+		MockHttpServletResponse httpServletResponse =
+			new MockHttpServletResponse();
+
+		_cookiesPreAction.run(httpServletRequest, httpServletResponse);
+
+		Cookie[] responseCookies = httpServletResponse.getCookies();
+
+		Assert.assertEquals(
+			Arrays.toString(responseCookies), 5, responseCookies.length);
+
+		Cookie userConsentConfiguredCookie = httpServletResponse.getCookie(
+			CookiesConstants.NAME_USER_CONSENT_CONFIGURED);
+
+		Assert.assertNotNull(userConsentConfiguredCookie);
+		Assert.assertNull(userConsentConfiguredCookie.getValue());
+		Assert.assertEquals(0, userConsentConfiguredCookie.getMaxAge());
+
+		Cookie consentTypeNecessaryCookie = httpServletResponse.getCookie(
+			CookiesConstants.NAME_CONSENT_TYPE_NECESSARY);
+
+		Assert.assertNotNull(consentTypeNecessaryCookie);
+		Assert.assertNull(consentTypeNecessaryCookie.getValue());
+		Assert.assertEquals(0, consentTypeNecessaryCookie.getMaxAge());
+
+		String[] optionalConsentCookieNames = {
+			CookiesConstants.NAME_CONSENT_TYPE_PERSONALIZATION,
+			CookiesConstants.NAME_CONSENT_TYPE_PERFORMANCE,
+			CookiesConstants.NAME_CONSENT_TYPE_FUNCTIONAL
+		};
+
+		for (String optionalCookieName : optionalConsentCookieNames) {
+			Cookie optionalCookie = httpServletResponse.getCookie(
+				optionalCookieName);
+
+			Assert.assertNotNull(optionalCookie);
+			Assert.assertNull(optionalCookie.getValue());
+			Assert.assertEquals(0, optionalCookie.getMaxAge());
+		}
+	}
+
+	@Test
+	public void testCookieManagementDisabledWithConsentCookies()
+		throws Exception {
+
+		setCookieManagementConfiguration(false, false);
+
+		HttpServletRequest httpServletRequest = _getHttpServletRequest(
+			true, true, false);
+		MockHttpServletResponse httpServletResponse =
+			new MockHttpServletResponse();
+
+		_cookiesPreAction.run(httpServletRequest, httpServletResponse);
+
+		Cookie[] responseCookies = httpServletResponse.getCookies();
+
+		Assert.assertEquals(
+			Arrays.toString(responseCookies), 4, responseCookies.length);
+
+		Cookie userConsentConfiguredCookie = httpServletResponse.getCookie(
+			CookiesConstants.NAME_USER_CONSENT_CONFIGURED);
+
+		Assert.assertNull(userConsentConfiguredCookie);
+
+		Cookie consentTypeNecessaryCookie = httpServletResponse.getCookie(
+			CookiesConstants.NAME_CONSENT_TYPE_NECESSARY);
+
+		Assert.assertNotNull(consentTypeNecessaryCookie);
+		Assert.assertNull(consentTypeNecessaryCookie.getValue());
+		Assert.assertEquals(0, consentTypeNecessaryCookie.getMaxAge());
+
+		String[] optionalConsentCookieNames = {
+			CookiesConstants.NAME_CONSENT_TYPE_PERSONALIZATION,
+			CookiesConstants.NAME_CONSENT_TYPE_PERFORMANCE,
+			CookiesConstants.NAME_CONSENT_TYPE_FUNCTIONAL
+		};
+
+		for (String optionalCookieName : optionalConsentCookieNames) {
+			Cookie optionalCookie = httpServletResponse.getCookie(
+				optionalCookieName);
+
+			Assert.assertNotNull(optionalCookie);
+			Assert.assertNull(optionalCookie.getValue());
+			Assert.assertEquals(0, optionalCookie.getMaxAge());
+		}
+	}
+
+	@Test
+	public void testCookieManagementDisabledWithoutCookies() throws Exception {
+		setCookieManagementConfiguration(false, false);
+
+		HttpServletRequest httpServletRequest = _getHttpServletRequest(
+			false, false, false);
+		MockHttpServletResponse httpServletResponse =
+			new MockHttpServletResponse();
+
+		_cookiesPreAction.run(httpServletRequest, httpServletResponse);
+
+		Cookie[] responseCookies = httpServletResponse.getCookies();
+
+		Assert.assertEquals(
+			Arrays.toString(responseCookies), 0, responseCookies.length);
+	}
+
+	@Test
+	public void testExplicitModeWithAllCookies() throws Exception {
+		setCookieManagementConfiguration(true, true);
+
+		HttpServletRequest httpServletRequest = _getHttpServletRequest(
+			true, true, true);
+		MockHttpServletResponse httpServletResponse =
+			new MockHttpServletResponse();
+
+		_cookiesPreAction.run(httpServletRequest, httpServletResponse);
+
+		Cookie[] responseCookies = httpServletResponse.getCookies();
+
+		Assert.assertEquals(
+			Arrays.toString(responseCookies), 0, responseCookies.length);
+	}
+
+	@Test
+	public void testExplicitModeWithConsentCookies() throws Exception {
+		setCookieManagementConfiguration(true, true);
+
+		HttpServletRequest httpServletRequest = _getHttpServletRequest(
+			true, true, false);
+		MockHttpServletResponse httpServletResponse =
+			new MockHttpServletResponse();
+
+		_cookiesPreAction.run(httpServletRequest, httpServletResponse);
+
+		Cookie[] responseCookies = httpServletResponse.getCookies();
+
+		Assert.assertEquals(
+			Arrays.toString(responseCookies), 3, responseCookies.length);
+
+		Cookie userConsentConfiguredCookie = httpServletResponse.getCookie(
+			CookiesConstants.NAME_USER_CONSENT_CONFIGURED);
+
+		Assert.assertNull(userConsentConfiguredCookie);
+
+		Cookie consentTypeNecessaryCookie = httpServletResponse.getCookie(
+			CookiesConstants.NAME_CONSENT_TYPE_NECESSARY);
+
+		Assert.assertNull(consentTypeNecessaryCookie);
+
+		String[] optionalConsentCookieNames = {
+			CookiesConstants.NAME_CONSENT_TYPE_PERSONALIZATION,
+			CookiesConstants.NAME_CONSENT_TYPE_PERFORMANCE,
+			CookiesConstants.NAME_CONSENT_TYPE_FUNCTIONAL
+		};
+
+		for (String optionalCookieName : optionalConsentCookieNames) {
+			Cookie optionalCookie = httpServletResponse.getCookie(
+				optionalCookieName);
+
+			Assert.assertNotNull(optionalCookie);
+			Assert.assertEquals("false", optionalCookie.getValue());
+			Assert.assertNotEquals(0, optionalCookie.getMaxAge());
+		}
+	}
+
+	@Test
+	public void testExplicitModeWithoutCookies() throws Exception {
+		setCookieManagementConfiguration(true, true);
+
+		HttpServletRequest httpServletRequest = _getHttpServletRequest(
+			false, false, false);
+		MockHttpServletResponse httpServletResponse =
+			new MockHttpServletResponse();
+
+		_cookiesPreAction.run(httpServletRequest, httpServletResponse);
+
+		Cookie[] responseCookies = httpServletResponse.getCookies();
+
+		Assert.assertEquals(
+			Arrays.toString(responseCookies), 4, responseCookies.length);
+
+		Cookie userConsentConfiguredCookie = httpServletResponse.getCookie(
+			CookiesConstants.NAME_USER_CONSENT_CONFIGURED);
+
+		Assert.assertNull(userConsentConfiguredCookie);
+
+		Cookie consentTypeNecessaryCookie = httpServletResponse.getCookie(
+			CookiesConstants.NAME_CONSENT_TYPE_NECESSARY);
+
+		Assert.assertNotNull(consentTypeNecessaryCookie);
+		Assert.assertEquals("true", consentTypeNecessaryCookie.getValue());
+		Assert.assertNotEquals(0, consentTypeNecessaryCookie.getMaxAge());
+
+		String[] optionalConsentCookieNames = {
+			CookiesConstants.NAME_CONSENT_TYPE_PERSONALIZATION,
+			CookiesConstants.NAME_CONSENT_TYPE_PERFORMANCE,
+			CookiesConstants.NAME_CONSENT_TYPE_FUNCTIONAL
+		};
+
+		for (String optionalCookieName : optionalConsentCookieNames) {
+			Cookie optionalCookie = httpServletResponse.getCookie(
+				optionalCookieName);
+
+			Assert.assertNotNull(optionalCookie);
+			Assert.assertEquals("false", optionalCookie.getValue());
+			Assert.assertNotEquals(0, optionalCookie.getMaxAge());
+		}
+	}
+
+	@Test
+	public void testImplicitModeWithAllCookies() throws Exception {
+		setCookieManagementConfiguration(true, false);
+
+		HttpServletRequest httpServletRequest = _getHttpServletRequest(
+			true, true, true);
+		MockHttpServletResponse httpServletResponse =
+			new MockHttpServletResponse();
+
+		_cookiesPreAction.run(httpServletRequest, httpServletResponse);
+
+		Cookie[] responseCookies = httpServletResponse.getCookies();
+
+		Assert.assertEquals(
+			Arrays.toString(responseCookies), 0, responseCookies.length);
+	}
+
+	@Test
+	public void testImplicitModeWithConsentCookies() throws Exception {
+		setCookieManagementConfiguration(true, false);
+
+		HttpServletRequest httpServletRequest = _getHttpServletRequest(
+			true, true, false);
+		MockHttpServletResponse httpServletResponse =
+			new MockHttpServletResponse();
+
+		_cookiesPreAction.run(httpServletRequest, httpServletResponse);
+
+		Cookie[] responseCookies = httpServletResponse.getCookies();
+
+		Assert.assertEquals(
+			Arrays.toString(responseCookies), 0, responseCookies.length);
+	}
+
+	@Test
+	public void testImplicitModeWithoutCookies() throws Exception {
+		setCookieManagementConfiguration(true, false);
+
+		HttpServletRequest httpServletRequest = _getHttpServletRequest(
+			false, false, false);
+		MockHttpServletResponse httpServletResponse =
+			new MockHttpServletResponse();
+
+		_cookiesPreAction.run(httpServletRequest, httpServletResponse);
+
+		Cookie[] responseCookies = httpServletResponse.getCookies();
+
+		Assert.assertEquals(
+			Arrays.toString(responseCookies), 4, responseCookies.length);
+
+		Cookie userConsentConfiguredCookie = httpServletResponse.getCookie(
+			CookiesConstants.NAME_USER_CONSENT_CONFIGURED);
+
+		Assert.assertNull(userConsentConfiguredCookie);
+
+		Cookie consentTypeNecessaryCookie = httpServletResponse.getCookie(
+			CookiesConstants.NAME_CONSENT_TYPE_NECESSARY);
+
+		Assert.assertNotNull(consentTypeNecessaryCookie);
+		Assert.assertEquals("true", consentTypeNecessaryCookie.getValue());
+		Assert.assertNotEquals(0, consentTypeNecessaryCookie.getMaxAge());
+
+		String[] optionalConsentCookieNames = {
+			CookiesConstants.NAME_CONSENT_TYPE_PERSONALIZATION,
+			CookiesConstants.NAME_CONSENT_TYPE_PERFORMANCE,
+			CookiesConstants.NAME_CONSENT_TYPE_FUNCTIONAL
+		};
+
+		for (String optionalCookieName : optionalConsentCookieNames) {
+			Cookie optionalCookie = httpServletResponse.getCookie(
+				optionalCookieName);
+
+			Assert.assertNotNull(optionalCookie);
+			Assert.assertEquals("true", optionalCookie.getValue());
+			Assert.assertNotEquals(0, optionalCookie.getMaxAge());
+		}
+	}
+
+	private HttpServletRequest _getHttpServletRequest(
+		boolean optionalCookies, boolean necessaryCookies,
+		boolean userConsentCookie) {
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setScopeGroupId(0);
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, themeDisplay);
+
+		List<Cookie> cookies = new ArrayList<>();
+
+		if (optionalCookies) {
+			cookies.add(
+				new Cookie(
+					CookiesConstants.NAME_CONSENT_TYPE_NECESSARY, "true"));
+		}
+
+		if (necessaryCookies) {
+			cookies.add(
+				new Cookie(
+					CookiesConstants.NAME_CONSENT_TYPE_FUNCTIONAL, "true"));
+			cookies.add(
+				new Cookie(
+					CookiesConstants.NAME_CONSENT_TYPE_PERFORMANCE, "true"));
+			cookies.add(
+				new Cookie(
+					CookiesConstants.NAME_CONSENT_TYPE_PERSONALIZATION,
+					"true"));
+		}
+
+		if (userConsentCookie) {
+			cookies.add(
+				new Cookie(
+					CookiesConstants.NAME_USER_CONSENT_CONFIGURED, "true"));
+		}
+
+		mockHttpServletRequest.setCookies(cookies.toArray(new Cookie[0]));
+		mockHttpServletRequest.setPathInfo(StringPool.BLANK);
+
+		return mockHttpServletRequest;
+	}
+
+	@Mock
+	private ConfigurationProvider _configurationProvider;
+
+	private final CookiesManager _cookiesManager = new CookiesManagerImpl();
+	private final CookiesPreAction _cookiesPreAction = new CookiesPreAction();
+
+	@Mock
+	private Portal _portal;
+
+}

--- a/portal-kernel/bnd.bnd
+++ b/portal-kernel/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 59.0.1
+Bundle-Version: 59.1.0
 Export-Package:\
 	!com.liferay.portal.kernel.internal.*,\
 	!com.liferay.portal.kernel.module.util,\

--- a/portal-kernel/src/com/liferay/portal/kernel/cookies/constants/CookiesConstants.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/cookies/constants/CookiesConstants.java
@@ -65,6 +65,9 @@ public class CookiesConstants {
 	public static final String NAME_REMOTE_PREFERENCE_PREFIX =
 		"REMOTE_PREFERENCE_";
 
+	public static final String NAME_USER_CONSENT_CONFIGURED =
+		"USER_CONSENT_CONFIGURED";
+
 	public static final String NAME_USER_UUID = "USER_UUID";
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/cookies/constants/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/cookies/constants/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/HttpOnlyCookieServletResponse.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/HttpOnlyCookieServletResponse.java
@@ -14,11 +14,12 @@
 
 package com.liferay.portal.kernel.servlet;
 
+import com.liferay.portal.kernel.cookies.constants.CookiesConstants;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.SystemProperties;
 
-import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 
 import javax.servlet.http.Cookie;
@@ -69,20 +70,27 @@ public class HttpOnlyCookieServletResponse extends HttpServletResponseWrapper {
 		super.addCookie(cookie);
 	}
 
-	private static final Set<String> _cookieHttpOnlyCookieNamesExcludes;
+	private static final Set<String> _cookieHttpOnlyCookieNamesExcludes =
+		new HashSet<String>() {
+			{
+				addAll(
+					SetUtil.fromArray(
+						CookiesConstants.NAME_CONSENT_TYPE_FUNCTIONAL,
+						CookiesConstants.NAME_CONSENT_TYPE_PERFORMANCE,
+						CookiesConstants.NAME_CONSENT_TYPE_PERSONALIZATION,
+						CookiesConstants.NAME_CONSENT_TYPE_NECESSARY,
+						CookiesConstants.NAME_USER_CONSENT_CONFIGURED));
 
-	static {
-		Set<String> cookieHttpOnlyCookieNamesExcludes = SetUtil.fromArray(
-			StringUtil.split(
-				SystemProperties.get("cookie.http.only.names.excludes")));
+				Set<String> cookieHttpOnlyCookieNamesExcludes =
+					SetUtil.fromArray(
+						StringUtil.split(
+							SystemProperties.get(
+								"cookie.http.only.names.excludes")));
 
-		if (cookieHttpOnlyCookieNamesExcludes.isEmpty()) {
-			_cookieHttpOnlyCookieNamesExcludes = Collections.emptySet();
-		}
-		else {
-			_cookieHttpOnlyCookieNamesExcludes =
-				cookieHttpOnlyCookieNamesExcludes;
-		}
-	}
+				if (!cookieHttpOnlyCookieNamesExcludes.isEmpty()) {
+					addAll(cookieHttpOnlyCookieNamesExcludes);
+				}
+			}
+		};
 
 }


### PR DESCRIPTION
Manually forwarded [with QA approval](https://github.com/liferay-frontend/liferay-portal/pull/2403#issuecomment-1167184931) because of unrelated CI failure. https://github.com/liferay-frontend/liferay-portal/pull/2403

---
### References

- [LPS-154839](https://issues.liferay.com/browse/LPS-154839)

### What is the goal?

Add `CookiesPreAction`, which adds or removes consent cookies to the current response depending on cookie management configuration and user's preferences.

These cookies are necessary in order to add the global JS utility for GDPR-compliant cookie management ([LPS-151966](https://issues.liferay.com/browse/LPS-151966)), as cookies can be set from both back and front end. Since whether a cookie can be set depends on the user's preferences (which are set on the front end) and backend config (cookie management enabled/disabled, implicit/explicit mode, which can be changed by an admin at any time), we are adding these cookies as a way to keep both in sync.
   
You can find more info in https://github.com/liferay-frontend/liferay-portal/pull/2303

### Notes

* The set/remove logic is as follows:
  * All cookies are removed if functionality is **disabled**
  * All cookies are set to true if functionality is **enabled**, **implicit** mode is active and the user **hasn't set their preferences before**
  * Necessary cookies are set to true and optional to false if functionality is **enabled**, **explicit** mode is active and the **user hasn't set their preferences** before
  * In all cases where any cookie is modified, user configuration cookie is cleared. This is fundamental to ensure that we don't consider a default value –such as all cookies being enabled in implicit mode– as the user's preference after configuration changes –such as changing from explicit mode to implicit to explicit again. 
* Liferay marks all cookies as HttpOnly by default, which makes them inaccessible from JS, breaking this functionality. This can only be overriden using config. I had to skip them from being marked as HttpOnly in code in [HttpOnlyCookieServletResponse](https://github.com/tinycarol/liferay-portal/blob/master/portal-kernel/src/com/liferay/portal/kernel/servlet/HttpOnlyCookieServletResponse.java#L72) so it won't interfere with user's config. 
* The way to remove the cookies is to expire them (set max-age to 0), which will make the browser delete the cookie
* New cookies will last one year (365 days), after which the user may be re-prompted for their consent depending on config

### What does it look like?

<img width="1720" alt="Console showing all unit tests passing" src="https://user-images.githubusercontent.com/6642927/175034097-c68e9472-676b-4cb7-aa9c-80fa2bea650b.png">
