### PR TITLE
LPS-143632 Fix Remove LanguageUtil usages in object module

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -73,7 +73,7 @@ import com.liferay.portal.kernel.dao.orm.Property;
 import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
 import com.liferay.portal.kernel.dependency.manager.DependencyManagerSyncUtil;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.ResourceAction;
@@ -778,7 +778,7 @@ public class ObjectDefinitionLocalServiceImpl
 			ObjectEntryTable.INSTANCE.userName.getName(), dbTableName,
 			ObjectFieldConstants.DB_TYPE_STRING, null, false, false, null,
 			LocalizedMapUtil.getLocalizedMap(
-				LanguageUtil.get(LocaleUtil.getDefault(), "author")),
+				_language.get(LocaleUtil.getDefault(), "author")),
 			"creator", false, false);
 
 		_objectFieldLocalService.addSystemObjectField(
@@ -787,7 +787,7 @@ public class ObjectDefinitionLocalServiceImpl
 			ObjectEntryTable.INSTANCE.createDate.getName(), dbTableName,
 			ObjectFieldConstants.DB_TYPE_DATE, null, false, false, null,
 			LocalizedMapUtil.getLocalizedMap(
-				LanguageUtil.get(LocaleUtil.getDefault(), "create-date")),
+				_language.get(LocaleUtil.getDefault(), "create-date")),
 			"createDate", false, false);
 
 		String dbColumnName = ObjectEntryTable.INSTANCE.objectEntryId.getName();
@@ -806,7 +806,7 @@ public class ObjectDefinitionLocalServiceImpl
 				ObjectEntryTable.INSTANCE.getTableName(),
 				ObjectFieldConstants.DB_TYPE_STRING, null, false, false, null,
 				LocalizedMapUtil.getLocalizedMap(
-					LanguageUtil.get(
+					_language.get(
 						LocaleUtil.getDefault(), "external-reference-code")),
 				"externalReferenceCode", false, false);
 		}
@@ -817,7 +817,7 @@ public class ObjectDefinitionLocalServiceImpl
 			dbTableName, ObjectFieldConstants.DB_TYPE_LONG, null, false, false,
 			null,
 			LocalizedMapUtil.getLocalizedMap(
-				LanguageUtil.get(LocaleUtil.getDefault(), "id")),
+				_language.get(LocaleUtil.getDefault(), "id")),
 			"id", false, false);
 
 		_objectFieldLocalService.addSystemObjectField(
@@ -826,7 +826,7 @@ public class ObjectDefinitionLocalServiceImpl
 			ObjectEntryTable.INSTANCE.modifiedDate.getName(), dbTableName,
 			ObjectFieldConstants.DB_TYPE_DATE, null, false, false, null,
 			LocalizedMapUtil.getLocalizedMap(
-				LanguageUtil.get(LocaleUtil.getDefault(), "modified-date")),
+				_language.get(LocaleUtil.getDefault(), "modified-date")),
 			"modifiedDate", false, false);
 
 		_objectFieldLocalService.addSystemObjectField(
@@ -835,7 +835,7 @@ public class ObjectDefinitionLocalServiceImpl
 			ObjectEntryTable.INSTANCE.status.getName(), dbTableName,
 			ObjectFieldConstants.DB_TYPE_INTEGER, null, false, false, null,
 			LocalizedMapUtil.getLocalizedMap(
-				LanguageUtil.get(LocaleUtil.getDefault(), "status")),
+				_language.get(LocaleUtil.getDefault(), "status")),
 			"status", false, false);
 
 		if (objectFields != null) {
@@ -997,7 +997,7 @@ public class ObjectDefinitionLocalServiceImpl
 		for (LayoutClassedModelUsage layoutClassedModelUsage :
 				layoutClassedModelUsages) {
 
-			Set<Locale> availableLocales = LanguageUtil.getAvailableLocales(
+			Set<Locale> availableLocales = _language.getAvailableLocales(
 				layoutClassedModelUsage.getGroupId());
 
 			for (Locale locale : availableLocales) {
@@ -1365,6 +1365,9 @@ public class ObjectDefinitionLocalServiceImpl
 
 	@Reference
 	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private Language _language;
 
 	@Reference
 	private LayoutClassedModelUsageLocalService


### PR DESCRIPTION
@brianchandotcom 
Hi Brian,

Per our tester Kristin,
Recent merge of this https://github.com/liferay-core-infra/liferay-portal/pull/1168 caused portal failure.

> [exec] /opt/dev/projects/github/liferay-portal/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java:809: error: cannot find symbol
> [exec] LanguageUtil.get(
> [exec] ^
> [exec] symbol: variable LanguageUtil
> [exec] location: class ObjectDefinitionLocalServiceImpl
> [exec] Note: Some input files use or override a deprecated API.
> [exec] Note: Recompile with -Xlint:deprecation for details.
> [exec] Note: Some input files use unchecked or unsafe operations.
> [exec] Note: Recompile with -Xlint:unchecked for details.
> [exec] 1 error

After investigation, the LanguageUtil https://github.com/brianchandotcom/liferay-portal/pull/120975 on line 809 was just merged in yesterday causing this issue. This pull includes the new Util usage and convert it to service reference.

Thank you!
