### PR TITLE
LPS-161245 Creates a new property called resizeDirection for liferay-editor:editor tag

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/BaseCKEditorConfigContributor.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/BaseCKEditorConfigContributor.java
@@ -113,7 +113,12 @@ public class BaseCKEditorConfigContributor extends BaseEditorConfigContributor {
 				CKEditorConstants.ATTRIBUTE_NAMESPACE + ":resizable"));
 
 		if (resizable) {
-			jsonObject.put("resize_dir", "vertical");
+			String resizeDirection = GetterUtil.getString(
+				inputEditorTaglibAttributes.get(
+					CKEditorConstants.ATTRIBUTE_NAMESPACE +
+						":resizeDirection"));
+
+			jsonObject.put("resizeDirection", resizeDirection);
 		}
 
 		jsonObject.put("resize_enabled", resizable);

--- a/modules/apps/frontend-editor/frontend-editor-taglib/bnd.bnd
+++ b/modules/apps/frontend-editor/frontend-editor-taglib/bnd.bnd
@@ -1,7 +1,7 @@
 Bundle-Activator: com.liferay.frontend.editor.taglib.internal.activator.EditorTaglibBundleActivator
 Bundle-Name: Liferay Frontend Editor Taglib
 Bundle-SymbolicName: com.liferay.frontend.editor.taglib
-Bundle-Version: 4.0.9
+Bundle-Version: 4.1.0
 Export-Package: com.liferay.frontend.editor.taglib.servlet.taglib
 Provide-Capability:\
 	osgi.extender;\

--- a/modules/apps/frontend-editor/frontend-editor-taglib/src/main/java/com/liferay/frontend/editor/taglib/servlet/taglib/EditorTag.java
+++ b/modules/apps/frontend-editor/frontend-editor-taglib/src/main/java/com/liferay/frontend/editor/taglib/servlet/taglib/EditorTag.java
@@ -138,6 +138,10 @@ public class EditorTag extends BaseValidatorTagSupport {
 		return _placeholder;
 	}
 
+	public String getResizeDirection() {
+		return _resizeDirection;
+	}
+
 	public String getToolbarSet() {
 		return _toolbarSet;
 	}
@@ -258,6 +262,10 @@ public class EditorTag extends BaseValidatorTagSupport {
 		_resizable = resizable;
 	}
 
+	public void setResizeDirection(String resizeDir) {
+		_resizeDirection = resizeDir;
+	}
+
 	public void setShowSource(boolean showSource) {
 		_showSource = showSource;
 	}
@@ -299,6 +307,7 @@ public class EditorTag extends BaseValidatorTagSupport {
 		_placeholder = null;
 		_required = false;
 		_resizable = true;
+		_resizeDirection = "vertical";
 		_showSource = true;
 		_skipEditorLoading = false;
 		_toolbarSet = _TOOLBAR_SET_DEFAULT;
@@ -370,6 +379,8 @@ public class EditorTag extends BaseValidatorTagSupport {
 			httpServletRequest, "required", String.valueOf(_required));
 		setNamespacedAttribute(
 			httpServletRequest, "resizable", String.valueOf(_resizable));
+		setNamespacedAttribute(
+			httpServletRequest, "resizeDirection", _resizeDirection);
 		setNamespacedAttribute(
 			httpServletRequest, "showSource", String.valueOf(_showSource));
 		setNamespacedAttribute(
@@ -564,6 +575,7 @@ public class EditorTag extends BaseValidatorTagSupport {
 	private String _placeholder;
 	private boolean _required;
 	private boolean _resizable = true;
+	private String _resizeDirection = "vertical";
 	private boolean _showSource = true;
 	private boolean _skipEditorLoading;
 	private String _toolbarSet = _TOOLBAR_SET_DEFAULT;

--- a/modules/apps/frontend-editor/frontend-editor-taglib/src/main/resources/META-INF/liferay-editor.tld
+++ b/modules/apps/frontend-editor/frontend-editor-taglib/src/main/resources/META-INF/liferay-editor.tld
@@ -136,6 +136,12 @@
 			<type>boolean</type>
 		</attribute>
 		<attribute>
+			<description>Set editor's resizing directions. The default value is <![CDATA[<code>vertical</code>]]>. Possible values are <![CDATA[<code>vertical</code>]]>, <![CDATA[<code>horizontal</code>]]> and <![CDATA[<code>both</code>]]>.</description>
+			<name>resizeDirection</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
 			<description>Whether to enable editing the HTML source code of the content. The default value is <![CDATA[<code>true</code>]]>.</description>
 			<name>showSource</name>
 			<required>false</required>
@@ -161,7 +167,7 @@
 		</attribute>
 	</tag>
 	<tag>
-		<description></description>
+		<description/>
 		<name>resources</name>
 		<tag-class>com.liferay.frontend.editor.taglib.servlet.taglib.ResourcesTag</tag-class>
 		<body-content>empty</body-content>

--- a/modules/apps/frontend-editor/frontend-editor-taglib/src/main/resources/com/liferay/frontend/editor/taglib/servlet/taglib/packageinfo
+++ b/modules/apps/frontend-editor/frontend-editor-taglib/src/main/resources/com/liferay/frontend/editor/taglib/servlet/taglib/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0


### PR DESCRIPTION
Came from: https://github.com/brianchandotcom/liferay-portal/pull/122649#issuecomment-1237515612

I tested locally and it's working.

## How to test locally:

1. Go to *ckeditor-sample-web module
2. Inside liferay-editor:editor tag call, replace with the following snippet:

```jsp
<liferay-editor:editor
	contents="<%= sampleEditorContents %>"
	editorName="ckeditor"
	name="sampleBalloonEditor"
	placeholder="content"
	resizable="<%= Boolean.TRUE %>"
	resizeDirection="vertical"
/>
```
3. Drop a CKEditor Sample on a page and try to resize. You'll notice we can only resize it vertically.


