### PR TITLE
LPS-158192 Only add calendar on enter or click event

### DIFF
--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/view_calendar_menus.jspf
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/view_calendar_menus.jspf
@@ -530,11 +530,13 @@
 			'<%= calendarResourcesURL %>',
 			addOtherCalendarInput,
 			(event) => {
-				window.<portlet:namespace />otherCalendarList.add(event.result.raw);
+				if (window.event.keyCode === 13 || window.event.type === 'click') {
+					window.<portlet:namespace />otherCalendarList.add(event.result.raw);
 
-				<portlet:namespace />refreshVisibleCalendarRenderingRules();
+					<portlet:namespace />refreshVisibleCalendarRenderingRules();
 
-				addOtherCalendarInput.val('');
+					addOtherCalendarInput.val('');
+				}
 			}
 		);
 	</c:if>


### PR DESCRIPTION
FWD: https://github.com/fortunatomaldonado/liferay-portal/pull/34

https://issues.liferay.com/browse/LPS-158192
Another fix for accessibility specifically HRG_05.

When searching in the Other Calendar search bar, the calendar being search will be added if the user enters 'Tab'.
I was able to resolve this by only adding the calendar when there is an 'enter' or 'click' event from the user.

Let me know if there are any questions or comments about this.
Thank you!