### PR TITLE
LPS-160378 Regenerate test snapshots

### DIFF
--- a/modules/apps/translation/translation-web/test/js/translate/__snapshots__/Translate.js.snap
+++ b/modules/apps/translation/translation-web/test/js/translate/__snapshots__/Translate.js.snap
@@ -57,7 +57,7 @@ exports[`Translate renders with auto-translate disabled 1`] = `
                   <button
                     aria-controls="clay-dropdown-menu-21"
                     aria-expanded="false"
-                    aria-haspopup="menu"
+                    aria-haspopup="true"
                     class="dropdown-toggle btn btn-monospaced btn-sm btn-secondary"
                     style=""
                     type="button"
@@ -96,7 +96,7 @@ exports[`Translate renders with auto-translate disabled 1`] = `
                   <button
                     aria-controls="clay-dropdown-menu-22"
                     aria-expanded="false"
-                    aria-haspopup="menu"
+                    aria-haspopup="true"
                     class="dropdown-toggle btn btn-monospaced btn-sm btn-secondary"
                     style=""
                     type="button"
@@ -631,7 +631,7 @@ exports[`Translate renders with auto-translate enabled 1`] = `
                   <button
                     aria-controls="clay-dropdown-menu-1"
                     aria-expanded="false"
-                    aria-haspopup="menu"
+                    aria-haspopup="true"
                     class="dropdown-toggle btn btn-monospaced btn-sm btn-secondary"
                     style=""
                     type="button"
@@ -670,7 +670,7 @@ exports[`Translate renders with auto-translate enabled 1`] = `
                   <button
                     aria-controls="clay-dropdown-menu-2"
                     aria-expanded="false"
-                    aria-haspopup="menu"
+                    aria-haspopup="true"
                     class="dropdown-toggle btn btn-monospaced btn-sm btn-secondary"
                     style=""
                     type="button"
@@ -1449,7 +1449,7 @@ exports[`Translate renders with experiences selector 1`] = `
                   <button
                     aria-controls="clay-dropdown-menu-3"
                     aria-expanded="false"
-                    aria-haspopup="menu"
+                    aria-haspopup="true"
                     class="dropdown-toggle btn btn-monospaced btn-sm btn-secondary"
                     style=""
                     type="button"
@@ -1488,7 +1488,7 @@ exports[`Translate renders with experiences selector 1`] = `
                   <button
                     aria-controls="clay-dropdown-menu-4"
                     aria-expanded="false"
-                    aria-haspopup="menu"
+                    aria-haspopup="true"
                     class="dropdown-toggle btn btn-monospaced btn-sm btn-secondary"
                     style=""
                     type="button"

--- a/modules/dxp/apps/analytics/analytics-reports-web/test/js/components/__snapshots__/Translation.js.snap
+++ b/modules/dxp/apps/analytics/analytics-reports-web/test/js/components/__snapshots__/Translation.js.snap
@@ -14,7 +14,7 @@ exports[`Translation renders 1`] = `
         <button
           aria-controls="clay-dropdown-menu-1"
           aria-expanded="false"
-          aria-haspopup="menu"
+          aria-haspopup="true"
           class="dropdown-toggle btn-monospaced btn btn-sm btn-secondary"
           style=""
           type="button"


### PR DESCRIPTION
Clay's update arrived late due to some issues we sent the [wrong commits in the manual forward](https://github.com/brianchandotcom/liferay-portal/pull/121818) and it was [sent a week later](https://github.com/brianchandotcom/liferay-portal/pull/122081) and that caused the problem of losing sync with the master changes which probably had new tests that were using the old version of Clay, this just recreates the snapshots of the affected tests.