### PR TITLE
LPS-157466 When the session cannot be extended because it was already expired, the browser should stop trying to extend it and it should display a warning to the final user

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
@@ -103,7 +103,13 @@ AUI.add(
 					instance.set('timestamp');
 
 					if (event.src === SRC) {
-						Liferay.Util.fetch(URL_BASE + 'extend_session');
+						Liferay.Util.fetch(URL_BASE + 'extend_session').then(
+							(response) => {
+								if (response.status === 500) {
+									instance.expire();
+								}
+							}
+						);
 					}
 				},
 

--- a/portal-web/docroot/html/portal/extend_session.jsp
+++ b/portal-web/docroot/html/portal/extend_session.jsp
@@ -17,15 +17,17 @@
 <%@ include file="/html/portal/init.jsp" %>
 
 <%
-if (_log.isWarnEnabled()) {
-	String requestedSessionId = request.getRequestedSessionId();
+String requestedSessionId = request.getRequestedSessionId();
 
-	if (Validator.isNotNull(requestedSessionId) && !StringUtil.equals(requestedSessionId, session.getId())) {
-		_log.warn("Unable to extend the HTTP session. Review the portal property \"session.timeout\" if this warning is displayed frequently.");
+if (Validator.isNotNull(requestedSessionId) && !StringUtil.equals(requestedSessionId, session.getId())) {
+	response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
 
-		if (_log.isDebugEnabled()) {
-			_log.debug("The requested session " + requestedSessionId + " is not the same as session " + session.getId());
-		}
+	if (_log.isWarnEnabled()) {
+		_log.warn("Unable to extend the HTTP session.");
+	}
+
+	if (_log.isDebugEnabled()) {
+		_log.debug("The requested session " + requestedSessionId + " is not the same as session " + session.getId());
 	}
 }
 


### PR DESCRIPTION
From: https://github.com/liferay-frontend/liferay-portal/pull/2471

QA ✅ : https://github.com/liferay-frontend/liferay-portal/pull/2471#issuecomment-1188047640