### PR TITLE
Lps 154744 Unit test (rename vars and randomize)

### DIFF
--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/test/java/com/liferay/portal/security/sso/openid/connect/internal/OpenIdConnectAddRoleToUserLoginTest.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/test/java/com/liferay/portal/security/sso/openid/connect/internal/OpenIdConnectAddRoleToUserLoginTest.java
@@ -163,7 +163,7 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 		role.setType(RoleConstants.TYPE_REGULAR);
 
 		long[] roleIds = null;
-		String issuerProvider = "issuer Provicer";
+		String issuerProvider = "issuer Provider";
 
 		_setUpEnvironment(role, roleIds, null);
 		setUpPropsUtil(issuer, roleName);
@@ -271,7 +271,7 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 		role.setType(RoleConstants.TYPE_REGULAR);
 
 		long[] roleIds = null;
-		String issuerProvider = "issuer Provicer";
+		String issuerProvider = "issuer Provider";
 
 		_setUpEnvironment(role, roleIds, null);
 		setUpPropsUtil(issuer, roleName);

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/test/java/com/liferay/portal/security/sso/openid/connect/internal/OpenIdConnectAddRoleToUserLoginTest.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/test/java/com/liferay/portal/security/sso/openid/connect/internal/OpenIdConnectAddRoleToUserLoginTest.java
@@ -64,19 +64,16 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 			new OpenIdConnectUserInfoProcessorImpl();
 
 		ReflectionTestUtil.setFieldValue(
-			_openIdConnectUserInfoProcessorImpl, "_userLocalService",
-			_userLocalServiceMock);
-
-		ReflectionTestUtil.setFieldValue(
 			_openIdConnectUserInfoProcessorImpl, "_companyLocalService",
 			_companyLocalServiceMock);
-
 		ReflectionTestUtil.setFieldValue(
 			_openIdConnectUserInfoProcessorImpl, "_props", _props);
-
 		ReflectionTestUtil.setFieldValue(
 			_openIdConnectUserInfoProcessorImpl, "_roleLocalService",
 			_roleLocalServiceMock);
+		ReflectionTestUtil.setFieldValue(
+			_openIdConnectUserInfoProcessorImpl, "_userLocalService",
+			_userLocalServiceMock);
 	}
 
 	@Test

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/test/java/com/liferay/portal/security/sso/openid/connect/internal/OpenIdConnectAddRoleToUserLoginTest.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/test/java/com/liferay/portal/security/sso/openid/connect/internal/OpenIdConnectAddRoleToUserLoginTest.java
@@ -322,19 +322,16 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 		).thenReturn(
 			emailAddress
 		);
-
-		Mockito.when(
-			_userInfo.getGivenName()
-		).thenReturn(
-			emailAddress
-		);
-
 		Mockito.when(
 			_userInfo.getFamilyName()
 		).thenReturn(
 			emailAddress
 		);
-
+		Mockito.when(
+			_userInfo.getGivenName()
+		).thenReturn(
+			emailAddress
+		);
 		Mockito.when(
 			_userInfo.getMiddleName()
 		).thenReturn(

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/test/java/com/liferay/portal/security/sso/openid/connect/internal/OpenIdConnectAddRoleToUserLoginTest.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/test/java/com/liferay/portal/security/sso/openid/connect/internal/OpenIdConnectAddRoleToUserLoginTest.java
@@ -95,7 +95,7 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 		Assert.assertEquals(
 			_USEROK_ID,
 			_openIdConnectUserInfoProcessorImpl.processUserInfo(
-				_userInfo, _COMPANY_ID, issuer, _mainPath, _portalURL));
+				_userInfo, _COMPANY_ID, issuer, _MAIN_PATH, _PORTAL_URL));
 	}
 
 	@Test
@@ -114,7 +114,7 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 		Assert.assertEquals(
 			_USEROK_ID,
 			_openIdConnectUserInfoProcessorImpl.processUserInfo(
-				_userInfo, _COMPANY_ID, issuer, _mainPath, _portalURL));
+				_userInfo, _COMPANY_ID, issuer, _MAIN_PATH, _PORTAL_URL));
 	}
 
 	@Test
@@ -149,7 +149,7 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 		Assert.assertEquals(
 			_USEROK_ID,
 			_openIdConnectUserInfoProcessorImpl.processUserInfo(
-				_userInfo, _COMPANY_ID, issuer, _mainPath, _portalURL));
+				_userInfo, _COMPANY_ID, issuer, _MAIN_PATH, _PORTAL_URL));
 	}
 
 	@Test
@@ -177,7 +177,8 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 		Assert.assertEquals(
 			_USEROK_ID,
 			_openIdConnectUserInfoProcessorImpl.processUserInfo(
-				_userInfo, _COMPANY_ID, issuerProvider, _mainPath, _portalURL));
+				_userInfo, _COMPANY_ID, issuerProvider, _MAIN_PATH,
+				_PORTAL_URL));
 	}
 
 	@Test
@@ -205,7 +206,7 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 		Assert.assertEquals(
 			_USEROK_ID,
 			_openIdConnectUserInfoProcessorImpl.processUserInfo(
-				_userInfo, _COMPANY_ID, issuer, _mainPath, _portalURL));
+				_userInfo, _COMPANY_ID, issuer, _MAIN_PATH, _PORTAL_URL));
 	}
 
 	@Test
@@ -224,7 +225,7 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 		Assert.assertEquals(
 			_USEROK_ID,
 			_openIdConnectUserInfoProcessorImpl.processUserInfo(
-				_userInfo, _COMPANY_ID, issuer, _mainPath, _portalURL));
+				_userInfo, _COMPANY_ID, issuer, _MAIN_PATH, _PORTAL_URL));
 	}
 
 	@Test
@@ -243,7 +244,7 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 		Assert.assertEquals(
 			_USEROK_ID,
 			_openIdConnectUserInfoProcessorImpl.processUserInfo(
-				_userInfo, _COMPANY_ID, issuer, _mainPath, _portalURL));
+				_userInfo, _COMPANY_ID, issuer, _MAIN_PATH, _PORTAL_URL));
 	}
 
 	@Test
@@ -262,7 +263,7 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 		Assert.assertEquals(
 			_USEROK_ID,
 			_openIdConnectUserInfoProcessorImpl.processUserInfo(
-				_userInfo, _COMPANY_ID, issuer, _mainPath, _portalURL));
+				_userInfo, _COMPANY_ID, issuer, _MAIN_PATH, _PORTAL_URL));
 	}
 
 	@Test
