### PR TITLE
Revert "LPS-162237 Add exception to existing log call"

### DIFF
--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/index/CompanyIndexFactory.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/index/CompanyIndexFactory.java
@@ -460,9 +460,7 @@ public class CompanyIndexFactory
 					elasticsearchConnectionNotInitializedException) {
 
 			if (_log.isInfoEnabled()) {
-				_log.info(
-					"Skipping index settings contributor",
-					elasticsearchConnectionNotInitializedException);
+				_log.info("Skipping index settings contributor");
 			}
 
 			return;


### PR DESCRIPTION
This reverts commit 61b327e6ed995354c71eb68d64f7d34ffe959ef9.

https://issues.liferay.com/browse/LPS-162237

@ling-alan-huang @brianchandotcom  we're reverting this commit since it's causing `ElasticsearchConnectionNotInitializedException` to be thrown at Portal startup as INFO logs for all tests on CI. [See example CI startup log](https://testray.liferay.com/reports/production/logs/2022-09/test-1-1/test-portal-acceptance-upstream-dxp(master)/3831/functional-smoke-tomcat90-mysql57-jdk8/0/0/liferay-log.txt.gz?authuser=0)

Forwarding manually due to unrelated failures in relevant: https://github.com/joshchong/liferay-portal/pull/603#issuecomment-1256613717