### PR TITLE
LPS-163962 Avoid typing any non-numeric characters and make years dynamic in DatePicker component

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-web/types/src/main/resources/META-INF/resources/js/OAuth2Client.d.ts
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/types/src/main/resources/META-INF/resources/js/OAuth2Client.d.ts
@@ -11,36 +11,41 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
+
 interface IOAuth2ClientFromParametersOptions {
-    authorizeURL?: string;
-    clientId: string;
-    homePageURL: string;
-    redirectURIs?: Array<string>;
-    tokenURL?: string;
+	authorizeURL?: string;
+	clientId: string;
+	homePageURL: string;
+	redirectURIs?: Array<string>;
+	tokenURL?: string;
 }
 interface IOAuth2ClientOptions {
-    authorizeURL: string;
-    clientId: string;
-    encodedRedirectURL: string;
-    homePageURL: string;
-    redirectURIs: Array<string>;
-    tokenURL: string;
+	authorizeURL: string;
+	clientId: string;
+	encodedRedirectURL: string;
+	homePageURL: string;
+	redirectURIs: Array<string>;
+	tokenURL: string;
 }
 declare class OAuth2Client {
-    private authorizeURL;
-    private clientId;
-    private encodedRedirectURL;
-    private homePageURL;
-    private redirectURIs;
-    private tokenURL;
-    constructor(options: IOAuth2ClientOptions);
-    fetch(url: RequestInfo, options?: any): Promise<any>;
-    private _createIframe;
-    private _fetch;
-    private _getOrRequestToken;
-    private _requestTokenSilently;
-    private _requestToken;
+	private authorizeURL;
+	private clientId;
+	private encodedRedirectURL;
+	private homePageURL;
+	private redirectURIs;
+	private tokenURL;
+	constructor(options: IOAuth2ClientOptions);
+	fetch(url: RequestInfo, options?: any): Promise<any>;
+	private _createIframe;
+	private _fetch;
+	private _getOrRequestToken;
+	private _requestTokenSilently;
+	private _requestToken;
 }
-export declare function FromParameters(options: IOAuth2ClientFromParametersOptions): OAuth2Client;
-export declare function FromUserAgentApplication(userAgentApplicationName: string): OAuth2Client;
+export declare function FromParameters(
+	options: IOAuth2ClientFromParametersOptions
+): OAuth2Client;
+export declare function FromUserAgentApplication(
+	userAgentApplicationName: string
+): OAuth2Client;
 export {};

--- a/modules/apps/oauth2-provider/oauth2-provider-web/types/src/main/resources/META-INF/resources/js/liferay.d.ts
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/types/src/main/resources/META-INF/resources/js/liferay.d.ts
@@ -11,4 +11,5 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
+
 export {};

--- a/modules/apps/object/object-js-components-web/package.json
+++ b/modules/apps/object/object-js-components-web/package.json
@@ -2,6 +2,7 @@
 	"dependencies": {
 		"@types/codemirror": "^5.60.5",
 		"codemirror": "^5.59.0",
+		"moment": "^2.22.2",
 		"text-mask-core": "^5.1.2"
 	},
 	"main": "index.js",

--- a/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/DatePicker.tsx
+++ b/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/DatePicker.tsx
@@ -13,9 +13,12 @@
  */
 
 import ClayDatePicker from '@clayui/date-picker';
+import moment from 'moment';
 import React from 'react';
 
 import {FieldBase} from './FieldBase';
+
+const NON_NUMERIC_REGEX = /[^0-9-]/;
 
 export function DatePicker({
 	className,
@@ -40,13 +43,15 @@ export function DatePicker({
 			required={required}
 		>
 			<ClayDatePicker
-				onChange={onChange}
+				onChange={(value: string) => {
+					onChange(value.replace(NON_NUMERIC_REGEX, ''));
+				}}
 				placeholder="YYYY-MM-DD"
 				range={range}
 				value={value}
 				years={{
-					end: 2024,
-					start: 1997,
+					end: moment().year() + 5,
+					start: moment().year() - 5,
 				}}
 			/>
 		</FieldBase>
@@ -62,7 +67,7 @@ interface IProps
 	id?: string;
 	label?: string;
 	name?: string;
-	onChange?: (value: string) => void;
+	onChange: (value: string) => void;
 	range?: boolean;
 	required?: boolean;
 	value?: string;

--- a/modules/apps/object/object-js-components-web/types/src/main/resources/META-INF/resources/components/DatePicker.d.ts
+++ b/modules/apps/object/object-js-components-web/types/src/main/resources/META-INF/resources/components/DatePicker.d.ts
@@ -34,7 +34,7 @@ interface IProps
 	id?: string;
 	label?: string;
 	name?: string;
-	onChange?: (value: string) => void;
+	onChange: (value: string) => void;
 	range?: boolean;
 	required?: boolean;
 	value?: string;


### PR DESCRIPTION
Related Issue: https://issues.liferay.com/browse/LPS-163962

Hey @brianchandotcom, `react, moment and ClayDatePicker` are from different libraries and for different purposes. 

* `react` is needed for the file to recognize that we are using `JSX`, 
* `moment` I am using to get the current year data more easily 
*  `ClayDatePicker` to display the Component of Clay's date. 

I'm using them together similar to what we're doing in Forms' DatePicker, see: https://github.com/brianchandotcom/liferay-portal/blob/c197f39756a2fe2b946f2425f55e62b83a194985/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/DatePicker/DatePicker.es.js#L15-L17