### PR TITLE
COMMERCE-9704 Fixed commerce channel delete method

### DIFF
--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CommerceChannelLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CommerceChannelLocalServiceImpl.java
@@ -178,7 +178,10 @@ public class CommerceChannelLocalServiceImpl
 		resourceLocalService.deleteResource(
 			commerceChannel, ResourceConstants.SCOPE_INDIVIDUAL);
 
-		Group group = fetchCommerceChannelGroup(
+		Group group = _groupLocalService.fetchGroup(
+			commerceChannel.getCompanyId(),
+			classNameLocalService.getClassNameId(
+				CommerceChannel.class.getName()),
 			commerceChannel.getCommerceChannelId());
 
 		if (group != null) {


### PR DESCRIPTION
Hey @brianchandotcom 

This is a follow-up PR for #122227 

We cannot delete deprecated methods into `CommercePriceListServiceImpl.java` because there are customers that are using them in their custom implementation of `CommerceProductPriceCalculation.java`

Thanks,
Alessio