### PR TITLE
LPS-161059: Expose batch action in the headless APIs

### DIFF
--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/KeywordResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/KeywordResourceImpl.java
@@ -141,10 +141,25 @@ public class KeywordResourceImpl extends BaseKeywordResourceImpl {
 					ActionKeys.MANAGE_TAG, "postSiteKeyword",
 					AssetTagsPermission.RESOURCE_NAME, siteId)
 			).put(
+				"createBatch",
+				addAction(
+					ActionKeys.MANAGE_TAG, "postSiteKeywordBatch",
+					AssetTagsPermission.RESOURCE_NAME, siteId)
+			).put(
+				"deleteBatch",
+				addAction(
+					ActionKeys.DELETE, "deleteKeywordBatch",
+					AssetTagsPermission.RESOURCE_NAME, null)
+			).put(
 				"get",
 				addAction(
 					ActionKeys.MANAGE_TAG, "getSiteKeywordsPage",
 					AssetTagsPermission.RESOURCE_NAME, siteId)
+			).put(
+				"updateBatch",
+				addAction(
+					ActionKeys.UPDATE, "putKeywordBatch",
+					AssetTagsPermission.RESOURCE_NAME, null)
 			).build(),
 			booleanQuery -> {
 			},

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyCategoryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyCategoryResourceImpl.java
@@ -233,10 +233,25 @@ public class TaxonomyCategoryResourceImpl
 					ActionKeys.ADD_CATEGORY, assetVocabulary,
 					"postTaxonomyVocabularyTaxonomyCategory")
 			).put(
+				"createBatch",
+				addAction(
+					ActionKeys.VIEW, assetVocabulary,
+					"postTaxonomyVocabularyTaxonomyCategoryBatch")
+			).put(
+				"deleteBatch",
+				addAction(
+					ActionKeys.DELETE, assetVocabulary,
+					"deleteTaxonomyCategoryBatch")
+			).put(
 				"get",
 				addAction(
 					ActionKeys.VIEW, assetVocabulary,
 					"getTaxonomyVocabularyTaxonomyCategoriesPage")
+			).put(
+				"updateBatch",
+				addAction(
+					ActionKeys.UPDATE, assetVocabulary,
+					"putTaxonomyCategoryBatch")
 			).build(),
 			aggregation,
 			booleanQuery -> {

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java
@@ -162,10 +162,26 @@ public class TaxonomyVocabularyResourceImpl
 					ActionKeys.ADD_VOCABULARY, "postSiteTaxonomyVocabulary",
 					AssetCategoriesPermission.RESOURCE_NAME, siteId)
 			).put(
+				"createBatch",
+				addAction(
+					ActionKeys.ADD_VOCABULARY,
+					"postSiteTaxonomyVocabularyBatch",
+					AssetCategoriesPermission.RESOURCE_NAME, siteId)
+			).put(
+				"deleteBatch",
+				addAction(
+					ActionKeys.DELETE, "deleteTaxonomyVocabularyBatch",
+					AssetCategoriesPermission.RESOURCE_NAME, null)
+			).put(
 				"get",
 				addAction(
 					ActionKeys.VIEW, "getSiteTaxonomyVocabulariesPage",
 					AssetCategoriesPermission.RESOURCE_NAME, siteId)
+			).put(
+				"updateBatch",
+				addAction(
+					ActionKeys.UPDATE, "putTaxonomyVocabularyBatch",
+					AssetCategoriesPermission.RESOURCE_NAME, null)
 			).build(),
 			booleanQuery -> {
 			},

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BlogPostingResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BlogPostingResourceImpl.java
@@ -168,6 +168,16 @@ public class BlogPostingResourceImpl extends BaseBlogPostingResourceImpl {
 					ActionKeys.ADD_ENTRY, "postSiteBlogPosting",
 					BlogsConstants.RESOURCE_NAME, siteId)
 			).put(
+				"createBatch",
+				addAction(
+					ActionKeys.ADD_ENTRY, "postSiteBlogPostingBatch",
+					BlogsConstants.RESOURCE_NAME, siteId)
+			).put(
+				"deleteBatch",
+				addAction(
+					ActionKeys.DELETE, "deleteBlogPostingBatch",
+					BlogsConstants.RESOURCE_NAME, null)
+			).put(
 				"subscribe",
 				addAction(
 					ActionKeys.SUBSCRIBE, "putSiteBlogPostingSubscribe",
@@ -177,6 +187,11 @@ public class BlogPostingResourceImpl extends BaseBlogPostingResourceImpl {
 				addAction(
 					ActionKeys.SUBSCRIBE, "putSiteBlogPostingUnsubscribe",
 					BlogsConstants.RESOURCE_NAME, siteId)
+			).put(
+				"updateBatch",
+				addAction(
+					ActionKeys.UPDATE, "putBlogPostingBatch",
+					BlogsConstants.RESOURCE_NAME, null)
 			).build(),
 			booleanQuery -> {
 			},

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/CommentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/CommentResourceImpl.java
@@ -57,7 +57,6 @@ import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.util.SearchUtil;
 
-import java.util.Collections;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -171,6 +170,12 @@ public class CommentResourceImpl extends BaseCommentResourceImpl {
 					"postBlogPostingComment", blogsEntry.getUserId(),
 					BlogsEntry.class.getName(), blogsEntry.getGroupId())
 			).put(
+				"createBatch",
+				addAction(
+					ActionKeys.ADD_DISCUSSION, blogPostingId,
+					"postBlogPostingCommentBatch", blogsEntry.getUserId(),
+					BlogsEntry.class.getName(), blogsEntry.getGroupId())
+			).put(
 				"get",
 				addAction(
 					ActionKeys.VIEW, blogPostingId,
@@ -207,8 +212,18 @@ public class CommentResourceImpl extends BaseCommentResourceImpl {
 		throws Exception {
 
 		return _getComments(
-			Collections.emptyMap(), parentCommentId, search, aggregation,
-			filter, pagination, sorts);
+			HashMapBuilder.put(
+				"deleteBatch",
+				addAction(
+					ActionKeys.DELETE, "deleteCommentBatch",
+					Comment.class.getName(), null)
+			).put(
+				"updateBatch",
+				addAction(
+					ActionKeys.UPDATE, "putCommentBatch",
+					Comment.class.getName(), null)
+			).build(),
+			parentCommentId, search, aggregation, filter, pagination, sorts);
 	}
 
 	@Override
@@ -233,6 +248,12 @@ public class CommentResourceImpl extends BaseCommentResourceImpl {
 				addAction(
 					ActionKeys.ADD_DISCUSSION, documentId,
 					"postDocumentComment", dlFileEntry.getUserId(),
+					DLFileEntry.class.getName(), dlFileEntry.getGroupId())
+			).put(
+				"createBatch",
+				addAction(
+					ActionKeys.ADD_DISCUSSION, documentId,
+					"postDocumentCommentBatch", dlFileEntry.getUserId(),
 					DLFileEntry.class.getName(), dlFileEntry.getGroupId())
 			).put(
 				"get",
@@ -362,6 +383,13 @@ public class CommentResourceImpl extends BaseCommentResourceImpl {
 					ActionKeys.ADD_DISCUSSION, structuredContentId,
 					"postStructuredContentComment", journalArticle.getUserId(),
 					JournalArticle.class.getName(), journalArticle.getGroupId())
+			).put(
+				"createBatch",
+				addAction(
+					ActionKeys.ADD_DISCUSSION, structuredContentId,
+					"postStructuredContentCommentBatch",
+					journalArticle.getUserId(), JournalArticle.class.getName(),
+					journalArticle.getGroupId())
 			).put(
 				"get",
 				addAction(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentFolderResourceImpl.java
@@ -155,10 +155,25 @@ public class DocumentFolderResourceImpl extends BaseDocumentFolderResourceImpl {
 					ActionKeys.ADD_FOLDER, "postSiteDocumentFolder",
 					DLConstants.RESOURCE_NAME, siteId)
 			).put(
+				"createBatch",
+				addAction(
+					ActionKeys.ADD_FOLDER, "postSiteDocumentFolderBatch",
+					DLConstants.RESOURCE_NAME, siteId)
+			).put(
+				"deleteBatch",
+				addAction(
+					ActionKeys.DELETE, "deleteDocumentFolderBatch",
+					DLConstants.RESOURCE_NAME, null)
+			).put(
 				"get",
 				addAction(
 					ActionKeys.VIEW, "getSiteDocumentFoldersPage",
 					DLConstants.RESOURCE_NAME, siteId)
+			).put(
+				"updateBatch",
+				addAction(
+					ActionKeys.UPDATE, "putDocumentFolderBatch",
+					DLConstants.RESOURCE_NAME, null)
 			).build(),
 			documentFolderId, siteId, flatten, search, aggregation, filter,
 			pagination, sorts);

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
@@ -182,10 +182,25 @@ public class DocumentResourceImpl extends BaseDocumentResourceImpl {
 					ActionKeys.ADD_DOCUMENT, "postAssetLibraryDocument",
 					DLConstants.RESOURCE_NAME, assetLibraryId)
 			).put(
+				"createBatch",
+				addAction(
+					ActionKeys.ADD_DOCUMENT, "postAssetLibraryDocumentBatch",
+					DLConstants.RESOURCE_NAME, assetLibraryId)
+			).put(
+				"deleteBatch",
+				addAction(
+					ActionKeys.DELETE, "deleteDocumentBatch",
+					DLConstants.RESOURCE_NAME, null)
+			).put(
 				"get",
 				addAction(
 					ActionKeys.VIEW, "getAssetLibraryDocumentsPage",
 					DLConstants.RESOURCE_NAME, assetLibraryId)
+			).put(
+				"updateBatch",
+				addAction(
+					ActionKeys.UPDATE, "putDocumentBatch",
+					DLConstants.RESOURCE_NAME, null)
 			).build(),
 			_createDocumentsPageBooleanQueryUnsafeConsumer(
 				assetLibraryId, flatten),
@@ -292,10 +307,25 @@ public class DocumentResourceImpl extends BaseDocumentResourceImpl {
 					ActionKeys.ADD_DOCUMENT, "postSiteDocument",
 					DLConstants.RESOURCE_NAME, siteId)
 			).put(
+				"createBatch",
+				addAction(
+					ActionKeys.ADD_DOCUMENT, "postSiteDocumentBatch",
+					DLConstants.RESOURCE_NAME, siteId)
+			).put(
+				"deleteBatch",
+				addAction(
+					ActionKeys.DELETE, "deleteDocumentBatch",
+					DLConstants.RESOURCE_NAME, null)
+			).put(
 				"get",
 				addAction(
 					ActionKeys.VIEW, "getSiteDocumentsPage",
 					DLConstants.RESOURCE_NAME, siteId)
+			).put(
+				"updateBatch",
+				addAction(
+					ActionKeys.UPDATE, "putDocumentBatch",
+					DLConstants.RESOURCE_NAME, null)
 			).build(),
 			_createDocumentsPageBooleanQueryUnsafeConsumer(siteId, flatten),
 			search, aggregation, filter, pagination, sorts);

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/KnowledgeBaseArticleResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/KnowledgeBaseArticleResourceImpl.java
@@ -156,6 +156,13 @@ public class KnowledgeBaseArticleResourceImpl
 					"postKnowledgeBaseArticleKnowledgeBaseArticle",
 					KBConstants.RESOURCE_NAME_ADMIN, kbArticle.getGroupId())
 			).put(
+				"createBatch",
+				addAction(
+					KBActionKeys.ADD_KB_ARTICLE,
+					"postKnowledgeBaseFolderKnowledgeBaseArticleBatch",
+					KBConstants.RESOURCE_NAME_ADMIN,
+					parentKnowledgeBaseArticleId)
+			).put(
 				"get",
 				addAction(
 					ActionKeys.VIEW,
@@ -262,6 +269,18 @@ public class KnowledgeBaseArticleResourceImpl
 					KBActionKeys.ADD_KB_ARTICLE, "postSiteKnowledgeBaseArticle",
 					KBConstants.RESOURCE_NAME_ADMIN, siteId)
 			).put(
+				"createBatch",
+				addAction(
+					KBActionKeys.ADD_KB_ARTICLE,
+					"postSiteKnowledgeBaseArticleBatch",
+					KBConstants.RESOURCE_NAME_ADMIN, siteId)
+			).put(
+				"deleteBatch",
+				addAction(
+					KBActionKeys.DELETE_KB_ARTICLES,
+					"deleteKnowledgeBaseArticleBatch",
+					KBConstants.RESOURCE_NAME_ADMIN, null)
+			).put(
 				"get",
 				addAction(
 					ActionKeys.VIEW, "getSiteKnowledgeBaseArticlesPage",
@@ -278,6 +297,12 @@ public class KnowledgeBaseArticleResourceImpl
 					ActionKeys.SUBSCRIBE,
 					"putSiteKnowledgeBaseArticleUnsubscribe",
 					KBConstants.RESOURCE_NAME_ADMIN, siteId)
+			).put(
+				"updateBatch",
+				addAction(
+					KBActionKeys.UPDATE_KB_ARTICLES_PRIORITIES,
+					"putKnowledgeBaseArticleBatch",
+					KBConstants.RESOURCE_NAME_ADMIN, null)
 			).build(),
 			booleanQuery -> {
 				if (!GetterUtil.getBoolean(flatten)) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/KnowledgeBaseFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/KnowledgeBaseFolderResourceImpl.java
@@ -137,10 +137,26 @@ public class KnowledgeBaseFolderResourceImpl
 					KBActionKeys.ADD_KB_FOLDER, "postSiteKnowledgeBaseFolder",
 					KBConstants.RESOURCE_NAME_ADMIN, siteId)
 			).put(
+				"createBatch",
+				addAction(
+					KBActionKeys.ADD_KB_FOLDER,
+					"postSiteKnowledgeBaseFolderBatch",
+					KBConstants.RESOURCE_NAME_ADMIN, siteId)
+			).put(
+				"deleteBatch",
+				addAction(
+					KBActionKeys.DELETE, "deleteKnowledgeBaseFolderBatch",
+					KBConstants.RESOURCE_NAME_ADMIN, null)
+			).put(
 				"get",
 				addAction(
 					ActionKeys.VIEW, "getSiteKnowledgeBaseFoldersPage",
 					KBConstants.RESOURCE_NAME_ADMIN, siteId)
+			).put(
+				"updateBatch",
+				addAction(
+					KBActionKeys.UPDATE, "putKnowledgeBaseFolderBatch",
+					KBConstants.RESOURCE_NAME_ADMIN, null)
 			).build(),
 			transform(
 				_kbFolderService.getKBFolders(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardMessageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardMessageResourceImpl.java
@@ -336,10 +336,20 @@ public class MessageBoardMessageResourceImpl
 
 		return _getMessageBoardMessagesPage(
 			HashMapBuilder.put(
+				"deleteBatch",
+				addAction(
+					ActionKeys.DELETE, "deleteMessageBoardMessageBatch",
+					MBConstants.RESOURCE_NAME, null)
+			).put(
 				"get",
 				addAction(
 					ActionKeys.VIEW, "getSiteMessageBoardMessagesPage",
 					MBConstants.RESOURCE_NAME, siteId)
+			).put(
+				"updateBatch",
+				addAction(
+					ActionKeys.UPDATE, "putMessageBoardMessageBatch",
+					MBConstants.RESOURCE_NAME, null)
 			).build(),
 			null, siteId, flatten, search, aggregation, filter, pagination,
 			sorts);

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardSectionResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardSectionResourceImpl.java
@@ -157,10 +157,25 @@ public class MessageBoardSectionResourceImpl
 					ActionKeys.ADD_CATEGORY, "postSiteMessageBoardSection",
 					MBConstants.RESOURCE_NAME, siteId)
 			).put(
+				"createBatch",
+				addAction(
+					ActionKeys.ADD_CATEGORY, "postSiteMessageBoardSectionBatch",
+					MBConstants.RESOURCE_NAME, siteId)
+			).put(
+				"deleteBatch",
+				addAction(
+					ActionKeys.DELETE, "deleteMessageBoardSectionBatch",
+					MBConstants.RESOURCE_NAME, null)
+			).put(
 				"get",
 				addAction(
 					ActionKeys.VIEW, "getSiteMessageBoardSectionsPage",
 					MBConstants.RESOURCE_NAME, siteId)
+			).put(
+				"updateBatch",
+				addAction(
+					ActionKeys.UPDATE, "putMessageBoardSectionBatch",
+					MBConstants.RESOURCE_NAME, null)
 			).build(),
 			booleanQuery -> {
 				if (!GetterUtil.getBoolean(flatten)) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardThreadResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardThreadResourceImpl.java
@@ -343,10 +343,25 @@ public class MessageBoardThreadResourceImpl
 					ActionKeys.ADD_MESSAGE, "postSiteMessageBoardThread",
 					MBConstants.RESOURCE_NAME, siteId)
 			).put(
+				"createBatch",
+				addAction(
+					ActionKeys.ADD_MESSAGE, "postSiteMessageBoardThreadBatch",
+					MBConstants.RESOURCE_NAME, siteId)
+			).put(
+				"deleteBatch",
+				addAction(
+					ActionKeys.DELETE, "deleteMessageBoardThreadBatch",
+					MBConstants.RESOURCE_NAME, null)
+			).put(
 				"get",
 				addAction(
 					ActionKeys.VIEW, "getSiteMessageBoardThreadsPage",
 					MBConstants.RESOURCE_NAME, siteId)
+			).put(
+				"updateBatch",
+				addAction(
+					ActionKeys.UPDATE, "putMessageBoardThreadBatch",
+					MBConstants.RESOURCE_NAME, null)
 			).build(),
 			booleanQuery -> {
 				BooleanFilter booleanFilter =

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/NavigationMenuResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/NavigationMenuResourceImpl.java
@@ -52,7 +52,6 @@ import com.liferay.site.navigation.service.SiteNavigationMenuItemService;
 import com.liferay.site.navigation.service.SiteNavigationMenuService;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -96,12 +95,29 @@ public class NavigationMenuResourceImpl extends BaseNavigationMenuResourceImpl {
 		Long siteId, Pagination pagination) {
 
 		return Page.of(
-			Collections.singletonMap(
+			HashMapBuilder.put(
 				"create",
 				addAction(
 					SiteNavigationActionKeys.ADD_SITE_NAVIGATION_MENU,
 					"postSiteNavigationMenu",
-					SiteNavigationConstants.RESOURCE_NAME, siteId)),
+					SiteNavigationConstants.RESOURCE_NAME, siteId)
+			).put(
+				"createBatch",
+				addAction(
+					SiteNavigationActionKeys.ADD_SITE_NAVIGATION_MENU,
+					"postSiteNavigationMenuBatch",
+					SiteNavigationConstants.RESOURCE_NAME, siteId)
+			).put(
+				"deleteBatch",
+				addAction(
+					ActionKeys.DELETE, "deleteNavigationMenuBatch",
+					SiteNavigationConstants.RESOURCE_NAME, null)
+			).put(
+				"updateBatch",
+				addAction(
+					ActionKeys.UPDATE, "putNavigationMenuBatch",
+					SiteNavigationConstants.RESOURCE_NAME, null)
+			).build(),
 			transform(
 				_siteNavigationMenuService.getSiteNavigationMenus(
 					siteId, pagination.getStartPosition(),

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentFolderResourceImpl.java
@@ -174,10 +174,25 @@ public class StructuredContentFolderResourceImpl
 					ActionKeys.UPDATE, "postSiteStructuredContentFolder",
 					JournalConstants.RESOURCE_NAME, siteId)
 			).put(
+				"createBatch",
+				addAction(
+					ActionKeys.UPDATE, "postSiteStructuredContentFolderBatch",
+					JournalConstants.RESOURCE_NAME, siteId)
+			).put(
+				"deleteBatch",
+				addAction(
+					ActionKeys.DELETE, "deleteStructuredContentFolderBatch",
+					JournalConstants.RESOURCE_NAME, null)
+			).put(
 				"get",
 				addAction(
 					ActionKeys.VIEW, "getSiteStructuredContentFoldersPage",
 					JournalConstants.RESOURCE_NAME, siteId)
+			).put(
+				"updateBatch",
+				addAction(
+					ActionKeys.UPDATE, "putStructuredContentFolderBatch",
+					JournalConstants.RESOURCE_NAME, null)
 			).build(),
 			parentStructuredContentFolderId, siteId, search, aggregation,
 			filter, pagination, sorts);

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentResourceImpl.java
@@ -219,10 +219,26 @@ public class StructuredContentResourceImpl
 					ActionKeys.ADD_ARTICLE, "postAssetLibraryStructuredContent",
 					JournalConstants.RESOURCE_NAME, assetLibraryId)
 			).put(
+				"createBatch",
+				addAction(
+					ActionKeys.ADD_ARTICLE,
+					"postAssetLibraryStructuredContentBatch",
+					JournalConstants.RESOURCE_NAME, assetLibraryId)
+			).put(
+				"deleteBatch",
+				addAction(
+					ActionKeys.DELETE, "deleteStructuredContentBatch",
+					JournalConstants.RESOURCE_NAME, null)
+			).put(
 				"get",
 				addAction(
 					ActionKeys.VIEW, "getAssetLibraryStructuredContentsPage",
 					JournalConstants.RESOURCE_NAME, assetLibraryId)
+			).put(
+				"updateBatch",
+				addAction(
+					ActionKeys.UPDATE, "putStructuredContentBatch",
+					JournalConstants.RESOURCE_NAME, null)
 			).build(),
 			_createStructuredContentsPageBooleanQueryUnsafeConsumer(flatten),
 			assetLibraryId, search, aggregation, filter, pagination, sorts);
