### PR TITLE
LPS-161324 Reverting Remove SantizerUtil from modules

### DIFF
--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/persistence/impl/BlogsEntryPersistenceImpl.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/persistence/impl/BlogsEntryPersistenceImpl.java
@@ -23091,6 +23091,9 @@ public class BlogsEntryPersistenceImpl
 	@Reference
 	protected FinderCache finderCache;
 
+	@Reference
+	private volatile List<Sanitizer> _sanitizers;
+
 	private static Long _getTime(Date date) {
 		if (date == null) {
 			return null;
@@ -23155,9 +23158,6 @@ public class BlogsEntryPersistenceImpl
 
 	@Reference
 	private PortalUUID _portalUUID;
-
-	@Reference
-	private volatile List<Sanitizer> _sanitizers;
 
 	@Reference
 	private BlogsEntryModelArgumentsResolver _blogsEntryModelArgumentsResolver;

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/persistence/impl/BlogsEntryPersistenceImpl.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/persistence/impl/BlogsEntryPersistenceImpl.java
@@ -39,6 +39,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.sanitizer.Sanitizer;
 import com.liferay.portal.kernel.sanitizer.SanitizerException;
+import com.liferay.portal.kernel.sanitizer.SanitizerUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.security.permission.InlineSQLHelperUtil;
@@ -21969,27 +21970,21 @@ public class BlogsEntryPersistenceImpl
 
 			try {
 				blogsEntry.setTitle(
-					sanitize(
-						_sanitizers, companyId, groupId, userId,
-						BlogsEntry.class.getName(), entryId,
-						ContentTypes.TEXT_PLAIN,
-						new String[] {Sanitizer.MODE_ALL},
+					SanitizerUtil.sanitize(
+						companyId, groupId, userId, BlogsEntry.class.getName(),
+						entryId, ContentTypes.TEXT_PLAIN, Sanitizer.MODE_ALL,
 						blogsEntry.getTitle(), null));
 
 				blogsEntry.setContent(
-					sanitize(
-						_sanitizers, companyId, groupId, userId,
-						BlogsEntry.class.getName(), entryId,
-						ContentTypes.TEXT_HTML,
-						new String[] {Sanitizer.MODE_ALL},
+					SanitizerUtil.sanitize(
+						companyId, groupId, userId, BlogsEntry.class.getName(),
+						entryId, ContentTypes.TEXT_HTML, Sanitizer.MODE_ALL,
 						blogsEntry.getContent(), null));
 
 				blogsEntry.setCoverImageCaption(
-					sanitize(
-						_sanitizers, companyId, groupId, userId,
-						BlogsEntry.class.getName(), entryId,
-						ContentTypes.TEXT_HTML,
-						new String[] {Sanitizer.MODE_ALL},
+					SanitizerUtil.sanitize(
+						companyId, groupId, userId, BlogsEntry.class.getName(),
+						entryId, ContentTypes.TEXT_HTML, Sanitizer.MODE_ALL,
 						blogsEntry.getCoverImageCaption(), null));
 			}
 			catch (SanitizerException sanitizerException) {
@@ -23090,9 +23085,6 @@ public class BlogsEntryPersistenceImpl
 
 	@Reference
 	protected FinderCache finderCache;
-
-	@Reference
-	private volatile List<Sanitizer> _sanitizers;
 
 	private static Long _getTime(Date date) {
 		if (date == null) {

--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarBookingLocalServiceImpl.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarBookingLocalServiceImpl.java
@@ -72,6 +72,7 @@ import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.sanitizer.Sanitizer;
+import com.liferay.portal.kernel.sanitizer.SanitizerUtil;
 import com.liferay.portal.kernel.search.Indexable;
 import com.liferay.portal.kernel.search.IndexableType;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
@@ -155,15 +156,11 @@ public class CalendarBookingLocalServiceImpl
 		long calendarBookingId = counterLocalService.increment();
 
 		for (Map.Entry<Locale, String> entry : descriptionMap.entrySet()) {
-			String sanitizedDescription = entry.getValue();
-
-			for (Sanitizer sanitizer : _sanitizers) {
-				sanitizedDescription = sanitizer.sanitize(
-					calendar.getCompanyId(), calendar.getGroupId(), userId,
-					CalendarBooking.class.getName(), calendarBookingId,
-					ContentTypes.TEXT_HTML, new String[] {Sanitizer.MODE_ALL},
-					sanitizedDescription, null);
-			}
+			String sanitizedDescription = SanitizerUtil.sanitize(
+				calendar.getCompanyId(), calendar.getGroupId(), userId,
+				CalendarBooking.class.getName(), calendarBookingId,
+				ContentTypes.TEXT_HTML, Sanitizer.MODE_ALL, entry.getValue(),
+				null);
 
 			descriptionMap.put(entry.getKey(), sanitizedDescription);
 		}
@@ -1212,15 +1209,11 @@ public class CalendarBookingLocalServiceImpl
 		}
 
 		for (Map.Entry<Locale, String> entry : descriptionMap.entrySet()) {
-			String sanitizedDescription = entry.getValue();
-
-			for (Sanitizer sanitizer : _sanitizers) {
-				sanitizedDescription = sanitizer.sanitize(
-					calendar.getCompanyId(), calendar.getGroupId(), userId,
-					CalendarBooking.class.getName(), calendarBookingId,
-					ContentTypes.TEXT_HTML, new String[] {Sanitizer.MODE_ALL},
-					entry.getValue(), null);
-			}
+			String sanitizedDescription = SanitizerUtil.sanitize(
+				calendar.getCompanyId(), calendar.getGroupId(), userId,
+				CalendarBooking.class.getName(), calendarBookingId,
+				ContentTypes.TEXT_HTML, Sanitizer.MODE_ALL, entry.getValue(),
+				null);
 
 			descriptionMap.put(entry.getKey(), sanitizedDescription);
 		}
@@ -2756,9 +2749,6 @@ public class CalendarBookingLocalServiceImpl
 
 	@Reference
 	private ResourceLocalService _resourceLocalService;
-
-	@Reference
-	private List<Sanitizer> _sanitizers;
 
 	@Reference
 	private SocialActivityCounterLocalService

--- a/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/service/persistence/impl/ClientExtensionEntryPersistenceImpl.java
+++ b/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/service/persistence/impl/ClientExtensionEntryPersistenceImpl.java
@@ -39,6 +39,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.sanitizer.Sanitizer;
 import com.liferay.portal.kernel.sanitizer.SanitizerException;
+import com.liferay.portal.kernel.sanitizer.SanitizerUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.security.permission.InlineSQLHelperUtil;
@@ -4700,11 +4701,11 @@ public class ClientExtensionEntryPersistenceImpl
 
 			try {
 				clientExtensionEntry.setDescription(
-					sanitize(
-						_sanitizers, companyId, groupId, userId,
+					SanitizerUtil.sanitize(
+						companyId, groupId, userId,
 						ClientExtensionEntry.class.getName(),
 						clientExtensionEntryId, ContentTypes.TEXT_HTML,
-						new String[] {Sanitizer.MODE_ALL},
+						Sanitizer.MODE_ALL,
 						clientExtensionEntry.getDescription(), null));
 			}
 			catch (SanitizerException sanitizerException) {
@@ -5401,9 +5402,6 @@ public class ClientExtensionEntryPersistenceImpl
 
 	@Reference
 	protected FinderCache finderCache;
-
-	@Reference
-	private volatile List<Sanitizer> _sanitizers;
 
 	private static final String _SQL_SELECT_CLIENTEXTENSIONENTRY =
 		"SELECT clientExtensionEntry FROM ClientExtensionEntry clientExtensionEntry";

--- a/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/service/persistence/impl/ClientExtensionEntryPersistenceImpl.java
+++ b/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/service/persistence/impl/ClientExtensionEntryPersistenceImpl.java
@@ -5402,6 +5402,9 @@ public class ClientExtensionEntryPersistenceImpl
 	@Reference
 	protected FinderCache finderCache;
 
+	@Reference
+	private volatile List<Sanitizer> _sanitizers;
+
 	private static final String _SQL_SELECT_CLIENTEXTENSIONENTRY =
 		"SELECT clientExtensionEntry FROM ClientExtensionEntry clientExtensionEntry";
 
@@ -5460,9 +5463,6 @@ public class ClientExtensionEntryPersistenceImpl
 
 	@Reference
 	private PortalUUID _portalUUID;
-
-	@Reference
-	private volatile List<Sanitizer> _sanitizers;
 
 	@Reference
 	private ClientExtensionEntryModelArgumentsResolver

--- a/modules/apps/commerce/commerce-term-service/src/main/java/com/liferay/commerce/term/service/persistence/impl/CTermEntryLocalizationPersistenceImpl.java
+++ b/modules/apps/commerce/commerce-term-service/src/main/java/com/liferay/commerce/term/service/persistence/impl/CTermEntryLocalizationPersistenceImpl.java
@@ -1575,6 +1575,9 @@ public class CTermEntryLocalizationPersistenceImpl
 	@Reference
 	protected FinderCache finderCache;
 
+	@Reference
+	private volatile List<Sanitizer> _sanitizers;
+
 	private static final String _SQL_SELECT_CTERMENTRYLOCALIZATION =
 		"SELECT cTermEntryLocalization FROM CTermEntryLocalization cTermEntryLocalization";
 
@@ -1603,9 +1606,6 @@ public class CTermEntryLocalizationPersistenceImpl
 	protected FinderCache getFinderCache() {
 		return finderCache;
 	}
-
-	@Reference
-	private volatile List<Sanitizer> _sanitizers;
 
 	@Reference
 	private CTermEntryLocalizationModelArgumentsResolver

--- a/modules/apps/commerce/commerce-term-service/src/main/java/com/liferay/commerce/term/service/persistence/impl/CTermEntryLocalizationPersistenceImpl.java
+++ b/modules/apps/commerce/commerce-term-service/src/main/java/com/liferay/commerce/term/service/persistence/impl/CTermEntryLocalizationPersistenceImpl.java
@@ -37,6 +37,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.sanitizer.Sanitizer;
 import com.liferay.portal.kernel.sanitizer.SanitizerException;
+import com.liferay.portal.kernel.sanitizer.SanitizerUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.service.persistence.BasePersistence;
@@ -1165,11 +1166,11 @@ public class CTermEntryLocalizationPersistenceImpl
 
 			try {
 				cTermEntryLocalization.setDescription(
-					sanitize(
-						_sanitizers, companyId, groupId, userId,
+					SanitizerUtil.sanitize(
+						companyId, groupId, userId,
 						CTermEntryLocalization.class.getName(),
 						cTermEntryLocalizationId, ContentTypes.TEXT_HTML,
-						new String[] {Sanitizer.MODE_ALL},
+						Sanitizer.MODE_ALL,
 						cTermEntryLocalization.getDescription(), null));
 			}
 			catch (SanitizerException sanitizerException) {
@@ -1574,9 +1575,6 @@ public class CTermEntryLocalizationPersistenceImpl
 
 	@Reference
 	protected FinderCache finderCache;
-
-	@Reference
-	private volatile List<Sanitizer> _sanitizers;
 
 	private static final String _SQL_SELECT_CTERMENTRYLOCALIZATION =
 		"SELECT cTermEntryLocalization FROM CTermEntryLocalization cTermEntryLocalization";

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/info/display/field/DDMFormValuesInfoDisplayFieldProviderImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/info/display/field/DDMFormValuesInfoDisplayFieldProviderImpl.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.sanitizer.Sanitizer;
+import com.liferay.portal.kernel.sanitizer.SanitizerUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.DateUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -245,15 +246,10 @@ public class DDMFormValuesInfoDisplayFieldProviderImpl<T extends GroupedModel>
 			return jsonObject;
 		}
 
-		for (Sanitizer sanitizer : _sanitizers) {
-			valueString = sanitizer.sanitize(
-				t.getCompanyId(), t.getGroupId(), t.getUserId(),
-				t.getModelClassName(), (long)t.getPrimaryKeyObj(),
-				ContentTypes.TEXT_HTML, new String[] {Sanitizer.MODE_ALL},
-				valueString, null);
-		}
-
-		return valueString;
+		return SanitizerUtil.sanitize(
+			t.getCompanyId(), t.getGroupId(), t.getUserId(),
+			t.getModelClassName(), (long)t.getPrimaryKeyObj(),
+			ContentTypes.TEXT_HTML, Sanitizer.MODE_ALL, valueString, null);
 	}
 
 	private String _transformFileEntryURL(String data) {
@@ -290,8 +286,5 @@ public class DDMFormValuesInfoDisplayFieldProviderImpl<T extends GroupedModel>
 
 	@Reference
 	private DLURLHelper _dlURLHelper;
-
-	@Reference
-	private volatile List<Sanitizer> _sanitizers;
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/info/item/provider/DDMFormValuesInfoFieldValuesProviderImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/info/item/provider/DDMFormValuesInfoFieldValuesProviderImpl.java
@@ -44,6 +44,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.sanitizer.Sanitizer;
+import com.liferay.portal.kernel.sanitizer.SanitizerUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.DateUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -311,16 +312,11 @@ public class DDMFormValuesInfoFieldValuesProviderImpl
 				return JSONUtil.toString(optionLabelsJSONArray);
 			}
 
-			for (Sanitizer sanitizer : _sanitizers) {
-				valueString = sanitizer.sanitize(
-					groupedModel.getCompanyId(), groupedModel.getGroupId(),
-					groupedModel.getUserId(), groupedModel.getModelClassName(),
-					(long)groupedModel.getPrimaryKeyObj(),
-					ContentTypes.TEXT_HTML, new String[] {Sanitizer.MODE_ALL},
-					valueString, null);
-			}
-
-			return valueString;
+			return SanitizerUtil.sanitize(
+				groupedModel.getCompanyId(), groupedModel.getGroupId(),
+				groupedModel.getUserId(), groupedModel.getModelClassName(),
+				(long)groupedModel.getPrimaryKeyObj(), ContentTypes.TEXT_HTML,
+				Sanitizer.MODE_ALL, valueString, null);
 		}
 		catch (Exception exception) {
 			_log.error(
@@ -345,8 +341,5 @@ public class DDMFormValuesInfoFieldValuesProviderImpl
 
 	@Reference
 	private DLURLHelper _dlURLHelper;
-
-	@Reference
-	private volatile List<Sanitizer> _sanitizers;
 
 }

--- a/modules/apps/info/info-impl/src/main/java/com/liferay/info/internal/display/field/InfoDisplayFieldProviderImpl.java
+++ b/modules/apps/info/info-impl/src/main/java/com/liferay/info/internal/display/field/InfoDisplayFieldProviderImpl.java
@@ -21,6 +21,7 @@ import com.liferay.info.display.contributor.field.InfoDisplayContributorFieldTyp
 import com.liferay.info.display.field.InfoDisplayFieldProvider;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.sanitizer.Sanitizer;
+import com.liferay.portal.kernel.sanitizer.SanitizerUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.util.ContentTypes;
@@ -102,15 +103,12 @@ public class InfoDisplayFieldProviderImpl implements InfoDisplayFieldProvider {
 					infoDisplayContributorFieldType) &&
 				(fieldValue instanceof String)) {
 
-				for (Sanitizer sanitizer : _sanitizers) {
-					fieldValue = sanitizer.sanitize(
-						serviceContext.getCompanyId(),
-						serviceContext.getScopeGroupId(),
-						serviceContext.getUserId(), className, 0,
-						ContentTypes.TEXT_HTML,
-						new String[] {Sanitizer.MODE_ALL}, (String)fieldValue,
-						null);
-				}
+				fieldValue = SanitizerUtil.sanitize(
+					serviceContext.getCompanyId(),
+					serviceContext.getScopeGroupId(),
+					serviceContext.getUserId(), className, 0,
+					ContentTypes.TEXT_HTML, Sanitizer.MODE_ALL,
+					(String)fieldValue, null);
 			}
 
 			infoDisplayFieldsValues.putIfAbsent(
@@ -123,8 +121,5 @@ public class InfoDisplayFieldProviderImpl implements InfoDisplayFieldProvider {
 	@Reference
 	private InfoDisplayContributorFieldTracker
 		_infoDisplayContributorFieldTracker;
-
-	@Reference
-	private volatile List<Sanitizer> _sanitizers;
 
 }

--- a/modules/apps/info/info-impl/src/main/java/com/liferay/info/internal/item/field/reader/InfoItemFieldReaderFieldSetProviderImpl.java
+++ b/modules/apps/info/info-impl/src/main/java/com/liferay/info/internal/item/field/reader/InfoItemFieldReaderFieldSetProviderImpl.java
@@ -24,6 +24,7 @@ import com.liferay.info.item.field.reader.InfoItemFieldReaderTracker;
 import com.liferay.info.localized.InfoLocalizedValue;
 import com.liferay.portal.kernel.sanitizer.Sanitizer;
 import com.liferay.portal.kernel.sanitizer.SanitizerException;
+import com.liferay.portal.kernel.sanitizer.SanitizerUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.util.ContentTypes;
@@ -87,15 +88,12 @@ public class InfoItemFieldReaderFieldSetProviderImpl
 				(value instanceof String)) {
 
 				try {
-					for (Sanitizer sanitizer : _sanitizers) {
-						value = sanitizer.sanitize(
-							serviceContext.getCompanyId(),
-							serviceContext.getScopeGroupId(),
-							serviceContext.getUserId(), className, 0,
-							ContentTypes.TEXT_HTML,
-							new String[] {Sanitizer.MODE_ALL}, (String)value,
-							null);
-					}
+					value = SanitizerUtil.sanitize(
+						serviceContext.getCompanyId(),
+						serviceContext.getScopeGroupId(),
+						serviceContext.getUserId(), className, 0,
+						ContentTypes.TEXT_HTML, Sanitizer.MODE_ALL,
+						(String)value, null);
 				}
 				catch (SanitizerException sanitizerException) {
 					throw new RuntimeException(sanitizerException);
@@ -110,8 +108,5 @@ public class InfoItemFieldReaderFieldSetProviderImpl
 
 	@Reference
 	private InfoItemFieldReaderTracker _infoItemFieldReaderTracker;
-
-	@Reference
-	private volatile List<Sanitizer> _sanitizers;
 
 }

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -144,7 +144,7 @@ import com.liferay.portal.kernel.portletfilerepository.PortletFileRepository;
 import com.liferay.portal.kernel.repository.capabilities.TemporaryFileEntriesCapability;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.Folder;
-import com.liferay.portal.kernel.sanitizer.Sanitizer;
+import com.liferay.portal.kernel.sanitizer.SanitizerUtil;
 import com.liferay.portal.kernel.search.BaseModelSearchResult;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Hits;
@@ -7649,13 +7649,10 @@ public class JournalArticleLocalServiceImpl
 							contentType = ContentTypes.TEXT_HTML;
 						}
 
-						for (Sanitizer sanitizer : _sanitizers) {
-							dynamicContent = sanitizer.sanitize(
-								user.getCompanyId(), groupId, user.getUserId(),
-								JournalArticle.class.getName(), 0, contentType,
-								new String[] {Sanitizer.MODE_ALL},
-								dynamicContent, null);
-						}
+						dynamicContent = SanitizerUtil.sanitize(
+							user.getCompanyId(), groupId, user.getUserId(),
+							JournalArticle.class.getName(), 0, contentType,
+							dynamicContent);
 
 						dynamicContentElement.clearContent();
 
@@ -8296,14 +8293,9 @@ public class JournalArticleLocalServiceImpl
 		}
 
 		for (Map.Entry<Locale, String> entry : descriptionMap.entrySet()) {
-			String description = entry.getValue();
-
-			for (Sanitizer sanitizer : _sanitizers) {
-				sanitizer.sanitize(
-					companyId, groupId, userId, JournalArticle.class.getName(),
-					classPK, ContentTypes.TEXT_HTML,
-					new String[] {Sanitizer.MODE_ALL}, description, null);
-			}
+			String description = SanitizerUtil.sanitize(
+				companyId, groupId, userId, JournalArticle.class.getName(),
+				classPK, ContentTypes.TEXT_HTML, entry.getValue());
 
 			descriptionMap.put(entry.getKey(), description);
 		}
@@ -9509,9 +9501,6 @@ public class JournalArticleLocalServiceImpl
 
 	@Reference
 	private ResourceLocalService _resourceLocalService;
-
-	@Reference
-	private volatile List<Sanitizer> _sanitizers;
 
 	@Reference
 	private SubscriptionLocalService _subscriptionLocalService;

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/persistence/impl/KBArticlePersistenceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/persistence/impl/KBArticlePersistenceImpl.java
@@ -38,6 +38,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.sanitizer.Sanitizer;
 import com.liferay.portal.kernel.sanitizer.SanitizerException;
+import com.liferay.portal.kernel.sanitizer.SanitizerUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.security.permission.InlineSQLHelperUtil;
@@ -35059,11 +35060,9 @@ public class KBArticlePersistenceImpl
 
 			try {
 				kbArticle.setContent(
-					sanitize(
-						_sanitizers, companyId, groupId, userId,
-						KBArticle.class.getName(), kbArticleId,
-						ContentTypes.TEXT_HTML,
-						new String[] {Sanitizer.MODE_ALL},
+					SanitizerUtil.sanitize(
+						companyId, groupId, userId, KBArticle.class.getName(),
+						kbArticleId, ContentTypes.TEXT_HTML, Sanitizer.MODE_ALL,
 						kbArticle.getContent(), null));
 			}
 			catch (SanitizerException sanitizerException) {
@@ -36244,9 +36243,6 @@ public class KBArticlePersistenceImpl
 
 	@Reference
 	protected FinderCache finderCache;
-
-	@Reference
-	private volatile List<Sanitizer> _sanitizers;
 
 	private static final String _SQL_SELECT_KBARTICLE =
 		"SELECT kbArticle FROM KBArticle kbArticle";

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/persistence/impl/KBArticlePersistenceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/persistence/impl/KBArticlePersistenceImpl.java
@@ -36245,6 +36245,9 @@ public class KBArticlePersistenceImpl
 	@Reference
 	protected FinderCache finderCache;
 
+	@Reference
+	private volatile List<Sanitizer> _sanitizers;
+
 	private static final String _SQL_SELECT_KBARTICLE =
 		"SELECT kbArticle FROM KBArticle kbArticle";
 
@@ -36301,9 +36304,6 @@ public class KBArticlePersistenceImpl
 
 	@Reference
 	private PortalUUID _portalUUID;
-
-	@Reference
-	private volatile List<Sanitizer> _sanitizers;
 
 	@Reference
 	private KBArticleModelArgumentsResolver _kbArticleModelArgumentsResolver;

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/persistence/impl/KBTemplatePersistenceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/persistence/impl/KBTemplatePersistenceImpl.java
@@ -38,6 +38,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.sanitizer.Sanitizer;
 import com.liferay.portal.kernel.sanitizer.SanitizerException;
+import com.liferay.portal.kernel.sanitizer.SanitizerUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.security.permission.InlineSQLHelperUtil;
@@ -2605,12 +2606,10 @@ public class KBTemplatePersistenceImpl
 
 			try {
 				kbTemplate.setContent(
-					sanitize(
-						_sanitizers, companyId, groupId, userId,
-						KBTemplate.class.getName(), kbTemplateId,
-						ContentTypes.TEXT_HTML,
-						new String[] {Sanitizer.MODE_ALL},
-						kbTemplate.getContent(), null));
+					SanitizerUtil.sanitize(
+						companyId, groupId, userId, KBTemplate.class.getName(),
+						kbTemplateId, ContentTypes.TEXT_HTML,
+						Sanitizer.MODE_ALL, kbTemplate.getContent(), null));
 			}
 			catch (SanitizerException sanitizerException) {
 				throw new SystemException(sanitizerException);
@@ -3045,9 +3044,6 @@ public class KBTemplatePersistenceImpl
 
 	@Reference
 	protected FinderCache finderCache;
-
-	@Reference
-	private volatile List<Sanitizer> _sanitizers;
 
 	private static final String _SQL_SELECT_KBTEMPLATE =
 		"SELECT kbTemplate FROM KBTemplate kbTemplate";

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/persistence/impl/KBTemplatePersistenceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/persistence/impl/KBTemplatePersistenceImpl.java
@@ -3046,6 +3046,9 @@ public class KBTemplatePersistenceImpl
 	@Reference
 	protected FinderCache finderCache;
 
+	@Reference
+	private volatile List<Sanitizer> _sanitizers;
+
 	private static final String _SQL_SELECT_KBTEMPLATE =
 		"SELECT kbTemplate FROM KBTemplate kbTemplate";
 
@@ -3102,9 +3105,6 @@ public class KBTemplatePersistenceImpl
 
 	@Reference
 	private PortalUUID _portalUUID;
-
-	@Reference
-	private volatile List<Sanitizer> _sanitizers;
 
 	@Reference
 	private KBTemplateModelArgumentsResolver _kbTemplateModelArgumentsResolver;

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/persistence/impl/MBMessagePersistenceImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/persistence/impl/MBMessagePersistenceImpl.java
@@ -39,6 +39,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.sanitizer.Sanitizer;
 import com.liferay.portal.kernel.sanitizer.SanitizerException;
+import com.liferay.portal.kernel.sanitizer.SanitizerUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.security.permission.InlineSQLHelperUtil;
@@ -21712,11 +21713,9 @@ public class MBMessagePersistenceImpl
 
 			try {
 				mbMessage.setSubject(
-					sanitize(
-						_sanitizers, companyId, groupId, userId,
-						MBMessage.class.getName(), messageId,
-						ContentTypes.TEXT_PLAIN,
-						new String[] {Sanitizer.MODE_ALL},
+					SanitizerUtil.sanitize(
+						companyId, groupId, userId, MBMessage.class.getName(),
+						messageId, ContentTypes.TEXT_PLAIN, Sanitizer.MODE_ALL,
 						mbMessage.getSubject(), null));
 			}
 			catch (SanitizerException sanitizerException) {
@@ -22963,9 +22962,6 @@ public class MBMessagePersistenceImpl
 
 	@Reference
 	protected FinderCache finderCache;
-
-	@Reference
-	private volatile List<Sanitizer> _sanitizers;
 
 	private static final String _SQL_SELECT_MBMESSAGE =
 		"SELECT mbMessage FROM MBMessage mbMessage";

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/persistence/impl/MBMessagePersistenceImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/persistence/impl/MBMessagePersistenceImpl.java
@@ -22964,6 +22964,9 @@ public class MBMessagePersistenceImpl
 	@Reference
 	protected FinderCache finderCache;
 
+	@Reference
+	private volatile List<Sanitizer> _sanitizers;
+
 	private static final String _SQL_SELECT_MBMESSAGE =
 		"SELECT mbMessage FROM MBMessage mbMessage";
 
@@ -23020,9 +23023,6 @@ public class MBMessagePersistenceImpl
 
 	@Reference
 	private PortalUUID _portalUUID;
-
-	@Reference
-	private volatile List<Sanitizer> _sanitizers;
 
 	@Reference
 	private MBMessageModelArgumentsResolver _mbMessageModelArgumentsResolver;

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/persistence/impl/MBThreadPersistenceImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/persistence/impl/MBThreadPersistenceImpl.java
@@ -39,6 +39,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.sanitizer.Sanitizer;
 import com.liferay.portal.kernel.sanitizer.SanitizerException;
+import com.liferay.portal.kernel.sanitizer.SanitizerUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.security.permission.InlineSQLHelperUtil;
@@ -13535,12 +13536,10 @@ public class MBThreadPersistenceImpl
 
 			try {
 				mbThread.setTitle(
-					sanitize(
-						_sanitizers, companyId, groupId, userId,
-						MBThread.class.getName(), threadId,
-						ContentTypes.TEXT_PLAIN,
-						new String[] {Sanitizer.MODE_ALL}, mbThread.getTitle(),
-						null));
+					SanitizerUtil.sanitize(
+						companyId, groupId, userId, MBThread.class.getName(),
+						threadId, ContentTypes.TEXT_PLAIN, Sanitizer.MODE_ALL,
+						mbThread.getTitle(), null));
 			}
 			catch (SanitizerException sanitizerException) {
 				throw new SystemException(sanitizerException);
@@ -14413,9 +14412,6 @@ public class MBThreadPersistenceImpl
 
 	@Reference
 	protected FinderCache finderCache;
-
-	@Reference
-	private volatile List<Sanitizer> _sanitizers;
 
 	private static Long _getTime(Date date) {
 		if (date == null) {

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/persistence/impl/MBThreadPersistenceImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/persistence/impl/MBThreadPersistenceImpl.java
@@ -14414,6 +14414,9 @@ public class MBThreadPersistenceImpl
 	@Reference
 	protected FinderCache finderCache;
 
+	@Reference
+	private volatile List<Sanitizer> _sanitizers;
+
 	private static Long _getTime(Date date) {
 		if (date == null) {
 			return null;
@@ -14478,9 +14481,6 @@ public class MBThreadPersistenceImpl
 
 	@Reference
 	private PortalUUID _portalUUID;
-
-	@Reference
-	private volatile List<Sanitizer> _sanitizers;
 
 	@Reference
 	private MBThreadModelArgumentsResolver _mbThreadModelArgumentsResolver;

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -53,6 +53,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.sanitizer.Sanitizer;
+import com.liferay.portal.kernel.sanitizer.SanitizerUtil;
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Sort;
@@ -930,18 +931,14 @@ public class DefaultObjectEntryManagerImpl
 					ObjectFieldConstants.BUSINESS_TYPE_RICH_TEXT,
 					objectField.getBusinessType())) {
 
-				String value = String.valueOf(object);
-
-				for (Sanitizer sanitizer : _sanitizers) {
-					value = sanitizer.sanitize(
+				values.put(
+					name,
+					SanitizerUtil.sanitize(
 						objectField.getCompanyId(), groupId,
 						objectField.getUserId(),
 						objectDefinition.getClassName(), objectEntryId,
-						ContentTypes.TEXT_HTML,
-						new String[] {Sanitizer.MODE_ALL}, value, null);
-				}
-
-				values.put(name, value);
+						ContentTypes.TEXT_HTML, Sanitizer.MODE_ALL,
+						String.valueOf(object), null));
 
 				continue;
 			}
@@ -1018,9 +1015,6 @@ public class DefaultObjectEntryManagerImpl
 
 	@Reference
 	private Queries _queries;
-
-	@Reference
-	private volatile List<Sanitizer> _sanitizers;
 
 	@Reference
 	private SearchRequestBuilderFactory _searchRequestBuilderFactory;

--- a/modules/apps/portal-language/portal-language-override-service/src/main/java/com/liferay/portal/language/override/service/persistence/impl/PLOEntryPersistenceImpl.java
+++ b/modules/apps/portal-language/portal-language-override-service/src/main/java/com/liferay/portal/language/override/service/persistence/impl/PLOEntryPersistenceImpl.java
@@ -2763,6 +2763,9 @@ public class PLOEntryPersistenceImpl
 	@Reference
 	protected FinderCache finderCache;
 
+	@Reference
+	private volatile List<Sanitizer> _sanitizers;
+
 	private static final String _SQL_SELECT_PLOENTRY =
 		"SELECT ploEntry FROM PLOEntry ploEntry";
 
@@ -2793,9 +2796,6 @@ public class PLOEntryPersistenceImpl
 	protected FinderCache getFinderCache() {
 		return finderCache;
 	}
-
-	@Reference
-	private volatile List<Sanitizer> _sanitizers;
 
 	@Reference
 	private PLOEntryModelArgumentsResolver _ploEntryModelArgumentsResolver;

--- a/modules/apps/portal-language/portal-language-override-service/src/main/java/com/liferay/portal/language/override/service/persistence/impl/PLOEntryPersistenceImpl.java
+++ b/modules/apps/portal-language/portal-language-override-service/src/main/java/com/liferay/portal/language/override/service/persistence/impl/PLOEntryPersistenceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.sanitizer.Sanitizer;
 import com.liferay.portal.kernel.sanitizer.SanitizerException;
+import com.liferay.portal.kernel.sanitizer.SanitizerUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -2315,12 +2316,10 @@ public class PLOEntryPersistenceImpl
 
 			try {
 				ploEntry.setValue(
-					sanitize(
-						_sanitizers, companyId, groupId, userId,
-						PLOEntry.class.getName(), ploEntryId,
-						ContentTypes.TEXT_HTML,
-						new String[] {Sanitizer.MODE_ALL}, ploEntry.getValue(),
-						null));
+					SanitizerUtil.sanitize(
+						companyId, groupId, userId, PLOEntry.class.getName(),
+						ploEntryId, ContentTypes.TEXT_HTML, Sanitizer.MODE_ALL,
+						ploEntry.getValue(), null));
 			}
 			catch (SanitizerException sanitizerException) {
 				throw new SystemException(sanitizerException);
@@ -2762,9 +2761,6 @@ public class PLOEntryPersistenceImpl
 
 	@Reference
 	protected FinderCache finderCache;
-
-	@Reference
-	private volatile List<Sanitizer> _sanitizers;
 
 	private static final String _SQL_SELECT_PLOENTRY =
 		"SELECT ploEntry FROM PLOEntry ploEntry";

--- a/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/service/persistence/impl/RedirectEntryPersistenceImpl.java
+++ b/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/service/persistence/impl/RedirectEntryPersistenceImpl.java
@@ -4398,6 +4398,9 @@ public class RedirectEntryPersistenceImpl
 	@Reference
 	protected FinderCache finderCache;
 
+	@Reference
+	private volatile List<Sanitizer> _sanitizers;
+
 	private static final String _SQL_SELECT_REDIRECTENTRY =
 		"SELECT redirectEntry FROM RedirectEntry redirectEntry";
 
@@ -4454,9 +4457,6 @@ public class RedirectEntryPersistenceImpl
 
 	@Reference
 	private PortalUUID _portalUUID;
-
-	@Reference
-	private volatile List<Sanitizer> _sanitizers;
 
 	@Reference
 	private RedirectEntryModelArgumentsResolver

--- a/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/service/persistence/impl/RedirectEntryPersistenceImpl.java
+++ b/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/service/persistence/impl/RedirectEntryPersistenceImpl.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.sanitizer.Sanitizer;
 import com.liferay.portal.kernel.sanitizer.SanitizerException;
+import com.liferay.portal.kernel.sanitizer.SanitizerUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.security.permission.InlineSQLHelperUtil;
@@ -3918,19 +3919,17 @@ public class RedirectEntryPersistenceImpl
 
 			try {
 				redirectEntry.setDestinationURL(
-					sanitize(
-						_sanitizers, companyId, groupId, userId,
+					SanitizerUtil.sanitize(
+						companyId, groupId, userId,
 						RedirectEntry.class.getName(), redirectEntryId,
-						ContentTypes.TEXT_PLAIN,
-						new String[] {Sanitizer.MODE_ALL},
+						ContentTypes.TEXT_PLAIN, Sanitizer.MODE_ALL,
 						redirectEntry.getDestinationURL(), null));
 
 				redirectEntry.setSourceURL(
-					sanitize(
-						_sanitizers, companyId, groupId, userId,
+					SanitizerUtil.sanitize(
+						companyId, groupId, userId,
 						RedirectEntry.class.getName(), redirectEntryId,
-						ContentTypes.TEXT_PLAIN,
-						new String[] {Sanitizer.MODE_ALL},
+						ContentTypes.TEXT_PLAIN, Sanitizer.MODE_ALL,
 						redirectEntry.getSourceURL(), null));
 			}
 			catch (SanitizerException sanitizerException) {
@@ -4397,9 +4396,6 @@ public class RedirectEntryPersistenceImpl
 
 	@Reference
 	protected FinderCache finderCache;
-
-	@Reference
-	private volatile List<Sanitizer> _sanitizers;
 
 	private static final String _SQL_SELECT_REDIRECTENTRY =
 		"SELECT redirectEntry FROM RedirectEntry redirectEntry";

--- a/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/service/persistence/impl/RedirectNotFoundEntryPersistenceImpl.java
+++ b/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/service/persistence/impl/RedirectNotFoundEntryPersistenceImpl.java
@@ -1560,6 +1560,9 @@ public class RedirectNotFoundEntryPersistenceImpl
 	@Reference
 	protected FinderCache finderCache;
 
+	@Reference
+	private volatile List<Sanitizer> _sanitizers;
+
 	private static final String _SQL_SELECT_REDIRECTNOTFOUNDENTRY =
 		"SELECT redirectNotFoundEntry FROM RedirectNotFoundEntry redirectNotFoundEntry";
 
@@ -1588,9 +1591,6 @@ public class RedirectNotFoundEntryPersistenceImpl
 	protected FinderCache getFinderCache() {
 		return finderCache;
 	}
-
-	@Reference
-	private volatile List<Sanitizer> _sanitizers;
 
 	@Reference
 	private RedirectNotFoundEntryModelArgumentsResolver

--- a/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/service/persistence/impl/RedirectNotFoundEntryPersistenceImpl.java
+++ b/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/service/persistence/impl/RedirectNotFoundEntryPersistenceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.sanitizer.Sanitizer;
 import com.liferay.portal.kernel.sanitizer.SanitizerException;
+import com.liferay.portal.kernel.sanitizer.SanitizerUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -1152,12 +1153,12 @@ public class RedirectNotFoundEntryPersistenceImpl
 
 			try {
 				redirectNotFoundEntry.setUrl(
-					sanitize(
-						_sanitizers, companyId, groupId, userId,
+					SanitizerUtil.sanitize(
+						companyId, groupId, userId,
 						RedirectNotFoundEntry.class.getName(),
 						redirectNotFoundEntryId, ContentTypes.TEXT_PLAIN,
-						new String[] {Sanitizer.MODE_ALL},
-						redirectNotFoundEntry.getUrl(), null));
+						Sanitizer.MODE_ALL, redirectNotFoundEntry.getUrl(),
+						null));
 			}
 			catch (SanitizerException sanitizerException) {
 				throw new SystemException(sanitizerException);
@@ -1559,9 +1560,6 @@ public class RedirectNotFoundEntryPersistenceImpl
 
 	@Reference
 	protected FinderCache finderCache;
-
-	@Reference
-	private volatile List<Sanitizer> _sanitizers;
 
 	private static final String _SQL_SELECT_REDIRECTNOTFOUNDENTRY =
 		"SELECT redirectNotFoundEntry FROM RedirectNotFoundEntry redirectNotFoundEntry";

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageLocalServiceImpl.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageLocalServiceImpl.java
@@ -57,7 +57,7 @@ import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.portletfilerepository.PortletFileRepository;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.Folder;
-import com.liferay.portal.kernel.sanitizer.Sanitizer;
+import com.liferay.portal.kernel.sanitizer.SanitizerUtil;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistry;
 import com.liferay.portal.kernel.service.ResourceLocalService;
@@ -259,12 +259,9 @@ public class WikiPageLocalServiceImpl extends WikiPageLocalServiceBaseImpl {
 		_validateExternalReferenceCode(
 			externalReferenceCode, node.getGroupId());
 
-		for (Sanitizer sanitizer : _sanitizers) {
-			content = sanitizer.sanitize(
-				user.getCompanyId(), node.getGroupId(), userId,
-				WikiPage.class.getName(), pageId, "text/" + format,
-				new String[] {Sanitizer.MODE_ALL}, content, null);
-		}
+		content = SanitizerUtil.sanitize(
+			user.getCompanyId(), node.getGroupId(), userId,
+			WikiPage.class.getName(), pageId, "text/" + format, content);
 
 		title = _normalizeSpace(title);
 
@@ -3307,12 +3304,9 @@ public class WikiPageLocalServiceImpl extends WikiPageLocalServiceBaseImpl {
 			pageId = oldPage.getPageId();
 		}
 
-		for (Sanitizer sanitizer : _sanitizers) {
-			content = sanitizer.sanitize(
-				user.getCompanyId(), oldPage.getGroupId(), userId,
-				WikiPage.class.getName(), pageId, "text/" + format,
-				new String[] {Sanitizer.MODE_ALL}, content, null);
-		}
+		content = SanitizerUtil.sanitize(
+			user.getCompanyId(), oldPage.getGroupId(), userId,
+			WikiPage.class.getName(), pageId, "text/" + format, content);
 
 		long nodeId = oldPage.getNodeId();
 
@@ -3512,9 +3506,6 @@ public class WikiPageLocalServiceImpl extends WikiPageLocalServiceBaseImpl {
 
 	@Reference
 	private ResourceLocalService _resourceLocalService;
-
-	@Reference
-	private volatile List<Sanitizer> _sanitizers;
 
 	private ServiceTrackerMap<String, WikiPageRenameContentProcessor>
 		_serviceTrackerMap;

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/persistence/impl/WikiPagePersistenceImpl.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/persistence/impl/WikiPagePersistenceImpl.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.sanitizer.Sanitizer;
 import com.liferay.portal.kernel.sanitizer.SanitizerException;
+import com.liferay.portal.kernel.sanitizer.SanitizerUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.security.permission.InlineSQLHelperUtil;
@@ -23791,12 +23792,10 @@ public class WikiPagePersistenceImpl
 
 			try {
 				wikiPage.setTitle(
-					sanitize(
-						_sanitizers, companyId, groupId, userId,
-						WikiPage.class.getName(), pageId,
-						ContentTypes.TEXT_PLAIN,
-						new String[] {Sanitizer.MODE_ALL}, wikiPage.getTitle(),
-						null));
+					SanitizerUtil.sanitize(
+						companyId, groupId, userId, WikiPage.class.getName(),
+						pageId, ContentTypes.TEXT_PLAIN, Sanitizer.MODE_ALL,
+						wikiPage.getTitle(), null));
 			}
 			catch (SanitizerException sanitizerException) {
 				throw new SystemException(sanitizerException);
@@ -24947,9 +24946,6 @@ public class WikiPagePersistenceImpl
 
 	@Reference
 	protected FinderCache finderCache;
-
-	@Reference
-	private volatile List<Sanitizer> _sanitizers;
 
 	private static final String _SQL_SELECT_WIKIPAGE =
 		"SELECT wikiPage FROM WikiPage wikiPage";

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/persistence/impl/WikiPagePersistenceImpl.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/persistence/impl/WikiPagePersistenceImpl.java
@@ -24948,6 +24948,9 @@ public class WikiPagePersistenceImpl
 	@Reference
 	protected FinderCache finderCache;
 
+	@Reference
+	private volatile List<Sanitizer> _sanitizers;
+
 	private static final String _SQL_SELECT_WIKIPAGE =
 		"SELECT wikiPage FROM WikiPage wikiPage";
 
@@ -25004,9 +25007,6 @@ public class WikiPagePersistenceImpl
 
 	@Reference
 	private PortalUUID _portalUUID;
-
-	@Reference
-	private volatile List<Sanitizer> _sanitizers;
 
 	@Reference
 	private WikiPageModelArgumentsResolver _wikiPageModelArgumentsResolver;

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/service/persistence/impl/SXPBlueprintPersistenceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/service/persistence/impl/SXPBlueprintPersistenceImpl.java
@@ -3946,6 +3946,9 @@ public class SXPBlueprintPersistenceImpl
 	@Reference
 	protected FinderCache finderCache;
 
+	@Reference
+	private volatile List<Sanitizer> _sanitizers;
+
 	private static final String _SQL_SELECT_SXPBLUEPRINT =
 		"SELECT sxpBlueprint FROM SXPBlueprint sxpBlueprint";
 
@@ -4002,9 +4005,6 @@ public class SXPBlueprintPersistenceImpl
 
 	@Reference
 	private PortalUUID _portalUUID;
-
-	@Reference
-	private volatile List<Sanitizer> _sanitizers;
 
 	@Reference
 	private SXPBlueprintModelArgumentsResolver

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/service/persistence/impl/SXPBlueprintPersistenceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/service/persistence/impl/SXPBlueprintPersistenceImpl.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.sanitizer.Sanitizer;
 import com.liferay.portal.kernel.sanitizer.SanitizerException;
+import com.liferay.portal.kernel.sanitizer.SanitizerUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.security.permission.InlineSQLHelperUtil;
@@ -3504,11 +3505,10 @@ public class SXPBlueprintPersistenceImpl
 
 			try {
 				sxpBlueprint.setTitle(
-					sanitize(
-						_sanitizers, companyId, groupId, userId,
+					SanitizerUtil.sanitize(
+						companyId, groupId, userId,
 						SXPBlueprint.class.getName(), sxpBlueprintId,
-						ContentTypes.TEXT_PLAIN,
-						new String[] {Sanitizer.MODE_ALL},
+						ContentTypes.TEXT_PLAIN, Sanitizer.MODE_ALL,
 						sxpBlueprint.getTitle(), null));
 			}
 			catch (SanitizerException sanitizerException) {
@@ -3945,9 +3945,6 @@ public class SXPBlueprintPersistenceImpl
 
 	@Reference
 	protected FinderCache finderCache;
-
-	@Reference
-	private volatile List<Sanitizer> _sanitizers;
 
 	private static final String _SQL_SELECT_SXPBLUEPRINT =
 		"SELECT sxpBlueprint FROM SXPBlueprint sxpBlueprint";

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/service/persistence/impl/SXPElementPersistenceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/service/persistence/impl/SXPElementPersistenceImpl.java
@@ -6827,6 +6827,9 @@ public class SXPElementPersistenceImpl
 	@Reference
 	protected FinderCache finderCache;
 
+	@Reference
+	private volatile List<Sanitizer> _sanitizers;
+
 	private static final String _SQL_SELECT_SXPELEMENT =
 		"SELECT sxpElement FROM SXPElement sxpElement";
 
@@ -6883,9 +6886,6 @@ public class SXPElementPersistenceImpl
 
 	@Reference
 	private PortalUUID _portalUUID;
-
-	@Reference
-	private volatile List<Sanitizer> _sanitizers;
 
 	@Reference
 	private SXPElementModelArgumentsResolver _sxpElementModelArgumentsResolver;

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/service/persistence/impl/SXPElementPersistenceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/service/persistence/impl/SXPElementPersistenceImpl.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.sanitizer.Sanitizer;
 import com.liferay.portal.kernel.sanitizer.SanitizerException;
+import com.liferay.portal.kernel.sanitizer.SanitizerUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.security.permission.InlineSQLHelperUtil;
@@ -6323,12 +6324,10 @@ public class SXPElementPersistenceImpl
 
 			try {
 				sxpElement.setTitle(
-					sanitize(
-						_sanitizers, companyId, groupId, userId,
-						SXPElement.class.getName(), sxpElementId,
-						ContentTypes.TEXT_PLAIN,
-						new String[] {Sanitizer.MODE_ALL},
-						sxpElement.getTitle(), null));
+					SanitizerUtil.sanitize(
+						companyId, groupId, userId, SXPElement.class.getName(),
+						sxpElementId, ContentTypes.TEXT_PLAIN,
+						Sanitizer.MODE_ALL, sxpElement.getTitle(), null));
 			}
 			catch (SanitizerException sanitizerException) {
 				throw new SystemException(sanitizerException);
@@ -6826,9 +6825,6 @@ public class SXPElementPersistenceImpl
 
 	@Reference
 	protected FinderCache finderCache;
-
-	@Reference
-	private volatile List<Sanitizer> _sanitizers;
 
 	private static final String _SQL_SELECT_SXPELEMENT =
 		"SELECT sxpElement FROM SXPElement sxpElement";

--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_impl.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_impl.ftl
@@ -2970,6 +2970,11 @@ public class ${entity.name}PersistenceImpl extends BasePersistenceImpl<${entity.
 		protected ${localizedEntity.name}Persistence ${localizedEntity.variableName}Persistence;
 	</#if>
 
+	<#if sanitizeTuples?size != 0 && serviceBuilder.isVersionGTE_7_4_0() && dependencyInjectorDS>
+			@Reference
+			private volatile List<Sanitizer> _sanitizers;
+	</#if>
+
 	<#if entity.versionedEntity?? && entity.versionedEntity.localizedEntity??>
 		<#assign
 			versionedEntity = entity.versionedEntity
@@ -3146,11 +3151,6 @@ public class ${entity.name}PersistenceImpl extends BasePersistenceImpl<${entity.
 			@ServiceReference(type = PortalUUID.class)
 		</#if>
 		private PortalUUID ${portalUUID};
-	</#if>
-
-	<#if (sanitizeTuples?size != 0) && serviceBuilder.isVersionGTE_7_4_0() && dependencyInjectorDS>
-		@Reference
-		private volatile List<Sanitizer> _sanitizers;
 	</#if>
 
 	<#if serviceBuilder.isVersionGTE_7_4_0() && dependencyInjectorDS>

--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_impl.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_impl.ftl
@@ -913,14 +913,8 @@ public class ${entity.name}PersistenceImpl extends BasePersistenceImpl<${entity.
 						<#else>
 							<#assign modes = "StringUtil.split(\"" + sanitizeTuple.getObject(2) + "\")" />
 						</#if>
-							${entity.variableName}.set${colMethodName}(
-						<#if serviceBuilder.isVersionGTE_7_4_0() && dependencyInjectorDS>
-							sanitize(_sanitizers, companyId, groupId, userId, ${apiPackagePath}.model.${entity.name}.class.getName(),
-							${entity.PKVariableName}, ${contentType}, new String[] {${modes}}, ${entity.variableName}.get${colMethodName}(), null));
-						<#else>
-							SanitizerUtil.sanitize(companyId, groupId, userId, ${apiPackagePath}.model.${entity.name}.class.getName(),
-							${entity.PKVariableName}, ${contentType}, ${modes}, ${entity.variableName}.get${colMethodName}(), null));
-						</#if>
+
+						${entity.variableName}.set${colMethodName}(SanitizerUtil.sanitize(companyId, groupId, userId, ${apiPackagePath}.model.${entity.name}.class.getName(), ${entity.PKVariableName}, ${contentType}, ${modes}, ${entity.variableName}.get${colMethodName}(), null));
 					</#list>
 				}
 				catch (SanitizerException sanitizerException) {
@@ -2968,11 +2962,6 @@ public class ${entity.name}PersistenceImpl extends BasePersistenceImpl<${entity.
 		</#if>
 
 		protected ${localizedEntity.name}Persistence ${localizedEntity.variableName}Persistence;
-	</#if>
-
-	<#if sanitizeTuples?size != 0 && serviceBuilder.isVersionGTE_7_4_0() && dependencyInjectorDS>
-			@Reference
-			private volatile List<Sanitizer> _sanitizers;
 	</#if>
 
 	<#if entity.versionedEntity?? && entity.versionedEntity.localizedEntity??>

--- a/portal-kernel/src/com/liferay/portal/kernel/service/persistence/impl/BasePersistenceImpl.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/persistence/impl/BasePersistenceImpl.java
@@ -71,8 +71,6 @@ import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ModelListener;
 import com.liferay.portal.kernel.model.ModelListenerRegistrationUtil;
 import com.liferay.portal.kernel.model.ModelWrapper;
-import com.liferay.portal.kernel.sanitizer.Sanitizer;
-import com.liferay.portal.kernel.sanitizer.SanitizerException;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.persistence.BasePersistence;
@@ -937,21 +935,6 @@ public class BasePersistenceImpl<T extends BaseModel<T>>
 	 */
 	protected T removeImpl(T model) {
 		throw new UnsupportedOperationException();
-	}
-
-	protected String sanitize(
-			List<Sanitizer> sanitizers, long companyId, long groupId,
-			long userId, String className, long classPK, String contentType,
-			String[] modes, String content, Map<String, Object> options)
-		throws SanitizerException {
-
-		for (Sanitizer sanitizer : sanitizers) {
-			content = sanitizer.sanitize(
-				companyId, groupId, userId, className, classPK, contentType,
-				modes, content, options);
-		}
-
-		return content;
 	}
 
 	protected void setDBColumnNames(Map<String, String> dbColumnNames) {

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -536,7 +536,6 @@
         com.liferay.portal.kernel.language.LanguageUtil,\
         com.liferay.portal.kernel.language.UnicodeLanguageUtil,\
         com.liferay.portal.kernel.patcher.PatcherUtil,\
-        com.liferay.portal.kernel.sanitizer.SanitizerUtil,\
         com.liferay.portal.kernel.service.permission.CommonPermissionUtil,\
         com.liferay.portal.kernel.service.permission.GroupPermissionUtil,\
         com.liferay.portal.kernel.service.permission.OrganizationPermissionUtil,\


### PR DESCRIPTION
@brianchandotcom
Hi Brian,
This pull is to revert #123355

Per my discussion with Tina this morning, 
adding a List of Sanitizer service references in each component hurts performance and is unnecessary since Sanitizer services don't really change after they are initialized. 

The original way of using SanitizerUtil only have one set of service tracker.
The new way of using `@Reference` List have mutliple service trackers for each component using the service.

I reverted all commits from the pull above
Including [Revert "LPS-161324 regen"](https://github.com/brianchandotcom/liferay-portal/pull/123440/commits/78892751ea04c362804a4d9fb4ef7169a1011d3d) regenerated by you
but excluding [LPS-161324 Remove SanitizerUtil from util-spring](https://github.com/brianchandotcom/liferay-portal/pull/123355/commits/e94f6f1e085314ee25d651e713dee16e1a7b4d50) since I think that spring bean is still unnecessary.

Thank you!

CC. @tinatian

