### PR TITLE
LPS-154715 It's possible to remove the user role from the default associations

### DIFF
--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -9650,11 +9650,12 @@
 
     #
     # Input a list of default regular role names separated by \n characters that
-    # are associated with newly created users.
+    # are associated with newly created users. Signed-in users will be granted
+    # the "User" role at all times.
     #
     # Env: LIFERAY_ADMIN_PERIOD_DEFAULT_PERIOD_ROLE_PERIOD_NAMES
     #
-    admin.default.role.names=User
+    admin.default.role.names=
 
     #
     # Input a list of default user group names separated by \n characters that


### PR DESCRIPTION
Manual forward from [liferay-usm#648](https://github.com/liferay-usm/liferay-portal/pull/648).
https://issues.liferay.com/browse/LPS-154715