### PR TITLE
Lps 158192 12 2

### DIFF
--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/AssetVocabularyCategoriesSelector.es.js
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/AssetVocabularyCategoriesSelector.es.js
@@ -193,7 +193,7 @@ function AssetVocabulariesCategoriesSelector({
 				)}
 
 				{label && (
-					<label>
+					<label htmlFor={inputName + '_MultiSelect'}>
 						{label}
 
 						{required && (
@@ -211,6 +211,7 @@ function AssetVocabulariesCategoriesSelector({
 				<ClayInput.Group>
 					<ClayInput.GroupItem>
 						<ClayMultiSelect
+							id={inputName + '_MultiSelect'}
 							inputName={inputName}
 							items={selectedItems}
 							onChange={setInputValue}

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/AssetVocabularyCategoriesSelector.es.js
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/AssetVocabularyCategoriesSelector.es.js
@@ -235,7 +235,7 @@ function AssetVocabulariesCategoriesSelector({
 
 						{invalidItems && !!invalidItems.length && (
 							<ClayForm.FeedbackGroup>
-								<ClayForm.FeedbackItem>
+								<ClayForm.FeedbackItem aria-live="polite">
 									<ClayForm.FeedbackIndicator symbol="info-circle" />
 
 									{Lang.sub(

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/page.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/page.jsp
@@ -33,7 +33,7 @@ List<Map<String, Object>> vocabularies = (List<Map<String, Object>>)data.get("vo
 			<div class="field-content">
 				<div class="form-group" id="<%= "namespace_assetCategoriesSelector_" + vocabularyId %>">
 					<c:if test='<%= Validator.isNotNull(vocabulary.get("title")) %>'>
-						<label>
+						<label for="<%= "namespace_assetCategoriesSelector_" + vocabularyId + "_MultiSelect" %>">
 							<%= HtmlUtil.escape(GetterUtil.getString(vocabulary.get("title"))) %>
 
 							<c:if test='<%= GetterUtil.getBoolean(vocabulary.get("required")) %>'>
@@ -78,7 +78,7 @@ List<Map<String, Object>> vocabularies = (List<Map<String, Object>>)data.get("vo
 
 									</c:if>
 
-									<input class="form-control-inset" type="text" value="" />
+									<input class="form-control-inset" id="<%= "namespace_assetCategoriesSelector_" + vocabularyId + "_MultiSelect" %>" type="text" value="" />
 								</div>
 							</div>
 						</div>

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_tags_selector/AssetTagsSelector.es.js
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_tags_selector/AssetTagsSelector.es.js
@@ -204,11 +204,14 @@ function AssetTagsSelector({
 	return (
 		<div className="lfr-tags-selector-content" id={id}>
 			<ClayForm.Group>
-				<label>{label || Liferay.Language.get('tags')}</label>
+				<label htmlFor={inputName + '_MultiSelect'}>
+					{label || Liferay.Language.get('tags')}
+				</label>
 
 				<ClayInput.Group>
 					<ClayInput.GroupItem>
 						<ClayMultiSelect
+							id={inputName + '_MultiSelect'}
 							inputName={inputName}
 							items={selectedItems}
 							onBlur={handleInputBlur}

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_tags_selector/page.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_tags_selector/page.jsp
@@ -36,7 +36,7 @@ List<Map<String, String>> selectedItems = (List<Map<String, String>>)data.get("s
 		%>
 
 		<div class="form-group">
-			<label>
+			<label for="namespace_assetTagsSelector_MultiSelect">
 				<liferay-ui:message key="tags" />
 			</label>
 
@@ -57,7 +57,7 @@ List<Map<String, String>> selectedItems = (List<Map<String, String>>)data.get("s
 						}
 						%>
 
-						<input class="form-control-inset" type="text" value="" />
+						<input class="form-control-inset" id="namespace_assetTagsSelector_MultiSelect" type="text" value="" />
 					</div>
 				</div>
 			</div>

--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/edit_calendar_booking.jsp
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/edit_calendar_booking.jsp
@@ -1013,17 +1013,40 @@ while (manageableCalendarsIterator.hasNext()) {
 		startTimeInput.maxLength = maxLength;
 	}
 
+	var endDateContainer = document.getElementById(
+		'<portlet:namespace />endDateContainer'
+	);
+
+	endDateContainer
+		.querySelector('label')
+		.setAttribute('id', '<portlet:namespace />endDateContainerLabel');
+
+	endDateContainer.querySelectorAll('input').forEach((element) => {
+		element.setAttribute(
+			'aria-labeledby',
+			'<portlet:namespace />endDateContainerLabel'
+		);
+	});
+
+	var startDateContainer = document.getElementById(
+		'<portlet:namespace />startDateContainer'
+	);
+
+	startDateContainer
+		.querySelector('label')
+		.setAttribute('id', '<portlet:namespace />startDateContainerLabel');
+
+	startDateContainer.querySelectorAll('input').forEach((element) => {
+		element.setAttribute(
+			'aria-labeledby',
+			'<portlet:namespace />startDateContainerLabel'
+		);
+	});
+
 	var allDayCheckbox = document.getElementById('<portlet:namespace />allDay');
 
 	if (allDayCheckbox) {
 		allDayCheckbox.addEventListener('click', (event) => {
-			var endDateContainer = document.getElementById(
-				'<portlet:namespace />endDateContainer'
-			);
-			var startDateContainer = document.getElementById(
-				'<portlet:namespace />startDateContainer'
-			);
-
 			var endTimeHours;
 			var endTimeMinutes;
 			var startTimeHours;


### PR DESCRIPTION
From @holatuwol:

> ## Proposed solution
> 
> `asset_categories_selector` and `asset_tags_selector` both use `ClayMultiSelect`. `ClayMultiSelect` allows you to add dynamic `otherProps`, so the solution makes use of that to pass in an `id` that matches the `for` that is also added to the label. This allows the screen reader to read the label when you tab to the input field.
> 
> Note that this does not resolve the other major accessibility issue with these two input fields, which is that you cannot interact with ClayAutocomplete via keyboard. This arises due to ClayAutocomplete not being accessible, and it is being used by ClayMultiSelect for auto-complete functionality.
> 
> ## Steps to verify
> 
> 1. Choose to add a new to a calendar
> 2. Expand the Categorization section
> 3. Use the tab key to navigate to the Topic and Tags input fields
> 
> :heavy_check_mark:  Expected result is that the screen reader tells you the label for the input field you're interacting with
> :heavy_multiplication_x: Actual result is that the screen reader knows nothing about the input field's label