### PR TITLE
Revert "LPS-150092 Same thing"

### DIFF
--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/configuration/admin/service/OpenIdConnectProviderManagedServiceFactory.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/configuration/admin/service/OpenIdConnectProviderManagedServiceFactory.java
@@ -407,7 +407,13 @@ public class OpenIdConnectProviderManagedServiceFactory
 	private String _getPropertyAsString(
 		String key, Dictionary<String, ?> properties) {
 
-		return String.valueOf(properties.get(key));
+		String value = GetterUtil.getString(properties.get(key));
+
+		if (Validator.isNull(value)) {
+			return null;
+		}
+
+		return value;
 	}
 
 	private String _updateOAuthClientASLocalMetadata(


### PR DESCRIPTION
Hey @brianchandotcom 

We have to explicitly return null in this case, because there is some legacy issue with the configuration page that there will be empty configuration entry that is supposed to have a default value.

If we return empty string, the converted configuration entry will also contain empty value, but if we return null, the localService has logic to give a default value.