### PR TITLE
Lps 148397 2

### DIFF
--- a/build-dist.xml
+++ b/build-dist.xml
@@ -508,14 +508,18 @@ release was successful.</echo>
 	</target>
 
 	<target name="generate-tomcat-setenv">
-		<echo file="tools/servers/tomcat/bin/setenv.sh">CATALINA_OPTS="$CATALINA_OPTS ${app.server.tomcat.jvm.args} ${app.server.tomcat.jvm.mem}"</echo>
+		<echo file="tools/servers/tomcat/bin/setenv.sh">CATALINA_OPTS="$CATALINA_OPTS ${app.server.tomcat.jvm.args} ${app.server.tomcat.jvm.mem}"
+
+JDK_JAVA_OPTIONS="$JDK_JAVA_OPTIONS --add-opens=jdk.zipfs/jdk.nio.zipfs=ALL-UNNAMED"</echo>
 
 		<chmod
 			file="tools/servers/tomcat/bin/setenv.sh"
 			perm="a+x"
 		/>
 
-		<echo file="tools/servers/tomcat/bin/setenv.bat">set "CATALINA_OPTS=%CATALINA_OPTS% ${app.server.tomcat.jvm.args} ${app.server.tomcat.jvm.mem}"</echo>
+		<echo file="tools/servers/tomcat/bin/setenv.bat">set "CATALINA_OPTS=%CATALINA_OPTS% ${app.server.tomcat.jvm.args} ${app.server.tomcat.jvm.mem}"
+
+set "JDK_JAVA_OPTIONS=%JDK_JAVA_OPTIONS% --add-opens=jdk.zipfs/jdk.nio.zipfs=ALL-UNNAMED"</echo>
 	</target>
 
 	<target name="install-weblogic14-setup-files">

--- a/portal-impl/src/com/liferay/portal/zip/ZipWriterImpl.java
+++ b/portal-impl/src/com/liferay/portal/zip/ZipWriterImpl.java
@@ -20,6 +20,8 @@ import com.liferay.petra.memory.DeleteFileFinalizeAction;
 import com.liferay.petra.memory.FinalizeManager;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.SystemProperties;
 import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
@@ -30,6 +32,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+
+import java.lang.reflect.Field;
 
 import java.net.URI;
 
