### PR TITLE
LPS-157689 Remove "warning" text from alerts informing that segmentation is disabled

### DIFF
--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/edit_asset_list_entry.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/edit_asset_list_entry.jsp
@@ -39,7 +39,7 @@ renderResponse.setTitle(assetListDisplayContext.getAssetListEntryTitle());
 		dismissible="<%= true %>"
 		displayType="warning"
 	>
-		<strong class="lead mr-0"><%= LanguageUtil.get(request, "personalized-variations-cannot-be-displayed-because-segmentation-is-disabled") %></strong>
+		<strong><%= LanguageUtil.get(request, "personalized-variations-cannot-be-displayed-because-segmentation-is-disabled") %></strong>
 
 		<%
 		String segmentsConfigurationURL = editAssetListDisplayContext.getSegmentsCompanyConfigurationURL();

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/edit_asset_list_entry.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/edit_asset_list_entry.jsp
@@ -35,10 +35,11 @@ renderResponse.setTitle(assetListDisplayContext.getAssetListEntryTitle());
 
 <c:if test='<%= !(boolean)data.get("isSegmentationEnabled") %>'>
 	<clay:stripe
+		defaultTitleDisabled="<%= true %>"
 		dismissible="<%= true %>"
 		displayType="warning"
 	>
-		<strong class="lead"><%= LanguageUtil.get(request, "personalized-variations-cannot-be-displayed-because-segmentation-is-disabled") %></strong>
+		<strong class="lead mr-0"><%= LanguageUtil.get(request, "personalized-variations-cannot-be-displayed-because-segmentation-is-disabled") %></strong>
 
 		<%
 		String segmentsConfigurationURL = editAssetListDisplayContext.getSegmentsCompanyConfigurationURL();

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
@@ -2669,6 +2669,12 @@
 		<body-content>JSP</body-content>
 		<attribute>
 			<description></description>
+			<name>defaultTitleDisabled</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
 			<name>autoClose</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
@@ -2669,13 +2669,13 @@
 		<body-content>JSP</body-content>
 		<attribute>
 			<description></description>
-			<name>defaultTitleDisabled</name>
+			<name>autoClose</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
 			<description></description>
-			<name>autoClose</name>
+			<name>defaultTitleDisabled</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>

