### PR TITLE
LPS-162027 Added required field attribute to editor for KB Articles.

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_kb_article.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_kb_article.jsp
@@ -135,7 +135,10 @@ if (editKBArticleDisplayContext.isPortletTitleBasedNavigation()) {
 							%>'
 							name="contentEditor"
 							placeholder="content"
-						/>
+							required="<%= true %>"
+						>
+							<aui:validator name="required" />
+						</liferay-editor:editor>
 
 						<aui:input name="content" type="hidden" />
 					</div>


### PR DESCRIPTION
Forward: https://github.com/fortunatomaldonado/liferay-portal/pull/47

This pull has been approved here: https://github.com/fortunatomaldonado/liferay-portal/pull/47#issuecomment-1240750994
Let me know if there are any questions or comments.

Thank you!

> [LPS-162027](https://issues.liferay.com/browse/LPS-162027) Added the required field attribute to the content editor for KB articles. Here I followed the structure of other components that have editor content required (like Blog entries) and added the required field to the editor instead of adding an asterisk.