### PR TITLE
LPS-161366 Fix Private Pages indexation when request or response is not available

### DIFF
--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/spi/model/index/contributor/LayoutModelDocumentContributor.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/spi/model/index/contributor/LayoutModelDocumentContributor.java
@@ -35,7 +35,9 @@ import com.liferay.portal.kernel.model.LayoutTypePortlet;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextFactory;
@@ -227,8 +229,13 @@ public class LayoutModelDocumentContributor
 		ServiceContext mockServiceContext = ServiceContextFactory.getInstance(
 			httpServletRequest);
 
+		PermissionChecker originalPermissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
 		try {
 			ServiceContextThreadLocal.pushServiceContext(mockServiceContext);
+			PermissionThreadLocal.setPermissionChecker(
+				mockContextHelper.getPermissionChecker());
 
 			return LayoutPageTemplateStructureRenderUtil.renderLayoutContent(
 				_fragmentRendererController, httpServletRequest,
@@ -243,6 +250,9 @@ public class LayoutModelDocumentContributor
 			if (serviceContext != null) {
 				ServiceContextThreadLocal.pushServiceContext(serviceContext);
 			}
+
+			PermissionThreadLocal.setPermissionChecker(
+				originalPermissionChecker);
 		}
 	}
 
@@ -344,6 +354,16 @@ public class LayoutModelDocumentContributor
 			return httpServletRequest;
 		}
 
+		public PermissionChecker getPermissionChecker() throws PortalException {
+			if (_permissionChecker != null) {
+				return _permissionChecker;
+			}
+
+			_permissionChecker = PermissionCheckerFactoryUtil.create(_user);
+
+			return _permissionChecker;
+		}
+
 		private ThemeDisplay _getThemeDisplay() throws PortalException {
 			if (_themeDisplay != null) {
 				return _themeDisplay;
@@ -365,8 +385,7 @@ public class LayoutModelDocumentContributor
 
 			themeDisplay.setLayoutTypePortlet(
 				(LayoutTypePortlet)_layout.getLayoutType());
-			themeDisplay.setPermissionChecker(
-				PermissionCheckerFactoryUtil.create(_user));
+			themeDisplay.setPermissionChecker(getPermissionChecker());
 			themeDisplay.setPlid(_layout.getPlid());
 			themeDisplay.setPortalDomain(company.getVirtualHostname());
 			themeDisplay.setPortalURL(
@@ -385,6 +404,7 @@ public class LayoutModelDocumentContributor
 		}
 
 		private final Layout _layout;
+		private PermissionChecker _permissionChecker;
 		private ThemeDisplay _themeDisplay;
 		private final User _user;
 

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/spi/model/index/contributor/LayoutModelDocumentContributor.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/spi/model/index/contributor/LayoutModelDocumentContributor.java
@@ -158,16 +158,16 @@ public class LayoutModelDocumentContributor
 			httpServletResponse = serviceContext.getResponse();
 		}
 
-		if ((httpServletRequest == null) || (httpServletResponse == null)) {
-			return StringPool.BLANK;
+		if ((httpServletRequest != null) && (httpServletResponse != null)) {
+			return LayoutPageTemplateStructureRenderUtil.renderLayoutContent(
+				_fragmentRendererController, httpServletRequest,
+				httpServletResponse, layoutPageTemplateStructure,
+				FragmentEntryLinkConstants.VIEW, locale,
+				_segmentsExperienceLocalService.
+					fetchDefaultSegmentsExperienceId(layout.getPlid()));
 		}
 
-		return LayoutPageTemplateStructureRenderUtil.renderLayoutContent(
-			_fragmentRendererController, httpServletRequest,
-			httpServletResponse, layoutPageTemplateStructure,
-			FragmentEntryLinkConstants.VIEW, locale,
-			_segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
-				layout.getPlid()));
+		return StringPool.BLANK;
 	}
 
 	private int _getStatus(Layout layout) {

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/spi/model/index/contributor/LayoutModelDocumentContributor.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/spi/model/index/contributor/LayoutModelDocumentContributor.java
@@ -327,6 +327,28 @@ public class LayoutModelDocumentContributor
 					new MockHttpServletRequest(), "p_l_id=" + _layout.getPlid(),
 					false);
 