@@ -109,11 +113,7 @@ public class ZipWriterImpl implements ZipWriter {
 
 			Path path = fileSystem.getPath(name);
 
-			Path parentPath = path.getParent();
-
-			if (parentPath != null) {
-				Files.createDirectories(parentPath);
-			}
+			_createDirectories(fileSystem, path.getParent());
 
 			Files.write(
 				path, bytes, StandardOpenOption.CREATE,
@@ -140,11 +140,7 @@ public class ZipWriterImpl implements ZipWriter {
 
 			Path path = fileSystem.getPath(name);
 
-			Path parentPath = path.getParent();
-
-			if (parentPath != null) {
-				Files.createDirectories(parentPath);
-			}
+			_createDirectories(fileSystem, path.getParent());
 
 			Files.copy(inputStream, path, StandardCopyOption.REPLACE_EXISTING);
 		}
@@ -203,6 +199,68 @@ public class ZipWriterImpl implements ZipWriter {
 	public void umount() {
 	}
 
+	private void _createDirectories(FileSystem fileSystem, Path parentPath)
+		throws IOException {
+
+		if ((parentPath == null) || Files.exists(parentPath)) {
+			return;
+		}
+
+		Files.createDirectories(parentPath);
+
+		boolean needUTF8 = false;
+
+		String pathString = parentPath.toString();
+
+		for (int i = 0; i < pathString.length(); i++) {
+			if (pathString.charAt(i) > 128) {
+				needUTF8 = true;
+
+				break;
+			}
+		}
+
+		if (!needUTF8) {
+			return;
+		}
+
+		try {
+			Class<?> fileSystemClass = fileSystem.getClass();
+
+			Field inodesField = fileSystemClass.getDeclaredField("inodes");
+
+			inodesField.setAccessible(true);
+
+			Map<?, ?> inodes = (Map<?, ?>)inodesField.get(fileSystem);
+
+			for (Object inode : inodes.keySet()) {
+				try {
+					Class<?> inodeClass = inode.getClass();
+
+					Field flagField = inodeClass.getDeclaredField("flag");
+
+					flagField.setAccessible(true);
+
+					int flag = flagField.getInt(inode);
+
+					if ((flag & 2048) == 0) {
+						flagField.setInt(inode, flag | 2048);
+					}
+				}
+				catch (NoSuchFieldException noSuchFieldException) {
+				}
+			}
+		}
+		catch (ReflectiveOperationException reflectiveOperationException) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to force UTF-8 encoding for directory " +
+						parentPath,
+					reflectiveOperationException);
+			}
+		}
+	}
+
 	private void _writeExportEntries() {
 		try (FileSystem fileSystem = FileSystems.newFileSystem(
 				_uri, Collections.emptyMap())) {
@@ -217,11 +275,7 @@ public class ZipWriterImpl implements ZipWriter {
 
 				Path path = fileSystem.getPath(entry.getKey());
 
-				Path parentPath = path.getParent();
-
-				if (parentPath != null) {
-					Files.createDirectories(parentPath);
-				}
+				_createDirectories(fileSystem, path.getParent());
 
 				Files.write(
 					path, entry.getValue(), StandardOpenOption.CREATE,
@@ -236,6 +290,8 @@ public class ZipWriterImpl implements ZipWriter {
 			throw new UncheckedIOException(ioException);
 		}
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(ZipWriterImpl.class);
 
 	private List<Map.Entry<String, byte[]>> _exportEntries;
 	private long _exportEntriesBytes;

--- a/tools/servers/tomcat/bin/setenv.bat
+++ b/tools/servers/tomcat/bin/setenv.bat
@@ -1,1 +1,3 @@
 set "CATALINA_OPTS=%CATALINA_OPTS% -Dfile.encoding=UTF-8 -Djava.locale.providers=JRE,COMPAT,CLDR -Djava.net.preferIPv4Stack=true -Duser.timezone=GMT -Xms2560m -Xmx2560m -XX:MaxNewSize=1536m -XX:MaxMetaspaceSize=768m -XX:MetaspaceSize=768m -XX:NewSize=1536m -XX:SurvivorRatio=7"
+
+set "JDK_JAVA_OPTIONS=%JDK_JAVA_OPTIONS% --add-opens=jdk.zipfs/jdk.nio.zipfs=ALL-UNNAMED"

--- a/tools/servers/tomcat/bin/setenv.sh
+++ b/tools/servers/tomcat/bin/setenv.sh
@@ -1,1 +1,3 @@
 CATALINA_OPTS="$CATALINA_OPTS -Dfile.encoding=UTF-8 -Djava.locale.providers=JRE,COMPAT,CLDR -Djava.net.preferIPv4Stack=true -Duser.timezone=GMT -Xms2560m -Xmx2560m -XX:MaxNewSize=1536m -XX:MaxMetaspaceSize=768m -XX:MetaspaceSize=768m -XX:NewSize=1536m -XX:SurvivorRatio=7"
+
+JDK_JAVA_OPTIONS="$JDK_JAVA_OPTIONS --add-opens=jdk.zipfs/jdk.nio.zipfs=ALL-UNNAMED"


### PR DESCRIPTION
@brianchandotcom this is fixing a jdk nio2 zfs bug, it exists on all jdk versions with no fix. I figured out this workaround to fix the issue with minimum changes on our side. And it works on all supported jdk versions. So we are good for now.

The root issue is really low quality code in nio2 impls. We got rid of TrueZip a few years ago during that staging performance optimization process if you still remember. I choose nio2 zfs due to its uniformed read/write style which staging logic needs.
But after recent startup optimization fixes, we saw a lot of performance issue in nio2 impl, now this annoying bug too. I really think we should switch back to TIO to do this. The plain old ZipOutputStream does not have this unicode encoding issue.

But we need a round a re-engineering to make sure we won't bring back staging's performance issue. And provide a wrapping layer of ourselves to do the unified read/write but using tio apis.

This is hard to test automatically, we are just testing it manually for now. @vicnate5 is trying to find an automated way to test it.