### PR TITLE
LPS-152217: Update DELETE WikiPageAttachment using ERC

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/WikiPageAttachmentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/WikiPageAttachmentResourceImpl.java
@@ -18,6 +18,7 @@ import com.liferay.document.library.util.DLURLHelper;
 import com.liferay.headless.delivery.dto.v1_0.WikiPageAttachment;
 import com.liferay.headless.delivery.dto.v1_0.util.ContentValueUtil;
 import com.liferay.headless.delivery.resource.v1_0.WikiPageAttachmentResource;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.portletfilerepository.PortletFileRepository;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.Folder;
@@ -35,6 +36,7 @@ import com.liferay.wiki.service.WikiPageService;
 import java.util.Optional;
 
 import javax.ws.rs.BadRequestException;
+import javax.ws.rs.NotFoundException;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -58,8 +60,19 @@ public class WikiPageAttachmentResourceImpl
 		throws Exception {
 
 		WikiPage wikiPage =
-			_wikiPageService.getLatestPageByExternalReferenceCode(
+			_wikiPageService.fetchLatestPageByExternalReferenceCode(
 				siteId, wikiPageExternalReferenceCode);
+
+		if (wikiPage == null) {
+			StringBundler sb = new StringBundler(4);
+
+			sb.append("No wiki page exists with external reference code ");
+			sb.append(wikiPageExternalReferenceCode);
+			sb.append(" and site ID ");
+			sb.append(siteId);
+
+			throw new NotFoundException(sb.toString());
+		}
 
 		FileEntry fileEntry =
 			wikiPage.getAttachmentsFileEntryByExternalReferenceCode(


### PR DESCRIPTION
Hi Brian, according to the meeting we had on Tuesday to replace the `NotFoundException` with a new `ExceptionMapper`, @ccorreagg, @4lejandrito and I have been working on the possibilities of why we should keep `NotFoundException` until now. 

If you try `git grep "try (LogCapture logCapture = LoggerTestUtil.configureLog4J"`  and `git grep "throw new NotFoundException("` these patterns are used in liferay-portal. The resason why we should keep this implementation is to catch a 404 Not Found  and it is tested, you can also take a view in `CommentResourceImpl` and `CommentResourceTest` that we follow the same pattern. The `LogCapture` captures the log in the standard output, so the test does not fail, however it is expecting the HTTP status 404.