+			ThemeDisplay themeDisplay = _getThemeDisplay();
+
+			themeDisplay.setLanguageId(LocaleUtil.toLanguageId(locale));
+			themeDisplay.setLocale(locale);
+			themeDisplay.setRequest(httpServletRequest);
+			themeDisplay.setResponse(httpServletResponse);
+
+			httpServletRequest.setAttribute(
+				WebKeys.THEME_DISPLAY, themeDisplay);
+
+			httpServletRequest.setAttribute(WebKeys.LAYOUT, _layout);
+			httpServletRequest.setAttribute(WebKeys.USER, _user);
+			httpServletRequest.setAttribute(WebKeys.USER_ID, _user.getUserId());
+
+			return httpServletRequest;
+		}
+
+		private ThemeDisplay _getThemeDisplay() throws PortalException {
+			if (_themeDisplay != null) {
+				return _themeDisplay;
+			}
+
 			ThemeDisplay themeDisplay = ThemeDisplayFactory.create();
 
 			Company company = _companyLocalService.getCompany(
@@ -357,22 +379,13 @@ public class LayoutModelDocumentContributor
 			themeDisplay.setTimeZone(_user.getTimeZone());
 			themeDisplay.setUser(_user);
 
-			themeDisplay.setLanguageId(LocaleUtil.toLanguageId(locale));
-			themeDisplay.setLocale(locale);
-			themeDisplay.setRequest(httpServletRequest);
-			themeDisplay.setResponse(httpServletResponse);
+			_themeDisplay = themeDisplay;
 
-			httpServletRequest.setAttribute(
-				WebKeys.THEME_DISPLAY, themeDisplay);
-
-			httpServletRequest.setAttribute(WebKeys.LAYOUT, _layout);
-			httpServletRequest.setAttribute(WebKeys.USER, _user);
-			httpServletRequest.setAttribute(WebKeys.USER_ID, _user.getUserId());
-
-			return httpServletRequest;
+			return _themeDisplay;
 		}
 
 		private final Layout _layout;
+		private ThemeDisplay _themeDisplay;
 		private final User _user;
 
 	}

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/spi/model/index/contributor/LayoutModelDocumentContributor.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/spi/model/index/contributor/LayoutModelDocumentContributor.java
@@ -21,28 +21,76 @@ import com.liferay.layout.internal.search.util.LayoutPageTemplateStructureRender
 import com.liferay.layout.page.template.model.LayoutPageTemplateStructure;
 import com.liferay.layout.page.template.service.LayoutPageTemplateStructureLocalService;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.io.unsync.UnsyncPrintWriter;
+import com.liferay.portal.kernel.io.unsync.UnsyncStringWriter;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutSet;
+import com.liferay.portal.kernel.model.LayoutTypePortlet;
+import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextFactory;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.servlet.DirectRequestDispatcherFactoryUtil;
 import com.liferay.portal.kernel.servlet.DynamicServletRequest;
+import com.liferay.portal.kernel.servlet.HttpMethods;
+import com.liferay.portal.kernel.servlet.ServletContextPool;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ConcurrentHashMapBuilder;
 import com.liferay.portal.kernel.util.Html;
+import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
+import com.liferay.portal.theme.ThemeDisplayFactory;
 import com.liferay.segments.service.SegmentsExperienceLocalService;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.UnsupportedEncodingException;
+
+import java.security.Principal;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Enumeration;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
+import javax.servlet.AsyncContext;
+import javax.servlet.DispatcherType;
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.ServletInputStream;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import javax.servlet.http.HttpSessionContext;
+import javax.servlet.http.HttpUpgradeHandler;
+import javax.servlet.http.Part;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -106,12 +154,16 @@ public class LayoutModelDocumentContributor
 		Set<Locale> locales = _language.getAvailableLocales(
 			layout.getGroupId());
 
