### PR TITLE
LPS-152217: Expose ERC in WikiPageAttachment | master

### DIFF
--- a/modules/apps/archived/html-preview-service/src/main/java/com/liferay/html/preview/service/impl/HtmlPreviewEntryLocalServiceImpl.java
+++ b/modules/apps/archived/html-preview-service/src/main/java/com/liferay/html/preview/service/impl/HtmlPreviewEntryLocalServiceImpl.java
@@ -170,7 +170,7 @@ public class HtmlPreviewEntryLocalServiceImpl
 		}
 
 		return PortletFileRepositoryUtil.addPortletFileEntry(
-			groupId, userId, HtmlPreviewEntry.class.getName(),
+			null, groupId, userId, HtmlPreviewEntry.class.getName(),
 			htmlPreviewEntryId, HtmlPreviewEntry.class.getName(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, file,
 			String.valueOf(htmlPreviewEntryId), mimeType, false);

--- a/modules/apps/archived/sync-service/src/main/java/com/liferay/sync/service/impl/SyncDLFileVersionDiffLocalServiceImpl.java
+++ b/modules/apps/archived/sync-service/src/main/java/com/liferay/sync/service/impl/SyncDLFileVersionDiffLocalServiceImpl.java
@@ -70,8 +70,8 @@ public class SyncDLFileVersionDiffLocalServiceImpl
 			fileEntry.getCompanyId());
 
 		FileEntry dataFileEntry = _portletFileRepository.addPortletFileEntry(
-			company.getGroupId(), fileEntry.getUserId(),
-			SyncDLFileVersionDiff.class.getName(),
+			fileEntry.getExternalReferenceCode(), company.getGroupId(),
+			fileEntry.getUserId(), SyncDLFileVersionDiff.class.getName(),
 			syncDLFileVersionDiff.getSyncDLFileVersionDiffId(),
 			PortletKeys.DOCUMENT_LIBRARY,
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, file,

--- a/modules/apps/document-library/document-library-repository-portlet-file-repository-impl/src/main/java/com/liferay/document/library/repository/portlet/file/repository/internal/PortletFileRepositoryImpl.java
+++ b/modules/apps/document-library/document-library-repository-portlet-file-repository-impl/src/main/java/com/liferay/document/library/repository/portlet/file/repository/internal/PortletFileRepositoryImpl.java
@@ -177,9 +177,10 @@ public class PortletFileRepositoryImpl implements PortletFileRepository {
 
 	@Override
 	public FileEntry addPortletFileEntry(
-			long groupId, long userId, String className, long classPK,
-			String portletId, long folderId, InputStream inputStream,
-			String fileName, String mimeType, boolean indexingEnabled)
+			String externalReferenceCode, long groupId, long userId,
+			String className, long classPK, String portletId, long folderId,
+			InputStream inputStream, String fileName, String mimeType,
+			boolean indexingEnabled)
 		throws PortalException {
 
 		if (inputStream == null) {
@@ -551,6 +552,18 @@ public class PortletFileRepositoryImpl implements PortletFileRepository {
 			_repositoryProvider.getLocalRepository(groupId);
 
 		return localRepository.getFileEntryByUuid(uuid);
+	}
+
+	@Override
+	public FileEntry getPortletFileEntryByExternalReferenceCode(
+			long groupId, String externalReferenceCode)
+		throws PortalException {
+
+		LocalRepository localRepository =
+			_repositoryProvider.getLocalRepository(groupId);
+
+		return localRepository.getFileEntryByExternalReferenceCode(
+			externalReferenceCode);
 	}
 
 	@Override

--- a/modules/apps/document-library/document-library-repository-portlet-file-repository-impl/src/main/java/com/liferay/document/library/repository/portlet/file/repository/internal/PortletFileRepositoryImpl.java
+++ b/modules/apps/document-library/document-library-repository-portlet-file-repository-impl/src/main/java/com/liferay/document/library/repository/portlet/file/repository/internal/PortletFileRepositoryImpl.java
@@ -112,8 +112,8 @@ public class PortletFileRepositoryImpl implements PortletFileRepository {
 			file = FileUtil.createTempFile(bytes);
 
 			return addPortletFileEntry(
-				groupId, userId, className, classPK, portletId, folderId, file,
-				fileName, mimeType, indexingEnabled);
+				null, groupId, userId, className, classPK, portletId, folderId,
+				file, fileName, mimeType, indexingEnabled);
 		}
 		catch (IOException ioException) {
 			throw new SystemException(
@@ -127,8 +127,38 @@ public class PortletFileRepositoryImpl implements PortletFileRepository {
 	@Override
 	public FileEntry addPortletFileEntry(
 			long groupId, long userId, String className, long classPK,
-			String portletId, long folderId, File file, String fileName,
-			String mimeType, boolean indexingEnabled)
+			String portletId, long folderId, InputStream inputStream,
+			String fileName, String mimeType, boolean indexingEnabled)
+		throws PortalException {
+
+		if (inputStream == null) {
+			return null;
+		}
+
+		File file = null;
+
+		try {
+			file = FileUtil.createTempFile(inputStream);
+
+			return addPortletFileEntry(
+				null, groupId, userId, className, classPK, portletId, folderId,
+				file, fileName, mimeType, indexingEnabled);
+		}
+		catch (IOException ioException) {
+			throw new SystemException(
+				"Unable to write temporary file", ioException);
+		}
+		finally {
+			FileUtil.delete(file);
+		}
+	}
+
+	@Override
+	public FileEntry addPortletFileEntry(
+			String externalReferenceCode, long groupId, long userId,
+			String className, long classPK, String portletId, long folderId,
+			File file, String fileName, String mimeType,
+			boolean indexingEnabled)
 		throws PortalException {
 
 		if (Validator.isNull(fileName)) {
@@ -166,9 +196,9 @@ public class PortletFileRepositoryImpl implements PortletFileRepository {
 					repository.getRepositoryId());
 
 			return localRepository.addFileEntry(
-				null, userId, folderId, fileName, mimeType, fileName, fileName,
-				StringPool.BLANK, StringPool.BLANK, file, null, null,
-				serviceContext);
+				externalReferenceCode, userId, folderId, fileName, mimeType,
+				fileName, fileName, StringPool.BLANK, StringPool.BLANK, file,
+				null, null, serviceContext);
 		}
 		finally {
 			DLAppHelperThreadLocal.setEnabled(dlAppHelperEnabled);
@@ -193,8 +223,8 @@ public class PortletFileRepositoryImpl implements PortletFileRepository {
 			file = FileUtil.createTempFile(inputStream);
 
 			return addPortletFileEntry(
-				groupId, userId, className, classPK, portletId, folderId, file,
-				fileName, mimeType, indexingEnabled);
+				externalReferenceCode, groupId, userId, className, classPK,
+				portletId, folderId, file, fileName, mimeType, indexingEnabled);
 		}
 		catch (IOException ioException) {
 			throw new SystemException(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/upload/DDMFormUploadFileEntryHandler.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/upload/DDMFormUploadFileEntryHandler.java
@@ -104,7 +104,7 @@ public class DDMFormUploadFileEntryHandler implements UploadFileEntryHandler {
 			groupId, folderId, fileName);
 
 		return PortletFileRepositoryUtil.addPortletFileEntry(
-			groupId, userId, DDMFormInstance.class.getName(), 0,
+			null, groupId, userId, DDMFormInstance.class.getName(), 0,
 			DDMFormConstants.SERVICE_NAME, folderId, file, uniqueFileName,
 			mimeType, true);
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/bnd.bnd
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Delivery API
 Bundle-SymbolicName: com.liferay.headless.delivery.api
-Bundle-Version: 41.1.1
+Bundle-Version: 41.2.0
 Export-Package:\
 	com.liferay.headless.delivery.dto.v1_0,\
 	com.liferay.headless.delivery.dto.v1_0.util,\

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/WikiPageAttachment.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/WikiPageAttachment.java
@@ -151,6 +151,36 @@ public class WikiPageAttachment implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String encodingFormat;
 
+	@Schema(description = "The wiki page attachment's external reference code.")
+	public String getExternalReferenceCode() {
+		return externalReferenceCode;
+	}
+
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		this.externalReferenceCode = externalReferenceCode;
+	}
+
+	@JsonIgnore
+	public void setExternalReferenceCode(
+		UnsafeSupplier<String, Exception> externalReferenceCodeUnsafeSupplier) {
+
+		try {
+			externalReferenceCode = externalReferenceCodeUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField(
+		description = "The wiki page attachment's external reference code."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String externalReferenceCode;
+
 	@Schema(description = "The file's extension.")
 	public String getFileExtension() {
 		return fileExtension;
@@ -326,6 +356,20 @@ public class WikiPageAttachment implements Serializable {
 			sb.append("\"");
 
 			sb.append(_escape(encodingFormat));
+
+			sb.append("\"");
+		}
+
+		if (externalReferenceCode != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"externalReferenceCode\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(externalReferenceCode));
 
 			sb.append("\"");
 		}

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/WikiPageAttachmentResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/WikiPageAttachmentResource.java
@@ -58,6 +58,18 @@ public interface WikiPageAttachmentResource {
 		return FactoryHolder.factory.create();
 	}
 
+	public void
+			deleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode(
+				Long siteId, String wikiPageExternalReferenceCode,
+				String externalReferenceCode)
+		throws Exception;
+
+	public WikiPageAttachment
+			getSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode(
+				Long siteId, String wikiPageExternalReferenceCode,
+				String externalReferenceCode)
+		throws Exception;
+
 	public void deleteWikiPageAttachment(Long wikiPageAttachmentId)
 		throws Exception;
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/resources/com/liferay/headless/delivery/dto/v1_0/packageinfo
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/resources/com/liferay/headless/delivery/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 26.1.0
+version 26.2.0

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/resources/com/liferay/headless/delivery/resource/v1_0/packageinfo
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/resources/com/liferay/headless/delivery/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 15.6.0
+version 15.7.0

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/WikiPageAttachment.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/WikiPageAttachment.java
@@ -97,6 +97,27 @@ public class WikiPageAttachment implements Cloneable, Serializable {
 
 	protected String encodingFormat;
 
+	public String getExternalReferenceCode() {
+		return externalReferenceCode;
+	}
+
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		this.externalReferenceCode = externalReferenceCode;
+	}
+
+	public void setExternalReferenceCode(
+		UnsafeSupplier<String, Exception> externalReferenceCodeUnsafeSupplier) {
+
+		try {
+			externalReferenceCode = externalReferenceCodeUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String externalReferenceCode;
+
 	public String getFileExtension() {
 		return fileExtension;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/WikiPageAttachmentResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/WikiPageAttachmentResource.java
@@ -41,6 +41,30 @@ public interface WikiPageAttachmentResource {
 		return new Builder();
 	}
 
+	public void
+			deleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode(
+				Long siteId, String wikiPageExternalReferenceCode,
+				String externalReferenceCode)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			deleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCodeHttpResponse(
+				Long siteId, String wikiPageExternalReferenceCode,
+				String externalReferenceCode)
+		throws Exception;
+
+	public WikiPageAttachment
+			getSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode(
+				Long siteId, String wikiPageExternalReferenceCode,
+				String externalReferenceCode)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			getSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCodeHttpResponse(
+				Long siteId, String wikiPageExternalReferenceCode,
+				String externalReferenceCode)
+		throws Exception;
+
 	public void deleteWikiPageAttachment(Long wikiPageAttachmentId)
 		throws Exception;
 
@@ -170,6 +194,188 @@ public interface WikiPageAttachmentResource {
 
 	public static class WikiPageAttachmentResourceImpl
 		implements WikiPageAttachmentResource {
+
+		public void
+				deleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode(
+					Long siteId, String wikiPageExternalReferenceCode,
+					String externalReferenceCode)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				deleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCodeHttpResponse(
+					siteId, wikiPageExternalReferenceCode,
+					externalReferenceCode);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return;
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				deleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCodeHttpResponse(
+					Long siteId, String wikiPageExternalReferenceCode,
+					String externalReferenceCode)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.DELETE);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-delivery/v1.0/sites/{siteId}/wiki-pages/by-external-reference-code/{wikiPageExternalReferenceCode}/wiki-page-attachments/by-external-reference-code/{externalReferenceCode}");
+
+			httpInvoker.path("siteId", siteId);
+			httpInvoker.path(
+				"wikiPageExternalReferenceCode", wikiPageExternalReferenceCode);
+			httpInvoker.path("externalReferenceCode", externalReferenceCode);
+
+			httpInvoker.userNameAndPassword(
+				_builder._login + ":" + _builder._password);
+
+			return httpInvoker.invoke();
+		}
+
+		public WikiPageAttachment
+				getSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode(
+					Long siteId, String wikiPageExternalReferenceCode,
+					String externalReferenceCode)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				getSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCodeHttpResponse(
+					siteId, wikiPageExternalReferenceCode,
+					externalReferenceCode);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return WikiPageAttachmentSerDes.toDTO(content);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				getSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCodeHttpResponse(
+					Long siteId, String wikiPageExternalReferenceCode,
+					String externalReferenceCode)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-delivery/v1.0/sites/{siteId}/wiki-pages/by-external-reference-code/{wikiPageExternalReferenceCode}/wiki-page-attachments/by-external-reference-code/{externalReferenceCode}");
+
+			httpInvoker.path("siteId", siteId);
+			httpInvoker.path(
+				"wikiPageExternalReferenceCode", wikiPageExternalReferenceCode);
+			httpInvoker.path("externalReferenceCode", externalReferenceCode);
+
+			httpInvoker.userNameAndPassword(
+				_builder._login + ":" + _builder._password);
+
+			return httpInvoker.invoke();
+		}
 
 		public void deleteWikiPageAttachment(Long wikiPageAttachmentId)
 			throws Exception {

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/WikiPageAttachmentSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/WikiPageAttachmentSerDes.java
@@ -97,6 +97,20 @@ public class WikiPageAttachmentSerDes {
 			sb.append("\"");
 		}
 
+		if (wikiPageAttachment.getExternalReferenceCode() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"externalReferenceCode\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(wikiPageAttachment.getExternalReferenceCode()));
+
+			sb.append("\"");
+		}
+
 		if (wikiPageAttachment.getFileExtension() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -193,6 +207,15 @@ public class WikiPageAttachmentSerDes {
 				String.valueOf(wikiPageAttachment.getEncodingFormat()));
 		}
 
+		if (wikiPageAttachment.getExternalReferenceCode() == null) {
+			map.put("externalReferenceCode", null);
+		}
+		else {
+			map.put(
+				"externalReferenceCode",
+				String.valueOf(wikiPageAttachment.getExternalReferenceCode()));
+		}
+
 		if (wikiPageAttachment.getFileExtension() == null) {
 			map.put("fileExtension", null);
 		}
@@ -261,6 +284,14 @@ public class WikiPageAttachmentSerDes {
 			else if (Objects.equals(jsonParserFieldName, "encodingFormat")) {
 				if (jsonParserFieldValue != null) {
 					wikiPageAttachment.setEncodingFormat(
+						(String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(
+						jsonParserFieldName, "externalReferenceCode")) {
+
+				if (jsonParserFieldValue != null) {
+					wikiPageAttachment.setExternalReferenceCode(
 						(String)jsonParserFieldValue);
 				}
 			}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -5240,6 +5240,10 @@ components:
                         The file's media format (e.g., application/pdf, etc.).
                     readOnly: true
                     type: string
+                externalReferenceCode:
+                    description:
+                        The wiki page attachment's external reference code.
+                    type: string
                 fileExtension:
                     description:
                         The file's extension.
@@ -14347,6 +14351,65 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/WikiPage"
             tags: ["WikiPage"]
+    "/sites/{siteId}/wiki-pages/by-external-reference-code/{wikiPageExternalReferenceCode}/wiki-page-attachments/by-external-reference-code/{externalReferenceCode}":
+        delete:
+            # @review
+            description:
+                Delete the wiki page attachment by wiki page's and wiki page attachment's external reference codes.
+            parameters:
+                - in: path
+                  name: siteId
+                  required: true
+                  schema:
+                      format: int64
+                      type: integer
+                - in: path
+                  name: wikiPageExternalReferenceCode
+                  required: true
+                  schema:
+                      type: string
+                - in: path
+                  name: externalReferenceCode
+                  required: true
+                  schema:
+                      type: string
+            responses:
+                204:
+                    content:
+                        application/json: {}
+                        application/xml: {}
+            tags: ["WikiPageAttachment"]
+        get:
+            # @review
+            description:
+                Retrieves the wiki page attachment by wiki page's and wiki page attachment's external reference codes.
+            parameters:
+                - in: path
+                  name: siteId
+                  required: true
+                  schema:
+                      format: int64
+                      type: integer
+                - in: path
+                  name: wikiPageExternalReferenceCode
+                  required: true
+                  schema:
+                      type: string
+                - in: path
+                  name: externalReferenceCode
+                  required: true
+                  schema:
+                      type: string
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/WikiPageAttachment"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/WikiPageAttachment"
+            tags: ["WikiPageAttachment"]
     "/structured-content-folder/{structuredContentFolderId}/permissions":
         get:
             operationId: getStructuredContentFolderPermissionsPage

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -14356,6 +14356,7 @@ paths:
             # @review
             description:
                 Delete the wiki page attachment by wiki page's and wiki page attachment's external reference codes.
+            operationId: deleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode
             parameters:
                 - in: path
                   name: siteId
@@ -14383,6 +14384,7 @@ paths:
             # @review
             description:
                 Retrieves the wiki page attachment by wiki page's and wiki page attachment's external reference codes.
+            operationId: getSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode
             parameters:
                 - in: path
                   name: siteId

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/mutation/v1_0/Mutation.java
@@ -4349,6 +4349,30 @@ public class Mutation {
 	}
 
 	@GraphQLField(
+		description = "Delete the wiki page attachment by wiki page's and wiki page attachment's external reference codes."
+	)
+	public boolean
+			deleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode(
+				@GraphQLName("siteKey") @NotEmpty String siteKey,
+				@GraphQLName("wikiPageExternalReferenceCode") String
+					wikiPageExternalReferenceCode,
+				@GraphQLName("externalReferenceCode") String
+					externalReferenceCode)
+		throws Exception {
+
+		_applyVoidComponentServiceObjects(
+			_wikiPageAttachmentResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			wikiPageAttachmentResource ->
+				wikiPageAttachmentResource.
+					deleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode(
+						Long.valueOf(siteKey), wikiPageExternalReferenceCode,
+						externalReferenceCode));
+
+		return true;
+	}
+
+	@GraphQLField(
 		description = "Deletes the wiki page attachment and returns a 204 if the operation succeeds."
 	)
 	public boolean deleteWikiPageAttachment(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/query/v1_0/Query.java
@@ -3581,7 +3581,34 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {wikiPageAttachment(wikiPageAttachmentId: ___){contentUrl, contentValue, encodingFormat, fileExtension, id, sizeInBytes, title}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {wikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode(externalReferenceCode: ___, siteKey: ___, wikiPageExternalReferenceCode: ___){contentUrl, contentValue, encodingFormat, externalReferenceCode, fileExtension, id, sizeInBytes, title}}"}' -u 'test@liferay.com:test'
+	 */
+	@GraphQLField(
+		description = "Retrieves the wiki page attachment by wiki page's and wiki page attachment's external reference codes."
+	)
+	public WikiPageAttachment
+			wikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode(
+				@GraphQLName("siteKey") @NotEmpty String siteKey,
+				@GraphQLName("wikiPageExternalReferenceCode") String
+					wikiPageExternalReferenceCode,
+				@GraphQLName("externalReferenceCode") String
+					externalReferenceCode)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_wikiPageAttachmentResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			wikiPageAttachmentResource ->
+				wikiPageAttachmentResource.
+					getSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode(
+						Long.valueOf(siteKey), wikiPageExternalReferenceCode,
+						externalReferenceCode));
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {wikiPageAttachment(wikiPageAttachmentId: ___){contentUrl, contentValue, encodingFormat, externalReferenceCode, fileExtension, id, sizeInBytes, title}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField(description = "Retrieves the wiki page attachment.")
 	public WikiPageAttachment wikiPageAttachment(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiPageAttachmentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiPageAttachmentResourceImpl.java
@@ -77,6 +77,112 @@ public abstract class BaseWikiPageAttachmentResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
+	 * curl -X 'DELETE' 'http://localhost:8080/o/headless-delivery/v1.0/sites/{siteId}/wiki-pages/by-external-reference-code/{wikiPageExternalReferenceCode}/wiki-page-attachments/by-external-reference-code/{externalReferenceCode}'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Delete the wiki page attachment by wiki page's and wiki page attachment's external reference codes."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "siteId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "wikiPageExternalReferenceCode"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "externalReferenceCode"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(name = "WikiPageAttachment")
+		}
+	)
+	@javax.ws.rs.DELETE
+	@javax.ws.rs.Path(
+		"/sites/{siteId}/wiki-pages/by-external-reference-code/{wikiPageExternalReferenceCode}/wiki-page-attachments/by-external-reference-code/{externalReferenceCode}"
+	)
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public void
+			deleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode(
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("siteId")
+				Long siteId,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("wikiPageExternalReferenceCode")
+				String wikiPageExternalReferenceCode,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("externalReferenceCode")
+				String externalReferenceCode)
+		throws Exception {
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'GET' 'http://localhost:8080/o/headless-delivery/v1.0/sites/{siteId}/wiki-pages/by-external-reference-code/{wikiPageExternalReferenceCode}/wiki-page-attachments/by-external-reference-code/{externalReferenceCode}'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Retrieves the wiki page attachment by wiki page's and wiki page attachment's external reference codes."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "siteId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "wikiPageExternalReferenceCode"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "externalReferenceCode"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(name = "WikiPageAttachment")
+		}
+	)
+	@javax.ws.rs.GET
+	@javax.ws.rs.Path(
+		"/sites/{siteId}/wiki-pages/by-external-reference-code/{wikiPageExternalReferenceCode}/wiki-page-attachments/by-external-reference-code/{externalReferenceCode}"
+	)
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public WikiPageAttachment
+			getSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode(
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("siteId")
+				Long siteId,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("wikiPageExternalReferenceCode")
+				String wikiPageExternalReferenceCode,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("externalReferenceCode")
+				String externalReferenceCode)
+		throws Exception {
+
+		return new WikiPageAttachment();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
 	 * curl -X 'DELETE' 'http://localhost:8080/o/headless-delivery/v1.0/wiki-page-attachments/{wikiPageAttachmentId}'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiPageAttachmentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiPageAttachmentResourceTestCase.java
@@ -187,6 +187,7 @@ public abstract class BaseWikiPageAttachmentResourceTestCase {
 		wikiPageAttachment.setContentUrl(regex);
 		wikiPageAttachment.setContentValue(regex);
 		wikiPageAttachment.setEncodingFormat(regex);
+		wikiPageAttachment.setExternalReferenceCode(regex);
 		wikiPageAttachment.setFileExtension(regex);
 		wikiPageAttachment.setTitle(regex);
 
@@ -199,8 +200,206 @@ public abstract class BaseWikiPageAttachmentResourceTestCase {
 		Assert.assertEquals(regex, wikiPageAttachment.getContentUrl());
 		Assert.assertEquals(regex, wikiPageAttachment.getContentValue());
 		Assert.assertEquals(regex, wikiPageAttachment.getEncodingFormat());
+		Assert.assertEquals(
+			regex, wikiPageAttachment.getExternalReferenceCode());
 		Assert.assertEquals(regex, wikiPageAttachment.getFileExtension());
 		Assert.assertEquals(regex, wikiPageAttachment.getTitle());
+	}
+
+	@Test
+	public void testDeleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode()
+		throws Exception {
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		WikiPageAttachment wikiPageAttachment =
+			testDeleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_addWikiPageAttachment();
+
+		assertHttpResponseStatusCode(
+			204,
+			wikiPageAttachmentResource.
+				deleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCodeHttpResponse(
+					testDeleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_getSiteId(),
+					testDeleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_getWikiPageExternalReferenceCode(),
+					wikiPageAttachment.getExternalReferenceCode()));
+
+		assertHttpResponseStatusCode(
+			404,
+			wikiPageAttachmentResource.
+				getSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCodeHttpResponse(
+					testDeleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_getSiteId(),
+					testDeleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_getWikiPageExternalReferenceCode(),
+					wikiPageAttachment.getExternalReferenceCode()));
+
+		assertHttpResponseStatusCode(
+			404,
+			wikiPageAttachmentResource.
+				getSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCodeHttpResponse(
+					testDeleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_getSiteId(),
+					testDeleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_getWikiPageExternalReferenceCode(),
+					wikiPageAttachment.getExternalReferenceCode()));
+	}
+
+	protected Long
+			testDeleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_getSiteId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected String
+			testDeleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_getWikiPageExternalReferenceCode()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected WikiPageAttachment
+			testDeleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_addWikiPageAttachment()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
+	public void testGetSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode()
+		throws Exception {
+
+		WikiPageAttachment postWikiPageAttachment =
+			testGetSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_addWikiPageAttachment();
+
+		WikiPageAttachment getWikiPageAttachment =
+			wikiPageAttachmentResource.
+				getSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode(
+					testGetSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_getSiteId(),
+					testGetSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_getWikiPageExternalReferenceCode(),
+					postWikiPageAttachment.getExternalReferenceCode());
+
+		assertEquals(postWikiPageAttachment, getWikiPageAttachment);
+		assertValid(getWikiPageAttachment);
+	}
+
+	protected Long
+			testGetSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_getSiteId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected String
+			testGetSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_getWikiPageExternalReferenceCode()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected WikiPageAttachment
+			testGetSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_addWikiPageAttachment()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
+	public void testGraphQLGetSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode()
+		throws Exception {
+
+		WikiPageAttachment wikiPageAttachment =
+			testGraphQLGetSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_addWikiPageAttachment();
+
+		Assert.assertTrue(
+			equals(
+				wikiPageAttachment,
+				WikiPageAttachmentSerDes.toDTO(
+					JSONUtil.getValueAsString(
+						invokeGraphQLQuery(
+							new GraphQLField(
+								"wikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode",
+								new HashMap<String, Object>() {
+									{
+										put(
+											"siteKey",
+											"\"" +
+												testGraphQLGetSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_getSiteId() +
+													"\"");
+
+										put(
+											"wikiPageExternalReferenceCode",
+											"\"" +
+												testGraphQLGetSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_getWikiPageExternalReferenceCode() +
+													"\"");
+										put(
+											"externalReferenceCode",
+											"\"" +
+												wikiPageAttachment.
+													getExternalReferenceCode() +
+														"\"");
+									}
+								},
+								getGraphQLFields())),
+						"JSONObject/data",
+						"Object/wikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode"))));
+	}
+
+	protected Long
+			testGraphQLGetSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_getSiteId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected String
+			testGraphQLGetSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_getWikiPageExternalReferenceCode()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
+	public void testGraphQLGetSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCodeNotFound()
+		throws Exception {
+
+		String irrelevantWikiPageExternalReferenceCode =
+			"\"" + RandomTestUtil.randomString() + "\"";
+		String irrelevantExternalReferenceCode =
+			"\"" + RandomTestUtil.randomString() + "\"";
+
+		Assert.assertEquals(
+			"Not Found",
+			JSONUtil.getValueAsString(
+				invokeGraphQLQuery(
+					new GraphQLField(
+						"wikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode",
+						new HashMap<String, Object>() {
+							{
+								put(
+									"siteKey",
+									"\"" + irrelevantGroup.getGroupId() + "\"");
+								put(
+									"wikiPageExternalReferenceCode",
+									irrelevantWikiPageExternalReferenceCode);
+								put(
+									"externalReferenceCode",
+									irrelevantExternalReferenceCode);
+							}
+						},
+						getGraphQLFields())),
+				"JSONArray/errors", "Object/0", "JSONObject/extensions",
+				"Object/code"));
+	}
+
+	protected WikiPageAttachment
+			testGraphQLGetSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_addWikiPageAttachment()
+		throws Exception {
+
+		return testGraphQLWikiPageAttachment_addWikiPageAttachment();
 	}
 
 	@Test
@@ -578,6 +777,16 @@ public abstract class BaseWikiPageAttachmentResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals(
+					"externalReferenceCode", additionalAssertFieldName)) {
+
+				if (wikiPageAttachment.getExternalReferenceCode() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("fileExtension", additionalAssertFieldName)) {
 				if (wikiPageAttachment.getFileExtension() == null) {
 					valid = false;
@@ -732,6 +941,19 @@ public abstract class BaseWikiPageAttachmentResourceTestCase {
 				if (!Objects.deepEquals(
 						wikiPageAttachment1.getEncodingFormat(),
 						wikiPageAttachment2.getEncodingFormat())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
+					"externalReferenceCode", additionalAssertFieldName)) {
+
+				if (!Objects.deepEquals(
+						wikiPageAttachment1.getExternalReferenceCode(),
+						wikiPageAttachment2.getExternalReferenceCode())) {
 
 					return false;
 				}
@@ -905,6 +1127,15 @@ public abstract class BaseWikiPageAttachmentResourceTestCase {
 			return sb.toString();
 		}
 
+		if (entityFieldName.equals("externalReferenceCode")) {
+			sb.append("'");
+			sb.append(
+				String.valueOf(wikiPageAttachment.getExternalReferenceCode()));
+			sb.append("'");
+
+			return sb.toString();
+		}
+
 		if (entityFieldName.equals("fileExtension")) {
 			sb.append("'");
 			sb.append(String.valueOf(wikiPageAttachment.getFileExtension()));
@@ -985,6 +1216,8 @@ public abstract class BaseWikiPageAttachmentResourceTestCase {
 				contentValue = StringUtil.toLowerCase(
 					RandomTestUtil.randomString());
 				encodingFormat = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				externalReferenceCode = StringUtil.toLowerCase(
 					RandomTestUtil.randomString());
 				fileExtension = StringUtil.toLowerCase(
 					RandomTestUtil.randomString());

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/WikiPageAttachmentResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/WikiPageAttachmentResourceTest.java
@@ -23,6 +23,8 @@ import com.liferay.portal.kernel.test.constants.TestDataConstants;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.wiki.model.WikiNode;
 import com.liferay.wiki.model.WikiPage;
 import com.liferay.wiki.service.WikiNodeLocalServiceUtil;
@@ -34,6 +36,7 @@ import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
@@ -64,6 +67,97 @@ public class WikiPageAttachmentResourceTest
 			wikiNode.getNodeId(), RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(), false,
 			serviceContext);
+	}
+
+	@Override
+	@Test
+	public void testDeleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode()
+		throws Exception {
+
+		super.
+			testDeleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode();
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.portal.vulcan.internal.jaxrs.exception.mapper." +
+					"WebApplicationExceptionMapper",
+				LoggerTestUtil.ERROR)) {
+
+			WikiPageAttachment wikiPageAttachment =
+				testDeleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_addWikiPageAttachment();
+
+			// Nonexistent wiki page
+
+			assertHttpResponseStatusCode(
+				404,
+				wikiPageAttachmentResource.
+					deleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCodeHttpResponse(
+						testDeleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_getSiteId(),
+						RandomTestUtil.randomString(),
+						wikiPageAttachment.getExternalReferenceCode()));
+		}
+
+		// Nonexistent wiki page attachment
+
+		assertHttpResponseStatusCode(
+			204,
+			wikiPageAttachmentResource.
+				deleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCodeHttpResponse(
+					testDeleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_getSiteId(),
+					testDeleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_getWikiPageExternalReferenceCode(),
+					RandomTestUtil.randomString()));
+
+		// Wiki attachment associated to a different wiki page
+
+		WikiPage prevWikiPage = _wikiPage;
+
+		WikiPageAttachment wikiPageAttachment =
+			testDeleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_addWikiPageAttachment();
+
+		assertHttpResponseStatusCode(
+			204,
+			wikiPageAttachmentResource.
+				deleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCodeHttpResponse(
+					testDeleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_getSiteId(),
+					prevWikiPage.getExternalReferenceCode(),
+					wikiPageAttachment.getExternalReferenceCode()));
+	}
+
+	@Override
+	@Test
+	public void testGetSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode()
+		throws Exception {
+
+		super.
+			testGetSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode();
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.portal.vulcan.internal.jaxrs.exception.mapper." +
+					"WebApplicationExceptionMapper",
+				LoggerTestUtil.ERROR)) {
+
+			WikiPageAttachment wikiPageAttachment =
+				testGetSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_addWikiPageAttachment();
+
+			// Nonexistent wiki page
+
+			assertHttpResponseStatusCode(
+				404,
+				wikiPageAttachmentResource.
+					getSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCodeHttpResponse(
+						testGetSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_getSiteId(),
+						RandomTestUtil.randomString(),
+						wikiPageAttachment.getExternalReferenceCode()));
+		}
+
+		// Nonexistent wiki page attachment
+
+		assertHttpResponseStatusCode(
+			404,
+			wikiPageAttachmentResource.
+				getSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCodeHttpResponse(
+					testGetSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_getSiteId(),
+					testGetSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_getWikiPageExternalReferenceCode(),
+					RandomTestUtil.randomString()));
 	}
 
 	@Override
@@ -113,12 +207,60 @@ public class WikiPageAttachmentResourceTest
 
 	@Override
 	protected WikiPageAttachment
+			testDeleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_addWikiPageAttachment()
+		throws Exception {
+
+		return testDeleteWikiPageAttachment_addWikiPageAttachment();
+	}
+
+	@Override
+	protected Long
+			testDeleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_getSiteId()
+		throws Exception {
+
+		return _wikiPage.getGroupId();
+	}
+
+	@Override
+	protected String
+			testDeleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_getWikiPageExternalReferenceCode()
+		throws Exception {
+
+		return _wikiPage.getExternalReferenceCode();
+	}
+
+	@Override
+	protected WikiPageAttachment
 			testDeleteWikiPageAttachment_addWikiPageAttachment()
 		throws Exception {
 
 		return wikiPageAttachmentResource.postWikiPageWikiPageAttachment(
 			_wikiPage.getPageId(), randomWikiPageAttachment(),
 			getMultipartFiles());
+	}
+
+	@Override
+	protected WikiPageAttachment
+			testGetSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_addWikiPageAttachment()
+		throws Exception {
+
+		return testDeleteWikiPageAttachment_addWikiPageAttachment();
+	}
+
+	@Override
+	protected Long
+			testGetSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_getSiteId()
+		throws Exception {
+
+		return _wikiPage.getGroupId();
+	}
+
+	@Override
+	protected String
+			testGetSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_getWikiPageExternalReferenceCode()
+		throws Exception {
+
+		return _wikiPage.getExternalReferenceCode();
 	}
 
 	@Override
@@ -134,6 +276,30 @@ public class WikiPageAttachmentResourceTest
 	@Override
 	protected Long testGetWikiPageWikiPageAttachmentsPage_getWikiPageId() {
 		return _wikiPage.getPageId();
+	}
+
+	@Override
+	protected WikiPageAttachment
+			testGraphQLGetSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_addWikiPageAttachment()
+		throws Exception {
+
+		return testDeleteWikiPageAttachment_addWikiPageAttachment();
+	}
+
+	@Override
+	protected Long
+			testGraphQLGetSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_getSiteId()
+		throws Exception {
+
+		return _wikiPage.getGroupId();
+	}
+
+	@Override
+	protected String
+			testGraphQLGetSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_getWikiPageExternalReferenceCode()
+		throws Exception {
+
+		return _wikiPage.getExternalReferenceCode();
 	}
 
 	@Override

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMessageLocalServiceImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMessageLocalServiceImpl.java
@@ -605,7 +605,7 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 		Folder folder = message.addAttachmentsFolder();
 
 		_portletFileRepository.addPortletFileEntry(
-			message.getGroupId(), userId, MBMessage.class.getName(),
+			null, message.getGroupId(), userId, MBMessage.class.getName(),
 			message.getMessageId(), MBConstants.SERVICE_NAME,
 			folder.getFolderId(), file, fileName, mimeType, true);
 	}

--- a/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/service/impl/BackgroundTaskLocalServiceImpl.java
+++ b/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/service/impl/BackgroundTaskLocalServiceImpl.java
@@ -138,10 +138,10 @@ public class BackgroundTaskLocalServiceImpl
 		Folder folder = backgroundTask.addAttachmentsFolder();
 
 		PortletFileRepositoryUtil.addPortletFileEntry(
-			backgroundTask.getGroupId(), userId, BackgroundTask.class.getName(),
-			backgroundTask.getPrimaryKey(), PortletKeys.BACKGROUND_TASK,
-			folder.getFolderId(), file, fileName, ContentTypes.APPLICATION_ZIP,
-			false);
+			null, backgroundTask.getGroupId(), userId,
+			BackgroundTask.class.getName(), backgroundTask.getPrimaryKey(),
+			PortletKeys.BACKGROUND_TASK, folder.getFolderId(), file, fileName,
+			ContentTypes.APPLICATION_ZIP, false);
 	}
 
 	@Override

--- a/modules/apps/wiki/wiki-api/bnd.bnd
+++ b/modules/apps/wiki/wiki-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Wiki API
 Bundle-SymbolicName: com.liferay.wiki.api
-Bundle-Version: 9.1.1
+Bundle-Version: 9.2.0
 Export-Package:\
 	com.liferay.wiki.configuration,\
 	com.liferay.wiki.configuration.definition,\

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/exception/NoSuchWikiAttachmentException.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/exception/NoSuchWikiAttachmentException.java
@@ -11,6 +11,7 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
+
 package com.liferay.wiki.exception;
 
 import com.liferay.portal.kernel.exception.NoSuchModelException;

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/exception/NoSuchWikiAttachmentException.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/exception/NoSuchWikiAttachmentException.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+package com.liferay.wiki.exception;
+
+import com.liferay.portal.kernel.exception.NoSuchModelException;
+
+/**
+ * @author Brian Wing Shun Chan
+ */
+public class NoSuchWikiAttachmentException extends NoSuchModelException {
+
+	public NoSuchWikiAttachmentException() {
+	}
+
+	public NoSuchWikiAttachmentException(String msg) {
+		super(msg);
+	}
+
+	public NoSuchWikiAttachmentException(String msg, Throwable throwable) {
+		super(msg, throwable);
+	}
+
+	public NoSuchWikiAttachmentException(Throwable throwable) {
+		super(throwable);
+	}
+
+}

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/model/WikiPage.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/model/WikiPage.java
@@ -94,6 +94,11 @@ public interface WikiPage extends PersistedModel, WikiPageModel {
 	public int getAttachmentsFileEntriesCount(String[] mimeTypes)
 		throws com.liferay.portal.kernel.exception.PortalException;
 
+	public com.liferay.portal.kernel.repository.model.FileEntry
+			getAttachmentsFileEntryByExternalReferenceCode(
+				long groupId, String externalReferenceCode)
+		throws com.liferay.portal.kernel.exception.PortalException;
+
 	public long getAttachmentsFolderId();
 
 	public java.util.List<WikiPage> getChildPages();

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/model/WikiPageWrapper.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/model/WikiPageWrapper.java
@@ -312,6 +312,16 @@ public class WikiPageWrapper
 	}
 
 	@Override
+	public com.liferay.portal.kernel.repository.model.FileEntry
+			getAttachmentsFileEntryByExternalReferenceCode(
+				long groupId, String externalReferenceCode)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return model.getAttachmentsFileEntryByExternalReferenceCode(
+			groupId, externalReferenceCode);
+	}
+
+	@Override
 	public long getAttachmentsFolderId() {
 		return model.getAttachmentsFolderId();
 	}

--- a/modules/apps/wiki/wiki-api/src/main/resources/com/liferay/wiki/exception/packageinfo
+++ b/modules/apps/wiki/wiki-api/src/main/resources/com/liferay/wiki/exception/packageinfo
@@ -1,1 +1,1 @@
-version 1.3.0
+version 1.4.0

--- a/modules/apps/wiki/wiki-api/src/main/resources/com/liferay/wiki/model/packageinfo
+++ b/modules/apps/wiki/wiki-api/src/main/resources/com/liferay/wiki/model/packageinfo
@@ -1,1 +1,1 @@
-version 4.0.0
+version 4.1.0

--- a/modules/apps/wiki/wiki-service/service.xml
+++ b/modules/apps/wiki/wiki-service/service.xml
@@ -306,6 +306,7 @@
 		<exception>NodeName</exception>
 		<exception>NoSuchNode</exception>
 		<exception>NoSuchPage</exception>
+		<exception>NoSuchWikiAttachment</exception>
 		<exception>PageContent</exception>
 		<exception>PageTitle</exception>
 		<exception>PageVersion</exception>

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/model/impl/WikiPageImpl.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/model/impl/WikiPageImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.wiki.constants.WikiConstants;
+import com.liferay.wiki.exception.NoSuchWikiAttachmentException;
 import com.liferay.wiki.model.WikiNode;
 import com.liferay.wiki.model.WikiPage;
 import com.liferay.wiki.service.WikiNodeLocalServiceUtil;
@@ -167,6 +168,28 @@ public class WikiPageImpl extends WikiPageBaseImpl {
 		return PortletFileRepositoryUtil.getPortletFileEntriesCount(
 			getGroupId(), attachmentsFolderId, mimeTypes,
 			WorkflowConstants.STATUS_APPROVED);
+	}
+
+	@Override
+	public FileEntry getAttachmentsFileEntryByExternalReferenceCode(
+			long groupId, String externalReferenceCode)
+		throws PortalException {
+
+		FileEntry portletFileEntryByExternalReferenceCode =
+			PortletFileRepositoryUtil.
+				getPortletFileEntryByExternalReferenceCode(
+					groupId, externalReferenceCode);
+
+		long attachmentsFolderId = getAttachmentsFolderId();
+
+		if (attachmentsFolderId ==
+				portletFileEntryByExternalReferenceCode.getFolderId()) {
+
+			return portletFileEntryByExternalReferenceCode;
+		}
+
+		throw new NoSuchWikiAttachmentException(
+			"This file attachment does not belong to this wiki page");
 	}
 
 	@Override

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageLocalServiceImpl.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageLocalServiceImpl.java
@@ -352,7 +352,7 @@ public class WikiPageLocalServiceImpl extends WikiPageLocalServiceBaseImpl {
 			page.getGroupId(), folder.getFolderId(), fileName);
 
 		FileEntry fileEntry = _portletFileRepository.addPortletFileEntry(
-			page.getGroupId(), userId, WikiPage.class.getName(),
+			null, page.getGroupId(), userId, WikiPage.class.getName(),
 			page.getResourcePrimKey(), WikiConstants.SERVICE_NAME,
 			folder.getFolderId(), file, fileName, mimeType, true);
 

--- a/portal-impl/src/com/liferay/portlet/exportimport/service/impl/StagingLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/exportimport/service/impl/StagingLocalServiceImpl.java
@@ -604,7 +604,7 @@ public class StagingLocalServiceImpl extends StagingLocalServiceBaseImpl {
 
 		try {
 			PortletFileRepositoryUtil.addPortletFileEntry(
-				folder.getGroupId(), userId, Group.class.getName(),
+				null, folder.getGroupId(), userId, Group.class.getName(),
 				folder.getGroupId(), _PORTLET_REPOSITORY_ID,
 				folder.getFolderId(), new UnsyncByteArrayInputStream(bytes),
 				fileName, ContentTypes.APPLICATION_ZIP, false);
@@ -1029,7 +1029,7 @@ public class StagingLocalServiceImpl extends StagingLocalServiceBaseImpl {
 			}
 
 			PortletFileRepositoryUtil.addPortletFileEntry(
-				folder.getGroupId(), userId, Group.class.getName(),
+				null, folder.getGroupId(), userId, Group.class.getName(),
 				folder.getGroupId(), _PORTLET_REPOSITORY_ID,
 				folder.getFolderId(), tempFile,
 				getAssembledFileName(stagingRequestId),

--- a/portal-kernel/src/com/liferay/portal/kernel/portletfilerepository/PortletFileRepository.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portletfilerepository/PortletFileRepository.java
@@ -53,14 +53,22 @@ public interface PortletFileRepository {
 
 	public FileEntry addPortletFileEntry(
 			long groupId, long userId, String className, long classPK,
-			String portletId, long folderId, File file, String fileName,
-			String mimeType, boolean indexingEnabled)
+			String portletId, long folderId, InputStream inputStream,
+			String fileName, String mimeType, boolean indexingEnabled)
 		throws PortalException;
 
 	public FileEntry addPortletFileEntry(
-			long groupId, long userId, String className, long classPK,
-			String portletId, long folderId, InputStream inputStream,
-			String fileName, String mimeType, boolean indexingEnabled)
+			String externalReferenceCode, long groupId, long userId,
+			String className, long classPK, String portletId, long folderId,
+			File file, String fileName, String mimeType,
+			boolean indexingEnabled)
+		throws PortalException;
+
+	public FileEntry addPortletFileEntry(
+			String externalReferenceCode, long groupId, long userId,
+			String className, long classPK, String portletId, long folderId,
+			InputStream inputStream, String fileName, String mimeType,
+			boolean indexingEnabled)
 		throws PortalException;
 
 	public Folder addPortletFolder(
@@ -148,6 +156,10 @@ public interface PortletFileRepository {
 		throws PortalException;
 
 	public FileEntry getPortletFileEntry(String uuid, long groupId)
+		throws PortalException;
+
+	public FileEntry getPortletFileEntryByExternalReferenceCode(
+			long groupId, String externalReferenceCode)
 		throws PortalException;
 
 	public String getPortletFileEntryURL(

--- a/portal-kernel/src/com/liferay/portal/kernel/portletfilerepository/PortletFileRepositoryUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portletfilerepository/PortletFileRepositoryUtil.java
@@ -61,17 +61,6 @@ public class PortletFileRepositoryUtil {
 
 	public static FileEntry addPortletFileEntry(
 			long groupId, long userId, String className, long classPK,
-			String portletId, long folderId, File file, String fileName,
-			String mimeType, boolean indexingEnabled)
-		throws PortalException {
-
-		return _portletFileRepository.addPortletFileEntry(
-			groupId, userId, className, classPK, portletId, folderId, file,
-			fileName, mimeType, indexingEnabled);
-	}
-
-	public static FileEntry addPortletFileEntry(
-			long groupId, long userId, String className, long classPK,
 			String portletId, long folderId, InputStream inputStream,
 			String fileName, String mimeType, boolean indexingEnabled)
 		throws PortalException {
@@ -79,6 +68,31 @@ public class PortletFileRepositoryUtil {
 		return _portletFileRepository.addPortletFileEntry(
 			groupId, userId, className, classPK, portletId, folderId,
 			inputStream, fileName, mimeType, indexingEnabled);
+	}
+
+	public static FileEntry addPortletFileEntry(
+			String externalReferenceCode, long groupId, long userId,
+			String className, long classPK, String portletId, long folderId,
+			File file, String fileName, String mimeType,
+			boolean indexingEnabled)
+		throws PortalException {
+
+		return _portletFileRepository.addPortletFileEntry(
+			externalReferenceCode, groupId, userId, className, classPK,
+			portletId, folderId, file, fileName, mimeType, indexingEnabled);
+	}
+
+	public static FileEntry addPortletFileEntry(
+			String externalReferenceCode, long groupId, long userId,
+			String className, long classPK, String portletId, long folderId,
+			InputStream inputStream, String fileName, String mimeType,
+			boolean indexingEnabled)
+		throws PortalException {
+
+		return _portletFileRepository.addPortletFileEntry(
+			externalReferenceCode, groupId, userId, className, classPK,
+			portletId, folderId, inputStream, fileName, mimeType,
+			indexingEnabled);
 	}
 
 	public static Folder addPortletFolder(
@@ -261,6 +275,15 @@ public class PortletFileRepositoryUtil {
 		throws PortalException {
 
 		return _portletFileRepository.getPortletFileEntry(uuid, groupId);
+	}
+
+	public static FileEntry getPortletFileEntryByExternalReferenceCode(
+			long groupId, String externalReferenceCode)
+		throws PortalException {
+
+		return _portletFileRepository.
+			getPortletFileEntryByExternalReferenceCode(
+				groupId, externalReferenceCode);
 	}
 
 	public static String getPortletFileEntryURL(

--- a/portal-kernel/src/com/liferay/portal/kernel/portletfilerepository/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/portletfilerepository/packageinfo
@@ -1,1 +1,1 @@
-version 3.0.0
+version 4.0.0

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMPermissions.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMPermissions.testcase
@@ -2879,12 +2879,9 @@ definition {
 
 		DMDocument.enableActionsMenuOnPortlet();
 
-		Site.openSiteMembershipsAdmin(siteURLKey = "site-name");
-
-		Site.assignUserAsMemberCP(
-			userFirstName = "userfn",
-			userLastName = "userln",
-			userScreenName = "usersn");
+		JSONGroup.assignUserToGroup(
+			groupName = "Site Name",
+			userEmailAddress = "userea@liferay.com");
 
 		Navigator.openSitePage(
 			pageName = "Documents and Media Page",


### PR DESCRIPTION
Hi guys, I've opened this PR because most of the service changes I've made are related to your components. I'm going to introduced what are the changes that you should reviewed. Our team has verified that the errors appearing in the CI are not related, but we still want your approval, you can see [here](https://github.com/liferay-frontend/liferay-portal/pull/2512). You can check the desciption in the link of the PR from frontend-infra. Let's give you a little context.

## Main Objective
The main of this PR is to expose `externalReferenceCode` in WikiPageAttachments. For that reason I have made some changes in the service part and in the API part.

## Service part
The main changes that you should review, are the following:

- Those changes related to `PortletFileRepository` in portal-kernel. These changes are related because we add the new argument using `externalReferenceCode`.
- In the same way, in those modules I have implemented a new method to obtain a DLFile usign the `externalReferenceCode`, which is `getPortletFileEntryByExternalReferenceCode` .
- As there are some changes that affect the service part of DLFile, I want to be sure that the Staging mode works correctly, some changes are added.

## API part
However, this part can be ignored, beause it is reviewed by our members of the team.

If you have any problem, or any doubt, please contact me :smiley: 

**JIRA TICKET**
https://issues.liferay.com/browse/LPS-152217

