### PR TITLE
LPS-164037 Revert "LPS-161850 enable substitutable imports so that ev…

### DIFF
--- a/portal-test/bnd.bnd
+++ b/portal-test/bnd.bnd
@@ -30,8 +30,6 @@ Export-Package:\
 	org.junit.runner.*,\
 	org.junit.*,\
 	\
-	org.osgi.service.*,\
-	\
 	org.springframework.mock.web
 Import-Package: *;resolution:=optional
 Include-Resource:\

--- a/portal-test/moved-packages.txt
+++ b/portal-test/moved-packages.txt
@@ -1,1 +1,0 @@
-org.osgi.service.*

--- a/source-formatter-suppressions.xml
+++ b/source-formatter-suppressions.xml
@@ -58,7 +58,6 @@
 		<suppress checks="VariableNameCheck" files="portal-kernel/src/com/liferay/portal/kernel/display/context/BaseDisplayContext\.java" />
 	</checkstyle>
 	<source-check>
-		<suppress checks="BNDExportsCheck" files="portal-test/bnd.bnd" />
 		<suppress checks="CDNCheck" files="test\.properties" />
 		<suppress checks="GetterUtilCheck" files="portal-kernel/test/unit/com/liferay/portal/kernel/util/GetterUtilTest\.java" />
 		<suppress checks="JavaCleanUpMethodVariablesCheck" files="util-taglib/src/com/liferay/taglib/util/IncludeTag\.java" />


### PR DESCRIPTION
…erything works in OSGi integration test"

This export caused tons of modules reloading upon running the integration tests for the first time, which further causes connection failure. This reverts commit 1471db5c2bf7d2fcfd85e9f699775a592b8e7ca1.