### PR TITLE
LPS-163792 Add pagination page link for Web Contents

### DIFF
--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/portlet/action/GetContentDashboardItemVersionsMVCResourceCommand.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/portlet/action/GetContentDashboardItemVersionsMVCResourceCommand.java
@@ -20,6 +20,7 @@ import com.liferay.content.dashboard.item.ContentDashboardItemVersion;
 import com.liferay.content.dashboard.item.VersionableContentDashboardItem;
 import com.liferay.content.dashboard.web.internal.constants.ContentDashboardPortletKeys;
 import com.liferay.content.dashboard.web.internal.item.ContentDashboardItemFactoryTracker;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
@@ -153,21 +154,35 @@ public class GetContentDashboardItemVersionsMVCResourceCommand
 		HttpServletRequest httpServletRequest = _portal.getHttpServletRequest(
 			resourceRequest);
 
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		int displayVersions = ParamUtil.getInteger(
+			resourceRequest, "maxDisplayVersions",
+			_DEFAULT_MAX_DISPLAY_VERSIONS);
+
+		List<ContentDashboardItemVersion> contentDashboardItemVersions =
+			versionableContentDashboardItem.getAllContentDashboardItemVersions(
+				themeDisplay);
+
 		return JSONUtil.put(
 			"versions",
-			() -> {
-				int displayVersions = ParamUtil.getInteger(
-					resourceRequest, "maxDisplayVersions",
-					_DEFAULT_MAX_DISPLAY_VERSIONS);
-
-				return _getContentDashboardItemVersionsJSONArray(
-					displayVersions, httpServletRequest,
-					versionableContentDashboardItem);
-			}
+			_getContentDashboardItemVersionsJSONArray(
+				displayVersions, httpServletRequest,
+				versionableContentDashboardItem)
 		).put(
 			"viewVersionsURL",
-			versionableContentDashboardItem.getViewVersionsURL(
-				httpServletRequest)
+			() -> {
+				if (ListUtil.isEmpty(contentDashboardItemVersions) ||
+					(contentDashboardItemVersions.size() <= displayVersions)) {
+
+					return StringPool.BLANK;
+				}
+
+				return versionableContentDashboardItem.getViewVersionsURL(
+					httpServletRequest);
+			}
 		);
 	}
 

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/css/main.scss
@@ -137,6 +137,11 @@ html#{$cadmin-selector} {
 							margin-bottom: 8px;
 						}
 					}
