### PR TITLE
LPS-163610 - Permissions are not checked when listing Vocabularies in AssetCategoriesSelectorTag

### DIFF
--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyServiceImpl.java
@@ -285,7 +285,7 @@ public class AssetVocabularyServiceImpl extends AssetVocabularyServiceBaseImpl {
 	public List<AssetVocabulary> getGroupVocabularies(
 		long groupId, int visibilityType) {
 
-		return assetVocabularyLocalService.getGroupVocabularies(
+		return assetVocabularyPersistence.filterFindByG_V(
 			groupId, visibilityType);
 	}
 
@@ -316,7 +316,7 @@ public class AssetVocabularyServiceImpl extends AssetVocabularyServiceBaseImpl {
 	public List<AssetVocabulary> getGroupVocabularies(
 		long[] groupIds, int[] visibilityTypes) {
 
-		return assetVocabularyLocalService.getGroupVocabularies(
+		return assetVocabularyPersistence.filterFindByG_V(
 			groupIds, visibilityTypes);
 	}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-163610

There's no unique failure after checking on https://github.com/liferay-echo/liferay-portal/pull/9695, so I send to you directly, thanks!