### PR TITLE
LPS-161245 CKEditor config receives `resize_dir`, not `resizeDirection`

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/BaseCKEditorConfigContributor.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/BaseCKEditorConfigContributor.java
@@ -118,7 +118,7 @@ public class BaseCKEditorConfigContributor extends BaseEditorConfigContributor {
 					CKEditorConstants.ATTRIBUTE_NAMESPACE +
 						":resizeDirection"));
 
-			jsonObject.put("resizeDirection", resizeDirection);
+			jsonObject.put("resize_dir", resizeDirection);
 		}
 
 		jsonObject.put("resize_enabled", resizable);


### PR DESCRIPTION
Came from: https://github.com/brianchandotcom/liferay-portal/pull/122707#discussion_r970436473

This is a follow-up based on Dani's comment on https://github.com/brianchandotcom/liferay-portal/pull/122707#discussion_r970436473.

I tested locally and I noticed I missed this property name on CKEditor config