### PR TITLE
LPS-159740: An inconsistency in the behavior about wikiPage of API Explorer

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/WikiPageAttachmentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/WikiPageAttachmentResourceImpl.java
@@ -70,7 +70,7 @@ public class WikiPageAttachmentResourceImpl
 			Long wikiPageId)
 		throws Exception {
 
-		WikiPage wikiPage = _wikiPageService.getPageByPageId(wikiPageId);
+		WikiPage wikiPage = _wikiPageService.getPage(wikiPageId);
 
 		return Page.of(
 			transform(
@@ -83,7 +83,7 @@ public class WikiPageAttachmentResourceImpl
 			Long wikiPageId, MultipartBody multipartBody)
 		throws Exception {
 
-		WikiPage wikiPage = _wikiPageService.getPageByPageId(wikiPageId);
+		WikiPage wikiPage = _wikiPageService.getPage(wikiPageId);
 
 		_wikiPageModelResourcePermission.check(
 			PermissionThreadLocal.getPermissionChecker(), wikiPage,

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/WikiPageAttachmentResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/WikiPageAttachmentResourceTest.java
@@ -117,7 +117,7 @@ public class WikiPageAttachmentResourceTest
 		throws Exception {
 
 		return wikiPageAttachmentResource.postWikiPageWikiPageAttachment(
-			_wikiPage.getPageId(), randomWikiPageAttachment(),
+			_wikiPage.getResourcePrimKey(), randomWikiPageAttachment(),
 			getMultipartFiles());
 	}
 
@@ -127,13 +127,13 @@ public class WikiPageAttachmentResourceTest
 		throws Exception {
 
 		return wikiPageAttachmentResource.postWikiPageWikiPageAttachment(
-			_wikiPage.getPageId(), randomWikiPageAttachment(),
+			_wikiPage.getResourcePrimKey(), randomWikiPageAttachment(),
 			getMultipartFiles());
 	}
 
 	@Override
 	protected Long testGetWikiPageWikiPageAttachmentsPage_getWikiPageId() {
-		return _wikiPage.getPageId();
+		return _wikiPage.getResourcePrimKey();
 	}
 
 	@Override


### PR DESCRIPTION
This PR contains some requested changes from -> https://github.com/brianchandotcom/liferay-portal/pull/121944#issuecomment-1220637036


**What is new?:**

- Add new method (`getPageByResourcePrimKey`) in `WikiPageServiceImpl` to retrive a wiki page given a WikiPage resource Primary Key:

```
	public WikiPage getPageByResourcePrimKey(long resourcePrimKey)
		throws PortalException {

		WikiPage page = wikiPageLocalService.getPage(resourcePrimKey);

		_wikiPageModelResourcePermission.check(
			getPermissionChecker(), page, ActionKeys.VIEW);

		return page;
	}
```
- Update `WikiPageAttachmentsResourceImpl` using the new method.
- Update `WikiPageAttachmentResourceTest` retrieving the wikiPage resource Primary Key.

**SCENARIO** 

Once I create a wikiPage with attachments when I use getWikiPageWikiPageAttachmentsPage with wikiPageId.

**Before changes**
Response return "No WikiPage exists with the primary key"

**After changes**
Response 200 OK

**Ticket JIRA**
https://issues.liferay.com/browse/LPS-159740

cc/ @4lejandrito