### PR TITLE
LPS-162860 Remove `_STATE_` override that was causing the `boundingBox` to be undefined

### DIFF
--- a/modules/apps/map/map-openstreetmap/src/main/resources/META-INF/resources/js/MapOpenStreetMap.es.js
+++ b/modules/apps/map/map-openstreetmap/src/main/resources/META-INF/resources/js/MapOpenStreetMap.es.js
@@ -48,13 +48,13 @@ class MapOpenStreetMap extends MapBase {
 
 		super(args);
 
-		const {boundingBox, tileURI = defaultTileURI} = args;
+		const {tileURI = defaultTileURI} = args;
 
 		this._STATE_ = {
+			...this._STATE_,
 			tileURI,
 		};
 
-		this.boundingBox = boundingBox;
 		this._map = null;
 	}
 


### PR DESCRIPTION
## Manual forward of https://github.com/liferay-frontend/liferay-portal/pull/2715

Manually reviewed and approved by @magjed4289