### PR TITLE
LPS-160493 AB Sidebar Panel does not get updated on SPA navigation

### DIFF
--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/init.jsp
@@ -25,7 +25,6 @@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %><%@
 taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
 
 <%@ page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
-page import="com.liferay.portal.kernel.util.GetterUtil" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %><%@
 page import="com.liferay.segments.experiment.web.internal.constants.SegmentsExperimentWebKeys" %><%@
 page import="com.liferay.segments.experiment.web.internal.display.context.SegmentsExperimentDisplayContext" %><%@

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/SegmentsExperimentApp.es.js
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/SegmentsExperimentApp.es.js
@@ -61,50 +61,62 @@ export default function ({context, portletNamespace, props}) {
 		}
 	}, [segmentsExperimentPanelToggle, portletNamespace]);
 
-	return isAnalyticsSync ? (
-		<SegmentsExperimentsContext.Provider
-			value={{
-				APIService: APIService({
-					contentPageEditorNamespace:
-						context.contentPageEditorNamespace,
-					endpoints: {
-						calculateSegmentsExperimentEstimatedDurationURL,
-						createSegmentsExperimentURL,
-						createSegmentsVariantURL,
-						deleteSegmentsExperimentURL,
-						deleteSegmentsVariantURL,
-						editSegmentsExperimentStatusURL,
-						editSegmentsExperimentURL,
-						editSegmentsVariantURL,
-						runSegmentsExperimentURL,
-					},
-					namespace: context.namespace,
-				}),
-				editVariantLayoutURL: editSegmentsVariantLayoutURL,
-				imagesPath,
-				page,
-			}}
-		>
-			<div id={`${portletNamespace}-segments-experiment-root`}>
-				<SegmentsExperimentsSidebar
-					initialExperimentHistory={props.historySegmentsExperiments}
-					initialGoals={props.segmentsExperimentGoals}
-					initialSegmentsExperiment={props.segmentsExperiment}
-					initialSegmentsVariants={props.initialSegmentsVariants}
-					initialSelectedSegmentsExperienceId={
-						props.selectedSegmentsExperienceId
+	return (
+		<div id={`${portletNamespace}-segments-experiment-root`}>
+			{isAnalyticsSync ? (
+				<SegmentsExperimentsContext.Provider
+					value={{
+						APIService: APIService({
+							contentPageEditorNamespace:
+								context.contentPageEditorNamespace,
+							endpoints: {
+								calculateSegmentsExperimentEstimatedDurationURL,
+								createSegmentsExperimentURL,
+								createSegmentsVariantURL,
+								deleteSegmentsExperimentURL,
+								deleteSegmentsVariantURL,
+								editSegmentsExperimentStatusURL,
+								editSegmentsExperimentURL,
+								editSegmentsVariantURL,
+								runSegmentsExperimentURL,
+							},
+							namespace: context.namespace,
+						}),
+						editVariantLayoutURL: editSegmentsVariantLayoutURL,
+						imagesPath,
+						page,
+					}}
+				>
+					<div id={`${portletNamespace}-segments-experiment-root`}>
+						<SegmentsExperimentsSidebar
+							initialExperimentHistory={
+								props.historySegmentsExperiments
+							}
+							initialGoals={props.segmentsExperimentGoals}
+							initialSegmentsExperiment={props.segmentsExperiment}
+							initialSegmentsVariants={
+								props.initialSegmentsVariants
+							}
+							initialSelectedSegmentsExperienceId={
+								props.selectedSegmentsExperienceId
+							}
+							winnerSegmentsVariantId={
+								props.winnerSegmentsVariantId
+							}
+						/>
+					</div>
+				</SegmentsExperimentsContext.Provider>
+			) : (
+				<ConnectToAC
+					analyticsCloudTrialURL={props.analyticsData?.cloudTrialURL}
+					analyticsURL={props.analyticsData?.url}
+					hideAnalyticsReportsPanelURL={
+						props.hideSegmentsExperimentPanelURL
 					}
-					winnerSegmentsVariantId={props.winnerSegmentsVariantId}
+					isAnalyticsConnected={props.analyticsData?.isConnected}
+					pathToAssets={props.pathToAssets}
 				/>
-			</div>
-		</SegmentsExperimentsContext.Provider>
-	) : (
-		<ConnectToAC
-			analyticsCloudTrialURL={props.analyticsData?.cloudTrialURL}
-			analyticsURL={props.analyticsData?.url}
-			hideAnalyticsReportsPanelURL={props.hideSegmentsExperimentPanelURL}
-			isAnalyticsConnected={props.analyticsData?.isConnected}
-			pathToAssets={props.pathToAssets}
-		/>
+			)}
+		</div>
 	);
 }

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/ConnectToAC.es.js
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/ConnectToAC.es.js
@@ -92,7 +92,7 @@ export default function ConnectToAC({
 }
 
 ConnectToAC.propTypes = {
-	analyticsURL: PropTypes.string.isRequired,
+	analyticsURL: PropTypes.string,
 	hideAnalyticsReportsPanelURL: PropTypes.string.isRequired,
 	isAnalyticsConnected: PropTypes.bool.isRequired,
 	pathToAssets: PropTypes.string.isRequired,

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/segments_experiment_panel.jsp
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/segments_experiment_panel.jsp
@@ -26,5 +26,8 @@ SegmentsExperimentDisplayContext segmentsExperimentDisplayContext = (SegmentsExp
 		<span aria-hidden="true" class="loading-animation"></span>
 	</div>
 
-	<react:component module="js/SegmentsExperimentApp.es" props="<%= segmentsExperimentDisplayContext.getData() %>" />
+	<react:component
+		module="js/SegmentsExperimentApp.es"
+		props="<%= segmentsExperimentDisplayContext.getData() %>"
+	/>
 </section>

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/segments_experiment_panel.jsp
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/segments_experiment_panel.jsp
@@ -20,11 +20,11 @@
 SegmentsExperimentDisplayContext segmentsExperimentDisplayContext = (SegmentsExperimentDisplayContext)request.getAttribute(SegmentsExperimentWebKeys.SEGMENTS_EXPERIMENT_DISPLAY_CONTEXT);
 %>
 
-<div class="inline-item my-5 p-5 w-100">
-	<span aria-hidden="true" class="loading-animation"></span>
-</div>
+<!-- need this section wrap to avoid React complaining from the side_navigation.es.js node removal -->
+<section>
+	<div class="inline-item my-5 p-5 w-100">
+		<span aria-hidden="true" class="loading-animation"></span>
+	</div>
 
-<react:component
-	module="js/SegmentsExperimentApp.es"
-	props="<%= segmentsExperimentDisplayContext.getData() %>"
-/>
+	<react:component module="js/SegmentsExperimentApp.es" props="<%= segmentsExperimentDisplayContext.getData() %>" />
+</section>

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/view.jsp
@@ -23,10 +23,15 @@
 		</h1>
 
 		<span class="font-weight-bold">
-			<liferay-ui:message key="ab-test" /></span>
+		<liferay-ui:message key="ab-test" /></span>
 
-		<clay:button aria-label='<%= LanguageUtil.get(request, "close") %>' cssClass="sidenav-close text-secondary"
-			displayType="unstyled" icon="times" monospaced="<%= true %>" />
+		<clay:button
+			aria-label='<%= LanguageUtil.get(request, "close") %>'
+			cssClass="sidenav-close text-secondary"
+			displayType="unstyled"
+			icon="times"
+			monospaced="<%= true %>"
+		/>
 	</div>
 
 	<div class="sidebar-body">

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/view.jsp
@@ -18,22 +18,18 @@
 
 <div class="lfr-segments-experiment-sidebar" id="segmentsExperimentSidebar">
 	<div class="d-flex justify-content-between p-3 sidebar-header">
-		<h1 class="sr-only"><liferay-ui:message key="ab-test-panel" /></h1>
+		<h1 class="sr-only">
+			<liferay-ui:message key="ab-test-panel" />
+		</h1>
 
-		<span class="font-weight-bold"><liferay-ui:message key="ab-test" /></span>
+		<span class="font-weight-bold">
+			<liferay-ui:message key="ab-test" /></span>
 
-		<clay:button
-			aria-label='<%= LanguageUtil.get(request, "close") %>'
-			cssClass="sidenav-close text-secondary"
-			displayType="unstyled"
-			icon="times"
-			monospaced="<%= true %>"
-		/>
+		<clay:button aria-label='<%= LanguageUtil.get(request, "close") %>' cssClass="sidenav-close text-secondary"
+			displayType="unstyled" icon="times" monospaced="<%= true %>" />
 	</div>
 
 	<div class="sidebar-body">
-		<c:if test="<%= GetterUtil.getBoolean(request.getAttribute(SegmentsExperimentWebKeys.SEGMENTS_EXPERIMENT_PANEL_STATE_OPEN)) %>">
-			<liferay-util:include page="/segments_experiment_panel.jsp" servletContext="<%= application %>" />
-		</c:if>
+		<liferay-util:include page="/segments_experiment_panel.jsp" servletContext="<%= application %>" />
 	</div>
 </div>

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/com/liferay/segments/experiment/web/internal/product/navigation/control/menu/icon.tmpl
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/com/liferay/segments/experiment/web/internal/product/navigation/control/menu/icon.tmpl
@@ -1,5 +1,5 @@
 <li class="control-menu-nav-item d-none d-sm-inline-flex segments-experiment-icon ${cssClass}">
-	<a aria-label="${title}" class="control-menu-icon lfr-portal-tooltip product-menu-toggle sidenav-toggler" data-content="body" data-open-class="open-admin-panel" data-qa-id="segmentsExperimentPanel" data-target="#${portletNamespace}segmentsExperimentPanelId" data-title="${title}" data-toggle="liferay-sidenav" data-type="fixed-push" data-type-mobile="fixed" ${dataURL} href="javascript:void(0);" id="${portletNamespace}segmentsExperimentPanelToggleId">
+	<a aria-label="${title}" class="control-menu-icon lfr-portal-tooltip product-menu-toggle sidenav-toggler" data-content="body" data-open-class="open-admin-panel" data-qa-id="segmentsExperimentPanel" data-target="#${portletNamespace}segmentsExperimentPanelId" data-title="${title}" data-fetch="${dataURL}" data-toggle="liferay-sidenav" data-type="fixed-push" data-type-mobile="fixed" ${dataURL} href="javascript:void(0);" id="${portletNamespace}segmentsExperimentPanelToggleId">
 		${iconTag}
 	</a>
 </li>

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/com/liferay/segments/experiment/web/internal/product/navigation/control/menu/icon.tmpl
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/com/liferay/segments/experiment/web/internal/product/navigation/control/menu/icon.tmpl
@@ -1,5 +1,5 @@
 <li class="control-menu-nav-item d-none d-sm-inline-flex segments-experiment-icon ${cssClass}">
-	<a aria-label="${title}" class="control-menu-icon lfr-portal-tooltip product-menu-toggle sidenav-toggler" data-content="body" data-open-class="open-admin-panel" data-qa-id="segmentsExperimentPanel" data-target="#${portletNamespace}segmentsExperimentPanelId" data-title="${title}" data-fetch="${dataURL}" data-toggle="liferay-sidenav" data-type="fixed-push" data-type-mobile="fixed" ${dataURL} href="javascript:void(0);" id="${portletNamespace}segmentsExperimentPanelToggleId">
+	<a aria-label="${title}" class="control-menu-icon lfr-portal-tooltip product-menu-toggle sidenav-toggler" data-content="body" data-open-class="open-admin-panel" data-qa-id="segmentsExperimentPanel" data-target="#${portletNamespace}segmentsExperimentPanelId" data-title="${title}" data-toggle="liferay-sidenav" data-type="fixed-push" data-type-mobile="fixed" ${dataURL} href="javascript:void(0);" id="${portletNamespace}segmentsExperimentPanelToggleId">
 		${iconTag}
 	</a>
 </li>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/abtest/ABTest.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/abtest/ABTest.path
@@ -37,7 +37,7 @@
 </tr>
 <tr>
 	<td>AB_TEST_SIDE_BAR</td>
-	<td>//*[contains(@class, 'sidebar sidebar-light sidenav-menu sidebar-sm')]//*[text() ='A/B Test']</td>
+	<td>//div[contains(@class,'sidebar') and descendant::*[contains(.,'A/B Test')]]</td>
 	<td></td>
 </tr>
 <tr>
@@ -87,7 +87,7 @@
 </tr>
 <tr>
 	<td>HIDE_AB_TEST_BUTTON</td>
-	<td>//div[contains(@class,'sidebar') and descendant::span[contains(.,'A/B Test')]] //a[contains(.,'Do not show me this again')]</td>
+	<td>//div[contains(@class,'sidebar') and descendant::*[contains(.,'A/B Test')]] //a[contains(.,'Do not show me this again')]</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
The QA Team has validated this PR and it was stuck in the CI. [Here the original PR](https://github.com/liferay-tango/liferay-portal/pull/2721).

[Jira ticket](https://issues.liferay.com/browse/LPS-160493)

## Motivation

After some refactoring, the mechanism that builds and updates the content of the Segments Experiment panel does not as often as it should.
The most noticeable issue is on SPA navigation, because the `URL` that the `side_navigation.es.js` module uses for [fetching the data automatically](https://github.com/liferay/liferay-portal/blob/278ea6228e43709cb67afa278db3cd348b619f32/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/side_navigation.es.js#L405) gets static 🤷 

## Proposed solution

As we did in other panels, we could move from this _black-box_ approach to a more open/transparent one. It feels the less problematic way and easier to debug in case of refactoring, etc.

By now, as today, we're just trying to make it work, using the `side_navigation.es.js` as is, but placing some workarounds to keep the url updated and living along with React.

## Video Recording of how to test it

https://user-images.githubusercontent.com/5776822/185906632-23f7487a-66bb-4825-ba07-bdaec44c074e.mp4


