### PR TITLE
LPS-161944 Auto SF

### DIFF
--- a/modules/apps/layout/layout-test-util/src/main/java/com/liferay/layout/test/util/LayoutTestUtil.java
+++ b/modules/apps/layout/layout-test-util/src/main/java/com/liferay/layout/test/util/LayoutTestUtil.java
@@ -401,10 +401,6 @@ public class LayoutTestUtil {
 			boolean hidden)
 		throws Exception {
 
-		Group group = GroupLocalServiceUtil.getGroup(groupId);
-
-		User user = UserTestUtil.getAdminUser(group.getCompanyId());
-
 		String friendlyURL =
 			StringPool.SLASH + FriendlyURLNormalizerUtil.normalize(name);
 
@@ -417,6 +413,10 @@ public class LayoutTestUtil {
 				_log.debug(noSuchLayoutException);
 			}
 		}
+
+		Group group = GroupLocalServiceUtil.getGroup(groupId);
+
+		User user = UserTestUtil.getAdminUser(group.getCompanyId());
 
 		String description = "This is a test page.";
 


### PR DESCRIPTION
https://github.com/liferay/liferay-portal/commit/c95cb6f9939982f83d957b98ef79c051622f5fe2 broke this check:

1: For better performance, the variable declaration for 'user' should come after the 'return' statement on line '412': /modules/apps/layout/layout-test-util/src/main/java/com/liferay/layout/test/util/LayoutTestUtil.java 406 (Checkstyle:VariableDeclarationAsUsedCheck)