### PR TITLE
LPS-146432 Organization segments used in Experiences are not updated after organization creation

### DIFF
--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/odata/search/ODataSearchAdapterImpl.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/odata/search/ODataSearchAdapterImpl.java
@@ -37,8 +37,6 @@ import com.liferay.portal.kernel.search.filter.BooleanFilter;
 import com.liferay.portal.kernel.search.generic.BooleanQueryImpl;
 import com.liferay.portal.kernel.search.generic.MatchAllQuery;
 import com.liferay.portal.kernel.search.generic.TermRangeQueryImpl;
-import com.liferay.portal.kernel.security.permission.PermissionChecker;
-import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Props;
 import com.liferay.portal.kernel.util.PropsKeys;
@@ -180,13 +178,6 @@ public class ODataSearchAdapterImpl implements ODataSearchAdapter {
 
 		searchContext.setCompanyId(companyId);
 		searchContext.setGroupIds(new long[] {-1L});
-
-		PermissionChecker permissionChecker =
-			PermissionThreadLocal.getPermissionChecker();
-
-		if (permissionChecker != null) {
-			searchContext.setUserId(permissionChecker.getUserId());
-		}
 
 		QueryConfig queryConfig = searchContext.getQueryConfig();
 


### PR DESCRIPTION
Motivation
=======
This PR solves this bug related to the Segments
[LPS-146432](https://issues.liferay.com/browse/146432)

Proposed Solution
========
The proposed solution consist in not adding the userId to the search context. This is because we will only retrieve those elements created by the user