--- a/modules/apps/segments/segments-simulation-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/segments/segments-simulation-web/src/main/resources/META-INF/resources/view.jsp
@@ -35,10 +35,11 @@ SegmentsSimulationDisplayContext segmentsSimulationDisplayContext = (SegmentsSim
 				<ul class="list-unstyled">
 					<c:if test="<%= !segmentsSimulationDisplayContext.isSegmentationEnabled() %>">
 						<clay:alert
+							defaultTitleDisabled="<%= true %>"
 							dismissible="<%= true %>"
 							displayType="warning"
 						>
-							<strong class="lead"><%= LanguageUtil.get(request, "experiences-cannot-be-displayed-because-segmentation-is-disabled") %></strong>
+							<strong class="lead mr-0"><%= LanguageUtil.get(request, "experiences-cannot-be-displayed-because-segmentation-is-disabled") %></strong>
 
 							<c:choose>
 								<c:when test="<%= segmentsSimulationDisplayContext.getSegmentsCompanyConfigurationURL() != null %>">

--- a/modules/apps/segments/segments-simulation-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/segments/segments-simulation-web/src/main/resources/META-INF/resources/view.jsp
@@ -39,7 +39,7 @@ SegmentsSimulationDisplayContext segmentsSimulationDisplayContext = (SegmentsSim
 							dismissible="<%= true %>"
 							displayType="warning"
 						>
-							<strong class="lead mr-0"><%= LanguageUtil.get(request, "experiences-cannot-be-displayed-because-segmentation-is-disabled") %></strong>
+							<strong><%= LanguageUtil.get(request, "experiences-cannot-be-displayed-because-segmentation-is-disabled") %></strong>
 
 							<c:choose>
 								<c:when test="<%= segmentsSimulationDisplayContext.getSegmentsCompanyConfigurationURL() != null %>">

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/segments_configuration.jsp
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/segments_configuration.jsp
@@ -70,7 +70,7 @@ SegmentsCompanyConfigurationDisplayContext segmentsCompanyConfigurationDisplayCo
 				defaultTitleDisabled="<%= true %>"
 				displayType="warning"
 			>
-				<strong class="lead mr-0"><%= LanguageUtil.get(request, "segmentation-is-disabled-in-system-settings") %></strong>
+				<strong><%= LanguageUtil.get(request, "segmentation-is-disabled-in-system-settings") %></strong>
 
 				<%
 				String segmentsConfigurationURL = segmentsCompanyConfigurationDisplayContext.getSegmentsCompanyConfigurationURL();
@@ -96,7 +96,7 @@ SegmentsCompanyConfigurationDisplayContext segmentsCompanyConfigurationDisplayCo
 				defaultTitleDisabled="<%= true %>"
 				displayType="warning"
 			>
-				<strong class="lead mr-0"><%= LanguageUtil.get(request, "assign-roles-by-segment-is-disabled-in-system-settings") %></strong>
+				<strong><%= LanguageUtil.get(request, "assign-roles-by-segment-is-disabled-in-system-settings") %></strong>
 
 				<%
 				String segmentsConfigurationURL = segmentsCompanyConfigurationDisplayContext.getSegmentsCompanyConfigurationURL();

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/segments_configuration.jsp
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/segments_configuration.jsp
@@ -67,9 +67,10 @@ SegmentsCompanyConfigurationDisplayContext segmentsCompanyConfigurationDisplayCo
 		<c:if test="<%= !segmentsCompanyConfigurationDisplayContext.isSegmentationEnabled() %>">
 			<clay:alert
 				cssClass="c-my-4"
+				defaultTitleDisabled="<%= true %>"
 				displayType="warning"
 			>
-				<strong class="lead"><%= LanguageUtil.get(request, "segmentation-is-disabled-in-system-settings") %></strong>
+				<strong class="lead mr-0"><%= LanguageUtil.get(request, "segmentation-is-disabled-in-system-settings") %></strong>
 
 				<%
 				String segmentsConfigurationURL = segmentsCompanyConfigurationDisplayContext.getSegmentsCompanyConfigurationURL();
@@ -92,9 +93,10 @@ SegmentsCompanyConfigurationDisplayContext segmentsCompanyConfigurationDisplayCo
 		<c:if test="<%= !segmentsCompanyConfigurationDisplayContext.isRoleSegmentationEnabled() %>">
 			<clay:alert
 				cssClass="c-my-4"
+				defaultTitleDisabled="<%= true %>"
 				displayType="warning"
 			>
-				<strong class="lead"><%= LanguageUtil.get(request, "assign-roles-by-segment-is-disabled-in-system-settings") %></strong>
+				<strong class="lead mr-0"><%= LanguageUtil.get(request, "assign-roles-by-segment-is-disabled-in-system-settings") %></strong>
 
 				<%
 				String segmentsConfigurationURL = segmentsCompanyConfigurationDisplayContext.getSegmentsCompanyConfigurationURL();

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/view.jsp
@@ -43,10 +43,11 @@ request.setAttribute("view.jsp-eventName", eventName);
 
 <c:if test="<%= !segmentsDisplayContext.isSegmentationEnabled(themeDisplay.getCompanyId()) %>">
 	<clay:stripe
+		defaultTitleDisabled="<%= true %>"
 		dismissible="<%= true %>"
 		displayType="warning"
 	>
-		<strong class="lead"><%= LanguageUtil.get(request, "segmentation-is-disabled") %></strong>
+		<strong class="lead mr-0"><%= LanguageUtil.get(request, "segmentation-is-disabled") %></strong>
 
 		<%
 		String segmentsConfigurationURL = segmentsDisplayContext.getSegmentsCompanyConfigurationURL(request);

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/view.jsp
@@ -47,7 +47,7 @@ request.setAttribute("view.jsp-eventName", eventName);
 		dismissible="<%= true %>"
 		displayType="warning"
 	>
-		<strong class="lead mr-0"><%= LanguageUtil.get(request, "segmentation-is-disabled") %></strong>
+		<strong><%= LanguageUtil.get(request, "segmentation-is-disabled") %></strong>
 
 		<%
 		String segmentsConfigurationURL = segmentsDisplayContext.getSegmentsCompanyConfigurationURL(request);


### PR DESCRIPTION
Manually forwarded since https://github.com/liferay-tango/liferay-portal/pull/2592 has unrelated test failures.

cc @Luizcarlosqueiroz

===

[Jira issue](https://issues.liferay.com/browse/LPS-157689)

## Motivation

Due to some implementation details between the Alert JSP tag and Alert React component, we should revisit the usages made in the last epic about the Instance Setting config for Segments.

## Solution proposed

- We made some fixes to the tag, adding a new prop, [in this pr ](https://github.com/liferay-frontend/liferay-portal/pull/2466)
- We added that attr to the tag
- Also we removed the margin between the title and the content

## How to verify

- Visit Instance settings > Segment and disable the service
- Visit 
  - Segments list
  - Collections
  - Simulation panel
  - Experiences dropdown
  - Segments Instance Settings
 
and confirm the alerts as shown as expected, that's it, **no default title**, **no margin** between title and content

![image](https://user-images.githubusercontent.com/19485114/177627500-978aaf48-9e13-4f02-8aee-7f0efdaedb13.png)
