### PR TITLE
LPS-154724 Fix path to target lfr-form-row and not lfr-form-rows

### DIFF
--- a/modules/apps/client-extension/client-extension-web/src/main/resources/META-INF/resources/admin/css/main.scss
+++ b/modules/apps/client-extension/client-extension-web/src/main/resources/META-INF/resources/admin/css/main.scss
@@ -1,27 +1,50 @@
-.portlet-remote-app-admin .lfr-form-row {
-	border: none;
-	padding: 0 0 30px;
+.portlet-remote-app-admin {
+	.lfr-form-rows {
+		counter-reset: line-number;
+	}
 
-	&:hover {
+	.undomanager {
+		display: none;
+	}
+
+	.lfr-form-row {
 		border: none;
+		counter-increment: line-number;
+		padding: 0;
+
+		&:not(:nth-child(2)) label:after {
+			content: '(' counter(line-number) ')';
+		}
+
+		&:hover {
+			border: none;
+		}
 	}
 
 	.lfr-autorow-controls {
+		bottom: auto;
 		position: absolute;
 		right: 0;
 		top: 0;
+	}
+
+	.toolbar-content {
+		display: flex;
+		gap: 4px;
 
 		button {
 			border-radius: 10px;
 			height: 20px;
-			margin-left: 4px;
 			padding: 0;
 			width: 20px;
 
 			.lexicon-icon {
-				height: 12px;
-				margin-top: -3px;
-				width: 12px;
+				height: 10px;
+				width: 10px;
+			}
+
+			&[disabled] {
+				display: none;
 			}
 		}
 	}

--- a/modules/apps/client-extension/client-extension-web/src/main/resources/META-INF/resources/admin/edit_custom_element.jsp
+++ b/modules/apps/client-extension/client-extension-web/src/main/resources/META-INF/resources/admin/edit_custom_element.jsp
@@ -26,7 +26,7 @@ CustomElementCET customElementCET = editClientExtensionEntryPartDisplayContext.g
 
 <aui:input label="use-esm" name="useESM" type="checkbox" value="<%= customElementCET.isUseESM() %>" />
 
-<div id="<portlet:namespace />_urls_field">
+<div class="lfr-form-rows" id="<portlet:namespace />_urls_field">
 
 	<%
 	for (String url : editClientExtensionEntryPartDisplayContext.getStrings(customElementCET.getURLs())) {
@@ -42,7 +42,7 @@ CustomElementCET customElementCET = editClientExtensionEntryPartDisplayContext.g
 
 </div>
 
-<div id="<portlet:namespace />_cssURLs_field">
+<div class="lfr-form-rows" id="<portlet:namespace />_cssURLs_field">
 
 	<%
 	for (String cssURL : editClientExtensionEntryPartDisplayContext.getStrings(customElementCET.getCSSURLs())) {

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/auto_fields.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/auto_fields.js
@@ -30,14 +30,14 @@ AUI.add(
 		];
 
 		const TPL_ADD_BUTTON =
-			'<button class="add-row btn btn-icon-only btn-monospaced btn-secondary toolbar-first toolbar-item" title="' +
+			'<button class="add-row btn btn-icon-only btn-monospaced btn-primary toolbar-first toolbar-item" title="' +
 			Liferay.Language.get('add') +
 			'" type="button">' +
 			Liferay.Util.getLexiconIconTpl('plus') +
 			'</button>';
 
 		const TPL_DELETE_BUTTON =
-			'<button class="btn btn-icon-only btn-monospaced btn-secondary delete-row toolbar-item toolbar-last" title="' +
+			'<button class="btn btn-icon-only btn-monospaced btn-primary delete-row toolbar-item toolbar-last" title="' +
 			Liferay.Language.get('remove') +
 			'" type="button">' +
 			Liferay.Util.getLexiconIconTpl('hr') +
@@ -46,8 +46,8 @@ AUI.add(
 		const TPL_AUTOROW_CONTROLS =
 			'<span class="lfr-autorow-controls toolbar toolbar-horizontal">' +
 			'<span class="toolbar-content">' +
-			TPL_ADD_BUTTON +
 			TPL_DELETE_BUTTON +
+			TPL_ADD_BUTTON +
 			'</span>' +
 			'</span>';
 

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/remoteapps/RemoteAppsEntry.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/remoteapps/RemoteAppsEntry.path
@@ -32,7 +32,7 @@
 </tr>
 <tr>
 	<td>URL_ROW_INDEX</td>
-	<td>//*[contains(@class,'form-row')][${key_index}]//input[(contains(@id,'${key_id}'))]</td>
+	<td>//*[@class='lfr-form-row'][${key_index}]//input[(contains(@id,'${key_id}'))]</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
This PR fixes the style of the repeatable fields in remote-apps (client-extensions)

![localhost_8080_group_guest___control_panel_manage_p_p_id=com_liferay_client_extension_web_internal_portlet_ClientExtensionAdminPortlet p_p_lifecycle=0 p_p_state=maximized p_p_mode=view _com_liferay_client_extension_web_internal_portlet_Clie](https://user-images.githubusercontent.com/46778114/185947208-0bb6434f-5a68-42ac-8e49-2e0ed5ccb32a.png)
