### PR TITLE
LPS-157088 Completely remove default title from Alert tag

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/bnd.bnd
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Frontend Taglib Clay
 Bundle-SymbolicName: com.liferay.frontend.taglib.clay
-Bundle-Version: 9.2.12
+Bundle-Version: 9.3.0
 Export-Package:\
 	com.liferay.frontend.taglib.clay.data,\
 	com.liferay.frontend.taglib.clay.data.set,\

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
@@ -82,5 +82,5 @@
 		"checkFormat": "liferay-npm-scripts check",
 		"format": "liferay-npm-scripts fix"
 	},
-	"version": "9.2.12"
+	"version": "9.3.0"
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/AlertTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/AlertTag.java
@@ -25,6 +25,8 @@ import java.util.Set;
 import javax.servlet.jsp.JspException;
 import javax.servlet.jsp.JspWriter;
 
+import static com.liferay.petra.string.StringPool.BLANK;
+
 /**
  * @author Chema Balsas
  */
@@ -47,6 +49,10 @@ public class AlertTag extends BaseContainerTag {
 		return _dismissible;
 	}
 
+	public boolean getDefaultTitleDisabled() {
+		return _defaultTitleDisabled;
+	}
+
 	public String getDisplayType() {
 		return _displayType;
 	}
@@ -65,6 +71,10 @@ public class AlertTag extends BaseContainerTag {
 
 	public void setAutoClose(boolean autoClose) {
 		_autoClose = autoClose;
+	}
+
+	public void setDefaultTitleDisabled(boolean defaultTitleDisabled) {
+		_defaultTitleDisabled = defaultTitleDisabled;
 	}
 
 	public void setDismissible(boolean dismissible) {
@@ -92,6 +102,7 @@ public class AlertTag extends BaseContainerTag {
 		super.cleanUp();
 
 		_autoClose = false;
+		_defaultTitleDisabled = false;
 		_dismissible = false;
 		_displayType = "info";
 		_message = null;
@@ -171,9 +182,19 @@ public class AlertTag extends BaseContainerTag {
 
 		jspWriter.write("</span></div></div><div class=\"autofit-col ");
 		jspWriter.write("autofit-col-expand\"><div class=\"autofit-section\">");
-		jspWriter.write("<strong class=\"lead\">");
-		jspWriter.write(_getTitle(_title, _displayType));
-		jspWriter.write(":</strong>");
+
+		if (_defaultTitleDisabled) {
+			if (Validator.isNotNull(_title)) {
+				jspWriter.write("<strong class=\"lead\">");
+				jspWriter.write(LanguageUtil.get(
+					TagResourceBundleUtil.getResourceBundle(pageContext), _title));
+				jspWriter.write("</strong>");
+			}
+		} else {
+			jspWriter.write("<strong class=\"lead\">");
+			jspWriter.write(_getTitle(_title, _displayType));
+			jspWriter.write(":</strong>");
+		}
 
 		if (Validator.isNotNull(_message)) {
 			jspWriter.write(
@@ -218,6 +239,7 @@ public class AlertTag extends BaseContainerTag {
 	private static final String _ATTRIBUTE_NAMESPACE = "clay:alert:";
 
 	private boolean _autoClose;
+	private boolean _defaultTitleDisabled;
 	private boolean _dismissible;
 	private String _displayType = "info";
 	private String _message;

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/AlertTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/AlertTag.java
@@ -25,8 +25,6 @@ import java.util.Set;
 import javax.servlet.jsp.JspException;
 import javax.servlet.jsp.JspWriter;
 
-import static com.liferay.petra.string.StringPool.BLANK;
-
 /**
  * @author Chema Balsas
  */
@@ -45,12 +43,12 @@ public class AlertTag extends BaseContainerTag {
 		return _autoClose;
 	}
 
-	public boolean getDismissible() {
-		return _dismissible;
-	}
-
 	public boolean getDefaultTitleDisabled() {
 		return _defaultTitleDisabled;
+	}
+
+	public boolean getDismissible() {
+		return _dismissible;
 	}
 
 	public String getDisplayType() {
@@ -186,11 +184,14 @@ public class AlertTag extends BaseContainerTag {
 		if (_defaultTitleDisabled) {
 			if (Validator.isNotNull(_title)) {
 				jspWriter.write("<strong class=\"lead\">");
-				jspWriter.write(LanguageUtil.get(
-					TagResourceBundleUtil.getResourceBundle(pageContext), _title));
+				jspWriter.write(
+					LanguageUtil.get(
+						TagResourceBundleUtil.getResourceBundle(pageContext),
+						_title));
 				jspWriter.write("</strong>");
 			}
-		} else {
+		}
+		else {
 			jspWriter.write("<strong class=\"lead\">");
 			jspWriter.write(_getTitle(_title, _displayType));
 			jspWriter.write(":</strong>");

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
@@ -29,6 +29,12 @@
 		</attribute>
 		<attribute>
 			<description></description>
+			<name>defaultTitleDisabled</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
 			<name>dismissible</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/com/liferay/frontend/taglib/clay/servlet/taglib/packageinfo
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/com/liferay/frontend/taglib/clay/servlet/taglib/packageinfo
@@ -1,1 +1,1 @@
-version 5.2.0
+version 5.3.0


### PR DESCRIPTION
Manually forwarded since https://github.com/liferay-frontend/liferay-portal/pull/2466 of ci:test:relevant had unrelated test failures.

cc @Esther-OC


=======

[Jira issue](https://issues.liferay.com/browse/LPS-157088)

## Motivation

The default _alert type_ title of the Alert JSP tag can be override using the title attr.
However this solution left a colon `:` at the end of the title that could be unwanted in some cases.

This PR tries to address this problem.

## Solution proposed

The component accepts a new bool attr `defaultTitleDisabled`
This use cases have been contemplated:

- Use the `defaultTitleDisabled` attr **without** `title` attr allows to build the content without adding the colon, or allows to disable the title at all using only the message (this practice is discouraged)
```
<clay:alert
  defaultTitleDisabled="<%= true %>"
  displayType="warning"
>
  <strong class="lead">Alert title.</strong>
  <span>Alert message</span>
</clay:alert>
```
- Use the `defaultTitleDisabled` attr **without** `title` attr allows to disable the title at all using only the message (this practice is discouraged)
```
<clay:alert
  defaultTitleDisabled="<%= true %>"
  displayType="warning"
>
  <span>Alert message</span>
</clay:alert>
```
- Use the `defaultTitleDisabled` attr **with** `title` attr renders the custom title without the colon, like the first case above. 
```
<clay:alert
  defaultTitleDisabled="<%= true %>"
  displayType="warning"
  title="Alert title."
>
  <span>Alert message</span>
</clay:alert>
```
- Without `defaultTitleDisabled` (or `false`) the alert behaves the same way than before


## How to verify

In any use case of the tag, try the different possibilities.

## Screenshots
![image](https://user-images.githubusercontent.com/19485114/176881320-5e55b531-efe9-4f15-ac87-4ab65bc81fec.png)


## Additional info

Every time I deploy `frontend-taglib-clay` the portal gets stuck, demanding a restart 🤷 