@@ -288,7 +289,8 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 		Assert.assertEquals(
 			_USEROK_ID,
 			_openIdConnectUserInfoProcessorImpl.processUserInfo(
-				_userInfo, _COMPANY_ID, issuerProvider, _mainPath, _portalURL));
+				_userInfo, _COMPANY_ID, issuerProvider, _MAIN_PATH,
+				_PORTAL_URL));
 	}
 
 	protected void setUpPropsUtil(String issuer, String roleName) {
@@ -313,9 +315,6 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 		_setUpLocaleUtil();
 
 		String emailAddress = "email@liferay.com";
-
-		_mainPath = "/c";
-		_portalURL = "http://localhost:8080";
 
 		Mockito.when(
 			_companyLocalServiceMock.getCompany(_COMPANY_ID)
@@ -453,6 +452,10 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 
 	private static final long _COMPANY_ID = 444444;
 
+	private static final String _MAIN_PATH = "/c";
+
+	private static final String _PORTAL_URL = "http://localhost:8080";
+
 	private static final String _ROLE_NAME_EXISTS = "Role exist";
 
 	private static final long _USERERROR_ID = 0;
@@ -465,8 +468,6 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 	private final CompanyLocalService _companyLocalServiceMock = Mockito.mock(
 		CompanyLocalService.class);
 	private final Company _companyMock = Mockito.mock(Company.class);
-	private String _mainPath;
-	private String _portalURL;
 	private final Props _props = Mockito.mock(Props.class);
 	private final RoleLocalService _roleLocalServiceMock = Mockito.mock(
 		RoleLocalService.class);

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/test/java/com/liferay/portal/security/sso/openid/connect/internal/OpenIdConnectAddRoleToUserLoginTest.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/test/java/com/liferay/portal/security/sso/openid/connect/internal/OpenIdConnectAddRoleToUserLoginTest.java
@@ -77,7 +77,7 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 	}
 
 	@Test
-	public void testBothPropertiesDefinedAndCorrectRole() {
+	public void testBothPropertiesDefinedAndCorrectRole() throws Exception {
 		String issuer = "issuer url";
 
 		String roleName = _ROLE_NAME_EXISTS;
@@ -96,23 +96,14 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 
 		setUpPropsUtil(issuer, roleName);
 
-		long userId = _USERERROR_ID;
-
-		try {
-			userId = _openIdConnectUserInfoProcessorImpl.processUserInfo(
-				_userInfo, _COMPANY_ID, issuer, _mainPath, _portalURL);
-
-			Assert.assertEquals(userId, _USEROK_ID);
-		}
-		catch (PortalException portalException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(portalException);
-			}
-		}
+		Assert.assertEquals(
+			_USEROK_ID,
+			_openIdConnectUserInfoProcessorImpl.processUserInfo(
+				_userInfo, _COMPANY_ID, issuer, _mainPath, _portalURL));
 	}
 
 	@Test
-	public void testBothPropertiesDefinedAndFakeRole() {
+	public void testBothPropertiesDefinedAndFakeRole() throws Exception {
 		String issuer = "issuer url";
 		String roleName = "Fake Role";
 
@@ -124,23 +115,16 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 
 		setUpPropsUtil(issuer, roleName);
 
-		long userId = _USERERROR_ID;
-
-		try {
-			userId = _openIdConnectUserInfoProcessorImpl.processUserInfo(
-				_userInfo, _COMPANY_ID, issuer, _mainPath, _portalURL);
-
-			Assert.assertEquals(userId, _USEROK_ID);
-		}
-		catch (PortalException portalException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(portalException);
-			}
-		}
+		Assert.assertEquals(
+			_USEROK_ID,
+			_openIdConnectUserInfoProcessorImpl.processUserInfo(
+				_userInfo, _COMPANY_ID, issuer, _mainPath, _portalURL));
 	}
 
 	@Test
-	public void testBothPropertiesDefinedAndRoleCorrectAndUserAlreadyExists() {
+	public void testBothPropertiesDefinedAndRoleCorrectAndUserAlreadyExists()
+		throws Exception {
+
 		String issuer = "issuer url";
 		String roleName = "Power User";
 
@@ -166,23 +150,16 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 
 		setUpPropsUtil(issuer, roleName);
 
-		long userId = _USERERROR_ID;
-
-		try {
-			userId = _openIdConnectUserInfoProcessorImpl.processUserInfo(
-				_userInfo, _COMPANY_ID, issuer, _mainPath, _portalURL);
-
-			Assert.assertEquals(userId, _USEROK_ID);
-		}
-		catch (PortalException portalException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(portalException);
-			}
-		}
+		Assert.assertEquals(
+			_USEROK_ID,
+			_openIdConnectUserInfoProcessorImpl.processUserInfo(
+				_userInfo, _COMPANY_ID, issuer, _mainPath, _portalURL));
 	}
 
 	@Test
-	public void testBothPropertiesDefinedAndRoleExistsButDifferentIssuers() {
+	public void testBothPropertiesDefinedAndRoleExistsButDifferentIssuers()
+		throws Exception {
+
 		String issuer = "issuer url";
 		String roleName = _ROLE_NAME_EXISTS;
 
@@ -201,23 +178,16 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 		_setUpEnvironment(role, roleIds, null);
 		setUpPropsUtil(issuer, roleName);
 
-		long userId = _USERERROR_ID;
-
-		try {
-			userId = _openIdConnectUserInfoProcessorImpl.processUserInfo(
-				_userInfo, _COMPANY_ID, issuerProvider, _mainPath, _portalURL);
-
-			Assert.assertEquals(userId, _USEROK_ID);
-		}
-		catch (PortalException portalException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(portalException);
-			}
-		}
+		Assert.assertEquals(
+			_USEROK_ID,
+			_openIdConnectUserInfoProcessorImpl.processUserInfo(
+				_userInfo, _COMPANY_ID, issuerProvider, _mainPath, _portalURL));
 	}
 
 	@Test
-	public void testBothPropertiesDefinedAndRoleNotRegularType() {
+	public void testBothPropertiesDefinedAndRoleNotRegularType()
+		throws Exception {
+
 		String issuer = "issuer url";
 		String roleName = _ROLE_NAME_EXISTS;
 
@@ -236,23 +206,14 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 
 		setUpPropsUtil(issuer, roleName);
 
-		long userId = _USERERROR_ID;
-
-		try {
-			userId = _openIdConnectUserInfoProcessorImpl.processUserInfo(
-				_userInfo, _COMPANY_ID, issuer, _mainPath, _portalURL);
-
-			Assert.assertEquals(userId, _USEROK_ID);
-		}
-		catch (PortalException portalException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(portalException);
-			}
-		}
+		Assert.assertEquals(
+			_USEROK_ID,
+			_openIdConnectUserInfoProcessorImpl.processUserInfo(
+				_userInfo, _COMPANY_ID, issuer, _mainPath, _portalURL));
 	}
 
 	@Test
-	public void testBothPropertiesDefinedButRoleNameWrong1() {
+	public void testBothPropertiesDefinedButRoleNameWrong1() throws Exception {
 		String issuer = "issuer url";
 		String roleName = "Power User=Publications Owner";
 
@@ -264,23 +225,14 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 
 		setUpPropsUtil(issuer, roleName);
 
-		long userId = _USERERROR_ID;
-
-		try {
-			userId = _openIdConnectUserInfoProcessorImpl.processUserInfo(
-				_userInfo, _COMPANY_ID, issuer, _mainPath, _portalURL);
-
-			Assert.assertEquals(userId, _USEROK_ID);
-		}
-		catch (PortalException portalException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(portalException);
-			}
-		}
+		Assert.assertEquals(
+			_USEROK_ID,
+			_openIdConnectUserInfoProcessorImpl.processUserInfo(
+				_userInfo, _COMPANY_ID, issuer, _mainPath, _portalURL));
 	}
 
 	@Test
-	public void testBothPropertiesDefinedButRoleNameWrong2() {
+	public void testBothPropertiesDefinedButRoleNameWrong2() throws Exception {
 		String issuer = "issuer url";
 		String roleName = "Power%20User";
 
@@ -292,23 +244,14 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 
 		setUpPropsUtil(issuer, roleName);
 
-		long userId = _USERERROR_ID;
-
-		try {
-			userId = _openIdConnectUserInfoProcessorImpl.processUserInfo(
-				_userInfo, _COMPANY_ID, issuer, _mainPath, _portalURL);
-
-			Assert.assertEquals(userId, _USEROK_ID);
-		}
-		catch (PortalException portalException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(portalException);
-			}
-		}
+		Assert.assertEquals(
+			_USEROK_ID,
+			_openIdConnectUserInfoProcessorImpl.processUserInfo(
+				_userInfo, _COMPANY_ID, issuer, _mainPath, _portalURL));
 	}
 
 	@Test
-	public void testIssuerPropertyDefinedSoRoleNotExists() {
+	public void testIssuerPropertyDefinedSoRoleNotExists() throws Exception {
 		String issuer = "issuer url";
 		String roleName = null;
 
@@ -320,23 +263,14 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 
 		setUpPropsUtil(issuer, roleName);
 
-		long userId = _USERERROR_ID;
-
-		try {
-			userId = _openIdConnectUserInfoProcessorImpl.processUserInfo(
-				_userInfo, _COMPANY_ID, issuer, _mainPath, _portalURL);
-
-			Assert.assertEquals(userId, _USEROK_ID);
-		}
-		catch (PortalException portalException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(portalException);
-			}
-		}
+		Assert.assertEquals(
+			_USEROK_ID,
+			_openIdConnectUserInfoProcessorImpl.processUserInfo(
+				_userInfo, _COMPANY_ID, issuer, _mainPath, _portalURL));
 	}
 
 	@Test
-	public void testRoleNamePropertyDefinedAndRoleExists() {
+	public void testRoleNamePropertyDefinedAndRoleExists() throws Exception {
 		String issuer = null;
 		String roleName = _ROLE_NAME_EXISTS;
 
@@ -355,19 +289,10 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 		_setUpEnvironment(role, roleIds, null);
 		setUpPropsUtil(issuer, roleName);
 
-		long userId = _USERERROR_ID;
-
-		try {
-			userId = _openIdConnectUserInfoProcessorImpl.processUserInfo(
-				_userInfo, _COMPANY_ID, issuerProvider, _mainPath, _portalURL);
-
-			Assert.assertEquals(userId, _USEROK_ID);
-		}
-		catch (PortalException portalException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(portalException);
-			}
-		}
+		Assert.assertEquals(
+			_USEROK_ID,
+			_openIdConnectUserInfoProcessorImpl.processUserInfo(
+				_userInfo, _COMPANY_ID, issuerProvider, _mainPath, _portalURL));
 	}
 
 	protected void setUpPropsUtil(String issuer, String roleName) {

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/test/java/com/liferay/portal/security/sso/openid/connect/internal/OpenIdConnectAddRoleToUserLoginTest.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/test/java/com/liferay/portal/security/sso/openid/connect/internal/OpenIdConnectAddRoleToUserLoginTest.java
@@ -79,7 +79,6 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 	@Test
 	public void testBothPropertiesDefinedAndCorrectRole() throws Exception {
 		String issuer = "issuer url";
-
 		String roleName = _ROLE_NAME_EXISTS;
 
 		Role role = new RoleImpl();

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/test/java/com/liferay/portal/security/sso/openid/connect/internal/OpenIdConnectAddRoleToUserLoginTest.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/test/java/com/liferay/portal/security/sso/openid/connect/internal/OpenIdConnectAddRoleToUserLoginTest.java
@@ -79,10 +79,8 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 		String roleName = _ROLE_NAME_EXISTS;
 
 		Role role = new RoleImpl();
-		long roleId = 3333;
 
-		role.setRoleId(roleId);
-
+		role.setRoleId(3333);
 		role.setName(roleName);
 		role.setType(RoleConstants.TYPE_REGULAR);
 
@@ -125,10 +123,8 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 		String roleName = "Power User";
 
 		Role role = new RoleImpl();
-		long roleId = 3333;
 
-		role.setRoleId(roleId);
-
+		role.setRoleId(3333);
 		role.setCompanyId(_COMPANY_ID);
 		role.setName(roleName);
 		role.setType(RoleConstants.TYPE_REGULAR);
@@ -160,10 +156,8 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 		String roleName = _ROLE_NAME_EXISTS;
 
 		Role role = new RoleImpl();
-		long roleId = 3333;
 
-		role.setRoleId(roleId);
-
+		role.setRoleId(3333);
 		role.setCompanyId(_COMPANY_ID);
 		role.setName(roleName);
 		role.setType(RoleConstants.TYPE_REGULAR);
@@ -189,10 +183,8 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 		String roleName = _ROLE_NAME_EXISTS;
 
 		Role role = new RoleImpl();
-		long roleId = 3333;
 
-		role.setRoleId(roleId);
-
+		role.setRoleId(3333);
 		role.setCompanyId(_COMPANY_ID);
 		role.setName(roleName);
 		role.setType(RoleConstants.TYPE_SITE);
@@ -272,10 +264,8 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 		String roleName = _ROLE_NAME_EXISTS;
 
 		Role role = new RoleImpl();
-		long roleId = 3333;
 
-		role.setRoleId(roleId);
-
+		role.setRoleId(3333);
 		role.setCompanyId(_COMPANY_ID);
 		role.setName(roleName);
 		role.setType(RoleConstants.TYPE_REGULAR);

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/test/java/com/liferay/portal/security/sso/openid/connect/internal/OpenIdConnectAddRoleToUserLoginTest.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/test/java/com/liferay/portal/security/sso/openid/connect/internal/OpenIdConnectAddRoleToUserLoginTest.java
@@ -384,30 +384,29 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 		);
 		Mockito.when(
 			_userLocalServiceMock.addUser(
-				Mockito.anyLong(), Mockito.eq(_COMPANY_ID),
-				Mockito.eq(true), Mockito.eq(null), Mockito.eq(null),
-				Mockito.eq(true), Mockito.eq(StringPool.BLANK),
-				Mockito.eq(emailAddress), Mockito.any(Locale.class),
-				Mockito.eq(emailAddress), Mockito.anyString(),
-				Mockito.anyString(), Mockito.anyLong(), Mockito.anyLong(),
-				Mockito.anyBoolean(), Mockito.anyInt(), Mockito.anyInt(),
-				Mockito.anyInt(), Mockito.anyString(), Mockito.eq(null),
-				Mockito.any(), Mockito.eq(roleIds), Mockito.eq(null),
-				Mockito.anyBoolean(), Mockito.any(ServiceContext.class))
+				Mockito.anyLong(), Mockito.eq(_COMPANY_ID), Mockito.eq(true),
+				Mockito.eq(null), Mockito.eq(null), Mockito.eq(true),
+				Mockito.eq(StringPool.BLANK), Mockito.eq(emailAddress),
+				Mockito.any(Locale.class), Mockito.eq(emailAddress),
+				Mockito.anyString(), Mockito.anyString(), Mockito.anyLong(),
+				Mockito.anyLong(), Mockito.anyBoolean(), Mockito.anyInt(),
+				Mockito.anyInt(), Mockito.anyInt(), Mockito.anyString(),
+				Mockito.eq(null), Mockito.any(), Mockito.eq(roleIds),
+				Mockito.eq(null), Mockito.anyBoolean(),
+				Mockito.any(ServiceContext.class))
 		).thenReturn(
 			user
 		);
 		Mockito.when(
 			_userLocalServiceMock.addUser(
-				Mockito.anyLong(), Mockito.eq(_COMPANY_ID),
-				Mockito.eq(true), Mockito.eq(null), Mockito.eq(null),
-				Mockito.eq(true), Mockito.eq(StringPool.BLANK),
-				Mockito.eq(emailAddress), Mockito.any(Locale.class),
-				Mockito.eq(emailAddress), Mockito.anyString(),
-				Mockito.anyString(), Mockito.anyLong(), Mockito.anyLong(),
-				Mockito.anyBoolean(), Mockito.anyInt(), Mockito.anyInt(),
-				Mockito.anyInt(), Mockito.anyString(), Mockito.eq(null),
-				Mockito.any(long[].class),
+				Mockito.anyLong(), Mockito.eq(_COMPANY_ID), Mockito.eq(true),
+				Mockito.eq(null), Mockito.eq(null), Mockito.eq(true),
+				Mockito.eq(StringPool.BLANK), Mockito.eq(emailAddress),
+				Mockito.any(Locale.class), Mockito.eq(emailAddress),
+				Mockito.anyString(), Mockito.anyString(), Mockito.anyLong(),
+				Mockito.anyLong(), Mockito.anyBoolean(), Mockito.anyInt(),
+				Mockito.anyInt(), Mockito.anyInt(), Mockito.anyString(),
+				Mockito.eq(null), Mockito.any(long[].class),
 				AdditionalMatchers.not(Mockito.eq(roleIds)),
 				Mockito.any(long[].class), Mockito.anyBoolean(),
 				Mockito.any(ServiceContext.class))

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/test/java/com/liferay/portal/security/sso/openid/connect/internal/OpenIdConnectAddRoleToUserLoginTest.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/test/java/com/liferay/portal/security/sso/openid/connect/internal/OpenIdConnectAddRoleToUserLoginTest.java
@@ -380,14 +380,6 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 		).thenReturn(
 			LocaleUtil.ENGLISH
 		);
-
-		Mockito.when(
-			_roleLocalServiceMock.fetchRole(
-				Mockito.eq(_COMPANY_ID), Mockito.eq(_ROLE_NAME_EXISTS))
-		).thenReturn(
-			role
-		);
-
 		Mockito.when(
 			_roleLocalServiceMock.fetchRole(
 				Mockito.eq(_COMPANY_ID),
@@ -395,7 +387,12 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 		).thenReturn(
 			null
 		);
-
+		Mockito.when(
+			_roleLocalServiceMock.fetchRole(
+				Mockito.eq(_COMPANY_ID), Mockito.eq(_ROLE_NAME_EXISTS))
+		).thenReturn(
+			role
+		);
 		Mockito.when(
 			_userLocalServiceMock.addUser(
 				Mockito.anyLong(), Mockito.eq(_COMPANY_ID),
@@ -428,14 +425,12 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 		).thenReturn(
 			userError
 		);
-
 		Mockito.when(
 			_userLocalServiceMock.updatePasswordReset(
 				Mockito.eq(user.getUserId()), Mockito.eq(false))
 		).thenReturn(
 			user
 		);
-
 		Mockito.when(
 			_userLocalServiceMock.updatePasswordReset(
 				Mockito.eq(userError.getUserId()), Mockito.eq(false))

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/test/java/com/liferay/portal/security/sso/openid/connect/internal/OpenIdConnectAddRoleToUserLoginTest.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/test/java/com/liferay/portal/security/sso/openid/connect/internal/OpenIdConnectAddRoleToUserLoginTest.java
@@ -15,9 +15,6 @@
 package com.liferay.portal.security.sso.openid.connect.internal;
 
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
@@ -310,7 +307,9 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 		);
 	}
 
-	private void _setUpEnvironment(Role role, long[] roleIds, User userExists) {
+	private void _setUpEnvironment(Role role, long[] roleIds, User userExists)
+		throws Exception {
+
 		_setUpLocaleUtil();
 
 		String emailAddress = "email@liferay.com";
@@ -341,26 +340,16 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 		).thenReturn(
 			emailAddress
 		);
-
-		try {
-			Mockito.when(
-				_companyLocalServiceMock.getCompany(_COMPANY_ID)
-			).thenReturn(
-				_companyMock
-			);
-		}
-		catch (PortalException portalException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(portalException);
-			}
-		}
-
+		Mockito.when(
+			_companyLocalServiceMock.getCompany(_COMPANY_ID)
+		).thenReturn(
+			_companyMock
+		);
 		Mockito.when(
 			_companyMock.isStrangers()
 		).thenReturn(
 			true
 		);
-
 		Mockito.when(
 			_companyMock.isStrangersWithMx()
 		).thenReturn(
@@ -389,19 +378,11 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 		).thenReturn(
 			userExists
 		);
-
-		try {
-			Mockito.when(
-				_companyMock.getLocale()
-			).thenReturn(
-				LocaleUtil.ENGLISH
-			);
-		}
-		catch (PortalException portalException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(portalException);
-			}
-		}
+		Mockito.when(
+			_companyMock.getLocale()
+		).thenReturn(
+			LocaleUtil.ENGLISH
+		);
 
 		Mockito.when(
 			_roleLocalServiceMock.fetchRole(
@@ -418,66 +399,52 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 			null
 		);
 
-		try {
-			Mockito.when(
-				_userLocalServiceMock.addUser(
-					Mockito.anyLong(), Mockito.eq(_COMPANY_ID),
-					Mockito.eq(true), Mockito.eq(null), Mockito.eq(null),
-					Mockito.eq(true), Mockito.eq(StringPool.BLANK),
-					Mockito.eq(emailAddress), Mockito.any(Locale.class),
-					Mockito.eq(emailAddress), Mockito.anyString(),
-					Mockito.anyString(), Mockito.anyLong(), Mockito.anyLong(),
-					Mockito.anyBoolean(), Mockito.anyInt(), Mockito.anyInt(),
-					Mockito.anyInt(), Mockito.anyString(), Mockito.eq(null),
-					Mockito.any(), Mockito.eq(roleIds), Mockito.eq(null),
-					Mockito.anyBoolean(), Mockito.any(ServiceContext.class))
-			).thenReturn(
-				user
-			);
-			Mockito.when(
-				_userLocalServiceMock.addUser(
-					Mockito.anyLong(), Mockito.eq(_COMPANY_ID),
-					Mockito.eq(true), Mockito.eq(null), Mockito.eq(null),
-					Mockito.eq(true), Mockito.eq(StringPool.BLANK),
-					Mockito.eq(emailAddress), Mockito.any(Locale.class),
-					Mockito.eq(emailAddress), Mockito.anyString(),
-					Mockito.anyString(), Mockito.anyLong(), Mockito.anyLong(),
-					Mockito.anyBoolean(), Mockito.anyInt(), Mockito.anyInt(),
-					Mockito.anyInt(), Mockito.anyString(), Mockito.eq(null),
-					Mockito.any(long[].class),
-					AdditionalMatchers.not(Mockito.eq(roleIds)),
-					Mockito.any(long[].class), Mockito.anyBoolean(),
-					Mockito.any(ServiceContext.class))
-			).thenReturn(
-				userError
-			);
-		}
-		catch (PortalException portalException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(portalException);
-			}
-		}
+		Mockito.when(
+			_userLocalServiceMock.addUser(
+				Mockito.anyLong(), Mockito.eq(_COMPANY_ID),
+				Mockito.eq(true), Mockito.eq(null), Mockito.eq(null),
+				Mockito.eq(true), Mockito.eq(StringPool.BLANK),
+				Mockito.eq(emailAddress), Mockito.any(Locale.class),
+				Mockito.eq(emailAddress), Mockito.anyString(),
+				Mockito.anyString(), Mockito.anyLong(), Mockito.anyLong(),
+				Mockito.anyBoolean(), Mockito.anyInt(), Mockito.anyInt(),
+				Mockito.anyInt(), Mockito.anyString(), Mockito.eq(null),
+				Mockito.any(), Mockito.eq(roleIds), Mockito.eq(null),
+				Mockito.anyBoolean(), Mockito.any(ServiceContext.class))
+		).thenReturn(
+			user
+		);
+		Mockito.when(
+			_userLocalServiceMock.addUser(
+				Mockito.anyLong(), Mockito.eq(_COMPANY_ID),
+				Mockito.eq(true), Mockito.eq(null), Mockito.eq(null),
+				Mockito.eq(true), Mockito.eq(StringPool.BLANK),
+				Mockito.eq(emailAddress), Mockito.any(Locale.class),
+				Mockito.eq(emailAddress), Mockito.anyString(),
+				Mockito.anyString(), Mockito.anyLong(), Mockito.anyLong(),
+				Mockito.anyBoolean(), Mockito.anyInt(), Mockito.anyInt(),
+				Mockito.anyInt(), Mockito.anyString(), Mockito.eq(null),
+				Mockito.any(long[].class),
+				AdditionalMatchers.not(Mockito.eq(roleIds)),
+				Mockito.any(long[].class), Mockito.anyBoolean(),
+				Mockito.any(ServiceContext.class))
+		).thenReturn(
+			userError
+		);
 
-		try {
-			Mockito.when(
-				_userLocalServiceMock.updatePasswordReset(
-					Mockito.eq(user.getUserId()), Mockito.eq(false))
-			).thenReturn(
-				user
-			);
+		Mockito.when(
+			_userLocalServiceMock.updatePasswordReset(
+				Mockito.eq(user.getUserId()), Mockito.eq(false))
+		).thenReturn(
+			user
+		);
 
-			Mockito.when(
-				_userLocalServiceMock.updatePasswordReset(
-					Mockito.eq(userError.getUserId()), Mockito.eq(false))
-			).thenReturn(
-				userError
-			);
-		}
-		catch (PortalException portalException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(portalException);
-			}
-		}
+		Mockito.when(
+			_userLocalServiceMock.updatePasswordReset(
+				Mockito.eq(userError.getUserId()), Mockito.eq(false))
+		).thenReturn(
+			userError
+		);
 	}
 
 	private void _setUpLocaleUtil() {
@@ -499,9 +466,6 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 	private static final long _USERERROR_ID = 0;
 
 	private static final long _USEROK_ID = 1;
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		OpenIdConnectAddRoleToUserLoginTest.class);
 
 	private static OpenIdConnectUserInfoProcessorImpl
 		_openIdConnectUserInfoProcessorImpl;

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/test/java/com/liferay/portal/security/sso/openid/connect/internal/OpenIdConnectAddRoleToUserLoginTest.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/test/java/com/liferay/portal/security/sso/openid/connect/internal/OpenIdConnectAddRoleToUserLoginTest.java
@@ -318,6 +318,21 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 		_portalURL = "http://localhost:8080";
 
 		Mockito.when(
+			_companyLocalServiceMock.getCompany(_COMPANY_ID)
+		).thenReturn(
+			_companyMock
+		);
+		Mockito.when(
+			_companyMock.isStrangers()
+		).thenReturn(
+			true
+		);
+		Mockito.when(
+			_companyMock.isStrangersWithMx()
+		).thenReturn(
+			true
+		);
+		Mockito.when(
 			_userInfo.getEmailAddress()
 		).thenReturn(
 			emailAddress
@@ -336,21 +351,6 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 			_userInfo.getMiddleName()
 		).thenReturn(
 			emailAddress
-		);
-		Mockito.when(
-			_companyLocalServiceMock.getCompany(_COMPANY_ID)
-		).thenReturn(
-			_companyMock
-		);
-		Mockito.when(
-			_companyMock.isStrangers()
-		).thenReturn(
-			true
-		);
-		Mockito.when(
-			_companyMock.isStrangersWithMx()
-		).thenReturn(
-			true
 		);
 
 		User user = new UserImpl();

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/test/java/com/liferay/portal/security/sso/openid/connect/internal/OpenIdConnectAddRoleToUserLoginTest.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/test/java/com/liferay/portal/security/sso/openid/connect/internal/OpenIdConnectAddRoleToUserLoginTest.java
@@ -1,0 +1,600 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.security.sso.openid.connect.internal;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Props;
+import com.liferay.portal.kernel.util.PropsUtil;
+import com.liferay.portal.model.impl.RoleImpl;
+import com.liferay.portal.model.impl.UserImpl;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import com.nimbusds.openid.connect.sdk.claims.UserInfo;
+
+import java.util.Locale;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.AdditionalMatchers;
+import org.mockito.Mockito;
+
+/**
+ * @author Álvaro Saugar
+ */
+public class OpenIdConnectAddRoleToUserLoginTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() throws Exception {
+		_openIdConnectUserInfoProcessorImpl =
+			new OpenIdConnectUserInfoProcessorImpl();
+
+		ReflectionTestUtil.setFieldValue(
+			_openIdConnectUserInfoProcessorImpl, "_userLocalService",
+			_userLocalServiceMock);
+
+		ReflectionTestUtil.setFieldValue(
+			_openIdConnectUserInfoProcessorImpl, "_companyLocalService",
+			_companyLocalServiceMock);
+
+		ReflectionTestUtil.setFieldValue(
+			_openIdConnectUserInfoProcessorImpl, "_props", _props);
+
+		ReflectionTestUtil.setFieldValue(
+			_openIdConnectUserInfoProcessorImpl, "_roleLocalService",
+			_roleLocalServiceMock);
+	}
+
+	@Test
+	public void testBothPropertiesDefinedAndCorrectRole() {
+		String issuer = "issuer url";
+
+		String roleName = _ROLE_NAME_EXISTS;
+
+		Role role = new RoleImpl();
+		long roleId = 3333;
+
+		role.setRoleId(roleId);
+
+		role.setName(roleName);
+		role.setType(RoleConstants.TYPE_REGULAR);
+
+		long[] roleIds = {role.getRoleId()};
+
+		_setUpEnvironment(role, roleIds, null);
+
+		setUpPropsUtil(issuer, roleName);
+
+		long userId = _USERERROR_ID;
+
+		try {
+			userId = _openIdConnectUserInfoProcessorImpl.processUserInfo(
+				_userInfo, _COMPANY_ID, issuer, _mainPath, _portalURL);
+
+			Assert.assertEquals(userId, _USEROK_ID);
+		}
+		catch (PortalException portalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(portalException);
+			}
+		}
+	}
+
+	@Test
+	public void testBothPropertiesDefinedAndFakeRole() {
+		String issuer = "issuer url";
+		String roleName = "Fake Role";
+
+		Role role = null;
+
+		long[] roleIds = null;
+
+		_setUpEnvironment(role, roleIds, null);
+
+		setUpPropsUtil(issuer, roleName);
+
+		long userId = _USERERROR_ID;
+
+		try {
+			userId = _openIdConnectUserInfoProcessorImpl.processUserInfo(
+				_userInfo, _COMPANY_ID, issuer, _mainPath, _portalURL);
+
+			Assert.assertEquals(userId, _USEROK_ID);
+		}
+		catch (PortalException portalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(portalException);
+			}
+		}
+	}
+
+	@Test
+	public void testBothPropertiesDefinedAndRoleCorrectAndUserAlreadyExists() {
+		String issuer = "issuer url";
+		String roleName = "Power User";
+
+		Role role = new RoleImpl();
+		long roleId = 3333;
+
+		role.setRoleId(roleId);
+
+		role.setCompanyId(_COMPANY_ID);
+		role.setName(roleName);
+		role.setType(RoleConstants.TYPE_REGULAR);
+
+		long[] roleIds = {role.getRoleId()};
+
+		User userExists = new UserImpl();
+
+		userExists.setUserId(_USEROK_ID);
+		userExists.setDigest("digest");
+		userExists.setScreenName(StringPool.BLANK);
+		userExists.setEmailAddress(StringPool.BLANK);
+
+		_setUpEnvironment(role, roleIds, userExists);
+
+		setUpPropsUtil(issuer, roleName);
+
+		long userId = _USERERROR_ID;
+
+		try {
+			userId = _openIdConnectUserInfoProcessorImpl.processUserInfo(
+				_userInfo, _COMPANY_ID, issuer, _mainPath, _portalURL);
+
+			Assert.assertEquals(userId, _USEROK_ID);
+		}
+		catch (PortalException portalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(portalException);
+			}
+		}
+	}
+
+	@Test
+	public void testBothPropertiesDefinedAndRoleExistsButDifferentIssuers() {
+		String issuer = "issuer url";
+		String roleName = _ROLE_NAME_EXISTS;
+
+		Role role = new RoleImpl();
+		long roleId = 3333;
+
+		role.setRoleId(roleId);
+
+		role.setCompanyId(_COMPANY_ID);
+		role.setName(roleName);
+		role.setType(RoleConstants.TYPE_REGULAR);
+
+		long[] roleIds = null;
+		String issuerProvider = "issuer Provicer";
+
+		_setUpEnvironment(role, roleIds, null);
+		setUpPropsUtil(issuer, roleName);
+
+		long userId = _USERERROR_ID;
+
+		try {
+			userId = _openIdConnectUserInfoProcessorImpl.processUserInfo(
+				_userInfo, _COMPANY_ID, issuerProvider, _mainPath, _portalURL);
+
+			Assert.assertEquals(userId, _USEROK_ID);
+		}
+		catch (PortalException portalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(portalException);
+			}
+		}
+	}
+
+	@Test
+	public void testBothPropertiesDefinedAndRoleNotRegularType() {
+		String issuer = "issuer url";
+		String roleName = _ROLE_NAME_EXISTS;
+
+		Role role = new RoleImpl();
+		long roleId = 3333;
+
+		role.setRoleId(roleId);
+
+		role.setCompanyId(_COMPANY_ID);
+		role.setName(roleName);
+		role.setType(RoleConstants.TYPE_SITE);
+
+		long[] roleIds = null;
+
+		_setUpEnvironment(role, roleIds, null);
+
+		setUpPropsUtil(issuer, roleName);
+
+		long userId = _USERERROR_ID;
+
+		try {
+			userId = _openIdConnectUserInfoProcessorImpl.processUserInfo(
+				_userInfo, _COMPANY_ID, issuer, _mainPath, _portalURL);
+
+			Assert.assertEquals(userId, _USEROK_ID);
+		}
+		catch (PortalException portalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(portalException);
+			}
+		}
+	}
+
+	@Test
+	public void testBothPropertiesDefinedButRoleNameWrong1() {
+		String issuer = "issuer url";
+		String roleName = "Power User=Publications Owner";
+
+		Role role = null;
+
+		long[] roleIds = null;
+
+		_setUpEnvironment(role, roleIds, null);
+
+		setUpPropsUtil(issuer, roleName);
+
+		long userId = _USERERROR_ID;
+
+		try {
+			userId = _openIdConnectUserInfoProcessorImpl.processUserInfo(
+				_userInfo, _COMPANY_ID, issuer, _mainPath, _portalURL);
+
+			Assert.assertEquals(userId, _USEROK_ID);
+		}
+		catch (PortalException portalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(portalException);
+			}
+		}
+	}
+
+	@Test
+	public void testBothPropertiesDefinedButRoleNameWrong2() {
+		String issuer = "issuer url";
+		String roleName = "Power%20User";
+
+		Role role = null;
+
+		long[] roleIds = null;
+
+		_setUpEnvironment(role, roleIds, null);
+
+		setUpPropsUtil(issuer, roleName);
+
+		long userId = _USERERROR_ID;
+
+		try {
+			userId = _openIdConnectUserInfoProcessorImpl.processUserInfo(
+				_userInfo, _COMPANY_ID, issuer, _mainPath, _portalURL);
+
+			Assert.assertEquals(userId, _USEROK_ID);
+		}
+		catch (PortalException portalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(portalException);
+			}
+		}
+	}
+
+	@Test
+	public void testIssuerPropertyDefinedSoRoleNotExists() {
+		String issuer = "issuer url";
+		String roleName = null;
+
+		Role role = null;
+
+		long[] roleIds = null;
+
+		_setUpEnvironment(role, roleIds, null);
+
+		setUpPropsUtil(issuer, roleName);
+
+		long userId = _USERERROR_ID;
+
+		try {
+			userId = _openIdConnectUserInfoProcessorImpl.processUserInfo(
+				_userInfo, _COMPANY_ID, issuer, _mainPath, _portalURL);
+
+			Assert.assertEquals(userId, _USEROK_ID);
+		}
+		catch (PortalException portalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(portalException);
+			}
+		}
+	}
+
+	@Test
+	public void testRoleNamePropertyDefinedAndRoleExists() {
+		String issuer = null;
+		String roleName = _ROLE_NAME_EXISTS;
+
+		Role role = new RoleImpl();
+		long roleId = 3333;
+
+		role.setRoleId(roleId);
+
+		role.setCompanyId(_COMPANY_ID);
+		role.setName(roleName);
+		role.setType(RoleConstants.TYPE_REGULAR);
+
+		long[] roleIds = null;
+		String issuerProvider = "issuer Provicer";
+
+		_setUpEnvironment(role, roleIds, null);
+		setUpPropsUtil(issuer, roleName);
+
+		long userId = _USERERROR_ID;
+
+		try {
+			userId = _openIdConnectUserInfoProcessorImpl.processUserInfo(
+				_userInfo, _COMPANY_ID, issuerProvider, _mainPath, _portalURL);
+
+			Assert.assertEquals(userId, _USEROK_ID);
+		}
+		catch (PortalException portalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(portalException);
+			}
+		}
+	}
+
+	protected void setUpPropsUtil(String issuer, String roleName) {
+		PropsUtil.setProps(_props);
+
+		Mockito.when(
+			_props.get("open.id.connect.user.info.processor.impl.issuer")
+		).thenReturn(
+			issuer
+		);
+
+		Mockito.when(
+			_props.get("open.id.connect.user.info.processor.impl.regular.role")
+		).thenReturn(
+			roleName
+		);
+	}
+
+	private void _setUpEnvironment(Role role, long[] roleIds, User userExists) {
+		_setUpLocaleUtil();
+
+		String emailAddress = "email@liferay.com";
+
+		_mainPath = "/c";
+		_portalURL = "http://localhost:8080";
+
+		Mockito.when(
+			_userInfo.getEmailAddress()
+		).thenReturn(
+			emailAddress
+		);
+
+		Mockito.when(
+			_userInfo.getGivenName()
+		).thenReturn(
+			emailAddress
+		);
+
+		Mockito.when(
+			_userInfo.getFamilyName()
+		).thenReturn(
+			emailAddress
+		);
+
+		Mockito.when(
+			_userInfo.getMiddleName()
+		).thenReturn(
+			emailAddress
+		);
+
+		try {
+			Mockito.when(
+				_companyLocalServiceMock.getCompany(_COMPANY_ID)
+			).thenReturn(
+				_companyMock
+			);
+		}
+		catch (PortalException portalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(portalException);
+			}
+		}
+
+		Mockito.when(
+			_companyMock.isStrangers()
+		).thenReturn(
+			true
+		);
+
+		Mockito.when(
+			_companyMock.isStrangersWithMx()
+		).thenReturn(
+			true
+		);
+
+		User user = new UserImpl();
+
+		user.setUserId(_USEROK_ID);
+		user.setDigest("digest");
+		user.setScreenName(StringPool.BLANK);
+		user.setEmailAddress(emailAddress);
+		user.setLanguageId("en");
+
+		User userError = new UserImpl();
+
+		userError.setUserId(_USERERROR_ID);
+		userError.setDigest("digest");
+		userError.setScreenName(StringPool.BLANK);
+		userError.setEmailAddress(emailAddress);
+		userError.setLanguageId("en");
+
+		Mockito.when(
+			_userLocalServiceMock.fetchUserByEmailAddress(
+				_COMPANY_ID, emailAddress)
+		).thenReturn(
+			userExists
+		);
+
+		try {
+			Mockito.when(
+				_companyMock.getLocale()
+			).thenReturn(
+				LocaleUtil.ENGLISH
+			);
+		}
+		catch (PortalException portalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(portalException);
+			}
+		}
+
+		Mockito.when(
+			_roleLocalServiceMock.fetchRole(
+				Mockito.eq(_COMPANY_ID), Mockito.eq(_ROLE_NAME_EXISTS))
+		).thenReturn(
+			role
+		);
+
+		Mockito.when(
+			_roleLocalServiceMock.fetchRole(
+				Mockito.eq(_COMPANY_ID),
+				AdditionalMatchers.not(Mockito.eq(_ROLE_NAME_EXISTS)))
+		).thenReturn(
+			null
+		);
+
+		try {
+			Mockito.when(
+				_userLocalServiceMock.addUser(
+					Mockito.anyLong(), Mockito.eq(_COMPANY_ID),
+					Mockito.eq(true), Mockito.eq(null), Mockito.eq(null),
+					Mockito.eq(true), Mockito.eq(StringPool.BLANK),
+					Mockito.eq(emailAddress), Mockito.any(Locale.class),
+					Mockito.eq(emailAddress), Mockito.anyString(),
+					Mockito.anyString(), Mockito.anyLong(), Mockito.anyLong(),
+					Mockito.anyBoolean(), Mockito.anyInt(), Mockito.anyInt(),
+					Mockito.anyInt(), Mockito.anyString(), Mockito.eq(null),
+					Mockito.any(), Mockito.eq(roleIds), Mockito.eq(null),
+					Mockito.anyBoolean(), Mockito.any(ServiceContext.class))
+			).thenReturn(
+				user
+			);
+			Mockito.when(
+				_userLocalServiceMock.addUser(
+					Mockito.anyLong(), Mockito.eq(_COMPANY_ID),
+					Mockito.eq(true), Mockito.eq(null), Mockito.eq(null),
+					Mockito.eq(true), Mockito.eq(StringPool.BLANK),
+					Mockito.eq(emailAddress), Mockito.any(Locale.class),
+					Mockito.eq(emailAddress), Mockito.anyString(),
+					Mockito.anyString(), Mockito.anyLong(), Mockito.anyLong(),
+					Mockito.anyBoolean(), Mockito.anyInt(), Mockito.anyInt(),
+					Mockito.anyInt(), Mockito.anyString(), Mockito.eq(null),
+					Mockito.any(long[].class),
+					AdditionalMatchers.not(Mockito.eq(roleIds)),
+					Mockito.any(long[].class), Mockito.anyBoolean(),
+					Mockito.any(ServiceContext.class))
+			).thenReturn(
+				userError
+			);
+		}
+		catch (PortalException portalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(portalException);
+			}
+		}
+
+		try {
+			Mockito.when(
+				_userLocalServiceMock.updatePasswordReset(
+					Mockito.eq(user.getUserId()), Mockito.eq(false))
+			).thenReturn(
+				user
+			);
+
+			Mockito.when(
+				_userLocalServiceMock.updatePasswordReset(
+					Mockito.eq(userError.getUserId()), Mockito.eq(false))
+			).thenReturn(
+				userError
+			);
+		}
+		catch (PortalException portalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(portalException);
+			}
+		}
+	}
+
+	private void _setUpLocaleUtil() {
+		LocaleUtil localeUtil = ReflectionTestUtil.getFieldValue(
+			LocaleUtil.class, "_localeUtil");
+
+		Map<String, Locale> locales = ReflectionTestUtil.getFieldValue(
+			localeUtil, "_locales");
+
+		locales.clear();
+
+		locales.put("en", LocaleUtil.ENGLISH);
+	}
+
+	private static final long _COMPANY_ID = 444444;
+
+	private static final String _ROLE_NAME_EXISTS = "Role exist";
+
+	private static final long _USERERROR_ID = 0;
+
+	private static final long _USEROK_ID = 1;
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		OpenIdConnectAddRoleToUserLoginTest.class);
+
+	private static OpenIdConnectUserInfoProcessorImpl
+		_openIdConnectUserInfoProcessorImpl;
+
+	private final CompanyLocalService _companyLocalServiceMock = Mockito.mock(
+		CompanyLocalService.class);
+	private final Company _companyMock = Mockito.mock(Company.class);
+	private String _mainPath;
+	private String _portalURL;
+	private final Props _props = Mockito.mock(Props.class);
+	private final RoleLocalService _roleLocalServiceMock = Mockito.mock(
+		RoleLocalService.class);
+	private final UserInfo _userInfo = Mockito.mock(UserInfo.class);
+	private final UserLocalService _userLocalServiceMock = Mockito.mock(
+		UserLocalService.class);
+
+}

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/test/java/com/liferay/portal/security/sso/openid/connect/internal/OpenIdConnectAddRoleToUserLoginTest.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/test/java/com/liferay/portal/security/sso/openid/connect/internal/OpenIdConnectAddRoleToUserLoginTest.java
@@ -164,7 +164,7 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 		role.setType(RoleConstants.TYPE_REGULAR);
 
 		long[] roleIds = null;
