### PR TITLE
LPS-162196 Name of class extending 'TextEditableElementParser' should end with 'TextEditableElementParser' 

### DIFF
--- a/modules/source-formatter.properties
+++ b/modules/source-formatter.properties
@@ -150,6 +150,9 @@
         org.osgi:org.osgi.core->org.osgi:osgi.core,\
         org.springframework:spring-orm->com.liferay:org.springframework.orm
 
+    source.check.JavaClassNameCheck.enforceExtendedClassNames=\
+        TextEditableElementParser
+
     source.check.JavaClassNameCheck.enforceImplementedClassNames=\
         BasicInfoListRenderer,\
         BorderedBasicInfoListRenderer,\

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaClassNameCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaClassNameCheck.java
@@ -111,6 +111,10 @@ public class JavaClassNameCheck extends BaseJavaTermCheck {
 		String fileName, String absolutePath, String className,
 		List<String> extendedClassNames) {
 
+		if (extendedClassNames.isEmpty()) {
+			return;
+		}
+
 		List<String> enforceExtendedClassNames = getAttributeValues(
 			_ENFORCE_EXTENDED_CLASS_NAMES_KEY, absolutePath);
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaClassNameCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaClassNameCheck.java
@@ -89,35 +89,59 @@ public class JavaClassNameCheck extends BaseJavaTermCheck {
 			javaClass.getImplementedClassNames();
 
 		if (implementedClassNames.isEmpty()) {
-			return javaTerm.getContent();
-		}
+			List<String> enforceExtendedClassNames = getAttributeValues(
+				_ENFORCE_EXTENDED_CLASS_NAMES_KEY, absolutePath);
 
-		List<String> enforceImplementedClassNames = getAttributeValues(
-			_ENFORCE_IMPLEMENTED_CLASS_NAMES_KEY, absolutePath);
+			List<String> extendedClassNames = javaClass.getExtendedClassNames();
 
-		outerLoop:
-		for (String implementedClassName : enforceImplementedClassNames) {
-			if (!implementedClassNames.contains(implementedClassName)) {
-				continue;
-			}
+			for (String enforceExtendedClassName : enforceExtendedClassNames) {
+				if (!extendedClassNames.contains(enforceExtendedClassName)) {
+					continue;
+				}
 
-			for (String extendedClassName : javaClass.getExtendedClassNames()) {
-				if (extendedClassName.startsWith("Base") &&
-					!extendedClassName.endsWith(implementedClassName)) {
+				if (!className.endsWith(enforceExtendedClassName)) {
+					addMessage(
+						fileName,
+						StringBundler.concat(
+							"Name of class extending '",
+							enforceExtendedClassName, "' should end with '",
+							enforceExtendedClassName, "'"));
 
-					continue outerLoop;
+					break;
 				}
 			}
+		}
+		else {
+			List<String> enforceImplementedClassNames = getAttributeValues(
+				_ENFORCE_IMPLEMENTED_CLASS_NAMES_KEY, absolutePath);
 
-			if (!className.endsWith(implementedClassName) &&
-				((implementedClassNames.size() == 1) ||
-				 implementedClassName.equals("ScreenNavigationCategory"))) {
+			outerLoop:
+			for (String implementedClassName : enforceImplementedClassNames) {
+				if (!implementedClassNames.contains(implementedClassName)) {
+					continue;
+				}
 
-				addMessage(
-					fileName,
-					StringBundler.concat(
-						"Name of class implementing '", implementedClassName,
-						"' should end with '", implementedClassName, "'"));
+				for (String extendedClassName :
+						javaClass.getExtendedClassNames()) {
+
+					if (extendedClassName.startsWith("Base") &&
+						!extendedClassName.endsWith(implementedClassName)) {
+
+						continue outerLoop;
+					}
+				}
+
+				if (!className.endsWith(implementedClassName) &&
+					((implementedClassNames.size() == 1) ||
+					 implementedClassName.equals("ScreenNavigationCategory"))) {
+
+					addMessage(
+						fileName,
+						StringBundler.concat(
+							"Name of class implementing '",
+							implementedClassName, "' should end with '",
+							implementedClassName, "'"));
+				}
 			}
 		}
 
@@ -173,6 +197,9 @@ public class JavaClassNameCheck extends BaseJavaTermCheck {
 					packageName, "'"));
 		}
 	}
+
+	private static final String _ENFORCE_EXTENDED_CLASS_NAMES_KEY =
+		"enforceExtendedClassNames";
 
 	private static final String _ENFORCE_IMPLEMENTED_CLASS_NAMES_KEY =
 		"enforceImplementedClassNames";

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaClassNameCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaClassNameCheck.java
@@ -85,64 +85,18 @@ public class JavaClassNameCheck extends BaseJavaTermCheck {
 			}
 		}
 
+		List<String> extendedClassNames = javaClass.getExtendedClassNames();
 		List<String> implementedClassNames =
 			javaClass.getImplementedClassNames();
 
 		if (implementedClassNames.isEmpty()) {
-			List<String> enforceExtendedClassNames = getAttributeValues(
-				_ENFORCE_EXTENDED_CLASS_NAMES_KEY, absolutePath);
-
-			List<String> extendedClassNames = javaClass.getExtendedClassNames();
-
-			for (String enforceExtendedClassName : enforceExtendedClassNames) {
-				if (!extendedClassNames.contains(enforceExtendedClassName)) {
-					continue;
-				}
-
-				if (!className.endsWith(enforceExtendedClassName)) {
-					addMessage(
-						fileName,
-						StringBundler.concat(
-							"Name of class extending '",
-							enforceExtendedClassName, "' should end with '",
-							enforceExtendedClassName, "'"));
-
-					break;
-				}
-			}
+			_checkClassNameByExtendedClasses(
+				fileName, absolutePath, className, extendedClassNames);
 		}
 		else {
-			List<String> enforceImplementedClassNames = getAttributeValues(
-				_ENFORCE_IMPLEMENTED_CLASS_NAMES_KEY, absolutePath);
-
-			outerLoop:
-			for (String implementedClassName : enforceImplementedClassNames) {
-				if (!implementedClassNames.contains(implementedClassName)) {
-					continue;
-				}
-
-				for (String extendedClassName :
-						javaClass.getExtendedClassNames()) {
-
-					if (extendedClassName.startsWith("Base") &&
-						!extendedClassName.endsWith(implementedClassName)) {
-
-						continue outerLoop;
-					}
-				}
-
-				if (!className.endsWith(implementedClassName) &&
-					((implementedClassNames.size() == 1) ||
-					 implementedClassName.equals("ScreenNavigationCategory"))) {
-
-					addMessage(
-						fileName,
-						StringBundler.concat(
-							"Name of class implementing '",
-							implementedClassName, "' should end with '",
-							implementedClassName, "'"));
-				}
-			}
+			_checkClassNameByImplementedClasses(
+				fileName, absolutePath, className, extendedClassNames,
+				implementedClassNames);
 		}
 
 		return javaTerm.getContent();
@@ -151,6 +105,66 @@ public class JavaClassNameCheck extends BaseJavaTermCheck {
 	@Override
 	protected String[] getCheckableJavaTermNames() {
 		return new String[] {JAVA_CLASS};
+	}
+
+	private void _checkClassNameByExtendedClasses(
+		String fileName, String absolutePath, String className,
+		List<String> extendedClassNames) {
+
+		List<String> enforceExtendedClassNames = getAttributeValues(
+			_ENFORCE_EXTENDED_CLASS_NAMES_KEY, absolutePath);
+
+		for (String enforceExtendedClassName : enforceExtendedClassNames) {
+			if (!extendedClassNames.contains(enforceExtendedClassName)) {
+				continue;
+			}
+
+			if (!className.endsWith(enforceExtendedClassName)) {
+				addMessage(
+					fileName,
+					StringBundler.concat(
+						"Name of class extending '", enforceExtendedClassName,
+						"' should end with '", enforceExtendedClassName, "'"));
+
+				break;
+			}
+		}
+	}
+
+	private void _checkClassNameByImplementedClasses(
+		String fileName, String absolutePath, String className,
+		List<String> extendedClassNames, List<String> implementedClassNames) {
+
+		List<String> enforceImplementedClassNames = getAttributeValues(
+			_ENFORCE_IMPLEMENTED_CLASS_NAMES_KEY, absolutePath);
+
+		outerLoop:
+		for (String implementedClassName : enforceImplementedClassNames) {
+			if (!implementedClassNames.contains(implementedClassName)) {
+				continue;
+			}
+
+			for (String extendedClassName : extendedClassNames) {
+				if (extendedClassName.startsWith("Base") &&
+					!extendedClassName.endsWith(implementedClassName)) {
+
+					continue outerLoop;
+				}
+			}
+
+			if (!className.endsWith(implementedClassName) &&
+				((implementedClassNames.size() == 1) ||
+				 implementedClassName.equals("ScreenNavigationCategory"))) {
+
+				addMessage(
+					fileName,
+					StringBundler.concat(
+						"Name of class implementing '", implementedClassName,
+						"' should end with '", implementedClassName, "'"));
+
+				break;
+			}
+		}
 	}
 
 	private void _checkTypo(

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaClassNameCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaClassNameCheck.java
@@ -143,28 +143,32 @@ public class JavaClassNameCheck extends BaseJavaTermCheck {
 			_ENFORCE_IMPLEMENTED_CLASS_NAMES_KEY, absolutePath);
 
 		outerLoop:
-		for (String implementedClassName : enforceImplementedClassNames) {
-			if (!implementedClassNames.contains(implementedClassName)) {
+		for (String enforceImplementedClassName :
+				enforceImplementedClassNames) {
+
+			if (!implementedClassNames.contains(enforceImplementedClassName)) {
 				continue;
 			}
 
 			for (String extendedClassName : extendedClassNames) {
 				if (extendedClassName.startsWith("Base") &&
-					!extendedClassName.endsWith(implementedClassName)) {
+					!extendedClassName.endsWith(enforceImplementedClassName)) {
 
 					continue outerLoop;
 				}
 			}
 
-			if (!className.endsWith(implementedClassName) &&
+			if (!className.endsWith(enforceImplementedClassName) &&
 				((implementedClassNames.size() == 1) ||
-				 implementedClassName.equals("ScreenNavigationCategory"))) {
+				 enforceImplementedClassName.equals(
+					 "ScreenNavigationCategory"))) {
 
 				addMessage(
 					fileName,
 					StringBundler.concat(
-						"Name of class implementing '", implementedClassName,
-						"' should end with '", implementedClassName, "'"));
+						"Name of class implementing '",
+						enforceImplementedClassName, "' should end with '",
+						enforceImplementedClassName, "'"));
 
 				break;
 			}


### PR DESCRIPTION
Tested [here](https://github.com/ling-alan-huang/liferay-portal/pull/1321), unrelated failures.

see: https://github.com/liferay/liferay-portal/commit/a331f88edda0857aa2525f791f406d8cd86f8b8e

https://issues.liferay.com/browse/LPS-162196
