### PR TITLE
LPS-158192 Display the icon when using keyboard navigation

### DIFF
--- a/modules/apps/contacts/contacts-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/contacts/contacts-web/src/main/resources/META-INF/resources/css/main.scss
@@ -546,6 +546,7 @@ $section-header-bg: #cce6f7;
 			top: 5px;
 		}
 
+		&:focus-within,
 		&:hover {
 			.lexicon-icon-pencil {
 				display: block;


### PR DESCRIPTION
Forward: https://github.com/fortunatomaldonado/liferay-portal/pull/32

https://issues.liferay.com/browse/LPS-158192
This is another accessibility fix specifically for HRG_29. Only the first commit is needed to resolve the issue.
Let me know if there are any questions or comments about this.
Thank you!

> @fortunatomaldonado This resolves an issue where a button is only displayed when the user hovers over it but when utilizing keyboard navigation the button never appears.
> 
> Steps to Reproduce
> 
> Click on user icon in upper right - My Profile
> Hover over the Profile widget so that the edit button appears
> Type the tab key until a small highlighted area above Test Test appears within the Profile widget. This is the edit button but the button itself does not appear when tabbing through the elements.
> Changes
> 
> The first commit makes it so that when the element is in focus then it will be shown.