### PR TITLE
LPS-158192 (HRG_08)

### DIFF
--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/scheduler_event_recorder.js
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/scheduler_event_recorder.js
@@ -746,7 +746,8 @@ AUI.add(
 						[
 							{
 								cssClass: 'close',
-								label: '\u00D7',
+								labelHTML:
+									'<span aria-label="close">&times;</span>',
 								on: {
 									click: A.bind(
 										instance._handleCancelEvent,

--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/view_calendars.jsp
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/view_calendars.jsp
@@ -196,7 +196,7 @@ CalendarResource calendarResource = (CalendarResource)request.getAttribute(Calen
 				var buttonClose = [
 					{
 						cssClass: 'close',
-						label: '\u00D7',
+						labelHTML: '<span aria-label="close">&times;</span>',
 						on: {
 							click: function () {
 								<portlet:namespace />importDialog.hide();


### PR DESCRIPTION
From @wanderlast:

> This is a fix for HRG-08 where the 'x' button is read as 'times' button rather than 'close' button. The label literally is the unicode character for times, so we need to add an aria-label. Unfortunately, the API doesn't have a specific way to pass this attribute in, so we use the workaround of using 'labelHTML' to directly include the aria-label. There seems to be some precedence for this already: edit_synced_contact_fields.jsp and transition.js are both examples of using labelHTML (although they are passing in an aria-hidden attribute instead).
> 
> Thanks!