### PR TITLE
LPS-147681 This should be PortletRequest.RESOURCE_PHASE

### DIFF
--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/entries/add_content_icon.jsp
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/entries/add_content_icon.jsp
@@ -34,7 +34,7 @@ String portletNamespace = PortalUtil.getPortletNamespace(ProductNavigationContro
 		data-type-mobile="fixed"
 		data-url="<%=
 			PortletURLBuilder.create(
-				PortletURLFactoryUtil.create(request, ProductNavigationControlMenuPortletKeys.PRODUCT_NAVIGATION_CONTROL_MENU, PortletRequest.RENDER_PHASE)
+				PortletURLFactoryUtil.create(request, ProductNavigationControlMenuPortletKeys.PRODUCT_NAVIGATION_CONTROL_MENU, PortletRequest.RESOURCE_PHASE)
 			).setMVCPath(
 				"/add_panel.jsp"
 			).setParameter(


### PR DESCRIPTION
Hi Brian,
This issue was found when we upgrade portlets from 2.0 to 3.0.

Without this changes, when we type anything in the search box, error comes out.

I just sent this fix without other opt-in 3.0 changes.

Tested [here](https://github.com/ling-alan-huang/liferay-portal/pull/1323), unrelated failures.

![2022-09-06 02-57-36屏幕截图](https://user-images.githubusercontent.com/29118518/188502848-a177a883-78db-4236-bed0-29e701f1e364.png)