-		String issuerProvider = "issuer Provider";
+		String issuerProvider = RandomTestUtil.randomString();
 
 		_setUpEnvironment(role, roleIds, null);
 		setUpPropsUtil(issuer, roleName);
@@ -272,7 +272,7 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 		role.setType(RoleConstants.TYPE_REGULAR);
 
 		long[] roleIds = null;
-		String issuerProvider = "issuer Provider";
+		String issuerProvider = RandomTestUtil.randomString();
 
 		_setUpEnvironment(role, roleIds, null);
 		setUpPropsUtil(issuer, roleName);
@@ -345,8 +345,10 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 
 		User user = new UserImpl();
 
+		String digest = RandomTestUtil.randomString();
+
 		user.setUserId(_CORRECT_USER_ID);
-		user.setDigest("digest");
+		user.setDigest(digest);
 		user.setScreenName(StringPool.BLANK);
 		user.setEmailAddress(emailAddress);
 		user.setLanguageId("en");
@@ -354,7 +356,7 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 		User userError = new UserImpl();
 
 		userError.setUserId(_INCORRECT_USER_ID);
-		userError.setDigest("digest");
+		userError.setDigest(digest);
 		userError.setScreenName(StringPool.BLANK);
 		userError.setEmailAddress(emailAddress);
 		userError.setLanguageId("en");
