### PR TITLE
LPS-160413 Apply SF check to `poshi.properties` to sort multiline values

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/PropertiesMultiLineValuesOrderCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/PropertiesMultiLineValuesOrderCheck.java
@@ -43,7 +43,7 @@ public class PropertiesMultiLineValuesOrderCheck extends BaseFileCheck {
 		String shortFileName = fileName.substring(pos + 1);
 
 		if (!shortFileName.matches(
-				"(ci|compatibility|system(-ext)?|test)\\.properties")) {
+				"(ci|compatibility|system(-ext)?|test|poshi)\\.properties")) {
 
 			return content;
 		}

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/PropertiesMultiLineValuesOrderCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/PropertiesMultiLineValuesOrderCheck.java
@@ -43,7 +43,7 @@ public class PropertiesMultiLineValuesOrderCheck extends BaseFileCheck {
 		String shortFileName = fileName.substring(pos + 1);
 
 		if (!shortFileName.matches(
-				"(ci|compatibility|system(-ext)?|test|poshi)\\.properties")) {
+				"(ci|compatibility|system(-ext)?|poshi|test)\\.properties")) {
 
 			return content;
 		}


### PR DESCRIPTION
This PR can fix Issue: https://github.com/liferay/liferay-portal/commit/382c62b24162a82f212a3f4232e313bda4ab46e0

Tested [here](https://github.com/ling-alan-huang/liferay-portal/pull/1270), unrelated failures.

SF failures relate the old version poshi-core dependence in SF