### PR TITLE
LPS-112222 In CI docker containers, time drifting happens randomly. D…

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -12108,6 +12108,7 @@ auto.deploy.dest.dir=C:/WINDOWS/system32/config/systemprofile/liferay/websphere-
 
 	<target name="prepare-system-ext-properties">
 		<echo file="${app.server.classes.portal.dir}/system-ext.properties">com.liferay.portal.kernel.util.ServiceProxyFactory.timeout=300000
+jdbc.datasource.anti.time.drift=true
 log.sanitizer.enabled=false</echo>
 
 		<get-testcase-property property.name="custom.system.properties" />

--- a/portal-impl/src/com/liferay/portal/dao/jdbc/DataSourceFactoryImpl.java
+++ b/portal-impl/src/com/liferay/portal/dao/jdbc/DataSourceFactoryImpl.java
@@ -18,6 +18,7 @@ import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.dao.jdbc.pool.metrics.HikariConnectionPoolMetrics;
+import com.liferay.portal.dao.jdbc.util.AntiTimeDriftDataSourceWrapper;
 import com.liferay.portal.dao.jdbc.util.DataSourceWrapper;
 import com.liferay.portal.dao.jdbc.util.RetryDataSourceWrapper;
 import com.liferay.portal.kernel.configuration.Filter;
@@ -175,6 +176,15 @@ public class DataSourceFactoryImpl implements DataSourceFactory {
 
 			if (dbType == DBType.SYBASE) {
 				dataSource = new RetryDataSourceWrapper(dataSource);
+			}
+		}
+
+		if (Boolean.getBoolean("jdbc.datasource.anti.time.drift")) {
+			DBType dbType = DBManagerUtil.getDBType(
+				DialectDetector.getDialect(dataSource));
+
+			if (dbType == DBType.DB2) {
+				dataSource = new AntiTimeDriftDataSourceWrapper(dataSource);
 			}
 		}
 

--- a/portal-impl/src/com/liferay/portal/dao/jdbc/util/AntiTimeDriftDataSourceWrapper.java
+++ b/portal-impl/src/com/liferay/portal/dao/jdbc/util/AntiTimeDriftDataSourceWrapper.java
@@ -1,0 +1,170 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.dao.jdbc.util;
+
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.ProxyUtil;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import java.util.Objects;
+
+import javax.sql.DataSource;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class AntiTimeDriftDataSourceWrapper extends DataSourceWrapper {
+
+	public AntiTimeDriftDataSourceWrapper(DataSource dataSource) {
+		super(dataSource);
+	}
+
+	@Override
+	public Connection getConnection() throws SQLException {
+		return (Connection)ProxyUtil.newProxyInstance(
+			AntiTimeDriftDataSourceWrapper.class.getClassLoader(),
+			new Class<?>[] {Connection.class},
+			new AntiTimeDriftInvocationHandler(super.getConnection()));
+	}
+
+	@Override
+	public Connection getConnection(String userName, String password)
+		throws SQLException {
+
+		return (Connection)ProxyUtil.newProxyInstance(
+			AntiTimeDriftDataSourceWrapper.class.getClassLoader(),
+			new Class<?>[] {Connection.class},
+			new AntiTimeDriftInvocationHandler(
+				super.getConnection(userName, password)));
+	}
+
+	private static synchronized boolean _checkTimeDrift() {
+		boolean drifted = false;
+
+		while (true) {
+			long currentTime = System.currentTimeMillis();
+
+			long delta = _previousTime - currentTime;
+
+			if (delta > 0) {
+				drifted = true;
+
+				delta += 1000;
+
+				if (_log.isDebugEnabled()) {
+					_log.debug(
+						"Detected time drifting, delay execution for " + delta +
+							"ms");
+				}
+
+				try {
+					Thread.sleep(delta);
+				}
+				catch (InterruptedException interruptedException) {
+				}
+			}
+			else {
+				_previousTime = currentTime;
+
+				break;
+			}
+		}
+
+		return drifted;
+	}
+
+	private static Object _wrapStatement(Object target) {
+		if (target instanceof Statement) {
+			Class<?> targetClass = target.getClass();
+
+			target = ProxyUtil.newProxyInstance(
+				targetClass.getClassLoader(), targetClass.getInterfaces(),
+				new AntiTimeDriftInvocationHandler(target));
+		}
+
+		return target;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		AntiTimeDriftDataSourceWrapper.class);
+
+	private static long _previousTime = System.currentTimeMillis();
+
+	private static class AntiTimeDriftInvocationHandler
+		implements InvocationHandler {
+
+		@Override
+		public Object invoke(Object object, Method method, Object[] args)
+			throws Throwable {
+
+			_checkTimeDrift();
+
+			try {
+				return _wrapStatement(method.invoke(_target, args));
+			}
+			catch (InvocationTargetException invocationTargetException1) {
+				Throwable throwable1 = invocationTargetException1.getCause();
+
+				if (throwable1 instanceof SQLException) {
+					SQLException sqlException = (SQLException)throwable1;
+
+					if ((sqlException.getErrorCode() == -204) &&
+						Objects.equals("42704", sqlException.getSQLState()) &&
+						_checkTimeDrift()) {
+
+						if (_log.isDebugEnabled()) {
+							_log.debug(
+								"Caught a \"SQLCODE=-204, SQLSTATE=42704\" " +
+									"and time drift, retry on the method call",
+								throwable1);
+						}
+
+						try {
+							return _wrapStatement(method.invoke(_target, args));
+						}
+						catch (InvocationTargetException
+									invocationTargetException2) {
+
+							Throwable throwable2 =
+								invocationTargetException2.getCause();
+
+							throwable2.addSuppressed(throwable1);
+
+							throw throwable2;
+						}
+					}
+				}
+
+				throw throwable1;
+			}
+		}
+
+		private AntiTimeDriftInvocationHandler(Object target) {
+			_target = target;
+		}
+
+		private final Object _target;
+
+	}
+
+}


### PR DESCRIPTION
…B2 jdbc driver seems having a timestamp base queue to communicate to DB2 server. When CI time drifting happens, we may see the index creation statement got an earlier timestamp comparing to the corresponding table creation statement, causing the very confusing "SQLCODE=-204, SQLSTATE=42704". This fix wraps up the DataSource on CI to detect time drifting on db accessing. Once detected time drifting, delay the execution to catch up the previous sampled time. Also on seeing "SQLCODE=-204, SQLSTATE=42704" together with time drifting, retry the failed sql statement to recover.