@@ -440,9 +442,9 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 		locales.put("en", LocaleUtil.ENGLISH);
 	}
 
-	private static final long _COMPANY_ID = 444444;
+	private static final long _COMPANY_ID = RandomTestUtil.randomLong();
 
-	private static final String _CORRECT_ROLE_NAME = "Role exist";
+	private static final String _CORRECT_ROLE_NAME = RandomTestUtil.randomString();
 
 	private static final long _CORRECT_USER_ID = 1;
 
@@ -450,7 +452,7 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 
 	private static final String _MAIN_PATH = "/c";
 
-	private static final String _PORTAL_URL = "http://localhost:8080";
+	private static final String _PORTAL_URL = RandomTestUtil.randomString();
 
 	private static OpenIdConnectUserInfoProcessorImpl
 		_openIdConnectUserInfoProcessorImpl;

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/test/java/com/liferay/portal/security/sso/openid/connect/internal/OpenIdConnectAddRoleToUserLoginTest.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/test/java/com/liferay/portal/security/sso/openid/connect/internal/OpenIdConnectAddRoleToUserLoginTest.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Props;
 import com.liferay.portal.kernel.util.PropsUtil;
@@ -75,8 +76,8 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 
 	@Test
 	public void testBothPropertiesDefinedAndCorrectRole() throws Exception {
-		String issuer = "issuer url";
-		String roleName = _ROLE_NAME_EXISTS;
+		String issuer = RandomTestUtil.randomString();
+		String roleName = _CORRECT_ROLE_NAME;
 
 		Role role = new RoleImpl();
 
@@ -91,14 +92,14 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 		setUpPropsUtil(issuer, roleName);
 
 		Assert.assertEquals(
-			_USEROK_ID,
+			_CORRECT_USER_ID,
 			_openIdConnectUserInfoProcessorImpl.processUserInfo(
 				_userInfo, _COMPANY_ID, issuer, _MAIN_PATH, _PORTAL_URL));
 	}
 
 	@Test
 	public void testBothPropertiesDefinedAndFakeRole() throws Exception {
-		String issuer = "issuer url";
+		String issuer = RandomTestUtil.randomString();
 		String roleName = "Fake Role";
 
 		Role role = null;
@@ -110,7 +111,7 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 		setUpPropsUtil(issuer, roleName);
 
 		Assert.assertEquals(
-			_USEROK_ID,
+			_CORRECT_USER_ID,
 			_openIdConnectUserInfoProcessorImpl.processUserInfo(
 				_userInfo, _COMPANY_ID, issuer, _MAIN_PATH, _PORTAL_URL));
 	}