+		MockContextHelper mockContextHelper = new MockContextHelper(
+			layout, _userLocalService.fetchDefaultUser(layout.getCompanyId()));
+
 		for (Locale locale : locales) {
 			String content = StringPool.BLANK;
 
 			try {
 				content = _getLayoutContent(
-					layout, layoutPageTemplateStructure, locale);
+					layout, layoutPageTemplateStructure, locale,
+					mockContextHelper);
 			}
 			catch (Exception exception) {
 				if (_log.isWarnEnabled()) {
@@ -137,7 +189,7 @@ public class LayoutModelDocumentContributor
 	private String _getLayoutContent(
 			Layout layout,
 			LayoutPageTemplateStructure layoutPageTemplateStructure,
-			Locale locale)
+			Locale locale, MockContextHelper mockContextHelper)
 		throws Exception {
 
 		if (!layout.isPrivateLayout()) {
@@ -167,7 +219,31 @@ public class LayoutModelDocumentContributor
 					fetchDefaultSegmentsExperienceId(layout.getPlid()));
 		}
 
-		return StringPool.BLANK;
+		httpServletResponse = new MockHttpServletResponse();
+
+		httpServletRequest = mockContextHelper.getHttpServletRequest(
+			httpServletResponse, locale);
+
+		ServiceContext mockServiceContext = ServiceContextFactory.getInstance(
+			httpServletRequest);
+
+		try {
+			ServiceContextThreadLocal.pushServiceContext(mockServiceContext);
+
+			return LayoutPageTemplateStructureRenderUtil.renderLayoutContent(
+				_fragmentRendererController, httpServletRequest,
+				httpServletResponse, layoutPageTemplateStructure,
+				FragmentEntryLinkConstants.VIEW, locale,
+				_segmentsExperienceLocalService.
+					fetchDefaultSegmentsExperienceId(layout.getPlid()));
+		}
+		finally {
+			ServiceContextThreadLocal.popServiceContext();
+
+			if (serviceContext != null) {
+				ServiceContextThreadLocal.pushServiceContext(serviceContext);
+			}
+		}
 	}
 
 	private int _getStatus(Layout layout) {
@@ -189,10 +265,26 @@ public class LayoutModelDocumentContributor
 			wrapperIndex + _WRAPPER_ELEMENT.length());
 	}
 
+	private boolean _isHttpsEnabled() {
+		if (Objects.equals(
+				Http.HTTPS,
+				PropsUtil.get(PropsKeys.PORTAL_INSTANCE_PROTOCOL)) ||
+			Objects.equals(
+				Http.HTTPS, PropsUtil.get(PropsKeys.WEB_SERVER_PROTOCOL))) {
+
+			return true;
+		}
+
+		return false;
+	}
+
 	private static final String _WRAPPER_ELEMENT = "id=\"wrapper\">";
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		LayoutModelDocumentContributor.class);
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
 
 	@Reference
 	private FragmentRendererController _fragmentRendererController;
@@ -211,6 +303,698 @@ public class LayoutModelDocumentContributor
 		_layoutPageTemplateStructureLocalService;
 
 	@Reference
+	private Portal _portal;
+
+	@Reference
 	private SegmentsExperienceLocalService _segmentsExperienceLocalService;
