### PR TITLE
LRCI-3132 Add ability to set the company default locale within poshi tests | master

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -11279,6 +11279,15 @@ include-and-override=${liferay.home}/portal-setup-wizard.properties</echo>
 		</if>
 
 		<if>
+			<isset property="test.company.default.locale" />
+			<then>
+				<echo append="true" file="portal-impl/src/portal-ext.properties">
+					company.default.locale=${test.company.default.locale}
+				</echo>
+			</then>
+		</if>
+
+		<if>
 			<isset property="test.set.default.portal.properties" />
 			<then>
 				<echo file="portal-impl/src/portal-ext.properties">liferay.home=${liferay.home}</echo>
@@ -12125,6 +12134,15 @@ auto.deploy.dest.dir=C:/WINDOWS/system32/config/systemprofile/liferay/websphere-
 			<then>
 				<echo append="true" file="${test.ext.properties.file}">
 					test.base.dir.name=${test.base.dir.name}
+				</echo>
+			</then>
+		</if>
+
+		<if>
+			<isset property="test.company.default.locale" />
+			<then>
+				<echo append="true" file="${test.ext.properties.file}">
+					test.company.default.locale=${test.company.default.locale}
 				</echo>
 			</then>
 		</if>

--- a/test.properties
+++ b/test.properties
@@ -8813,6 +8813,7 @@
         testray.component.names,\
         testray.main.component.name
 
+    #test.company.default.locale=
     test.ext.properties.file=portal-web/poshi-ext.properties
     #test.fix.pack.base.url=
     test.get.location.max.retries=3


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-3132

@brianchandotcom - If this looks okay can this be backported to `7.3.x` & `7.2.x`?

The errors are not related to this pull request:
https://github.com/michaelhashimoto/liferay-portal/pull/2432#issuecomment-1245745796