### PR TITLE
LCD 14464 sample workspace updates

### DIFF
--- a/workspaces/refresh.sh
+++ b/workspaces/refresh.sh
@@ -62,6 +62,10 @@ function refresh_sample_minimal_workspace {
 	cp sample-default-workspace/settings.gradle sample-minimal-workspace
 
 	cp -R sample-default-workspace/gradle sample-minimal-workspace
+
+	mkdir -p sample-minimal-workspace/configs/local
+
+	cp sample-default-workspace/configs/local/portal-ext.properties sample-minimal-workspace/configs/local
 }
 
 function main {

--- a/workspaces/refresh.sh
+++ b/workspaces/refresh.sh
@@ -41,6 +41,10 @@ function refresh_sample_default_workspace {
 
 	echo -e "\nliferay.workspace.docker.image.liferay=liferay/dxp:7.4.13.nightly-d4.1.4-20220628211901" >> gradle.properties
 
+	sed -i'.bak' 's/4.0.0/4.0.1/g' settings.gradle
+
+	rm settings.gradle.bak
+
 	touch modules/.touch
 	touch themes/.touch
 
@@ -55,6 +59,7 @@ function refresh_sample_minimal_workspace {
 	cp sample-default-workspace/.gitignore sample-minimal-workspace
 	cp sample-default-workspace/gradle.properties sample-minimal-workspace
 	cp sample-default-workspace/gradlew sample-minimal-workspace
+	cp sample-default-workspace/settings.gradle sample-minimal-workspace
 
 	cp -R sample-default-workspace/gradle sample-minimal-workspace
 }

--- a/workspaces/refresh.sh
+++ b/workspaces/refresh.sh
@@ -1,7 +1,17 @@
 #!/bin/bash
 
 function check_blade {
-	if [ ! -e ~/jpm/bin/blade ]
+	if [ -e ~/jpm/bin/blade ]
+	then
+		bladePath=~/jpm/bin/blade
+	fi
+
+	if [ -e ~/Library/PackageManager/bin/blade ]
+	then
+		bladePath=~/Library/PackageManager/bin/blade
+	fi
+
+	if [ -z "$bladePath" ]
 	then
 		echo "Blade CLI is not available. To install Blade CLI, execute the following command:"
 		echo ""
@@ -11,7 +21,7 @@ function check_blade {
 		exit 1
 	fi
 
-	~/jpm/bin/blade update -s
+	$bladePath  update -s
 }
 
 function refresh_sample_default_workspace {
@@ -23,7 +33,7 @@ function refresh_sample_default_workspace {
 
 	cd sample-default-workspace
 
-	~/jpm/bin/blade init --liferay-version dxp-7.4-u30
+	$bladePath init --liferay-version dxp-7.4-u30
 
 	echo -e "\n**/dist\n**/node_modules_cache\n.DS_Store" >> .gitignore
 

--- a/workspaces/refresh.sh
+++ b/workspaces/refresh.sh
@@ -10,6 +10,8 @@ function check_blade {
 
 		exit 1
 	fi
+
+	~/jpm/bin/blade update -s
 }
 
 function refresh_sample_default_workspace {

--- a/workspaces/refresh.sh
+++ b/workspaces/refresh.sh
@@ -39,7 +39,7 @@ function refresh_sample_default_workspace {
 
 	echo -e "\n\nfeature.flag.LPS-153457=true" >> configs/local/portal-ext.properties
 
-	echo -e "\nliferay.workspace.docker.image.liferay=liferay/dxp:7.4.13.nightly-d4.1.3-20220622090520" >> gradle.properties
+	echo -e "\nliferay.workspace.docker.image.liferay=liferay/dxp:7.4.13.nightly-d4.1.4-20220628211901" >> gradle.properties
 
 	touch modules/.touch
 	touch themes/.touch

--- a/workspaces/sample-default-workspace/gradle.properties
+++ b/workspaces/sample-default-workspace/gradle.properties
@@ -9,4 +9,4 @@ liferay.workspace.themes.dir=themes
 liferay.workspace.wars.dir=modules
 microsoft.translator.subscription.key=
 liferay.workspace.product=dxp-7.4-u30
-liferay.workspace.docker.image.liferay=liferay/dxp:7.4.13.nightly-d4.1.3-20220622090520
+liferay.workspace.docker.image.liferay=liferay/dxp:7.4.13.nightly-d4.1.4-20220628211901

--- a/workspaces/sample-default-workspace/settings.gradle
+++ b/workspaces/sample-default-workspace/settings.gradle
@@ -1,7 +1,7 @@
 buildscript {
 	dependencies {
 		classpath group: "biz.aQute.bnd", name: "biz.aQute.bnd", version: "5.2.0"
-		classpath(group: "com.liferay", name: "com.liferay.gradle.plugins.workspace", version: "3.4.38") {
+		classpath(group: "com.liferay", name: "com.liferay.gradle.plugins.workspace", version: "4.0.0") {
 			exclude group: "biz.aQute.bnd", module: "biz.aQute.bnd"
 		}
 		classpath group: "net.saliman", name: "gradle-properties-plugin", version: "1.4.6"

--- a/workspaces/sample-default-workspace/settings.gradle
+++ b/workspaces/sample-default-workspace/settings.gradle
@@ -1,7 +1,7 @@
 buildscript {
 	dependencies {
 		classpath group: "biz.aQute.bnd", name: "biz.aQute.bnd", version: "5.2.0"
-		classpath(group: "com.liferay", name: "com.liferay.gradle.plugins.workspace", version: "4.0.0") {
+		classpath(group: "com.liferay", name: "com.liferay.gradle.plugins.workspace", version: "4.0.1") {
 			exclude group: "biz.aQute.bnd", module: "biz.aQute.bnd"
 		}
 		classpath group: "net.saliman", name: "gradle-properties-plugin", version: "1.4.6"

--- a/workspaces/sample-minimal-workspace/configs/local/portal-ext.properties
+++ b/workspaces/sample-minimal-workspace/configs/local/portal-ext.properties
@@ -1,0 +1,11 @@
+include-and-override=portal-developer.properties
+
+#
+# MySQL
+#
+#jdbc.default.driverClassName=com.mysql.cj.jdbc.Driver
+#jdbc.default.url=jdbc:mysql://localhost/lportal?useUnicode=true&characterEncoding=UTF-8&useFastDateParsing=false
+#jdbc.default.username=root
+#jdbc.default.password=
+
+feature.flag.LPS-153457=true

--- a/workspaces/sample-minimal-workspace/gradle.properties
+++ b/workspaces/sample-minimal-workspace/gradle.properties
@@ -9,4 +9,4 @@ liferay.workspace.themes.dir=themes
 liferay.workspace.wars.dir=modules
 microsoft.translator.subscription.key=
 liferay.workspace.product=dxp-7.4-u30
-liferay.workspace.docker.image.liferay=liferay/dxp:7.4.13.nightly-d4.1.3-20220622090520
+liferay.workspace.docker.image.liferay=liferay/dxp:7.4.13.nightly-d4.1.4-20220628211901

--- a/workspaces/sample-minimal-workspace/settings.gradle
+++ b/workspaces/sample-minimal-workspace/settings.gradle
@@ -1,9 +1,10 @@
 buildscript {
 	dependencies {
 		classpath group: "biz.aQute.bnd", name: "biz.aQute.bnd", version: "5.2.0"
-		classpath(group: "com.liferay", name: "com.liferay.gradle.plugins.workspace", version: "4.0.0") {
+		classpath(group: "com.liferay", name: "com.liferay.gradle.plugins.workspace", version: "4.0.1") {
 			exclude group: "biz.aQute.bnd", module: "biz.aQute.bnd"
 		}
+		classpath group: "net.saliman", name: "gradle-properties-plugin", version: "1.4.6"
 	}
 
 	repositories {
@@ -16,5 +17,7 @@ buildscript {
 		}
 	}
 }
+
+apply plugin: "net.saliman.properties"
 
 apply plugin: "com.liferay.workspace"


### PR DESCRIPTION
- LCD-14464 use blade snapshots to get latest workspace version
- LCD-14464 support MacOS
- LCD-14464 refresh.sh
- LCD-14464 use latest nightly
- LCD-14464 use latest gradle-plugins-workspace
- LCD-14464 add feature flag to minimal workspace