@@ -334,10 +350,25 @@ public class StructuredContentResourceImpl
 					ActionKeys.ADD_ARTICLE, "postSiteStructuredContent",
 					JournalConstants.RESOURCE_NAME, siteId)
 			).put(
+				"createBatch",
+				addAction(
+					ActionKeys.ADD_ARTICLE, "postSiteStructuredContentBatch",
+					JournalConstants.RESOURCE_NAME, siteId)
+			).put(
+				"deleteBatch",
+				addAction(
+					ActionKeys.DELETE, "deleteStructuredContentBatch",
+					JournalConstants.RESOURCE_NAME, null)
+			).put(
 				"get",
 				addAction(
 					ActionKeys.VIEW, "getSiteStructuredContentsPage",
 					JournalConstants.RESOURCE_NAME, siteId)
+			).put(
+				"updateBatch",
+				addAction(
+					ActionKeys.UPDATE, "putStructuredContentBatch",
+					JournalConstants.RESOURCE_NAME, null)
 			).build(),
 			_createStructuredContentsPageBooleanQueryUnsafeConsumer(flatten),
 			siteId, search, aggregation, filter, pagination, sorts);

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/WikiNodeResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/WikiNodeResourceImpl.java
@@ -98,6 +98,21 @@ public class WikiNodeResourceImpl extends BaseWikiNodeResourceImpl {
 				addAction(
 					ActionKeys.ADD_NODE, "postSiteWikiNode",
 					WikiConstants.RESOURCE_NAME, siteId)
+			).put(
+				"createBatch",
+				addAction(
+					ActionKeys.ADD_NODE, "postSiteWikiNodeBatch",
+					WikiConstants.RESOURCE_NAME, siteId)
+			).put(
+				"deleteBatch",
+				addAction(
+					ActionKeys.DELETE, "deleteWikiNodeBatch",
+					WikiConstants.RESOURCE_NAME, null)
+			).put(
+				"updateBatch",
+				addAction(
+					ActionKeys.UPDATE, "putWikiNodeBatch",
+					WikiConstants.RESOURCE_NAME, null)
 			).build(),
 			booleanQuery -> {
 				BooleanFilter booleanFilter =

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/WikiPageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/WikiPageResourceImpl.java
@@ -133,6 +133,10 @@ public class WikiPageResourceImpl extends BaseWikiPageResourceImpl {
 				"add-page",
 				addAction(ActionKeys.ADD_PAGE, wikiNode, "postWikiNodeWikiPage")
 			).put(
+				"createBatch",
+				addAction(
+					ActionKeys.ADD_PAGE, wikiNode, "postWikiNodeWikiPageBatch")
+			).put(
 				"get",
 				addAction(ActionKeys.VIEW, wikiNode, "getWikiNodeWikiPagesPage")
 			).build(),
@@ -376,6 +380,11 @@ public class WikiPageResourceImpl extends BaseWikiPageResourceImpl {
 						"deleteWikiPage", wikiPage.getUserId(),
 						WikiPage.class.getName(), wikiPage.getGroupId())
 				).put(
+					"deleteBatch",
+					addAction(
+						ActionKeys.DELETE, "deleteWikiPageBatch",
+						WikiPage.class.getName(), null)
+				).put(
 					"get",
 					addAction(
 						ActionKeys.VIEW, wikiPage.getResourcePrimKey(),
@@ -399,6 +408,11 @@ public class WikiPageResourceImpl extends BaseWikiPageResourceImpl {
 						ActionKeys.SUBSCRIBE, wikiPage.getResourcePrimKey(),
 						"putWikiPageUnsubscribe", wikiPage.getUserId(),
 						WikiPage.class.getName(), wikiPage.getGroupId())
+				).put(
+					"updateBatch",
+					addAction(
+						ActionKeys.UPDATE, "putWikiPageBatch",
+						WikiPage.class.getName(), null)
 				).build(),
 				_dtoConverterRegistry, wikiPage.getResourcePrimKey(),
 				contextAcceptLanguage.getPreferredLocale(), contextUriInfo,

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/ActionUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/ActionUtil.java
@@ -170,7 +170,7 @@ public class ActionUtil {
 		PermissionChecker permissionChecker =
 			PermissionThreadLocal.getPermissionChecker();
 
-		if (modelResourcePermission == null) {
+		if ((modelResourcePermission == null) && (id != null)) {
 			List<String> modelResourceActions =
 				ResourceActionsUtil.getModelResourceActions(permissionName);
 
@@ -182,8 +182,9 @@ public class ActionUtil {
 				return null;
 			}
 		}
-		else if (!modelResourcePermission.contains(
-					permissionChecker, id, actionName)) {
+		else if ((id != null) &&
+				 !modelResourcePermission.contains(
+					 permissionChecker, id, actionName)) {
 
 			return null;
 		}


### PR DESCRIPTION
## This is the first version of exposing Batch Actions in Headless Delivery APIs

**What is new?**
- Exposing `createBatch`, `deleteBatch`, `updateBatch` methods in Headless APIs
- Update `portal-vulcan` permission checker without using ID methods

**NEW CHARACTERISTIC**
Here you can see an example of new actions of a particular Schema:

![image](https://user-images.githubusercontent.com/44723449/187464528-0149bc6b-7137-4026-9450-044b29b1ea94.png)

**HOW TO REPRODUCE**
1. Deploy `portal-vulcan-api`
2. Deploy `headless-delivery-impl`
3. Deploy `headless-admin-taxonomy`

**JIRA TICKET**
https://issues.liferay.com/browse/LPS-161059

cc/ @4lejandrito