### PR TITLE
LPS-161665 Enforce variable and method naming for type MockedStatic

### DIFF
--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -269,6 +269,7 @@
         JSONArray,\
         JSONObject,\
         Matcher,\
+        MockedStatic,\
         MockHttpServlet(Request|Response),\
         NamedList,\
         Optional,\
@@ -347,6 +348,7 @@
         JSONArray,\
         JSONObject,\
         Matcher,\
+        MockedStatic,\
         MockHttpServlet(Request|Response),\
         NamedList,\
         Object,\


### PR DESCRIPTION
Tesed [here](https://github.com/ling-alan-huang/liferay-portal/pull/1308), unrelated failures.