### PR TITLE
LPS-157076: Revert ERC tests usign UUID and fix service part

### DIFF
--- a/modules/apps/asset/asset-test/src/testIntegration/java/com/liferay/asset/service/test/AssetCategoryLocalServiceTest.java
+++ b/modules/apps/asset/asset-test/src/testIntegration/java/com/liferay/asset/service/test/AssetCategoryLocalServiceTest.java
@@ -119,6 +119,27 @@ public class AssetCategoryLocalServiceTest {
 			externalReferenceCode, assetCategory.getExternalReferenceCode());
 	}
 
+	@Test
+	public void testAddCategoryWithoutExternalReferenceCode() throws Exception {
+		AssetVocabulary assetVocabulary = AssetTestUtil.addVocabulary(
+			_group.getGroupId());
+
+		AssetCategory assetCategory1 = AssetTestUtil.addCategory(
+			_group.getGroupId(), assetVocabulary.getVocabularyId());
+
+		String externalReferenceCode =
+			assetCategory1.getExternalReferenceCode();
+
+		Assert.assertEquals(assetCategory1.getUuid(), externalReferenceCode);
+
+		AssetCategory assetCategory2 =
+			AssetCategoryLocalServiceUtil.
+				getAssetCategoryByExternalReferenceCode(
+					_group.getGroupId(), externalReferenceCode);
+
+		Assert.assertEquals(assetCategory1, assetCategory2);
+	}
+
 	@Test(expected = DuplicateCategoryException.class)
 	public void testCannotAddCategoryWithDuplicateName() throws Exception {
 		Map<Locale, String> titleMap = HashMapBuilder.put(

--- a/modules/apps/asset/asset-test/src/testIntegration/java/com/liferay/asset/service/test/AssetVocabularyServiceTest.java
+++ b/modules/apps/asset/asset-test/src/testIntegration/java/com/liferay/asset/service/test/AssetVocabularyServiceTest.java
@@ -149,6 +149,25 @@ public class AssetVocabularyServiceTest {
 	}
 
 	@Test
+	public void testAddVocabularyWithoutExternalReferenceCode()
+		throws Exception {
+
+		AssetVocabulary vocabulary1 = AssetTestUtil.addVocabulary(
+			_group.getGroupId());
+
+		String externalReferenceCode = vocabulary1.getExternalReferenceCode();
+
+		Assert.assertEquals(externalReferenceCode, vocabulary1.getUuid());
+
+		AssetVocabulary vocabulary2 =
+			AssetVocabularyLocalServiceUtil.
+				getAssetVocabularyByExternalReferenceCode(
+					_group.getGroupId(), externalReferenceCode);
+
+		Assert.assertEquals(vocabulary1, vocabulary2);
+	}
+
+	@Test
 	public void testDeleteVocabulary() throws Exception {
 		int initialAssetCategoriesCount = searchCount();
 		int initialResourceActionsCount =

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsEntryLocalServiceImpl.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsEntryLocalServiceImpl.java
@@ -300,10 +300,6 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 
 		long entryId = counterLocalService.increment();
 
-		if (Validator.isNull(externalReferenceCode)) {
-			externalReferenceCode = String.valueOf(entryId);
-		}
-
 		_validateExternalReferenceCode(externalReferenceCode, groupId);
 
 		if (Validator.isNotNull(urlTitle)) {
@@ -2346,6 +2342,10 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 	private void _validateExternalReferenceCode(
 			String externalReferenceCode, long groupId)
 		throws PortalException {
+
+		if (Validator.isNull(externalReferenceCode)) {
+			return;
+		}
 
 		BlogsEntry entry = blogsEntryPersistence.fetchByG_ERC(
 			groupId, externalReferenceCode);

--- a/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/service/test/BlogsEntryLocalServiceTest.java
+++ b/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/service/test/BlogsEntryLocalServiceTest.java
@@ -181,6 +181,29 @@ public class BlogsEntryLocalServiceTest {
 	}
 
 	@Test
+	public void testAddBlogsEntryWithoutExternalReferenceCode()
+		throws Exception {
+
+		BlogsEntry blogsEntry1 = BlogsEntryLocalServiceUtil.addEntry(
+			null, TestPropsValues.getUserId(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			RandomTestUtil.nextDate(), false, false, new String[0],
+			RandomTestUtil.randomString(), null, null,
+			ServiceContextTestUtil.getServiceContext());
+
+		String externalReferenceCode = blogsEntry1.getExternalReferenceCode();
+
+		Assert.assertEquals(externalReferenceCode, blogsEntry1.getUuid());
+
+		BlogsEntry blogsEntry2 =
+			BlogsEntryLocalServiceUtil.getBlogsEntryByExternalReferenceCode(
+				TestPropsValues.getGroupId(), externalReferenceCode);
+
+		Assert.assertEquals(blogsEntry1, blogsEntry2);
+	}
+
+	@Test
 	public void testAddCoverImageWithCoverImageURL() throws Exception {
 		BlogsEntry entry = addEntry(false);
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryLocalServiceTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryLocalServiceTest.java
@@ -288,6 +288,31 @@ public class DLFileEntryLocalServiceTest {
 	}
 
 	@Test
+	public void testAddFileEntryWithoutExternalReferenceCode()
+		throws Exception {
+
+		DLFileEntry dlFileEntry1 = DLFileEntryLocalServiceUtil.addFileEntry(
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			StringUtil.randomString(), ContentTypes.TEXT_PLAIN,
+			StringUtil.randomString(), StringUtil.randomString(),
+			StringPool.BLANK, StringPool.BLANK, -1, new HashMap<>(), null,
+			new ByteArrayInputStream(new byte[0]), 0, null, null,
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId()));
+
+		String externalReferenceCode = dlFileEntry1.getExternalReferenceCode();
+
+		Assert.assertEquals(externalReferenceCode, dlFileEntry1.getUuid());
+
+		DLFileEntry dlFileEntry2 =
+			DLFileEntryLocalServiceUtil.getDLFileEntryByExternalReferenceCode(
+				_group.getGroupId(), externalReferenceCode);
+
+		Assert.assertEquals(dlFileEntry1, dlFileEntry2);
+	}
+
+	@Test
 	public void testAddsFileEntryWithExpirationDateReviewDate()
 		throws Exception {
 

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalFolderLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalFolderLocalServiceImpl.java
@@ -119,10 +119,6 @@ public class JournalFolderLocalServiceImpl
 
 		long folderId = counterLocalService.increment();
 
-		if (Validator.isNull(externalReferenceCode)) {
-			externalReferenceCode = String.valueOf(folderId);
-		}
-
 		_validateExternalReferenceCode(externalReferenceCode, groupId);
 
 		JournalFolder folder = journalFolderPersistence.create(folderId);
@@ -1542,6 +1538,10 @@ public class JournalFolderLocalServiceImpl
 	private void _validateExternalReferenceCode(
 			String externalReferenceCode, long groupId)
 		throws PortalException {
+
+		if (Validator.isNull(externalReferenceCode)) {
+			return;
+		}
 
 		JournalFolder journalFolder = journalFolderPersistence.fetchByG_ERC(
 			groupId, externalReferenceCode);

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalFolderServiceTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalFolderServiceTest.java
@@ -184,6 +184,23 @@ public class JournalFolderServiceTest {
 	}
 
 	@Test
+	public void testAddJournalFolderWithoutExternalReferenceCode()
+		throws Exception {
+
+		JournalFolder folder1 = addJournalFolder(null);
+
+		String externalReferenceCode = folder1.getExternalReferenceCode();
+
+		Assert.assertEquals(externalReferenceCode, folder1.getUuid());
+
+		JournalFolder folder2 =
+			_journalFolderLocalService.getJournalFolderByExternalReferenceCode(
+				_group.getGroupId(), externalReferenceCode);
+
+		Assert.assertEquals(folder1, folder2);
+	}
+
+	@Test
 	public void testAddRestrictionToParentWithRestrictedChildFolder()
 		throws Exception {
 

--- a/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/test/KBArticleLocalServiceTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/test/KBArticleLocalServiceTest.java
@@ -454,6 +454,28 @@ public class KBArticleLocalServiceTest {
 	}
 
 	@Test
+	public void testAddKBArticleWithoutExternalReferenceCode()
+		throws Exception {
+
+		KBArticle kbArticle1 = KBArticleLocalServiceUtil.addKBArticle(
+			null, _user.getUserId(), _kbFolderClassNameId,
+			KBFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			StringUtil.randomString(), StringUtil.randomString(),
+			StringUtil.randomString(), StringUtil.randomString(),
+			StringPool.BLANK, null, null, _serviceContext);
+
+		String externalReferenceCode = kbArticle1.getExternalReferenceCode();
+
+		Assert.assertEquals(externalReferenceCode, kbArticle1.getUuid());
+
+		KBArticle kbArticle2 =
+			KBArticleLocalServiceUtil.getLatestKBArticleByExternalReferenceCode(
+				_group.getGroupId(), externalReferenceCode);
+
+		Assert.assertEquals(kbArticle1, kbArticle2);
+	}
+
+	@Test
 	public void testAddKBArticleWithValidParentKBArticle() throws Exception {
 		KBArticle kbArticle = KBArticleLocalServiceUtil.addKBArticle(
 			null, _user.getUserId(), _kbFolderClassNameId,

--- a/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/test/KBFolderLocalServiceTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/test/KBFolderLocalServiceTest.java
@@ -109,6 +109,27 @@ public class KBFolderLocalServiceTest {
 	}
 
 	@Test
+	public void testAddKBFolderWithoutExternalReferenceCode() throws Exception {
+		KBFolder kbFolder1 = KBFolderLocalServiceUtil.addKBFolder(
+			null, _user.getUserId(), _group.getGroupId(),
+			PortalUtil.getClassNameId(KBFolderConstants.getClassName()),
+			KBFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			ServiceContextTestUtil.getServiceContext(
+				_group, _user.getUserId()));
+
+		String externalReferenceCode = kbFolder1.getExternalReferenceCode();
+
+		Assert.assertEquals(externalReferenceCode, kbFolder1.getUuid());
+
+		KBFolder kbFolder2 =
+			KBFolderLocalServiceUtil.getKBFolderByExternalReferenceCode(
+				_group.getGroupId(), externalReferenceCode);
+
+		Assert.assertEquals(kbFolder1, kbFolder2);
+	}
+
+	@Test
 	public void testGetKBFoldersAndKBArticlesCountInKBFolder()
 		throws Exception {
 

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/test/MBMessageLocalServiceTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/test/MBMessageLocalServiceTest.java
@@ -224,6 +224,27 @@ public class MBMessageLocalServiceTest {
 	}
 
 	@Test
+	public void testAddMessageWithoutExternalReferenceCode() throws Exception {
+		User user = TestPropsValues.getUser();
+
+		MBMessage mbMessage1 = MBMessageLocalServiceUtil.addMessage(
+			user.getUserId(), user.getFullName(), _group.getGroupId(),
+			MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			ServiceContextTestUtil.getServiceContext());
+
+		String externalReferenceCode = mbMessage1.getExternalReferenceCode();
+
+		Assert.assertEquals(externalReferenceCode, mbMessage1.getUuid());
+
+		MBMessage mbMessage2 =
+			MBMessageLocalServiceUtil.getMBMessageByExternalReferenceCode(
+				_group.getGroupId(), externalReferenceCode);
+
+		Assert.assertEquals(mbMessage1, mbMessage2);
+	}
+
+	@Test
 	public void testAddXSSMessageWithInvalidFormat() throws Exception {
 		String subject = "<script>alert(1)</script>";
 		String body = "<script>alert(2)</script>";

--- a/modules/apps/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/service/test/WikiNodeLocalServiceTest.java
+++ b/modules/apps/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/service/test/WikiNodeLocalServiceTest.java
@@ -17,6 +17,7 @@ package com.liferay.wiki.service.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.portletfilerepository.PortletFileRepositoryUtil;
@@ -91,6 +92,28 @@ public class WikiNodeLocalServiceTest {
 
 		Assert.assertEquals(
 			externalReferenceCode, wikiNode.getExternalReferenceCode());
+	}
+
+	@Test
+	public void testAddNodeWithoutExternalReferenceCode()
+		throws PortalException {
+
+		User user = TestPropsValues.getUser();
+
+		WikiNode wikiNode1 = WikiNodeLocalServiceUtil.addNode(
+			user.getUserId(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(),
+			ServiceContextTestUtil.getServiceContext());
+
+		String externalReferenceCode = wikiNode1.getExternalReferenceCode();
+
+		Assert.assertEquals(externalReferenceCode, wikiNode1.getUuid());
+
+		WikiNode wikiNode2 =
+			WikiNodeLocalServiceUtil.getWikiNodeByExternalReferenceCode(
+				TestPropsValues.getGroupId(), externalReferenceCode);
+
+		Assert.assertEquals(wikiNode1, wikiNode2);
 	}
 
 	@Test

--- a/modules/apps/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/service/test/WikiPageLocalServiceTest.java
+++ b/modules/apps/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/service/test/WikiPageLocalServiceTest.java
@@ -196,6 +196,24 @@ public class WikiPageLocalServiceTest {
 		Assert.assertEquals("ChildPage 1", page.getTitle());
 	}
 
+	@Test
+	public void testAddPageWithoutExternalReferenceCode() throws Exception {
+		WikiPage wikiPage1 = WikiTestUtil.addPage(
+			TestPropsValues.getUserId(), _node.getNodeId(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(), true,
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		String externalReferenceCode = wikiPage1.getExternalReferenceCode();
+
+		Assert.assertEquals(externalReferenceCode, wikiPage1.getUuid());
+
+		WikiPage wikiPage2 =
+			WikiPageLocalServiceUtil.getLatestPageByExternalReferenceCode(
+				_group.getGroupId(), externalReferenceCode);
+
+		Assert.assertEquals(wikiPage1, wikiPage2);
+	}
+
 	@Test(expected = AssetCategoryTestException.class)
 	public void testAddPageWithoutRequiredCategory() throws Exception {
 		AssetVocabulary assetVocabulary = getRequiredAssetVocabulary();


### PR DESCRIPTION
**What is new?**

- Update `AssetCategoryLocalServiceTest` and `AssetVocabularyServiceTest` without using `externalRefereceCode`
- Update `BlogEntryLocalServiceTest` without using `externalRefereceCode` and `BlogsEnryLocalService` setting an UUID if the `externalReferenceCode` is NULL.
- Update `DLAppServiceWhenAddingAFileEntryTest` and `DLFileEntryLocalServiceTest` without using `externalRefereceCode`.
- Update `JournlFolderServiceTest` without using `externalRefereceCode` and `JournalFolderLocalService` setting an UUID if the `externalReferenceCode` is NULL.
- Update `KBArticleLocalServiceTest` and `KBFolderLocalServiceTest` without using `externalRefereceCode`.
- Update `MBMessageLocalServiceTest`  without using `externalRefereceCode`.
- Update `WikiNodeLocalServiceTest` and `WikiPageLocalServiceTest` without using `externalRefereceCode`

**Note:** Just reverting all these tests that have been deleted: 5b97d89eb16a79a073e4db6d9522069545200107

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-157076