### PR TITLE
[7.4-blocker] LPS-158224 We need to set the custom externalReferenceCode AFTER renaming the ootb elements in the SXPBlueprintUpgradeProcess (1_3_0)

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/upgrade/v1_3_0/SXPBlueprintUpgradeProcess.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/upgrade/v1_3_0/SXPBlueprintUpgradeProcess.java
@@ -229,12 +229,14 @@ public class SXPBlueprintUpgradeProcess extends UpgradeProcess {
 					String title = resultSet.getString("title");
 
 					if (resultSet.getBoolean("readOnly")) {
-						externalReferenceCode = _getExternalReferenceCode(
-							title);
 						description = _renameDescription(description);
 						elementDefinitionJSON = _renameElementDefinitionJSON(
 							elementDefinitionJSON);
+
 						title = _renameTitle(title);
+
+						externalReferenceCode = _getExternalReferenceCode(
+							title);
 					}
 
 					preparedStatement2.setString(1, externalReferenceCode);


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-158224

Hi Brian,

@joshchong discovered this discrepancy during the QA review. We need to set the ERC after the title has been renamed to have the custom ERC generated based on the correct title.

Please, merge this to U34.

:white_check_mark: Tested manually locally.

Thanks,
Tibor

