### PR TITLE
LPS-154539 Import `openModal` instead of using `Liferay.Util.openModal`

### DIFF
--- a/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/js/openDeleteCategoryModal.js
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/js/openDeleteCategoryModal.js
@@ -12,14 +12,14 @@
  * details.
  */
 
-import {sub} from 'frontend-js-web';
+import {openModal, sub} from 'frontend-js-web';
 
 export default function openDeleteCategoryModal({
 	message,
 	multiple = false,
 	onDelete,
 }) {
-	Liferay.Util.openModal({
+	openModal({
 		bodyHTML:
 			message ||
 			Liferay.Language.get('are-you-sure-you-want-to-delete-this'),

--- a/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/js/openDeleteVocabularyModal.js
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/js/openDeleteVocabularyModal.js
@@ -12,13 +12,13 @@
  * details.
  */
 
-import {sub} from 'frontend-js-web';
+import {openModal, sub} from 'frontend-js-web';
 
 export default function openDeleteVocabularyModal({
 	multiple = false,
 	onDelete,
 }) {
-	Liferay.Util.openModal({
+	openModal({
 		bodyHTML: Liferay.Language.get('are-you-sure-you-want-to-delete-this'),
 		buttons: [
 			{

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/openDeleteAssetEntryListModal.js
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/openDeleteAssetEntryListModal.js
@@ -12,13 +12,13 @@
  * details.
  */
 
-import {sub} from 'frontend-js-web';
+import {openModal, sub} from 'frontend-js-web';
 
 export default function openDeleteAssetEntryListModal({
 	multiple = false,
 	onDelete,
 }) {
-	Liferay.Util.openModal({
+	openModal({
 		bodyHTML: Liferay.Language.get(
 			'deleting-a-collection-is-an-action-impossible-to-revert'
 		),

--- a/modules/apps/asset/asset-tags-admin-web/src/main/resources/META-INF/resources/js/openDeleteTagModal.js
+++ b/modules/apps/asset/asset-tags-admin-web/src/main/resources/META-INF/resources/js/openDeleteTagModal.js
@@ -12,10 +12,10 @@
  * details.
  */
 
-import {sub} from 'frontend-js-web';
+import {openModal, sub} from 'frontend-js-web';
 
 export default function openDeleteTagModal({multiple = false, onDelete}) {
-	Liferay.Util.openModal({
+	openModal({
 		bodyHTML: Liferay.Language.get('are-you-sure-you-want-to-delete-this'),
 		buttons: [
 			{

--- a/modules/apps/commerce/commerce-order-content-web/src/main/resources/META-INF/resources/js/edit_commerce_order.js
+++ b/modules/apps/commerce/commerce-order-content-web/src/main/resources/META-INF/resources/js/edit_commerce_order.js
@@ -12,6 +12,8 @@
  * details.
  */
 
+import {openModal} from 'frontend-js-web';
+
 export default function ({commerceOrderImporterTypeKey, title, url}) {
 	const commerceOrderImporterTypeKeySelector = document.querySelector(
 		`.${commerceOrderImporterTypeKey}`
@@ -20,7 +22,7 @@ export default function ({commerceOrderImporterTypeKey, title, url}) {
 	commerceOrderImporterTypeKeySelector.addEventListener('click', (event) => {
 		event.preventDefault();
 
-		Liferay.Util.openModal({
+		openModal({
 			id: commerceOrderImporterTypeKey,
 			iframeBodyCssClass: '',
 			title,

--- a/modules/apps/cookies/cookies-banner-web/src/main/resources/META-INF/resources/cookies_banner/js/CookiesBanner.js
+++ b/modules/apps/cookies/cookies-banner-web/src/main/resources/META-INF/resources/cookies_banner/js/CookiesBanner.js
@@ -12,6 +12,8 @@
  * details.
  */
 
+import {openModal} from 'frontend-js-web';
+
 import {
 	acceptAllCookies,
 	declineAllCookies,
@@ -70,7 +72,7 @@ export default function ({
 		});
 
 		configurationButton.addEventListener('click', () => {
-			Liferay.Util.openModal({
+			openModal({
 				buttons: [
 					{
 						displayType: 'secondary',

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/dynamic_include/StagingIndicator.js
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/dynamic_include/StagingIndicator.js
@@ -14,6 +14,7 @@
 
 import {Align, ClayDropDownWithItems} from '@clayui/drop-down';
 import ClayIcon from '@clayui/icon';
+import {openModal} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -23,7 +24,7 @@ const Component = ({iconClass, iconName, items, title}) => {
 			return {
 				...item,
 				onClick() {
-					Liferay.Util.openModal({
+					openModal({
 						title: item.label,
 						url: item.publishURL,
 					});

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/openDeleteFragmentCollectionModal.js
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/openDeleteFragmentCollectionModal.js
@@ -12,13 +12,13 @@
  * details.
  */
 
-import {sub} from 'frontend-js-web';
+import {openModal, sub} from 'frontend-js-web';
 
 export default function openDeleteFragmentCollectionModal({
 	multiple = false,
 	onDelete,
 }) {
-	Liferay.Util.openModal({
+	openModal({
 		bodyHTML: Liferay.Language.get(
 			'deleting-a-fragment-set-is-an-action-impossible-to-revert'
 		),

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/openDeleteFragmentCollectionResourceModal.js
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/openDeleteFragmentCollectionResourceModal.js
@@ -12,13 +12,13 @@
  * details.
  */
 
-import {sub} from 'frontend-js-web';
+import {openModal, sub} from 'frontend-js-web';
 
 export default function openDeleteFragmentCollectionResourceModal({
 	multiple = false,
 	onDelete,
 }) {
-	Liferay.Util.openModal({
+	openModal({
 		bodyHTML: Liferay.Language.get('are-you-sure-you-want-to-delete-this'),
 		buttons: [
 			{

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/openDeleteFragmentModal.js
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/openDeleteFragmentModal.js
@@ -12,10 +12,10 @@
  * details.
  */
 
-import {sub} from 'frontend-js-web';
+import {openModal, sub} from 'frontend-js-web';
 
 export default function openDeleteFragmentModal({multiple = false, onDelete}) {
-	Liferay.Util.openModal({
+	openModal({
 		bodyHTML: Liferay.Language.get(
 			'deleting-a-fragment-is-an-action-impossible-to-revert'
 		),

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts
@@ -187,6 +187,8 @@ export function minimizePortlet(
 	options?: object
 ): void;
 
+export function openModal(props: Object): void;
+
 export function openSelectionModal<T>(init: {
 	buttonAddLabel?: string;
 	buttonCancelLabel?: string;

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/modals/openDeleteArticleModal.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/modals/openDeleteArticleModal.js
@@ -12,8 +12,10 @@
  * details.
  */
 
+import {openModal} from 'frontend-js-web';
+
 export default function openDeleteArticleModal({onDelete}) {
-	Liferay.Util.openModal({
+	openModal({
 		bodyHTML: Liferay.Language.get('are-you-sure-you-want-to-delete-this'),
 		buttons: [
 			{

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/openDeleteLayoutModal.js
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/openDeleteLayoutModal.js
@@ -12,14 +12,14 @@
  * details.
  */
 
-import {sub} from 'frontend-js-web';
+import {openModal, sub} from 'frontend-js-web';
 
 export default function openDeleteLayoutModal({
 	message,
 	multiple = false,
 	onDelete,
 }) {
-	Liferay.Util.openModal({
+	openModal({
 		bodyHTML: message,
 		buttons: [
 			{

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/openWarningModal.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/openWarningModal.js
@@ -12,13 +12,15 @@
  * details.
  */
 
+import {openModal} from 'frontend-js-web';
+
 export default function openWarningModal({
 	action,
 	actionLabel,
 	message,
 	title,
 }) {
-	Liferay.Util.openModal({
+	openModal({
 		bodyHTML: `<p class="text-secondary">${message}</p>`,
 		buttons: [
 			{

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/modal/openDeletePageTemplateModal.js
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/modal/openDeletePageTemplateModal.js
@@ -12,14 +12,14 @@
  * details.
  */
 
-import {sub} from 'frontend-js-web';
+import {openModal, sub} from 'frontend-js-web';
 
 export default function openDeletePageTemplateModal({
 	message,
 	onDelete,
 	title,
 }) {
-	Liferay.Util.openModal({
+	openModal({
 		bodyHTML:
 			message ||
 			Liferay.Language.get('are-you-sure-you-want-to-delete-this'),

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/js/MBPortlet.es.js
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/js/MBPortlet.es.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {fetch, sub} from 'frontend-js-web';
+import {fetch, openModal, sub} from 'frontend-js-web';
 
 const RECENTLY_REMOVED_ATTACHMENTS = {
 	multiple: Liferay.Language.get('x-recently-removed-attachments'),
@@ -125,7 +125,7 @@ class MBPortlet {
 
 		if (viewRemovedAttachmentsLink) {
 			this._addEventListener(viewRemovedAttachmentsLink, 'click', () => {
-				Liferay.Util.openModal({
+				openModal({
 					id: this._namespace + 'openRemovedPageAttachments',
 					onClose: this._updateRemovedAttachments.bind(this),
 					title: Liferay.Language.get('removed-attachments'),

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/js/PagesTree.es.js
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/js/PagesTree.es.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {delegate} from 'frontend-js-web';
+import {delegate, openModal} from 'frontend-js-web';
 
 const KEY_ENTER = 13;
 
@@ -60,7 +60,7 @@ export default function ({namespace}) {
 	eventDelegates.push(linkActionKeyupHandler);
 
 	const viewCollectionItemsActionOptionQuery = (event) => {
-		Liferay.Util.openModal({
+		openModal({
 			id: `${namespace}viewCollectionItemsDialog`,
 			title: Liferay.Language.get('collection-items'),
 			url: event.delegateTarget.dataset.viewCollectionItemsUrl,

--- a/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/js/openDeleteSiteNavigationMenuModal.js
+++ b/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/js/openDeleteSiteNavigationMenuModal.js
@@ -12,13 +12,13 @@
  * details.
  */
 
-import {sub} from 'frontend-js-web';
+import {openModal, sub} from 'frontend-js-web';
 
 export default function openDeleteSiteNavigationMenuModal({
 	multiple = false,
 	onDelete,
 }) {
-	Liferay.Util.openModal({
+	openModal({
 		bodyHTML: Liferay.Language.get('are-you-sure-you-want-to-delete-this'),
 		buttons: [
 			{

--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/js/openDeleteSiteModal.js
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/js/openDeleteSiteModal.js
@@ -12,10 +12,10 @@
  * details.
  */
 
-import {sub} from 'frontend-js-web';
+import {openModal, sub} from 'frontend-js-web';
 
 export default function openDeleteSiteModal({multiple = false, onDelete}) {
-	Liferay.Util.openModal({
+	openModal({
 		bodyHTML: Liferay.Language.get(
 			'deleting-a-site-is-an-action-impossible-to-revert'
 		),

--- a/modules/apps/style-book/style-book-web/src/main/resources/META-INF/resources/js/openDeleteStyleBookModal.js
+++ b/modules/apps/style-book/style-book-web/src/main/resources/META-INF/resources/js/openDeleteStyleBookModal.js
@@ -12,10 +12,10 @@
  * details.
  */
 
-import {sub} from 'frontend-js-web';
+import {openModal, sub} from 'frontend-js-web';
 
 export default function openDeleteStyleBookModal({multiple = false, onDelete}) {
-	Liferay.Util.openModal({
+	openModal({
 		bodyHTML: Liferay.Language.get(
 			'deleting-a-style-book-is-an-action-impossible-to-revert'
 		),

--- a/modules/apps/template/template-web/src/main/resources/META-INF/resources/js/modal/openDeleteTemplateModal.js
+++ b/modules/apps/template/template-web/src/main/resources/META-INF/resources/js/modal/openDeleteTemplateModal.js
@@ -12,10 +12,10 @@
  * details.
  */
 
-import {sub} from 'frontend-js-web';
+import {openModal, sub} from 'frontend-js-web';
 
 export default function openDeleteTemplateModal({multiple = false, onDelete}) {
-	Liferay.Util.openModal({
+	openModal({
 		bodyHTML: Liferay.Language.get('are-you-sure-you-want-to-delete-this'),
 		buttons: [
 			{

--- a/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/js/openDeleteEntryModal.js
+++ b/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/js/openDeleteEntryModal.js
@@ -12,8 +12,10 @@
  * details.
  */
 
+import {openModal} from 'frontend-js-web';
+
 export default function openDeleteEntryModal({onDelete}) {
-	Liferay.Util.openModal({
+	openModal({
 		bodyHTML: Liferay.Language.get('are-you-sure-you-want-to-delete-this'),
 		buttons: [
 			{

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-liferay-online/src/main/resources/site-initializer/layout-set/private/js.js
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-liferay-online/src/main/resources/site-initializer/layout-set/private/js.js
@@ -9,6 +9,8 @@
  * distribution rights of the Software.
  */
 
+import {openModal} from 'frontend-js-web';
+
 let copySaved = '';
 
 const starterkitList = document.getElementsByClassName('liferay-online-item');
@@ -65,7 +67,7 @@ function openItem(
 	redirectURL,
 	siteInitializerKey
 ) {
-	Liferay.Util.openModal({
+	openModal({
 		bodyHTML: `<div class="form-group" id="snGroup">
 				 <label for="siteName">Site name
 					 <small> (more than 4 characters)</small>

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-liferay-online/src/main/resources/site-initializer/layout-set/public/js.js
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-liferay-online/src/main/resources/site-initializer/layout-set/public/js.js
@@ -9,6 +9,9 @@
  * distribution rights of the Software.
  */
 
+import {openModal} from 'frontend-js-web';
+
+
 let copySaved = '';
 
 const starterkitList = document.getElementsByClassName('liferay-online-item');
@@ -65,7 +68,7 @@ function openItem(
 	redirectURL,
 	siteInitializerKey
 ) {
-	Liferay.Util.openModal({
+	openModal({
 		bodyHTML: `<div class="form-group" id="snGroup">
 				 <label for="siteName">Site name
 					 <small> (more than 4 characters)</small>


### PR DESCRIPTION
Manual forward of https://github.com/liferay-frontend/liferay-portal/pull/2431. Approved by our QA to manually forward

This PR replaces our usages of `Liferay.Util.openModal` with `import {openModal} from 'frontend-js-web'`.