### PR TITLE
LPS-157932 Server Admin portal property "Source" icons are not visible

### DIFF
--- a/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/view_portal_properties.jsp
+++ b/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/view_portal_properties.jsp
@@ -103,7 +103,8 @@ ViewPortalPropertiesDisplayContext viewPortalPropertiesDisplayContext = new View
 						name="source"
 					>
 						<liferay-ui:icon
-							iconCssClass='<%= overriddenPropertyValue ? "icon-hdd" : "icon-file-alt" %>'
+							icon='<%= overriddenPropertyValue ? "hdd" : "document" %>'
+							markupView="lexicon"
 							message='<%= LanguageUtil.get(request, overriddenPropertyValue ? "the-value-of-this-property-was-overridden-using-the-control-panel-and-is-stored-in-the-database" : "the-value-of-this-property-is-read-from-a-portal.properties-file-or-one-of-its-extension-files") %>'
 						/>
 					</liferay-ui:search-container-column-text>


### PR DESCRIPTION
Manual forward from [liferay-usm#640](https://github.com/liferay-usm/liferay-portal/pull/640).

https://issues.liferay.com/browse/LPS-157932