+
+	@Reference
+	private UserLocalService _userLocalService;
+
+	private class MockContextHelper {
+
+		public MockContextHelper(Layout layout, User user) {
+			_layout = layout;
+			_user = user;
+		}
+
+		public HttpServletRequest getHttpServletRequest(
+				HttpServletResponse httpServletResponse, Locale locale)
+			throws PortalException {
+
+			HttpServletRequest httpServletRequest =
+				DynamicServletRequest.addQueryString(
+					new MockHttpServletRequest(), "p_l_id=" + _layout.getPlid(),
+					false);
+
+			ThemeDisplay themeDisplay = ThemeDisplayFactory.create();
+
+			Company company = _companyLocalService.getCompany(
+				_layout.getCompanyId());
+
+			themeDisplay.setCompany(company);
+
+			themeDisplay.setLayout(_layout);
+
+			LayoutSet layoutSet = _layout.getLayoutSet();
+
+			themeDisplay.setLayoutSet(layoutSet);
+			themeDisplay.setLookAndFeel(layoutSet.getTheme(), null);
+
+			themeDisplay.setLayoutTypePortlet(
+				(LayoutTypePortlet)_layout.getLayoutType());
+			themeDisplay.setPermissionChecker(
+				PermissionCheckerFactoryUtil.create(_user));
+			themeDisplay.setPlid(_layout.getPlid());
+			themeDisplay.setPortalDomain(company.getVirtualHostname());
+			themeDisplay.setPortalURL(
+				company.getPortalURL(_layout.getGroupId()));
+			themeDisplay.setRealUser(_user);
+			themeDisplay.setScopeGroupId(_layout.getGroupId());
+			themeDisplay.setServerPort(
+				_portal.getPortalServerPort(_isHttpsEnabled()));
+			themeDisplay.setSiteGroupId(_layout.getGroupId());
+			themeDisplay.setTimeZone(_user.getTimeZone());
+			themeDisplay.setUser(_user);
+
+			themeDisplay.setLanguageId(LocaleUtil.toLanguageId(locale));
+			themeDisplay.setLocale(locale);
+			themeDisplay.setRequest(httpServletRequest);
+			themeDisplay.setResponse(httpServletResponse);
+
+			httpServletRequest.setAttribute(
+				WebKeys.THEME_DISPLAY, themeDisplay);
+
+			httpServletRequest.setAttribute(WebKeys.LAYOUT, _layout);
+			httpServletRequest.setAttribute(WebKeys.USER, _user);
+			httpServletRequest.setAttribute(WebKeys.USER_ID, _user.getUserId());
+
+			return httpServletRequest;
+		}
+
+		private final Layout _layout;
+		private final User _user;
+
+	}
+
+	private class MockHttpServletRequest implements HttpServletRequest {
+
+		@Override
+		public boolean authenticate(HttpServletResponse httpServletResponse)
+			throws IOException, ServletException {
+
+			return false;
+		}
+
+		@Override
+		public String changeSessionId() {
+			return null;
+		}
+
+		@Override
+		public AsyncContext getAsyncContext() {
+			return null;
+		}
+
+		@Override
+		public Object getAttribute(String name) {
+			return _attributes.get(name);
+		}
+
+		@Override
+		public Enumeration<String> getAttributeNames() {
+			return Collections.enumeration(_attributes.keySet());
+		}
+
+		@Override
+		public String getAuthType() {
+			return null;
+		}
+
+		@Override
+		public String getCharacterEncoding() {
+			return null;
+		}
+
+		@Override
+		public int getContentLength() {
+			return 0;
+		}
+
+		@Override
+		public long getContentLengthLong() {
+			return 0;
+		}
+
+		@Override
+		public String getContentType() {
+			return null;
+		}
+
+		@Override
+		public String getContextPath() {
+			return null;
+		}
+
+		@Override
+		public Cookie[] getCookies() {
+			return new Cookie[0];
+		}
+
+		@Override
+		public long getDateHeader(String s) {
+			return 0;
+		}
+
+		@Override
+		public DispatcherType getDispatcherType() {
+			return null;
+		}
+
+		@Override
+		public String getHeader(String name) {
+			return null;
+		}
+
+		@Override
+		public Enumeration<String> getHeaderNames() {
+			return Collections.emptyEnumeration();
+		}
+
+		@Override
+		public Enumeration<String> getHeaders(String name) {
+			return null;
+		}
+
+		@Override
+		public ServletInputStream getInputStream() throws IOException {
+			return null;
+		}
+
+		@Override
+		public int getIntHeader(String s) {
+			return 0;
+		}
+
+		@Override
+		public String getLocalAddr() {
+			return null;
+		}
+
+		@Override
+		public Locale getLocale() {
+			return null;
+		}
+
+		@Override
+		public Enumeration<Locale> getLocales() {
+			return null;
+		}
+
+		@Override
+		public String getLocalName() {
+			return null;
+		}
+
+		@Override
+		public int getLocalPort() {
+			return 0;
+		}
+
+		@Override
+		public String getMethod() {
+			return HttpMethods.GET;
+		}
+
+		@Override
+		public String getParameter(String name) {
+			return null;
+		}
+
+		@Override
+		public Map<String, String[]> getParameterMap() {
+			return Collections.emptyMap();
+		}
+
+		@Override
+		public Enumeration<String> getParameterNames() {
+			return null;
+		}
+
+		@Override
+		public String[] getParameterValues(String name) {
+			return new String[0];
+		}
+
+		@Override
+		public Part getPart(String s) throws IOException, ServletException {
+			return null;
+		}
+
+		@Override
+		public Collection<Part> getParts()
+			throws IOException, ServletException {
+
+			return null;
+		}
+
+		@Override
+		public String getPathInfo() {
+			return null;
+		}
+
+		@Override
+		public String getPathTranslated() {
+			return null;
+		}
+
+		@Override
+		public String getProtocol() {
+			return null;
+		}
+
+		@Override
+		public String getQueryString() {
+			return null;
+		}
+
+		@Override
+		public BufferedReader getReader() throws IOException {
+			return null;
+		}
+
+		@Override
+		public String getRealPath(String s) {
+			return null;
+		}
+
+		@Override
+		public String getRemoteAddr() {
+			return null;
+		}
+
+		@Override
+		public String getRemoteHost() {
+			return null;
+		}
+
+		@Override
+		public int getRemotePort() {
+			return 0;
+		}
+
+		@Override
+		public String getRemoteUser() {
+			return null;
+		}
+
+		@Override
+		public RequestDispatcher getRequestDispatcher(String path) {
+			return DirectRequestDispatcherFactoryUtil.getRequestDispatcher(
+				ServletContextPool.get(StringPool.BLANK), path);
+		}
+
+		@Override
+		public String getRequestedSessionId() {
+			return null;
+		}
+
+		@Override
+		public String getRequestURI() {
+			return StringPool.BLANK;
+		}
+
+		@Override
+		public StringBuffer getRequestURL() {
+			return null;
+		}
+
+		@Override
+		public String getScheme() {
+			return null;
+		}
+
+		@Override
+		public String getServerName() {
+			return null;
+		}
+
+		@Override
+		public int getServerPort() {
+			return 0;
+		}
+
+		@Override
+		public ServletContext getServletContext() {
+			return ServletContextPool.get(StringPool.BLANK);
+		}
+
+		@Override
+		public String getServletPath() {
+			return null;
+		}
+
+		@Override
+		public HttpSession getSession() {
+			return _httpSession;
+		}
+
+		@Override
+		public HttpSession getSession(boolean createIfAbsent) {
+			return _httpSession;
+		}
+
+		@Override
+		public Principal getUserPrincipal() {
+			return null;
+		}
+
+		@Override
+		public boolean isAsyncStarted() {
+			return false;
+		}
+
+		@Override
+		public boolean isAsyncSupported() {
+			return false;
+		}
+
+		@Override
+		public boolean isRequestedSessionIdFromCookie() {
+			return false;
+		}
+
+		@Override
+		public boolean isRequestedSessionIdFromUrl() {
+			return false;
+		}
+
+		@Override
+		public boolean isRequestedSessionIdFromURL() {
+			return false;
+		}
+
+		@Override
+		public boolean isRequestedSessionIdValid() {
+			return false;
+		}
+
+		@Override
+		public boolean isSecure() {
+			return false;
+		}
+
+		@Override
+		public boolean isUserInRole(String user) {
+			return false;
+		}
+
+		@Override
+		public void login(String user, String password)
+			throws ServletException {
+		}
+
+		@Override
+		public void logout() throws ServletException {
+		}
+
+		@Override
+		public void removeAttribute(String name) {
+			_attributes.remove(name);
+		}
+
+		@Override
+		public void setAttribute(String name, Object value) {
+			if ((name != null) && (value != null)) {
+				_attributes.put(name, value);
+			}
+		}
+
+		@Override
+		public void setCharacterEncoding(String encoding)
+			throws UnsupportedEncodingException {
+		}
+
+		@Override
+		public AsyncContext startAsync() throws IllegalStateException {
+			return null;
+		}
+
+		@Override
+		public AsyncContext startAsync(
+				ServletRequest servletRequest, ServletResponse servletResponse)
+			throws IllegalStateException {
+
+			return null;
+		}
+
+		@Override
+		public <T extends HttpUpgradeHandler> T upgrade(Class<T> handlerClass)
+			throws IOException, ServletException {
+
+			return null;
+		}
+
+		private final Map<String, Object> _attributes =
+			ConcurrentHashMapBuilder.<String, Object>put(
+				WebKeys.CTX, ServletContextPool.get(StringPool.BLANK)
+			).build();
+
+		private final HttpSession _httpSession = new HttpSession() {
+
+			@Override
+			public Object getAttribute(String name) {
+				return _attributes.get(name);
+			}
+
+			@Override
+			public Enumeration<String> getAttributeNames() {
+				return Collections.enumeration(_attributes.keySet());
+			}
+
+			@Override
+			public long getCreationTime() {
+				return 0;
+			}
+
+			@Override
+			public String getId() {
+				return StringPool.BLANK;
+			}
+
+			@Override
+			public long getLastAccessedTime() {
+				return 0;
+			}
+
+			@Override
+			public int getMaxInactiveInterval() {
+				return 0;
+			}
+
+			@Override
+			public ServletContext getServletContext() {
+				return null;
+			}
+
+			@Override
+			public HttpSessionContext getSessionContext() {
+				return null;
+			}
+
+			@Override
+			public Object getValue(String name) {
+				return null;
+			}
+
+			@Override
+			public String[] getValueNames() {
+				return new String[0];
+			}
+
+			@Override
+			public void invalidate() {
+			}
+
+			@Override
+			public boolean isNew() {
+				return true;
+			}
+
+			@Override
+			public void putValue(String name, Object value) {
+			}
+
+			@Override
+			public void removeAttribute(String name) {
+			}
+
+			@Override
+			public void removeValue(String name) {
+			}
+
+			@Override
+			public void setAttribute(String name, Object value) {
+				_attributes.put(name, value);
+			}
+
+			@Override
+			public void setMaxInactiveInterval(int interval) {
+			}
+
+		};
+
+	}
+
+	private class MockHttpServletResponse implements HttpServletResponse {
+
+		@Override
+		public void addCookie(Cookie cookie) {
+		}
+
+		@Override
+		public void addDateHeader(String s, long l) {
+		}
+
+		@Override
+		public void addHeader(String s, String s1) {
+		}
+
+		@Override
+		public void addIntHeader(String s, int i) {
+		}
+
+		@Override
+		public boolean containsHeader(String s) {
+			return false;
+		}
+
+		@Override
+		public String encodeRedirectUrl(String s) {
+			return null;
+		}
+
+		@Override
+		public String encodeRedirectURL(String s) {
+			return null;
+		}
+
+		@Override
+		public String encodeUrl(String s) {
+			return null;
+		}
+
+		@Override
+		public String encodeURL(String s) {
+			return null;
+		}
+
+		@Override
+		public void flushBuffer() throws IOException {
+		}
+
+		@Override
+		public int getBufferSize() {
+			return 0;
+		}
+
+		@Override
+		public String getCharacterEncoding() {
+			return null;
+		}
+
+		@Override
+		public String getContentType() {
+			return null;
+		}
+
+		@Override
+		public String getHeader(String s) {
+			return null;
+		}
+
+		@Override
+		public Collection<String> getHeaderNames() {
+			return null;
+		}
+
+		@Override
+		public Collection<String> getHeaders(String s) {
+			return null;
+		}
+
+		@Override
+		public Locale getLocale() {
+			return null;
+		}
+
+		@Override
+		public ServletOutputStream getOutputStream() throws IOException {
+			return null;
+		}
+
+		@Override
+		public int getStatus() {
+			return 0;
+		}
+
+		@Override
+		public PrintWriter getWriter() throws IOException {
+			return _unsyncPrintWriter;
+		}
+
+		@Override
+		public boolean isCommitted() {
+			return false;
+		}
+
+		@Override
+		public void reset() {
+		}
+
+		@Override
+		public void resetBuffer() {
+		}
+
+		@Override
+		public void sendError(int i) throws IOException {
+		}
+
+		@Override
+		public void sendError(int i, String s) throws IOException {
+		}
+
+		@Override
+		public void sendRedirect(String s) throws IOException {
+		}
+
+		@Override
+		public void setBufferSize(int i) {
+		}
+
+		@Override
+		public void setCharacterEncoding(String s) {
+		}
+
+		@Override
+		public void setContentLength(int i) {
+		}
+
+		@Override
+		public void setContentLengthLong(long l) {
+		}
+
+		@Override
+		public void setContentType(String s) {
+		}
+
+		@Override
+		public void setDateHeader(String s, long l) {
+		}
+
+		@Override
+		public void setHeader(String s, String s1) {
+		}
+
+		@Override
+		public void setIntHeader(String s, int i) {
+		}
+
+		@Override
+		public void setLocale(Locale locale) {
+		}
+
+		@Override
+		public void setStatus(int i) {
+		}
+
+		@Override
+		public void setStatus(int i, String s) {
+		}
+
+		private final UnsyncPrintWriter _unsyncPrintWriter =
+			new UnsyncPrintWriter(new UnsyncStringWriter());
+
+	}
 
 }


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-161366

Hi @brianchandotcom 
This fix works correctly with all the cases that I have tested. I think that as a temporary fix it can be valid, although I think that it should not be the definitive solution.
This approach was already tried a while ago in [this PR](https://github.com/shuyangzhou/liferay-portal/pull/9614) and Shuyang made these reflections about it:

> @pavel-savinov I remember last time this pull was causing issue. Fundamentally, the issue is at the DummyHttpServletRequest/DummyHttpServletResponse, doing so bypasses the filters, causing numerous problems. I am strongly against this solution, don't try to fix it, it will break overtime again and again as other changes go into the request processing chain without knowing there is piece of code mocking request like this directly.
> 
> For the backend logic you need to call, you will have to expose it as a real service to invoke, don't mock the invoker on top of web layer.

Thanks!

Regards