### PR TITLE
LPS-158039 All BaseAuthVerifierPipelineConfigurator subclass should b…

### DIFF
--- a/modules/apps/portal-security/portal-security-auth-verifier/src/main/java/com/liferay/portal/security/auth/verifier/internal/basic/auth/header/BasicAuthHeaderAuthVerifierPipelineConfigurator.java
+++ b/modules/apps/portal-security/portal-security-auth-verifier/src/main/java/com/liferay/portal/security/auth/verifier/internal/basic/auth/header/BasicAuthHeaderAuthVerifierPipelineConfigurator.java
@@ -25,7 +25,7 @@ import org.osgi.service.component.annotations.ConfigurationPolicy;
  */
 @Component(
 	configurationPid = "com.liferay.portal.security.auth.verifier.internal.basic.auth.header.configuration.BasicAuthHeaderAuthVerifierConfiguration",
-	configurationPolicy = ConfigurationPolicy.OPTIONAL, service = {}
+	configurationPolicy = ConfigurationPolicy.REQUIRE, service = {}
 )
 public class BasicAuthHeaderAuthVerifierPipelineConfigurator
 	extends BaseAuthVerifierPipelineConfigurator {

--- a/modules/apps/portal-security/portal-security-auth-verifier/src/main/java/com/liferay/portal/security/auth/verifier/internal/digest/authentication/DigestAuthenticationAuthVerifierPipelineConfigurator.java
+++ b/modules/apps/portal-security/portal-security-auth-verifier/src/main/java/com/liferay/portal/security/auth/verifier/internal/digest/authentication/DigestAuthenticationAuthVerifierPipelineConfigurator.java
@@ -26,7 +26,7 @@ import org.osgi.service.component.annotations.ConfigurationPolicy;
  */
 @Component(
 	configurationPid = "com.liferay.portal.security.auth.verifier.internal.digest.authentication.configuration.DigestAuthenticationAuthVerifierConfiguration",
-	configurationPolicy = ConfigurationPolicy.OPTIONAL, service = {}
+	configurationPolicy = ConfigurationPolicy.REQUIRE, service = {}
 )
 @Deprecated
 public class DigestAuthenticationAuthVerifierPipelineConfigurator

--- a/modules/apps/portal-security/portal-security-auth-verifier/src/main/java/com/liferay/portal/security/auth/verifier/internal/portal/session/PortalSessionAuthVerifierPipelineConfigurator.java
+++ b/modules/apps/portal-security/portal-security-auth-verifier/src/main/java/com/liferay/portal/security/auth/verifier/internal/portal/session/PortalSessionAuthVerifierPipelineConfigurator.java
@@ -30,7 +30,7 @@ import org.osgi.service.component.annotations.ConfigurationPolicy;
  */
 @Component(
 	configurationPid = "com.liferay.portal.security.auth.verifier.internal.portal.session.configuration.PortalSessionAuthVerifierConfiguration",
-	configurationPolicy = ConfigurationPolicy.OPTIONAL, service = {}
+	configurationPolicy = ConfigurationPolicy.REQUIRE, service = {}
 )
 public class PortalSessionAuthVerifierPipelineConfigurator
 	extends BaseAuthVerifierPipelineConfigurator {

--- a/modules/apps/portal-security/portal-security-auth-verifier/src/main/java/com/liferay/portal/security/auth/verifier/internal/request/parameter/RequestParameterAuthVerifierPipelineConfigurator.java
+++ b/modules/apps/portal-security/portal-security-auth-verifier/src/main/java/com/liferay/portal/security/auth/verifier/internal/request/parameter/RequestParameterAuthVerifierPipelineConfigurator.java
@@ -25,7 +25,7 @@ import org.osgi.service.component.annotations.ConfigurationPolicy;
  */
 @Component(
 	configurationPid = "com.liferay.portal.security.auth.verifier.internal.request.parameter.configuration.RequestParameterAuthVerifierConfiguration",
-	configurationPolicy = ConfigurationPolicy.OPTIONAL, service = {}
+	configurationPolicy = ConfigurationPolicy.REQUIRE, service = {}
 )
 public class RequestParameterAuthVerifierPipelineConfigurator
 	extends BaseAuthVerifierPipelineConfigurator {

--- a/modules/apps/portal-security/portal-security-auth-verifier/src/main/java/com/liferay/portal/security/auth/verifier/internal/tunnel/TunnelAuthVerifierPipelineConfigurator.java
+++ b/modules/apps/portal-security/portal-security-auth-verifier/src/main/java/com/liferay/portal/security/auth/verifier/internal/tunnel/TunnelAuthVerifierPipelineConfigurator.java
@@ -25,7 +25,7 @@ import org.osgi.service.component.annotations.ConfigurationPolicy;
  */
 @Component(
 	configurationPid = "com.liferay.portal.security.auth.verifier.internal.tunnel.configuration.TunnelAuthVerifierConfiguration",
-	configurationPolicy = ConfigurationPolicy.OPTIONAL, service = {}
+	configurationPolicy = ConfigurationPolicy.REQUIRE, service = {}
 )
 public class TunnelAuthVerifierPipelineConfigurator
 	extends BaseAuthVerifierPipelineConfigurator {


### PR DESCRIPTION
…e required for configuration, because BaseAuthVerifierPipelineConfigurator.activate() has a properties level enabled checking.