### PR TITLE
LPS-158192

### DIFF
--- a/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/control_menu/page.jsp
+++ b/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/control_menu/page.jsp
@@ -59,13 +59,14 @@ for (ProductNavigationControlMenuCategory productNavigationControlMenuCategory :
 					<%
 					for (Map.Entry<ProductNavigationControlMenuCategory, List<ProductNavigationControlMenuEntry>> entry : productNavigationControlMenuEntriesMap.entrySet()) {
 						ProductNavigationControlMenuCategory productNavigationControlMenuCategory = entry.getKey();
+						List<ProductNavigationControlMenuEntry> productNavigationControlMenuEntryList = entry.getValue();
 					%>
 
 						<li class="control-menu-nav-category <%= productNavigationControlMenuCategory.getKey() %>-control-group">
-							<ul class="control-menu-nav">
+							<ul class="control-menu-nav" role="<%= (productNavigationControlMenuEntryList.size() == 1) ? "presentation" : "menu" %>">
 
 								<%
-								for (ProductNavigationControlMenuEntry productNavigationControlMenuEntry : entry.getValue()) {
+								for (ProductNavigationControlMenuEntry productNavigationControlMenuEntry : productNavigationControlMenuEntryList) {
 									if (productNavigationControlMenuEntry.includeIcon(request, PipingServletResponseFactory.createPipingServletResponse(pageContext))) {
 										continue;
 									}


### PR DESCRIPTION
FWD: https://github.com/fortunatomaldonado/liferay-portal/pull/54

This is another accessibility fix.
Please let me know if there are any questions.

> https://issues.liferay.com/browse/LPP-46636
> 
> Hi @fortunatomaldonado,
> 
> This is technically yet another one of the accessibility issues thus why I'm sending it to you. Essentially, due to the way that the control menu is internally structured, technically the bar is actually a menu with three separate submenus (there's a picture on https://issues.liferay.com/browse/LPP-46636 that should help illustrate what I'm talking about) and not just one large header. Due to this, the screen reader (correctly) reads the semantics as a list with three items (the three submenus) -> list with one item (since in a default instance the first submenu only has one item which is the link to the product menu) -> the product menu link . However, the client finds this confusing. As a compromise, I'm changing the logic slightly to add a check for the size of the list per a suggestion made in [PTR-3328](https://issues.liferay.com/browse/PTR-3328). If there's only one item, the role for the second list is changed to presentation to remove its semantics. I've made the other role to be explicitly 'menu' since it's technically a menu, but let me know if you feel like that's inappropriate for the role. Thanks!