@@ -119,7 +120,7 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 	public void testBothPropertiesDefinedAndRoleCorrectAndUserAlreadyExists()
 		throws Exception {
 
-		String issuer = "issuer url";
+		String issuer = RandomTestUtil.randomString();
 		String roleName = "Power User";
 
 		Role role = new RoleImpl();
@@ -133,7 +134,7 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 
 		User userExists = new UserImpl();
 
-		userExists.setUserId(_USEROK_ID);
+		userExists.setUserId(_CORRECT_USER_ID);
 		userExists.setDigest("digest");
 		userExists.setScreenName(StringPool.BLANK);
 		userExists.setEmailAddress(StringPool.BLANK);
@@ -143,7 +144,7 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 		setUpPropsUtil(issuer, roleName);
 
 		Assert.assertEquals(
-			_USEROK_ID,
+			_CORRECT_USER_ID,
 			_openIdConnectUserInfoProcessorImpl.processUserInfo(
 				_userInfo, _COMPANY_ID, issuer, _MAIN_PATH, _PORTAL_URL));
 	}
@@ -152,8 +153,8 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 	public void testBothPropertiesDefinedAndRoleExistsButDifferentIssuers()
 		throws Exception {
 
-		String issuer = "issuer url";
-		String roleName = _ROLE_NAME_EXISTS;
+		String issuer = RandomTestUtil.randomString();
+		String roleName = _CORRECT_ROLE_NAME;
 
 		Role role = new RoleImpl();
 
@@ -169,7 +170,7 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 		setUpPropsUtil(issuer, roleName);
 
 		Assert.assertEquals(
-			_USEROK_ID,
+			_CORRECT_USER_ID,
 			_openIdConnectUserInfoProcessorImpl.processUserInfo(
 				_userInfo, _COMPANY_ID, issuerProvider, _MAIN_PATH,
 				_PORTAL_URL));
@@ -179,8 +180,8 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 	public void testBothPropertiesDefinedAndRoleNotRegularType()
 		throws Exception {
 
-		String issuer = "issuer url";
-		String roleName = _ROLE_NAME_EXISTS;
+		String issuer = RandomTestUtil.randomString();
+		String roleName = _CORRECT_ROLE_NAME;
 
 		Role role = new RoleImpl();
 
@@ -196,14 +197,14 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 		setUpPropsUtil(issuer, roleName);
 
 		Assert.assertEquals(
-			_USEROK_ID,
+			_CORRECT_USER_ID,
 			_openIdConnectUserInfoProcessorImpl.processUserInfo(
 				_userInfo, _COMPANY_ID, issuer, _MAIN_PATH, _PORTAL_URL));
 	}
 
 	@Test
 	public void testBothPropertiesDefinedButRoleNameWrong1() throws Exception {
-		String issuer = "issuer url";
+		String issuer = RandomTestUtil.randomString();
 		String roleName = "Power User=Publications Owner";
 
 		Role role = null;
@@ -215,14 +216,14 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 		setUpPropsUtil(issuer, roleName);
 
 		Assert.assertEquals(
-			_USEROK_ID,
+			_CORRECT_USER_ID,
 			_openIdConnectUserInfoProcessorImpl.processUserInfo(
 				_userInfo, _COMPANY_ID, issuer, _MAIN_PATH, _PORTAL_URL));
 	}
 
 	@Test
 	public void testBothPropertiesDefinedButRoleNameWrong2() throws Exception {
-		String issuer = "issuer url";
+		String issuer = RandomTestUtil.randomString();
 		String roleName = "Power%20User";
 
 		Role role = null;
@@ -234,14 +235,14 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 		setUpPropsUtil(issuer, roleName);
 
 		Assert.assertEquals(
-			_USEROK_ID,
+			_CORRECT_USER_ID,
 			_openIdConnectUserInfoProcessorImpl.processUserInfo(
 				_userInfo, _COMPANY_ID, issuer, _MAIN_PATH, _PORTAL_URL));
 	}
 
 	@Test
 	public void testIssuerPropertyDefinedSoRoleNotExists() throws Exception {
-		String issuer = "issuer url";
+		String issuer = RandomTestUtil.randomString();
 		String roleName = null;
 
 		Role role = null;
@@ -253,7 +254,7 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 		setUpPropsUtil(issuer, roleName);
 
 		Assert.assertEquals(
-			_USEROK_ID,
+			_CORRECT_USER_ID,
 			_openIdConnectUserInfoProcessorImpl.processUserInfo(
 				_userInfo, _COMPANY_ID, issuer, _MAIN_PATH, _PORTAL_URL));
 	}
@@ -261,7 +262,7 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 	@Test
 	public void testRoleNamePropertyDefinedAndRoleExists() throws Exception {
 		String issuer = null;
-		String roleName = _ROLE_NAME_EXISTS;
+		String roleName = _CORRECT_ROLE_NAME;
 
 		Role role = new RoleImpl();
 
@@ -277,7 +278,7 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 		setUpPropsUtil(issuer, roleName);
 
 		Assert.assertEquals(
-			_USEROK_ID,
+			_CORRECT_USER_ID,
 			_openIdConnectUserInfoProcessorImpl.processUserInfo(
 				_userInfo, _COMPANY_ID, issuerProvider, _MAIN_PATH,
 				_PORTAL_URL));
@@ -344,7 +345,7 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 
 		User user = new UserImpl();
 
-		user.setUserId(_USEROK_ID);
+		user.setUserId(_CORRECT_USER_ID);
 		user.setDigest("digest");
 		user.setScreenName(StringPool.BLANK);
 		user.setEmailAddress(emailAddress);
@@ -352,7 +353,7 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 
 		User userError = new UserImpl();
 
-		userError.setUserId(_USERERROR_ID);
+		userError.setUserId(_INCORRECT_USER_ID);
 		userError.setDigest("digest");
 		userError.setScreenName(StringPool.BLANK);
 		userError.setEmailAddress(emailAddress);
@@ -372,13 +373,13 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 		Mockito.when(
 			_roleLocalServiceMock.fetchRole(
 				Mockito.eq(_COMPANY_ID),
-				AdditionalMatchers.not(Mockito.eq(_ROLE_NAME_EXISTS)))
+				AdditionalMatchers.not(Mockito.eq(_CORRECT_ROLE_NAME)))
 		).thenReturn(
 			null
 		);
 		Mockito.when(
 			_roleLocalServiceMock.fetchRole(
-				Mockito.eq(_COMPANY_ID), Mockito.eq(_ROLE_NAME_EXISTS))
+				Mockito.eq(_COMPANY_ID), Mockito.eq(_CORRECT_ROLE_NAME))
 		).thenReturn(
 			role
 		);
