### PR TITLE
LPS-160134 Bring back state management to the GoogleMapsDialog class

### DIFF
--- a/modules/apps/map/map-google-maps/src/main/resources/META-INF/resources/js/GoogleMapsDialog.es.js
+++ b/modules/apps/map/map-google-maps/src/main/resources/META-INF/resources/js/GoogleMapsDialog.es.js
@@ -17,14 +17,27 @@
  * @review
  */
 export default class GoogleMapsDialog {
+	get map() {
+		return this._STATE_.map;
+	}
+
+	set map(map) {
+		this._STATE_.map = map;
+	}
 
 	/**
 	 * Creates a new map dialog using Google Map's API
 	 * @param  {Array} args List of arguments to be passed to State
 	 * @review
 	 */
-	constructor() {
+	constructor(args = {}) {
+		const {map} = args;
+
 		this._dialog = new google.maps.InfoWindow();
+
+		this._STATE_ = {
+			map,
+		};
 	}
 
 	/**


### PR DESCRIPTION
## Manual forward of https://github.com/liferay-frontend/liferay-portal/pull/2704

QA gave confirmation failing test is unrelated [[testray](https://testray.liferay.com/home/-/testray/case_results?testrayBuildId=1970345109&testrayRunId=1970359545)]