### PR TITLE
LPS-160493 AB Sidebar Panel does not get updated on SPA navigation

### DIFF
--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/display/context/ContentDashboardAdminDisplayContext.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/display/context/ContentDashboardAdminDisplayContext.java
@@ -35,6 +35,7 @@ import com.liferay.learn.LearnMessageUtil;
 import com.liferay.petra.portlet.url.builder.PortletURLBuilder;
 import com.liferay.petra.reflect.GenericUtil;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -52,6 +53,7 @@ import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.SessionClicks;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
@@ -71,6 +73,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.portlet.ActionURL;
+import javax.portlet.ResourceURL;
 import javax.portlet.WindowStateException;
 
 /**
@@ -359,6 +362,12 @@ public class ContentDashboardAdminDisplayContext {
 		return sb.toString();
 	}
 
+	public String getPanelState() {
+		return SessionClicks.get(
+			_portal.getHttpServletRequest(_liferayPortletRequest),
+			"com.liferay.content.dashboard.web_panelState", "closed");
+	}
+
 	public long getScopeId() {
 		if (_scopeId > 0) {
 			return _scopeId;
@@ -387,6 +396,34 @@ public class ContentDashboardAdminDisplayContext {
 
 	public SearchContainer<ContentDashboardItem<?>> getSearchContainer() {
 		return _searchContainer;
+	}
+
+	public String getSelectedItemFetchURL(
+		ContentDashboardItem contentDashboardItem) {
+
+		ResourceURL resourceURL = _liferayPortletResponse.createResourceURL();
+
+		resourceURL.setParameter(
+			"backURL", _portal.getCurrentURL(_liferayPortletRequest));
+
+		InfoItemReference infoItemReference =
+			contentDashboardItem.getInfoItemReference();
+
+		resourceURL.setParameter("className", infoItemReference.getClassName());
+		resourceURL.setParameter(
+			"classPK", String.valueOf(infoItemReference.getClassPK()));
+
+		resourceURL.setResourceID(
+			"/content_dashboard/get_content_dashboard_item_info");
+
+		return resourceURL.toString();
+	}
+
+	public String getSelectedItemRowId() {
+		return SessionClicks.get(
+			_portal.getHttpServletRequest(_liferayPortletRequest),
+			"com.liferay.content.dashboard.web_selectedItemRowId",
+			StringPool.BLANK);
 	}
 
 	public Integer getStatus() {

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanel.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanel.js
@@ -18,6 +18,7 @@ import {useIsMounted} from '@liferay/frontend-js-react-web';
 import {fetch} from 'frontend-js-web';
 import React, {useEffect, useImperativeHandle, useReducer, useRef} from 'react';
 
+import {CLOSE_PANEL_VALUE} from '../utils/constants';
 import Sidebar from './Sidebar';
 
 const initialState = {
@@ -27,9 +28,23 @@ const initialState = {
 	open: true,
 };
 
+const handleSessionOnSidebarClose = () => {
+	Liferay.Util.Session.set(
+		'com.liferay.content.dashboard.web_panelState',
+		CLOSE_PANEL_VALUE
+	);
+
+	Liferay.Util.Session.set(
+		'com.liferay.content.dashboard.web_panelCurrentItemInfo',
+		null
+	);
+};
+
 const dataReducer = (state, action) => {
 	switch (action.type) {
 		case 'CLOSE_SIDEBAR':
+			handleSessionOnSidebarClose();
+
 			return {
 				...state,
 				isOpen: false,

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanel.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanel.js
@@ -28,7 +28,7 @@ const initialState = {
 	open: true,
 };
 
-const handleSessionOnSidebarClose = () => {
+const resetSessionPanelValues = () => {
 	Liferay.Util.Session.set(
 		'com.liferay.content.dashboard.web_panelState',
 		CLOSE_PANEL_VALUE
@@ -43,7 +43,7 @@ const handleSessionOnSidebarClose = () => {
 const dataReducer = (state, action) => {
 	switch (action.type) {
 		case 'CLOSE_SIDEBAR':
-			handleSessionOnSidebarClose();
+			resetSessionPanelValues();
 
 			return {
 				...state,
@@ -149,6 +149,25 @@ const SidebarPanel = React.forwardRef(
 		useEffect(() => {
 			CurrentViewRef.current = View;
 		}, [View]);
+
+		useEffect(() => {
+			const navigationEventHandler = Liferay.on(
+				'startNavigate',
+				({path, target}) => {
+					const [, paramString] = target.currentURL.split('?');
+					const params = new URLSearchParams(paramString);
+					const currentPortletId = params.get('p_p_id');
+
+					if (!path.includes(currentPortletId)) {
+						resetSessionPanelValues();
+					}
+				}
+			);
+
+			return () => {
+				navigationEventHandler.detach();
+			};
+		}, []);
 
 		useImperativeHandle(ref, () => ({
 			close: () => safeDispatch({type: 'CLOSE_SIDEBAR'}),

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanel.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanel.js
@@ -35,8 +35,8 @@ const handleSessionOnSidebarClose = () => {
 	);
 
 	Liferay.Util.Session.set(
-		'com.liferay.content.dashboard.web_panelCurrentItemInfo',
-		null
+		'com.liferay.content.dashboard.web_selectedItemRowId',
+		''
 	);
 };
 

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/transformers/ActionsComponentPropsTransformer.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/transformers/ActionsComponentPropsTransformer.js
@@ -20,6 +20,8 @@ import SidebarPanelInfoViewCollapsable from '../components/SidebarPanelInfoView/
 import SidebarPanelMetricsView from '../components/SidebarPanelMetricsView';
 import {OPEN_PANEL_VALUE} from '../utils/constants';
 
+const ACTIVE_ROW_CSS_CLASS = 'table-active';
+
 const handlePanelStateFromSession = ({
 	currentRowId,
 	namespace,
@@ -67,10 +69,10 @@ const handleSessionOnSidebarOpen = ({rowId}) => {
 
 const deselectAllRows = (portletNamespace) => {
 	const activeRows = document.querySelectorAll(
-		`[data-searchcontainerid="${portletNamespace}content"] tr.active`
+		`[data-searchcontainerid="${portletNamespace}content"] tr.${ACTIVE_ROW_CSS_CLASS}`
 	);
 
-	activeRows.forEach((row) => row.classList.remove('active'));
+	activeRows.forEach((row) => row.classList.remove(ACTIVE_ROW_CSS_CLASS));
 };
 
 const getRow = (portletNamespace, rowId) =>
@@ -87,7 +89,7 @@ const selectRow = (portletNamespace, rowId) => {
 		return;
 	}
 
-	currentRow.classList.add('active');
+	currentRow.classList.add(ACTIVE_ROW_CSS_CLASS);
 };
 
 const showSidebar = ({View, fetchURL, portletNamespace}) => {

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/transformers/ActionsComponentPropsTransformer.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/transformers/ActionsComponentPropsTransformer.js
@@ -74,7 +74,7 @@ const handleSessionOnSidebarOpen = ({panelState, rowId, selectedItemRowId}) => {
 
 const deselectAllRows = (portletNamespace) => {
 	const activeRows = document.querySelectorAll(
-		`[data-searchcontainerid="${portletNamespace}content"] tr.${ACTIVE_ROW_CSS_CLASS}`
+		`#${portletNamespace}contentSearchContainer tr.${ACTIVE_ROW_CSS_CLASS}`
 	);
 
 	activeRows.forEach((row) => row.classList.remove(ACTIVE_ROW_CSS_CLASS));
@@ -82,7 +82,7 @@ const deselectAllRows = (portletNamespace) => {
 
 const getRow = (portletNamespace, rowId) =>
 	document.querySelector(
-		`[data-searchcontainerid="${portletNamespace}content"] [data-rowid="${rowId}"]`
+		`#${portletNamespace}contentSearchContainer [data-rowid="${rowId}"]`
 	);
 
 const selectRow = (portletNamespace, rowId) => {

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/transformers/ActionsComponentPropsTransformer.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/transformers/ActionsComponentPropsTransformer.js
@@ -56,15 +56,20 @@ const handlePanelStateFromSession = ({
 	selectRow(namespace, selectedItemRowId);
 };
 
-const handleSessionOnSidebarOpen = ({rowId}) => {
-	Liferay.Util.Session.set(
-		'com.liferay.content.dashboard.web_panelState',
-		OPEN_PANEL_VALUE
-	);
-	Liferay.Util.Session.set(
-		'com.liferay.content.dashboard.web_selectedItemRowId',
-		rowId
-	);
+const handleSessionOnSidebarOpen = ({panelState, rowId, selectedItemRowId}) => {
+	if (panelState !== OPEN_PANEL_VALUE) {
+		Liferay.Util.Session.set(
+			'com.liferay.content.dashboard.web_panelState',
+			OPEN_PANEL_VALUE
+		);
+	}
+
+	if (selectedItemRowId !== rowId) {
+		Liferay.Util.Session.set(
+			'com.liferay.content.dashboard.web_selectedItemRowId',
+			rowId
+		);
+	}
 };
 
 const deselectAllRows = (portletNamespace) => {
@@ -125,10 +130,21 @@ const showSidebar = ({View, fetchURL, portletNamespace}) => {
 };
 
 const actions = {
-	showInfo({fetchURL, portletNamespace, rowId}) {
+	showInfo({
+		fetchURL,
+		panelState,
+		portletNamespace,
+		rowId,
+		selectedItemRowId,
+	}) {
 		selectRow(portletNamespace, rowId);
 
-		handleSessionOnSidebarOpen({fetchURL, portletNamespace, rowId});
+		handleSessionOnSidebarOpen({
+			fetchURL,
+			panelState,
+			rowId,
+			selectedItemRowId,
+		});
 
 		showSidebar({
 			View: Liferay.FeatureFlags['LPS-161013']
@@ -154,6 +170,8 @@ export default function propsTransformer({
 	portletNamespace,
 	...otherProps
 }) {
+	const {panelState, selectedItemRowId} = additionalProps;
+
 	handlePanelStateFromSession(additionalProps);
 
 	return {
@@ -169,8 +187,10 @@ export default function propsTransformer({
 
 						actions[action]({
 							fetchURL: item.data.fetchURL,
+							panelState,
 							portletNamespace,
 							rowId: item.data.classPK,
+							selectedItemRowId,
 						});
 					}
 				},

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/utils/constants.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/utils/constants.js
@@ -42,3 +42,6 @@ export const COLORS = [
 ];
 
 export const DEFAULT_COLOR = '#CDCED9';
+
+export const OPEN_PANEL_VALUE = 'open';
+export const CLOSE_PANEL_VALUE = 'closed';

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/view.jsp
@@ -290,6 +290,19 @@ ContentDashboardAdminDisplayContext contentDashboardAdminDisplayContext = (Conte
 
 					<liferay-ui:search-container-column-text>
 						<clay:dropdown-actions
+							additionalProps='<%=
+								HashMapBuilder.<String, Object>put(
+									"currentRowId", rowId
+								).put(
+									"namespace", liferayPortletResponse.getNamespace()
+								).put(
+									"panelState", contentDashboardAdminDisplayContext.getPanelState()
+								).put(
+									"selectedItemFetchURL", contentDashboardAdminDisplayContext.getSelectedItemFetchURL(contentDashboardItem)
+								).put(
+									"selectedItemRowId", contentDashboardAdminDisplayContext.getSelectedItemRowId()
+								).build()
+							%>'
 							dropdownItems="<%= contentDashboardAdminDisplayContext.getDropdownItems(contentDashboardItem) %>"
 							propsTransformer="js/transformers/ActionsComponentPropsTransformer"
 						/>


### PR DESCRIPTION
QA team has validated this PR but it is stuck in the CI.  The original PR is [here](https://github.com/liferay-tango/liferay-portal/pull/2721).


[Jira ticket](https://issues.liferay.com/browse/LPS-160493)

## Motivation

After some refactoring, the mechanism that builds and updates the content of the Segments Experiment panel does not as often as it should.
The most noticeable issue is on SPA navigation, because the `URL` that the `side_navigation.es.js` module uses for [fetching the data automatically](https://github.com/liferay/liferay-portal/blob/278ea6228e43709cb67afa278db3cd348b619f32/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/side_navigation.es.js#L405) gets static 🤷 

## Proposed solution

As we did in other panels, we could move from this _black-box_ approach to a more open/transparent one. It feels the less problematic way and easier to debug in case of refactoring, etc.

By now, as today, we're just trying to make it work, using the `side_navigation.es.js` as is, but placing some workarounds to keep the url updated and living along with React.

## Video Recording of how to test it

https://user-images.githubusercontent.com/5776822/185906632-23f7487a-66bb-4825-ba07-bdaec44c074e.mp4


