### PR TITLE
LPS-158192 Changed aria-label from submit to search for accessibility

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/bar/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/bar/view.jsp
@@ -132,7 +132,7 @@ SearchBarPortletDisplayContext searchBarPortletDisplayContext = (SearchBarPortle
 
 										<div class="input-group-append input-group-item input-group-item-shrink">
 											<clay:button
-												aria-label='<%= LanguageUtil.get(request, "submit") %>'
+												aria-label='<%= LanguageUtil.get(request, "search") %>'
 												displayType="secondary"
 												icon="search"
 												type="submit"
@@ -147,7 +147,7 @@ SearchBarPortletDisplayContext searchBarPortletDisplayContext = (SearchBarPortle
 
 											<div class="input-group-inset-item input-group-inset-item-after">
 												<clay:button
-													aria-label='<%= LanguageUtil.get(request, "submit") %>'
+													aria-label='<%= LanguageUtil.get(request, "search") %>'
 													displayType="unstyled"
 													icon="search"
 													type="submit"


### PR DESCRIPTION
Forward: https://github.com/fortunatomaldonado/liferay-portal/pull/33

This is one of many fixes for accessibility being tracked in [LPS-158192](https://issues.liferay.com/browse/LPS-158192).
Let me know if anything should be changed in this process.

Thank you.

> [LPS-158192](https://issues.liferay.com/browse/LPS-158192) Changed aria-label from submit to search as a better description for screen reader.

This resolves the issue where the screen reader announced the search button as "submit button," as described in HRG_20.
The screen reader seems to read the aria-label, so I changed the value to read "search" instead of "submit". This fixes the issue for all search buttons that I was able to test.