### PR TITLE
LPS-162783 UpgradeGroup can throw NullPointerExeption if typeSettings has no languageId

### DIFF
--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeGroup.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeGroup.java
@@ -124,7 +124,9 @@ public class UpgradeGroup extends UpgradeProcess {
 					).build();
 
 				String defaultLanguageId =
-					typeSettingsUnicodeProperties.getProperty("languageId");
+					typeSettingsUnicodeProperties.getProperty(
+						"languageId",
+						LocaleUtil.toLanguageId(LocaleUtil.getSiteDefault()));
 
 				Locale currentDefaultLocale =
 					LocaleThreadLocal.getSiteDefaultLocale();


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-162783