### PR TITLE
LPS-159174 Fix creating more than one virtual instance with same ClientExtensionEntry

### DIFF
--- a/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/type/deployer/CETDeployerImpl.java
+++ b/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/type/deployer/CETDeployerImpl.java
@@ -15,7 +15,6 @@
 package com.liferay.client.extension.web.internal.type.deployer;
 
 import com.liferay.client.extension.constants.ClientExtensionEntryConstants;
-import com.liferay.client.extension.model.ClientExtensionEntry;
 import com.liferay.client.extension.type.CET;
 import com.liferay.client.extension.type.CustomElementCET;
 import com.liferay.client.extension.type.IFrameCET;
@@ -118,13 +117,14 @@ public class CETDeployerImpl implements CETDeployer {
 	}
 
 	private String _getPortletId(CET cet) {
-		ClientExtensionEntry clientExtensionEntry =
-			cet.getClientExtensionEntry();
+		String externalReferenceCode = cet.getExternalReferenceCode();
 
 		return StringBundler.concat(
 			"com_liferay_client_extension_web_internal_portlet_",
 			"ClientExtensionEntryPortlet_",
-			clientExtensionEntry.getClientExtensionEntryId());
+			externalReferenceCode.replaceAll(
+				"[^a-zA-Z0-9_]", StringPool.UNDERLINE),
+			StringPool.UNDERLINE, cet.getCompanyId());
 	}
 
 	private ServiceRegistration<ConfigurationAction>

--- a/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/type/deployer/CETDeployerImpl.java
+++ b/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/type/deployer/CETDeployerImpl.java
@@ -15,6 +15,7 @@
 package com.liferay.client.extension.web.internal.type.deployer;
 
 import com.liferay.client.extension.constants.ClientExtensionEntryConstants;
+import com.liferay.client.extension.model.ClientExtensionEntry;
 import com.liferay.client.extension.type.CET;
 import com.liferay.client.extension.type.CustomElementCET;
 import com.liferay.client.extension.type.IFrameCET;
@@ -117,13 +118,13 @@ public class CETDeployerImpl implements CETDeployer {
 	}
 
 	private String _getPortletId(CET cet) {
-		String externalReferenceCode = cet.getExternalReferenceCode();
+		ClientExtensionEntry clientExtensionEntry =
+			cet.getClientExtensionEntry();
 
 		return StringBundler.concat(
 			"com_liferay_client_extension_web_internal_portlet_",
 			"ClientExtensionEntryPortlet_",
-			externalReferenceCode.replaceAll(
-				"[^a-zA-Z0-9_]", StringPool.UNDERLINE));
+			clientExtensionEntry.getClientExtensionEntryId());
 	}
 
 	private ServiceRegistration<ConfigurationAction>

--- a/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/upgrade/registry/ClientExtensionWebUpgradeStepRegistrator.java
+++ b/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/upgrade/registry/ClientExtensionWebUpgradeStepRegistrator.java
@@ -14,20 +14,9 @@
 
 package com.liferay.client.extension.web.internal.upgrade.registry;
 
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Release;
-import com.liferay.portal.kernel.upgrade.BasePortletIdUpgradeProcess;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
-import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
-
-import java.sql.Connection;
-import java.sql.ResultSet;
-import java.sql.Statement;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -44,17 +33,8 @@ public class ClientExtensionWebUpgradeStepRegistrator
 	public void register(Registry registry) {
 		registry.register(
 			"0.0.0", "1.0.0",
-			new BasePortletIdUpgradeProcess() {
-
-				@Override
-				protected String[][] getRenamePortletIdsArray() {
-					return _getRenamePortletIdsArray(
-						connection, "remote_app_",
-						"com_liferay_remote_app_web_internal_portlet_" +
-							"RemoteAppEntryPortlet_");
-				}
-
-			});
+			new com.liferay.client.extension.web.internal.upgrade.v1_0_0.
+				UpgradePortletId());
 
 		registry.register(
 			"1.0.0", "2.0.0",
@@ -68,60 +48,9 @@ public class ClientExtensionWebUpgradeStepRegistrator
 				}
 
 			},
