### PR TITLE
LPS-163949 search-experiences-web: Sort parameters inside util function validateRequired

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/EditSXPBlueprintForm.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/EditSXPBlueprintForm.js
@@ -291,10 +291,10 @@ function EditSXPBlueprintForm({
 							const configError =
 								validateRequired(
 									configValue,
-									type,
-									typeOptions.required,
+									name,
 									typeOptions.nullable,
-									name
+									typeOptions.required,
+									type
 								) ||
 								validateBoost(configValue, type) ||
 								validateNumberRange(
@@ -314,8 +314,13 @@ function EditSXPBlueprintForm({
 					const configValue = uiConfigurationValues?.sxpElement;
 
 					const configError =
-						validateRequired(configValue, INPUT_TYPES.JSON) ||
-						validateJSON(configValue, INPUT_TYPES.JSON);
+						validateRequired(
+							configValue,
+							'',
+							false,
+							true,
+							INPUT_TYPES.JSON
+						) || validateJSON(configValue, INPUT_TYPES.JSON);
 
 					if (configError) {
 						configErrors.sxpElement = configError;

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/validation.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/validation.js
@@ -73,10 +73,10 @@ export function validateNumberRange(configValue, type, typeOptions) {
 
 export function validateRequired(
 	configValue,
-	type,
-	required = true,
+	name,
 	nullable = false,
-	name = ''
+	required = true,
+	type
 ) {
 	if (!required || nullable) {
 		return;

--- a/modules/dxp/apps/search-experiences/search-experiences-web/test/js/utils/validation.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/test/js/utils/validation.js
@@ -170,25 +170,31 @@ describe('validation', () => {
 
 	describe('validateRequired', () => {
 		it('returns error message for empty string', () => {
-			expect(validateRequired('', INPUT_TYPES.NUMBER)).toEqual(
-				ERROR_MESSAGES.REQUIRED
-			);
+			expect(
+				validateRequired('', 'boost', false, true, INPUT_TYPES.NUMBER)
+			).toEqual(ERROR_MESSAGES.REQUIRED);
 		});
 
 		it('returns error message for empty array', () => {
-			expect(validateRequired([], INPUT_TYPES.MULTISELECT)).toEqual(
-				ERROR_MESSAGES.REQUIRED
-			);
+			expect(
+				validateRequired(
+					[],
+					'selection',
+					false,
+					true,
+					INPUT_TYPES.MULTISELECT
+				)
+			).toEqual(ERROR_MESSAGES.REQUIRED);
 		});
 
 		it('returns error message for empty category selector list', () => {
 			expect(
 				validateRequired(
 					[],
-					INPUT_TYPES.NUMBER,
-					true,
+					'asset_category_id',
 					false,
-					'asset_category_id'
+					true,
+					INPUT_TYPES.NUMBER
 				)
 			).toEqual(ERROR_MESSAGES.REQUIRED_CATEGORY_SELECTOR);
 		});
@@ -200,6 +206,9 @@ describe('validation', () => {
 						field: '',
 						locale: '',
 					},
+					'field',
+					false,
+					true,
 					INPUT_TYPES.FIELD_MAPPING
 				)
 			).toEqual(ERROR_MESSAGES.REQUIRED);
@@ -220,6 +229,9 @@ describe('validation', () => {
 							locale: '${context.language_id}',
 						},
 					],
+					'fields',
+					false,
+					true,
 					INPUT_TYPES.FIELD_MAPPING_LIST
 				)
 			).toEqual(ERROR_MESSAGES.REQUIRED);
@@ -227,7 +239,37 @@ describe('validation', () => {
 
 		it('returns undefined for non-empty string', () => {
 			expect(
-				validateRequired('test', INPUT_TYPES.NUMBER)
+				validateRequired(
+					'test',
+					'boost',
+					false,
+					true,
+					INPUT_TYPES.NUMBER
+				)
+			).toBeUndefined();
+		});
+
+		it('returns undefined when nullable is true', () => {
+			expect(
+				validateRequired(
+					'',
+					'boost',
+					true,
+					undefined,
+					INPUT_TYPES.NUMBER
+				)
+			).toBeUndefined();
+		});
+
+		it('returns undefined for required is false', () => {
+			expect(
+				validateRequired(
+					'',
+					'boost',
+					undefined,
+					false,
+					INPUT_TYPES.NUMBER
+				)
 			).toBeUndefined();
 		});
 
@@ -235,6 +277,9 @@ describe('validation', () => {
 			expect(
 				validateRequired(
 					[{label: 'test', value: 'test'}],
+					'selection',
+					false,
+					true,
 					INPUT_TYPES.MULTISELECT
 				)
 			).toBeUndefined();
@@ -247,6 +292,9 @@ describe('validation', () => {
 						field: 'localized_title',
 						locale: '${context.language_id}',
 					},
+					'field',
+					false,
+					true,
 					INPUT_TYPES.FIELD_MAPPING
 				)
 			).toBeUndefined();
@@ -267,6 +315,9 @@ describe('validation', () => {
 							locale: '${context.language_id}',
 						},
 					],
+					'fields',
+					false,
+					true,
 					INPUT_TYPES.FIELD_MAPPING_LIST
 				)
 			).toBeUndefined();


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-163949 - Change validateRequired so this can be sorted

From @oliv-yu:
Sorted parameters + updated all places where `validateRequired` was called. Also added two frontend tests since it looks like there's no coverage for varied `nullable` and `required` parameters. Let me know if I should add anything else! Thanks

Tested here: https://github.com/liferay-search/liferay-portal/pull/581
Failures were unrelated.

@thektan