### PR TITLE
LPS-163493 enable substitutable imports so that everything works in OSGi integration test

### DIFF
--- a/portal-test/bnd.bnd
+++ b/portal-test/bnd.bnd
@@ -30,6 +30,8 @@ Export-Package:\
 	org.junit.runner.*,\
 	org.junit.*,\
 	\
+	org.osgi.service.*,\
+	\
 	org.springframework.mock.web
 Import-Package: *;resolution:=optional
 Include-Resource:\

--- a/portal-test/moved-packages.txt
+++ b/portal-test/moved-packages.txt
@@ -1,0 +1,1 @@
+org.osgi.service.*

--- a/source-formatter-suppressions.xml
+++ b/source-formatter-suppressions.xml
@@ -58,6 +58,7 @@
 		<suppress checks="VariableNameCheck" files="portal-kernel/src/com/liferay/portal/kernel/display/context/BaseDisplayContext\.java" />
 	</checkstyle>
 	<source-check>
+		<suppress checks="BNDExportsCheck" files="portal-test/bnd.bnd" />
 		<suppress checks="CDNCheck" files="test\.properties" />
 		<suppress checks="GetterUtilCheck" files="portal-kernel/test/unit/com/liferay/portal/kernel/util/GetterUtilTest\.java" />
 		<suppress checks="JavaCleanUpMethodVariablesCheck" files="util-taglib/src/com/liferay/taglib/util/IncludeTag\.java" />


### PR DESCRIPTION
Commit from Ray Augé to solve the problems in the integration tests. In this test with ConfigurationAdmin.