-			new BasePortletIdUpgradeProcess() {
-
-				@Override
-				protected String[][] getRenamePortletIdsArray() {
-					return ArrayUtil.append(
-						new String[][] {
-							{
-								"com_liferay_remote_app_admin_web_portlet_" +
-									"RemoteAppAdminPortlet",
-								"com_liferay_client_extension_web_internal_" +
-									"portlet_ClientExtensionAdminPortlet"
-							}
-						},
-						_getRenamePortletIdsArray(
-							connection,
-							"com_liferay_remote_app_web_internal_portlet_" +
-								"RemoteAppEntryPortlet_",
-							"com_liferay_client_extension_web_internal_" +
-								"portlet_ClientExtensionEntryPortlet_"));
-				}
-
-			});
+			new com.liferay.client.extension.web.internal.upgrade.v2_0_0.
+				UpgradePortletId());
 	}
-
-	private String[][] _getRenamePortletIdsArray(
-		Connection connection, String oldPortletIdPrefix,
-		String newPortletIdPrefix) {
-
-		List<String[]> portletIds = new ArrayList<>();
-
-		try (Statement statement = connection.createStatement();
-			ResultSet resultSet = statement.executeQuery(
-				"select clientExtensionEntryId from ClientExtensionEntry ")) {
-
-			while (resultSet.next()) {
-				long clientExtensionEntryId = resultSet.getLong(
-					"clientExtensionEntryId");
-
-				portletIds.add(
-					new String[] {
-						oldPortletIdPrefix + clientExtensionEntryId,
-						newPortletIdPrefix + clientExtensionEntryId
-					});
-			}
-		}
-		catch (Exception exception) {
-			_log.error(exception);
-		}
-
-		return portletIds.toArray(new String[0][0]);
-	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		ClientExtensionWebUpgradeStepRegistrator.class);
 
 	@Reference(
 		target = "(&(release.bundle.symbolic.name=com.liferay.client.extension.service)(release.schema.version>=3.0.0))"

--- a/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/upgrade/registry/ClientExtensionWebUpgradeStepRegistrator.java
+++ b/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/upgrade/registry/ClientExtensionWebUpgradeStepRegistrator.java
@@ -50,6 +50,11 @@ public class ClientExtensionWebUpgradeStepRegistrator
 			},
 			new com.liferay.client.extension.web.internal.upgrade.v2_0_0.
 				UpgradePortletId());