@@ -441,15 +442,15 @@ public class OpenIdConnectAddRoleToUserLoginTest {
 
 	private static final long _COMPANY_ID = 444444;
 
+	private static final String _CORRECT_ROLE_NAME = "Role exist";
+
+	private static final long _CORRECT_USER_ID = 1;
+
+	private static final long _INCORRECT_USER_ID = 0;
+
 	private static final String _MAIN_PATH = "/c";
 
 	private static final String _PORTAL_URL = "http://localhost:8080";
-
-	private static final String _ROLE_NAME_EXISTS = "Role exist";
-
-	private static final long _USERERROR_ID = 0;
-
-	private static final long _USEROK_ID = 1;
 
 	private static OpenIdConnectUserInfoProcessorImpl
 		_openIdConnectUserInfoProcessorImpl;


### PR DESCRIPTION
**NOTE**: This is a temporal solution to test this subtask while the Story is defined and solved.

[LPS-154744](https://issues.liferay.com/browse/LPS-154744)

Test cases made:

- Happy path - testBothPropertiesDefinedAndCorrectRole

- Test cases defined in [LPS-156733](https://issues.liferay.com/browse/LPS-156733)

  - TC1: testIssuerPropertyDefinedSoRoleNotExists
  - TC2: testBothPropertiesDefinedAndFakeRole
  - TC3: testBothPropertiesDefinedAndRoleNotRegularType
  - TC4: testBothPropertiesDefinedAndRoleCorrectAndUserAlreadyExists
  - TC5: testBothPropertiesDefinedButRoleNameWrong1
  - TC6: testBothPropertiesDefinedButRoleNameWrong2

- Changing the issuer:

  - Issuer defined in property is different that the request - testBothPropertiesDefinedAndRoleExistsButDifferentIssuers
  - the issuer property is blank - testRoleNamePropertyDefinedAndRoleExists