### PR TITLE
LPS-158192 Remove role menuitem from separators in simple menus.

### DIFF
--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/simple_menu.js
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/simple_menu.js
@@ -50,7 +50,7 @@ AUI.add(
 		const TPL_ICON = '<i class="{iconClass}"></i>';
 
 		const TPL_SIMPLE_MENU_ITEM =
-			'<li class="{cssClass}" data-id="{id}" role="menuitem" tabindex="-1"></li>';
+			'<li class="{cssClass}" data-id="{id}" role="{role}" tabindex="-1"></li>';
 
 		const getItemHandler = A.cached((id, items) => {
 			let found = null;
@@ -291,8 +291,11 @@ AUI.add(
 
 						let cssClass = CSS_SIMPLE_MENU_ITEM;
 
+						let role = 'menuitem';
+
 						if (caption === STR_DASH) {
 							cssClass = CSS_SIMPLE_MENU_SEPARATOR;
+							role = '';
 						}
 
 						if (hiddenItems.indexOf(id) > -1) {
@@ -318,6 +321,7 @@ AUI.add(
 								cssClass,
 								icon,
 								id,
+								role,
 							})
 						);
 


### PR DESCRIPTION
FWD: https://github.com/fortunatomaldonado/liferay-portal/pull/41

This resolves an accessibility issue where the SR reads out the line separator as a menu item.
Let me know if there are any questions or comments about this.

Thank you!

> [LPS-158192](https://issues.liferay.com/browse/LPS-158192) HRG_04 - Remove role menuitem from separators in simple menus.