### PR TITLE
LPS-158192 Add Enter events to open calendar dropdown menu

### DIFF
--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/calendar_list.js
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/calendar_list.js
@@ -170,50 +170,52 @@ AUI.add(
 					}
 				},
 
-				_onClick(event) {
-					const instance = this;
+				_onEvents(event) {
+					if (event.keyCode === 13 || event.type === 'click') {
+						const instance = this;
 
-					const target = event.target.ancestor(
-						STR_DOT + CSS_CALENDAR_LIST_ITEM_ARROW,
-						true,
-						STR_DOT + CSS_CALENDAR_LIST_ITEM
-					);
+						const target = event.target.ancestor(
+							STR_DOT + CSS_CALENDAR_LIST_ITEM_ARROW,
+							true,
+							STR_DOT + CSS_CALENDAR_LIST_ITEM
+						);
 
-					if (target) {
-						let activeNode = instance.activeNode;
+						if (target) {
+							let activeNode = instance.activeNode;
 
-						if (activeNode) {
-							activeNode.removeClass(
-								CSS_CALENDAR_LIST_ITEM_ACTIVE
+							if (activeNode) {
+								activeNode.removeClass(
+									CSS_CALENDAR_LIST_ITEM_ACTIVE
+								);
+							}
+
+							activeNode = event.currentTarget;
+
+							instance.activeItem = instance.getCalendarByNode(
+								activeNode
 							);
+
+							activeNode.addClass(CSS_CALENDAR_LIST_ITEM_ACTIVE);
+
+							instance.activeNode = activeNode;
+
+							const simpleMenu = instance.simpleMenu;
+
+							simpleMenu.setAttrs({
+								alignNode: target,
+								toggler: target,
+								visible:
+									simpleMenu.get('align.node') !== target ||
+									!simpleMenu.get('visible'),
+							});
 						}
+						else {
+							const calendar = instance.getCalendarByNode(
+								event.currentTarget
+							);
 
-						activeNode = event.currentTarget;
-
-						instance.activeItem = instance.getCalendarByNode(
-							activeNode
-						);
-
-						activeNode.addClass(CSS_CALENDAR_LIST_ITEM_ACTIVE);
-
-						instance.activeNode = activeNode;
-
-						const simpleMenu = instance.simpleMenu;
-
-						simpleMenu.setAttrs({
-							alignNode: target,
-							toggler: target,
-							visible:
-								simpleMenu.get('align.node') !== target ||
-								!simpleMenu.get('visible'),
-						});
-					}
-					else {
-						const calendar = instance.getCalendarByNode(
-							event.currentTarget
-						);
-
-						calendar.set('visible', !calendar.get('visible'));
+							calendar.set('visible', !calendar.get('visible'));
+						}
 					}
 				},
 
@@ -392,7 +394,14 @@ AUI.add(
 
 					contentBox.delegate(
 						'click',
-						instance._onClick,
+						instance._onEvents,
+						STR_DOT + CSS_CALENDAR_LIST_ITEM,
+						instance
+					);
+
+					contentBox.delegate(
+						'keyup',
+						instance._onEvents,
 						STR_DOT + CSS_CALENDAR_LIST_ITEM,
 						instance
 					);

--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/view_calendar_menus.jspf
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/view_calendar_menus.jspf
@@ -498,22 +498,36 @@
 	A.one('#<portlet:namespace />calendarListContainer').delegate(
 		'click',
 		(event) => {
-			var currentTarget = event.currentTarget;
-
-			window.<portlet:namespace />calendarListsMenu.calendarResourceId = currentTarget.getAttribute(
-				'data-calendarResourceId'
-			);
-
-			window.<portlet:namespace />calendarListsMenu.setAttrs({
-				alignNode: currentTarget,
-				toggler: currentTarget,
-				visible: !window.<portlet:namespace />calendarListsMenu.get(
-					'visible'
-				),
-			});
+			<portlet:namespace />calendarListContainerEventHandler(event);
 		},
 		'.calendar-resource-arrow'
 	);
+
+	A.one('#<portlet:namespace />calendarListContainer').delegate(
+		'keyup',
+		(event) => {
+			if (event.keyCode === 13) {
+				<portlet:namespace />calendarListContainerEventHandler(event);
+			}
+		},
+		'.calendar-resource-arrow'
+	);
+
+	window.<portlet:namespace />calendarListContainerEventHandler = function (
+		event
+	) {
+		var currentTarget = event.currentTarget;
+
+		window.<portlet:namespace />calendarListsMenu.calendarResourceId = currentTarget.getAttribute(
+			'data-calendarResourceId'
+		);
+
+		window.<portlet:namespace />calendarListsMenu.setAttrs({
+			alignNode: currentTarget,
+			toggler: currentTarget,
+			visible: !window.<portlet:namespace />calendarListsMenu.get('visible'),
+		});
+	};
 
 	window.<portlet:namespace />toggler = new A.TogglerDelegate({
 		animated: true,


### PR DESCRIPTION
From @fortunatomaldonado:

> https://issues.liferay.com/browse/LPS-158192
> 
> The user is not able to access the dropdown menus of the Calendar only using the keyboard.
> 
> For this, I created "Enter" event listeners for both dropdown menus in calendar_list.js and view_calendar_menu.jspf. I tried to simplify the events so there is no duplicate code.
> 
> Let me know if there are any questions or comments about this.
> Thank you!