+
+					.sidebar-list-group .list-group-item .autofit-col {
+						padding-bottom: 12px;
+						padding-top: 12px;
+					}
 				}
 
 				.sidebar-header {

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/VersionsContent.tsx
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/VersionsContent.tsx
@@ -117,12 +117,16 @@ const VersionsContent = ({
 				</ul>
 			)}
 			{viewVersionsURL && (
-				<ClayLink
-					className="d-flex justify-content-center mt-3"
-					href={viewVersionsURL}
-				>
-					{Liferay.Language.get('view-more')}
-				</ClayLink>
+				<div className="d-flex justify-content-center">
+					<ClayLink
+						button
+						className="mt-3"
+						displayType="secondary"
+						href={viewVersionsURL}
+					>
+						{Liferay.Language.get('view-more')}
+					</ClayLink>
+				</div>
 			)}
 		</>
 	);

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/VersionsContent.tsx
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/VersionsContent.tsx
@@ -38,9 +38,14 @@ const VersionsContent = ({
 	onError,
 }: IProps) => {
 	const [loading, setLoading] = useState(false);
-	const [versions, setVersions] = useState([] as IVersion[]);
-	const [viewVersionsURL, setViewVersionsURL] = useState('');
+
+	const [versionsData, setVersionsData] = useState({
+		versions: [],
+		viewVersionsURL: '',
+	} as IData);
+
 	const isFirst: boolean = useIsFirstRender();
+
 	const getVersionsData = useCallback(async (): Promise<void> => {
 		try {
 			setLoading(true);
@@ -50,9 +55,9 @@ const VersionsContent = ({
 				throw new Error(`Failed to fetch ${getItemVersionsURL}`);
 			}
 
-			const {versions, viewVersionsURL}: IData = await response.json();
-			setVersions(versions);
-			setViewVersionsURL(viewVersionsURL);
+			const data: IData = await response.json();
+
+			setVersionsData(data);
 		}
 		catch (error: unknown) {
 			onError();
@@ -73,8 +78,11 @@ const VersionsContent = ({
 		if (isFirst) {
 			return;
 		}
+
 		getVersionsData();
 	}, [getVersionsData, isFirst]);
+
+	const {versions, viewVersionsURL} = versionsData;
 
 	return (
 		<>
@@ -131,7 +139,6 @@ const VersionsContent = ({
 		</>
 	);
 };
-
 interface IData {
 	versions: IVersion[];
 	viewVersionsURL: string;

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/VersionsContent.tsx
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/VersionsContent.tsx
@@ -96,7 +96,7 @@ const VersionsContent = ({
 						<ul className="list-group sidebar-list-group">
 							{versions.map((version) => (
 								<li
-									className="list-group-item list-group-item-flex"
+									className="list-group-item list-group-item-flex p-0"
 									key={version.version}
 								>
 									<ClayLayout.ContentCol expand>

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/VersionsContent.tsx
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/VersionsContent.tsx
@@ -91,50 +91,61 @@ const VersionsContent = ({
 					<ClayLoadingIndicator small />
 				</div>
 			) : (
-				<ul className="list-group sidebar-list-group">
-					{versions.map((version) => (
-						<li
-							className="list-group-item list-group-item-flex"
-							key={version.version}
-						>
-							<ClayLayout.ContentCol expand>
-								<div className="list-group-title">
-									{Liferay.Language.get('version') + ' '}
+				<>
+					{versions && (
+						<ul className="list-group sidebar-list-group">
+							{versions.map((version) => (
+								<li
+									className="list-group-item list-group-item-flex"
+									key={version.version}
+								>
+									<ClayLayout.ContentCol expand>
+										<div className="list-group-title">
+											{Liferay.Language.get('version') +
+												' '}
 
-									{version.version}
-								</div>
+											{version.version}
+										</div>
 
-								<div className="list-group-subtitle">
-									{sub(Liferay.Language.get('x-by-x'), [
-										formatDate(
-											version.createDate,
-											languageTag
-										),
-										version.userName,
-									])}
-								</div>
+										<div className="list-group-subtitle">
+											{sub(
+												Liferay.Language.get('x-by-x'),
+												[
+													formatDate(
+														version.createDate,
+														languageTag
+													),
+													version.userName,
+												]
+											)}
+										</div>
 
-								<div className="list-group-subtext">
-									{version.changeLog
-										? version.changeLog
-										: Liferay.Language.get('no-change-log')}
-								</div>
-							</ClayLayout.ContentCol>
-						</li>
-					))}
-				</ul>
-			)}
-			{viewVersionsURL && (
-				<div className="d-flex justify-content-center">
-					<ClayLink
-						button
-						className="mt-3"
-						displayType="secondary"
-						href={viewVersionsURL}
-					>
-						{Liferay.Language.get('view-more')}
-					</ClayLink>
-				</div>
+										<div className="list-group-subtext">
+											{version.changeLog
+												? version.changeLog
+												: Liferay.Language.get(
+														'no-change-log'
+												  )}
+										</div>
+									</ClayLayout.ContentCol>
+								</li>
+							))}
+						</ul>
+					)}
+
+					{viewVersionsURL && (
+						<div className="d-flex justify-content-center">
+							<ClayLink
+								button
+								className="mt-3"
+								displayType="secondary"
+								href={viewVersionsURL}
+							>
+								{Liferay.Language.get('view-more')}
+							</ClayLink>
+						</div>
+					)}
+				</>
 			)}
 		</>
 	);

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/VersionsContent.tsx
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/VersionsContent.tsx
@@ -13,6 +13,7 @@
  */
 
 import ClayLayout from '@clayui/layout';
+import ClayLink from '@clayui/link';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import {fetch, sub} from 'frontend-js-web';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
@@ -38,6 +39,7 @@ const VersionsContent = ({
 }: IProps) => {
 	const [loading, setLoading] = useState(false);
 	const [versions, setVersions] = useState([] as IVersion[]);
+	const [viewVersionsURL, setViewVersionsURL] = useState('');
 	const isFirst: boolean = useIsFirstRender();
 	const getVersionsData = useCallback(async (): Promise<void> => {
 		try {
@@ -48,8 +50,9 @@ const VersionsContent = ({
 				throw new Error(`Failed to fetch ${getItemVersionsURL}`);
 			}
 
-			const {versions}: IData = await response.json();
+			const {versions, viewVersionsURL}: IData = await response.json();
 			setVersions(versions);
+			setViewVersionsURL(viewVersionsURL);
 		}
 		catch (error: unknown) {
 			onError();
@@ -113,12 +116,21 @@ const VersionsContent = ({
 					))}
 				</ul>
 			)}
+			{viewVersionsURL && (
+				<ClayLink
+					className="d-flex justify-content-center mt-3"
+					href={viewVersionsURL}
+				>
+					{Liferay.Language.get('view-more')}
+				</ClayLink>
+			)}
 		</>
 	);
 };
 
 interface IData {
 	versions: IVersion[];
+	viewVersionsURL: string;
 }
 
 interface IProps {

--- a/modules/apps/content-dashboard/content-dashboard-web/types/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/VersionsContent.d.ts
+++ b/modules/apps/content-dashboard/content-dashboard-web/types/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/VersionsContent.d.ts
@@ -12,8 +12,6 @@
  * details.
  */
 
-/// <reference types="react" />
-
 declare const VersionsContent: ({
 	getItemVersionsURL,
 	languageTag,


### PR DESCRIPTION
[Jira issue](https://issues.liferay.com/browse/LPS-163792)

## Motivation

We'll render a button pointing to the main versions view for a web content.
This button is hidden if the number of versions of the asset is lower that the number of versions displayed by default in the tab.

## Solution proposed

The BE only sends the property `viewVersionsURL` with a value if the button needs to be render.
This way the FE knows how to properly build the UI.

## How to verify

- Create a web content
- Generate 11 versions, at least, for the asset
- Visit the Content Dashboard
- Click on the item info button in order to open the sidebar panel
- In the sidebar panel, click on Versions tab
**Expected**: a _View More_ button s shown at the bottom of the versions list, linking to the main versions list for the asset

![image](https://user-images.githubusercontent.com/19485114/192525819-66945595-6bf2-4a8a-a50b-6307c127747c.png)
