### PR TITLE
LPS-99999 Fix a test that was failing due to wrong date formatting

### DIFF
--- a/modules/dxp/apps/analytics/analytics-reports-web/test/js/components/BasicInformation.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/test/js/components/BasicInformation.js
@@ -55,7 +55,7 @@ describe('BasicInformation', () => {
 
 		expect(getByText(testProps.canonicalURL)).toBeInTheDocument();
 
-		const formattedPublishDate = 'September 20, 2021';
+		const formattedPublishDate = '20 September 2021';
 
 		expect(
 			getByText('published-on-' + formattedPublishDate)


### PR DESCRIPTION
Hey Brian, as we talked about. Here's a simple fix for the failing test. Locally running `yarn test` the test passes with no issues. It also makes sense that this would be the date format if we take a look at this piece of code:
```
const formattedPublishDate = Intl.DateTimeFormat(languageTag, {
	day: 'numeric',
	month: 'long',
	year: 'numeric',
}).format(new Date(publishDate));
```

This should return the formatted date and looking at the positions of the `day`, `month`, `year` properties it implies that the new format is correct.