### PR TITLE
LPS-93012 Removes form-text css class and replace readonly="true" for disabled see https://clayui.com/docs/components/input/markup.html#clay-sidebar

### DIFF
--- a/modules/apps/user-groups-admin/user-groups-admin-web/src/main/resources/META-INF/resources/edit_user_group.jsp
+++ b/modules/apps/user-groups-admin/user-groups-admin-web/src/main/resources/META-INF/resources/edit_user_group.jsp
@@ -131,9 +131,9 @@ renderResponse.setTitle((userGroup == null) ? LanguageUtil.get(request, "new-use
 
 		<c:if test="<%= (userGroupGroup != null) || !layoutSetPrototypes.isEmpty() %>">
 			<aui:fieldset cssClass="text-muted">
-				<h5>
+				<p class="text-secondary">
 					<liferay-ui:message key="the-pages-of-a-user-group-cannot-be-accessed-directly-by-end-users" />
-				</h5>
+				</p>
 
 				<%
 				boolean hasUnlinkLayoutSetPrototypePermission = PortalPermissionUtil.contains(permissionChecker, ActionKeys.UNLINK_LAYOUT_SET_PROTOTYPE);

--- a/portal-web/docroot/html/taglib/ui/input_resource/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_resource/page.jsp
@@ -22,7 +22,7 @@ String title = (String)request.getAttribute("liferay-ui:input-resource:title");
 String url = (String)request.getAttribute("liferay-ui:input-resource:url");
 %>
 
-<input class="form-control form-text lfr-input-resource <%= GetterUtil.getString((String)request.getAttribute("liferay-ui:input-resource:cssClass")) %>" <%= Validator.isNotNull(id) ? "id=\"" + namespace + id + "\"" : StringPool.BLANK %> onClick="this.select();" readonly="true" <%= Validator.isNotNull(title) ? "title=\"" + LanguageUtil.get(resourceBundle, title) + "\"" : StringPool.BLANK %> type="text" value="<%= HtmlUtil.escapeAttribute(url) %>" />
+<input class="form-control lfr-input-resource <%= GetterUtil.getString((String)request.getAttribute("liferay-ui:input-resource:cssClass")) %>" <%= Validator.isNotNull(id) ? "id=\"" + namespace + id + "\"" : StringPool.BLANK %> onClick="this.select();" disabled <%= Validator.isNotNull(title) ? "title=\"" + LanguageUtil.get(resourceBundle, title) + "\"" : StringPool.BLANK %> type="text" value="<%= HtmlUtil.escapeAttribute(url) %>" />
 
 <aui:script>
 	var inputField = document.getElementById('<portlet:namespace /><%= id %>');


### PR DESCRIPTION
Manually forward since tests results failures are not related with the changes in this pr see: https://github.com/liferay-echo/liferay-portal/pull/8895#issuecomment-1182636272