+
+		registry.register(
+			"2.0.0", "3.0.0",
+			new com.liferay.client.extension.web.internal.upgrade.v3_0_0.
+				UpgradePortletId());
 	}
 
 	@Reference(

--- a/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/upgrade/v1_0_0/UpgradePortletId.java
+++ b/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/upgrade/v1_0_0/UpgradePortletId.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.client.extension.web.internal.upgrade.v1_0_0;
+
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.upgrade.BasePortletIdUpgradeProcess;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Brian Wing Shun Chan
+ */
+public class UpgradePortletId extends BasePortletIdUpgradeProcess {
+
+	@Override
+	protected String[][] getRenamePortletIdsArray() {
+		return getRenamePortletIdsArray(
+			connection, "remote_app_",
+			"com_liferay_remote_app_web_internal_portlet_" +
+				"RemoteAppEntryPortlet_");
+	}
+
+	protected String[][] getRenamePortletIdsArray(
+		Connection connection, String oldPortletIdPrefix,
+		String newPortletIdPrefix) {
+
+		List<String[]> portletIds = new ArrayList<>();
+
+		try (Statement statement = connection.createStatement();
+			ResultSet resultSet = statement.executeQuery(
+				"select clientExtensionEntryId from ClientExtensionEntry ")) {
+
+			while (resultSet.next()) {
+				long clientExtensionEntryId = resultSet.getLong(
+					"clientExtensionEntryId");
+
+				portletIds.add(
+					new String[] {
+						oldPortletIdPrefix + clientExtensionEntryId,
+						newPortletIdPrefix + clientExtensionEntryId
+					});
+			}
+		}
+		catch (Exception exception) {
+			_log.error(exception);
+		}
+
+		return portletIds.toArray(new String[0][0]);
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		UpgradePortletId.class);
+
+}

--- a/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/upgrade/v1_0_0/UpgradePortletId.java
+++ b/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/upgrade/v1_0_0/UpgradePortletId.java
@@ -46,7 +46,7 @@ public class UpgradePortletId extends BasePortletIdUpgradeProcess {
 
 		try (Statement statement = connection.createStatement();
 			ResultSet resultSet = statement.executeQuery(
-				"select clientExtensionEntryId from ClientExtensionEntry ")) {
+				"select clientExtensionEntryId from ClientExtensionEntry")) {
 
 			while (resultSet.next()) {
 				long clientExtensionEntryId = resultSet.getLong(

--- a/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/upgrade/v2_0_0/UpgradePortletId.java
+++ b/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/upgrade/v2_0_0/UpgradePortletId.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.client.extension.web.internal.upgrade.v2_0_0;
+
+import com.liferay.portal.kernel.util.ArrayUtil;
+
+/**
+ * @author Brian Wing Shun Chan
+ */
+public class UpgradePortletId
+	extends com.liferay.client.extension.web.internal.upgrade.v1_0_0.
+				UpgradePortletId {
+
+	@Override
+	protected String[][] getRenamePortletIdsArray() {
+		return ArrayUtil.append(
+			new String[][] {
+				{
+					"com_liferay_remote_app_admin_web_portlet_" +
+						"RemoteAppAdminPortlet",
+					"com_liferay_client_extension_web_internal_" +
+						"portlet_ClientExtensionAdminPortlet"
+				}
+			},
+			getRenamePortletIdsArray(
+				connection,
+				"com_liferay_remote_app_web_internal_portlet_" +
+					"RemoteAppEntryPortlet_",
+				"com_liferay_client_extension_web_internal_" +
+					"portlet_ClientExtensionEntryPortlet_"));
+	}
+
+}

--- a/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/upgrade/v3_0_0/UpgradePortletId.java
+++ b/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/upgrade/v3_0_0/UpgradePortletId.java
@@ -79,18 +79,18 @@ public class UpgradePortletId extends BasePortletIdUpgradeProcess {
 
 		try (Statement statement = connection.createStatement();
 			ResultSet resultSet = statement.executeQuery(
-				"select externalReferenceCode, clientExtensionEntryId from " +
+				"select clientExtensionEntryId, companyId from " +
 					"ClientExtensionEntry")) {
 
 			while (resultSet.next()) {
-				String externalReferenceCode = resultSet.getString(
-					"externalReferenceCode");
 				long clientExtensionEntryId = resultSet.getLong(
 					"clientExtensionEntryId");
+				long companyId = resultSet.getLong(
+					"companyId");
 
 				portletIds.add(
 					new String[] {
-						portletIdPrefix + externalReferenceCode,
+						portletIdPrefix + companyId,
 						portletIdPrefix + clientExtensionEntryId
 					});
 			}

--- a/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/upgrade/v3_0_0/UpgradePortletId.java
+++ b/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/upgrade/v3_0_0/UpgradePortletId.java
@@ -14,6 +14,7 @@
 
 package com.liferay.client.extension.web.internal.upgrade.v3_0_0;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.upgrade.BasePortletIdUpgradeProcess;
@@ -29,6 +30,39 @@ import java.util.List;
  * @author Brian Wing Shun Chan
  */
 public class UpgradePortletId extends BasePortletIdUpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		try (Statement statement = connection.createStatement();
+			ResultSet resultSet = statement.executeQuery(
+				"select externalReferenceCode, clientExtensionEntryId from " +
+					"ClientExtensionEntry")) {
+
+			while (resultSet.next()) {
+				String externalReferenceCode = resultSet.getString(
+					"externalReferenceCode");
+
+				runSQL(
+					StringBundler.concat(
+						"delete from Portlet where portletId = '",
+						"com_liferay_client_extension_web_internal_portlet_",
+						"ClientExtensionEntryPortlet_", externalReferenceCode,
+						"'"));
+
+				runSQL(
+					StringBundler.concat(
+						"delete from ResourcePermission where name = '",
+						"com_liferay_client_extension_web_internal_portlet_",
+						"ClientExtensionEntryPortlet_", externalReferenceCode,
+						"'"));
+			}
+		}
+		catch (Exception exception) {
+			_log.error(exception);
+		}
+
+		super.doUpgrade();
+	}
 
 	@Override
 	protected String[][] getRenamePortletIdsArray() {

--- a/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/upgrade/v3_0_0/UpgradePortletId.java
+++ b/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/upgrade/v3_0_0/UpgradePortletId.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.client.extension.web.internal.upgrade.v3_0_0;
+
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.upgrade.BasePortletIdUpgradeProcess;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Brian Wing Shun Chan
+ */
+public class UpgradePortletId extends BasePortletIdUpgradeProcess {
+
+	@Override
+	protected String[][] getRenamePortletIdsArray() {
+		return getRenamePortletIdsArray(
+			connection,
+			"com_liferay_client_extension_web_internal_" +
+				"portlet_ClientExtensionEntryPortlet_");
+	}
+
+	protected String[][] getRenamePortletIdsArray(
+		Connection connection, String portletIdPrefix) {
+
+		List<String[]> portletIds = new ArrayList<>();
+
+		try (Statement statement = connection.createStatement();
+			ResultSet resultSet = statement.executeQuery(
+				"select externalReferenceCode, clientExtensionEntryId from " +
+					"ClientExtensionEntry")) {
+
+			while (resultSet.next()) {
+				String externalReferenceCode = resultSet.getString(
+					"externalReferenceCode");
+				long clientExtensionEntryId = resultSet.getLong(
+					"clientExtensionEntryId");
+
+				portletIds.add(
+					new String[] {
+						portletIdPrefix + externalReferenceCode,
+						portletIdPrefix + clientExtensionEntryId
+					});
+			}
+		}
+		catch (Exception exception) {
+			_log.error(exception);
+		}
+
+		return portletIds.toArray(new String[0][0]);
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		UpgradePortletId.class);
+
+}

--- a/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/upgrade/v3_0_0/UpgradePortletId.java
+++ b/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/upgrade/v3_0_0/UpgradePortletId.java
@@ -15,6 +15,7 @@
 package com.liferay.client.extension.web.internal.upgrade.v3_0_0;
 
 import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.upgrade.BasePortletIdUpgradeProcess;
@@ -79,19 +80,20 @@ public class UpgradePortletId extends BasePortletIdUpgradeProcess {
 
 		try (Statement statement = connection.createStatement();
 			ResultSet resultSet = statement.executeQuery(
-				"select clientExtensionEntryId, companyId from " +
+				"select externalReferenceCode, companyId from " +
 					"ClientExtensionEntry")) {
 
 			while (resultSet.next()) {
-				long clientExtensionEntryId = resultSet.getLong(
-					"clientExtensionEntryId");
-				long companyId = resultSet.getLong(
-					"companyId");
+				long companyId = resultSet.getLong("companyId");
+				String externalReferenceCode = resultSet.getString(
+					"externalReferenceCode");
 
 				portletIds.add(
 					new String[] {
-						portletIdPrefix + companyId,
-						portletIdPrefix + clientExtensionEntryId
+						portletIdPrefix + externalReferenceCode,
+						StringBundler.concat(
+							portletIdPrefix, externalReferenceCode,
+							StringPool.UNDERLINE, companyId)
 					});
 			}
 		}

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
@@ -693,7 +693,8 @@ public class BundleSiteInitializer implements SiteInitializer {
 					StringBundler.concat(
 						"[$CLIENT_EXTENSION_ENTRY_ID:",
 						jsonObject.getString("clientExtensionEntryKey"), "$]"),
-					jsonObject.getString("externalReferenceCode")));
+					jsonObject.getString("externalReferenceCode") + "_" +
+						serviceContext.getCompanyId()));
 		}
 
 		return clientExtensionEntryIdsStringUtilReplaceValues;


### PR DESCRIPTION
- LPS-159174 use clientxtensionEntryId instead externalRefenceCode
- LPS-159174 Move to individual classes - no logic changes
- LPS-159174 No need for space
- LPS-159174 Do not save in the DB by ERC, but by ID
- LPS-159174 delete before upgrade
- LPS-159174 Append comapanyId instead clientExtensionId
- LPS-159174 Append _companyId
