### PR TITLE
LPS-159730 Unable to change search bar suggestions result destination page

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/SearchBarPortletDestinationUtil.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/SearchBarPortletDestinationUtil.java
@@ -50,7 +50,7 @@ public class SearchBarPortletDestinationUtil {
 		ThemeDisplay themeDisplay) {
 
 		Optional<String> optional =
-			searchBarPortletPreferences.getDestination();
+			searchBarPortletPreferences.getDestinationOptional();
 
 		if (!optional.isPresent() ||
 			isSameDestination(

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/SearchBarPortletPreferences.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/SearchBarPortletPreferences.java
@@ -54,7 +54,7 @@ public interface SearchBarPortletPreferences {
 	public static final String PREFERENCE_KEY_USE_ADVANCED_SEARCH_SYNTAX =
 		"useAdvancedSearchSyntax";
 
-	public Optional<String> getDestination();
+	public Optional<String> getDestinationOptional();
 
 	public String getDestinationString();
 

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/SearchBarPortletPreferencesImpl.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/SearchBarPortletPreferencesImpl.java
@@ -36,14 +36,14 @@ public class SearchBarPortletPreferencesImpl
 	}
 
 	@Override
-	public Optional<String> getDestination() {
+	public Optional<String> getDestinationOptional() {
 		return _portletPreferencesHelper.getString(
 			SearchBarPortletPreferences.PREFERENCE_KEY_DESTINATION);
 	}
 
 	@Override
 	public String getDestinationString() {
-		Optional<String> valueOptional = getDestination();
+		Optional<String> valueOptional = getDestinationOptional();
 
 		return valueOptional.orElse(StringPool.BLANK);
 	}

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/SearchBarPortletDisplayContext.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/SearchBarPortletDisplayContext.java
@@ -25,8 +25,8 @@ public class SearchBarPortletDisplayContext {
 		return _currentSiteSearchScopeParameterString;
 	}
 
-	public String getDestination() {
-		return _destination;
+	public String getDestinationFriendlyURL() {
+		return _destinationFriendlyURL;
 	}
 
 	public long getDisplayStyleGroupId() {
@@ -136,8 +136,8 @@ public class SearchBarPortletDisplayContext {
 			searchScopeCurrentSiteParameterString;
 	}
 
-	public void setDestination(String destination) {
-		_destination = destination;
+	public void setDestinationFriendlyURL(String destinationFriendlyURL) {
+		_destinationFriendlyURL = destinationFriendlyURL;
 	}
 
 	public void setDestinationUnreachable(boolean destinationUnreachable) {
@@ -255,7 +255,7 @@ public class SearchBarPortletDisplayContext {
 
 	private boolean _availableEverythingSearchScope;
 	private String _currentSiteSearchScopeParameterString;
-	private String _destination;
+	private String _destinationFriendlyURL;
 	private boolean _destinationUnreachable;
 	private long _displayStyleGroupId;
 	private boolean _displayWarningIgnoredConfiguration;

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/SearchBarPortletDisplayContext.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/SearchBarPortletDisplayContext.java
@@ -25,6 +25,10 @@ public class SearchBarPortletDisplayContext {
 		return _currentSiteSearchScopeParameterString;
 	}
 
+	public String getDestination() {
+		return _destination;
+	}
+
 	public long getDisplayStyleGroupId() {
 		return _displayStyleGroupId;
 	}
@@ -130,6 +134,10 @@ public class SearchBarPortletDisplayContext {
 
 		_currentSiteSearchScopeParameterString =
 			searchScopeCurrentSiteParameterString;
+	}
+
+	public void setDestination(String destination) {
+		_destination = destination;
 	}
 
 	public void setDestinationUnreachable(boolean destinationUnreachable) {
@@ -247,6 +255,7 @@ public class SearchBarPortletDisplayContext {
 
 	private boolean _availableEverythingSearchScope;
 	private String _currentSiteSearchScopeParameterString;
+	private String _destination;
 	private boolean _destinationUnreachable;
 	private long _displayStyleGroupId;
 	private boolean _displayWarningIgnoredConfiguration;

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactory.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactory.java
@@ -118,7 +118,7 @@ public class SearchBarPortletDisplayContextFactory {
 			isAvailableEverythingSearchScope());
 		searchBarPortletDisplayContext.setCurrentSiteSearchScopeParameterString(
 			SearchScope.THIS_SITE.getParameterString());
-		searchBarPortletDisplayContext.setDestination(destination);
+		searchBarPortletDisplayContext.setDestinationFriendlyURL(destination);
 		searchBarPortletDisplayContext.setDisplayStyleGroupId(
 			getDisplayStyleGroupId(
 				searchBarPortletInstanceConfiguration, themeDisplay));

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactory.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactory.java
@@ -118,6 +118,7 @@ public class SearchBarPortletDisplayContextFactory {
 			isAvailableEverythingSearchScope());
 		searchBarPortletDisplayContext.setCurrentSiteSearchScopeParameterString(
 			SearchScope.THIS_SITE.getParameterString());
+		searchBarPortletDisplayContext.setDestination(destination);
 		searchBarPortletDisplayContext.setDisplayStyleGroupId(
 			getDisplayStyleGroupId(
 				searchBarPortletInstanceConfiguration, themeDisplay));

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactory.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactory.java
@@ -86,15 +86,16 @@ public class SearchBarPortletDisplayContextFactory {
 		ThemeDisplay themeDisplay = (ThemeDisplay)_renderRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
-		String destination = searchBarPortletPreferences.getDestinationString();
+		String destinationString =
+			searchBarPortletPreferences.getDestinationString();
 
-		if (Validator.isBlank(destination)) {
+		if (Validator.isBlank(destinationString)) {
 			searchBarPortletDisplayContext.setSearchURL(
 				_getURLCurrentPath(themeDisplay));
 		}
 		else {
 			String destinationURL = _getDestinationURL(
-				destination, themeDisplay);
+				destinationString, themeDisplay);
 
 			if (destinationURL == null) {
 				searchBarPortletDisplayContext.setDestinationUnreachable(true);
@@ -118,7 +119,8 @@ public class SearchBarPortletDisplayContextFactory {
 			isAvailableEverythingSearchScope());
 		searchBarPortletDisplayContext.setCurrentSiteSearchScopeParameterString(
 			SearchScope.THIS_SITE.getParameterString());
-		searchBarPortletDisplayContext.setDestinationFriendlyURL(destination);
+		searchBarPortletDisplayContext.setDestinationFriendlyURL(
+			destinationString);
 		searchBarPortletDisplayContext.setDisplayStyleGroupId(
 			getDisplayStyleGroupId(
 				searchBarPortletInstanceConfiguration, themeDisplay));
@@ -333,10 +335,10 @@ public class SearchBarPortletDisplayContextFactory {
 	}
 
 	private String _getDestinationURL(
-		String friendlyURL, ThemeDisplay themeDisplay) {
+		String destinationString, ThemeDisplay themeDisplay) {
 
 		Layout layout = fetchLayoutByFriendlyURL(
-			themeDisplay.getScopeGroupId(), _slashify(friendlyURL));
+			themeDisplay.getScopeGroupId(), _slashify(destinationString));
 
 		if (layout == null) {
 			return null;

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/suggestions/portlet/action/RedirectSuggestionsMVCActionCommand.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/suggestions/portlet/action/RedirectSuggestionsMVCActionCommand.java
@@ -124,7 +124,7 @@ public class RedirectSuggestionsMVCActionCommand extends BaseMVCActionCommand {
 		String path = url.substring(0, url.indexOf(friendlyURL));
 
 		Optional<String> destinationOptional =
-			searchBarPortletPreferences.getDestination();
+			searchBarPortletPreferences.getDestinationOptional();
 
 		String destination = destinationOptional.orElse(friendlyURL);
 

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SearchBar.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SearchBar.js
@@ -84,7 +84,7 @@ export default function SearchBar({
 		},
 		variables: {
 			currentURL: window.location.href,
-			destinationFriendlyURL: !searchURL.trim().length
+			destinationFriendlyURL: searchURL.trim().length
 				? searchURL
 				: '/search',
 			groupId: Liferay.ThemeDisplay.getScopeGroupId(),

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SearchBar.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SearchBar.js
@@ -25,6 +25,7 @@ import {navigate} from 'frontend-js-web';
 import React, {useRef, useState} from 'react';
 
 export default function SearchBar({
+	destinationFriendlyURL,
 	emptySearchEnabled,
 	keywords = '',
 	keywordsParameterName = 'q',
@@ -84,8 +85,8 @@ export default function SearchBar({
 		},
 		variables: {
 			currentURL: window.location.href,
-			destinationFriendlyURL: searchURL.trim().length
-				? searchURL
+			destinationFriendlyURL: destinationFriendlyURL.trim().length
+				? destinationFriendlyURL
 				: '/search',
 			groupId: Liferay.ThemeDisplay.getScopeGroupId(),
 			plid: Liferay.ThemeDisplay.getPlid(),

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/bar/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/bar/view.jsp
@@ -85,7 +85,7 @@ SearchBarPortletDisplayContext searchBarPortletDisplayContext = (SearchBarPortle
 								module="js/components/SearchBar"
 								props='<%=
 									HashMapBuilder.<String, Object>put(
-										"destinationFriendlyURL", searchBarPortletDisplayContext.getDestination()
+										"destinationFriendlyURL", searchBarPortletDisplayContext.getDestinationFriendlyURL()
 									).put(
 										"emptySearchEnabled", searchBarPortletDisplayContext.isEmptySearchEnabled()
 									).put(

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/bar/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/bar/view.jsp
@@ -85,6 +85,8 @@ SearchBarPortletDisplayContext searchBarPortletDisplayContext = (SearchBarPortle
 								module="js/components/SearchBar"
 								props='<%=
 									HashMapBuilder.<String, Object>put(
+										"destinationFriendlyURL", searchBarPortletDisplayContext.getDestination()
+									).put(
 										"emptySearchEnabled", searchBarPortletDisplayContext.isEmptySearchEnabled()
 									).put(
 										"keywords", searchBarPortletDisplayContext.getKeywords()


### PR DESCRIPTION
Manually forwarding this PR since it failed ci:forward due to an unrelated failure.

Copied from https://github.com/liferay-search/liferay-portal/pull/541:
> https://issues.liferay.com/browse/LPS-159730
> 
> Follow-up from https://github.com/brianchandotcom/liferay-portal/pull/122225
> 
> > We have
> > 
> > destinationFriendlyURL
> > destinationString
> > destination
> > 
> > That all seem to mean the same thing.
> > 
> > Please consolidate and resend.
> > 
> > destinationFriendlyURL is probably the best and most prescriptive name, but I don't have all the context. Thx.
> 
> **Notes:**
> - I didn't change the portlet preference `destination` to `destinationFriendlyURL` because it caused upgrade issues. 
> - The reason `destinationString` exists is because of the naming pattern `get*Optional` and `get*String` (see [SearchBarPortletPreferences.java#L57-L63](https://github.com/thektan/liferay-portal/blob/LPS-159730_UnableToChangeSearchBarSuggestionsDestinationPage/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/SearchBarPortletPreferences.java#L57-L63))
> - I did rename SearchBarPortletDisplayContext `getDestination` to `getDestinationFriendlyURL` to match it's purpose of using it for the Suggestions REST endpoint (see [view.jsp](https://github.com/thektan/liferay-portal/blob/LPS-159730_UnableToChangeSearchBarSuggestionsDestinationPage/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/bar/view.jsp#L88) and [rest-openapi.yaml](https://github.com/thektan/liferay-portal/blob/LPS-159730_UnableToChangeSearchBarSuggestionsDestinationPage/modules/apps/portal-search/portal-search-rest-impl/rest-openapi.yaml#L55))