### PR TITLE
LPS-155149 Intermittent failures occurring on com.liferay.document.library.social.test.DLFileEntryActivityInterpreterTest

### DIFF
--- a/modules/apps/bookmarks/bookmarks-test/src/testIntegration/java/com/liferay/bookmarks/social/test/BookmarksFolderActivityInterpreterTest.java
+++ b/modules/apps/bookmarks/bookmarks-test/src/testIntegration/java/com/liferay/bookmarks/social/test/BookmarksFolderActivityInterpreterTest.java
@@ -55,6 +55,12 @@ public class BookmarksFolderActivityInterpreterTest
 	@Override
 	protected void addActivities() throws Exception {
 		_folder = BookmarksTestUtil.addFolder(group.getGroupId(), "Folder");
+
+		_bookmarksFolderLocalService.moveFolderToTrash(
+			TestPropsValues.getUserId(), _folder.getFolderId());
+
+		_bookmarksFolderLocalService.restoreFolderFromTrash(
+			TestPropsValues.getUserId(), _folder.getFolderId());
 	}
 
 	@Override

--- a/modules/apps/social/social-activity-test-util/bnd.bnd
+++ b/modules/apps/social/social-activity-test-util/bnd.bnd
@@ -1,4 +1,4 @@
 Bundle-Name: Liferay Social Activity Test Utilities
 Bundle-SymbolicName: com.liferay.social.activity.test.util
-Bundle-Version: 5.0.3
+Bundle-Version: 6.0.0
 Export-Package: com.liferay.social.activity.test.util

--- a/modules/apps/social/social-activity-test-util/src/main/java/com/liferay/social/activity/test/util/BaseSocialActivityInterpreterTestCase.java
+++ b/modules/apps/social/social-activity-test-util/src/main/java/com/liferay/social/activity/test/util/BaseSocialActivityInterpreterTestCase.java
@@ -101,90 +101,6 @@ public abstract class BaseSocialActivityInterpreterTestCase {
 
 	protected abstract void addActivities() throws Exception;
 
-	private void _checkInterpret() throws Exception {
-		List<SocialActivity> activities = getActivities();
-
-		Assert.assertFalse(activities.toString(), activities.isEmpty());
-
-		SocialActivityInterpreter activityInterpreter =
-			getActivityInterpreter();
-
-		for (SocialActivity activity : activities) {
-			if (hasClassName(activityInterpreter, activity.getClassName()) &&
-				hasActivityType(activity.getType())) {
-
-				SocialActivityFeedEntry activityFeedEntry =
-					activityInterpreter.interpret(activity, serviceContext);
-
-				Assert.assertNotNull(activityFeedEntry);
-
-				String title = activityFeedEntry.getTitle();
-
-				Assert.assertFalse(
-					"Title contains parameters: " + title,
-					title.matches("\\{\\d\\}"));
-			}
-		}
-	}
-
-	private void _checkLinks() throws Exception {
-		List<SocialActivity> activities = getActivities();
-
-		Assert.assertFalse(activities.toString(), activities.isEmpty());
-
-		SocialActivityInterpreter activityInterpreter =
-			getActivityInterpreter();
-
-		for (SocialActivity activity : activities) {
-			if (hasClassName(activityInterpreter, activity.getClassName()) &&
-				hasActivityType(activity.getType())) {
-
-				SocialActivityFeedEntry activityFeedEntry =
-					activityInterpreter.interpret(activity, serviceContext);
-
-				PortletURL portletURL = trashHelper.getViewContentURL(
-					serviceContext.getRequest(), activity.getClassName(),
-					activity.getClassPK());
-
-				if (Validator.isNull(activityFeedEntry.getLink()) &&
-					(portletURL == null)) {
-
-					continue;
-				}
-
-				Assert.assertEquals(
-					portletURL.toString(), activityFeedEntry.getLink());
-			}
-		}
-	}
-
-	private void _checkRenaming(List<SocialActivity> originalActivities)
-		throws Exception {
-
-		Assert.assertFalse(
-			originalActivities.toString(), originalActivities.isEmpty());
-
-		String originalTitle = _getActivitiesFirstTitle(originalActivities);
-		Set<Long> originalIds = _getActivitiesIds(originalActivities);
-
-		List<SocialActivity> activities = getActivities();
-
-		Assert.assertFalse(activities.toString(), activities.isEmpty());
-
-		for (SocialActivity activity : activities) {
-			if (!originalIds.contains(activity.getActivityId())) {
-				String title = activity.getExtraDataValue(
-					"title", serviceContext.getLocale());
-
-				if (isSupportsRename(activity.getClassName()) &&
-					Validator.isNotNull(title)) {
-
-					Assert.assertNotEquals(originalTitle, title);
-				}
-			}
-		}
-	}
-
 	protected List<SocialActivity> getActivities() throws Exception {
 		return new ArrayList<>(
 			SocialActivityLocalServiceUtil.getGroupActivities(
@@ -275,6 +191,90 @@ public abstract class BaseSocialActivityInterpreterTestCase {
 
 	@Inject
 	protected TrashHelper trashHelper;
+
+	private void _checkInterpret() throws Exception {
+		List<SocialActivity> activities = getActivities();
+
+		Assert.assertFalse(activities.toString(), activities.isEmpty());
+
+		SocialActivityInterpreter activityInterpreter =
+			getActivityInterpreter();
+
+		for (SocialActivity activity : activities) {
+			if (hasClassName(activityInterpreter, activity.getClassName()) &&
+				hasActivityType(activity.getType())) {
+
+				SocialActivityFeedEntry activityFeedEntry =
+					activityInterpreter.interpret(activity, serviceContext);
+
+				Assert.assertNotNull(activityFeedEntry);
+
+				String title = activityFeedEntry.getTitle();
+
+				Assert.assertFalse(
+					"Title contains parameters: " + title,
+					title.matches("\\{\\d\\}"));
+			}
+		}
+	}
+
+	private void _checkLinks() throws Exception {
+		List<SocialActivity> activities = getActivities();
+
+		Assert.assertFalse(activities.toString(), activities.isEmpty());
+
+		SocialActivityInterpreter activityInterpreter =
+			getActivityInterpreter();
+
+		for (SocialActivity activity : activities) {
+			if (hasClassName(activityInterpreter, activity.getClassName()) &&
+				hasActivityType(activity.getType())) {
+
+				SocialActivityFeedEntry activityFeedEntry =
+					activityInterpreter.interpret(activity, serviceContext);
+
+				PortletURL portletURL = trashHelper.getViewContentURL(
+					serviceContext.getRequest(), activity.getClassName(),
+					activity.getClassPK());
+
+				if (Validator.isNull(activityFeedEntry.getLink()) &&
+					(portletURL == null)) {
+
+					continue;
+				}
+
+				Assert.assertEquals(
+					portletURL.toString(), activityFeedEntry.getLink());
+			}
+		}
+	}
+
+	private void _checkRenaming(List<SocialActivity> originalActivities)
+		throws Exception {
+
+		Assert.assertFalse(
+			originalActivities.toString(), originalActivities.isEmpty());
+
+		String originalTitle = _getActivitiesFirstTitle(originalActivities);
+		Set<Long> originalIds = _getActivitiesIds(originalActivities);
+
+		List<SocialActivity> activities = getActivities();
+
+		Assert.assertFalse(activities.toString(), activities.isEmpty());
+
+		for (SocialActivity activity : activities) {
+			if (!originalIds.contains(activity.getActivityId())) {
+				String title = activity.getExtraDataValue(
+					"title", serviceContext.getLocale());
+
+				if (isSupportsRename(activity.getClassName()) &&
+					Validator.isNotNull(title)) {
+
+					Assert.assertNotEquals(originalTitle, title);
+				}
+			}
+		}
+	}
 
 	private String _getActivitiesFirstTitle(
 			List<SocialActivity> originalActivities)

--- a/modules/apps/social/social-activity-test-util/src/main/java/com/liferay/social/activity/test/util/BaseSocialActivityInterpreterTestCase.java
+++ b/modules/apps/social/social-activity-test-util/src/main/java/com/liferay/social/activity/test/util/BaseSocialActivityInterpreterTestCase.java
@@ -86,22 +86,22 @@ public abstract class BaseSocialActivityInterpreterTestCase {
 
 		renameModels();
 
-		checkRenaming(originalActivities);
+		_checkRenaming(originalActivities);
 
 		if (isSupportsTrash()) {
 			moveModelsToTrash();
 
-			checkLinks();
+			_checkLinks();
 
 			restoreModelsFromTrash();
 		}
 
-		checkInterpret();
+		_checkInterpret();
 	}
 
 	protected abstract void addActivities() throws Exception;
 
-	protected void checkInterpret() throws Exception {
+	private void _checkInterpret() throws Exception {
 		List<SocialActivity> activities = getActivities();
 
 		Assert.assertFalse(activities.toString(), activities.isEmpty());
@@ -127,7 +127,7 @@ public abstract class BaseSocialActivityInterpreterTestCase {
 		}
 	}
 
-	protected void checkLinks() throws Exception {
+	private void _checkLinks() throws Exception {
 		List<SocialActivity> activities = getActivities();
 
 		Assert.assertFalse(activities.toString(), activities.isEmpty());
@@ -158,7 +158,7 @@ public abstract class BaseSocialActivityInterpreterTestCase {
 		}
 	}
 
-	protected void checkRenaming(List<SocialActivity> originalActivities)
+	private void _checkRenaming(List<SocialActivity> originalActivities)
 		throws Exception {
 
 		Assert.assertFalse(

--- a/modules/apps/social/social-activity-test-util/src/main/java/com/liferay/social/activity/test/util/BaseSocialActivityInterpreterTestCase.java
+++ b/modules/apps/social/social-activity-test-util/src/main/java/com/liferay/social/activity/test/util/BaseSocialActivityInterpreterTestCase.java
@@ -255,15 +255,15 @@ public abstract class BaseSocialActivityInterpreterTestCase {
 		Assert.assertFalse(
 			originalActivities.toString(), originalActivities.isEmpty());
 
-		String originalTitle = _getActivitiesFirstTitle(originalActivities);
-		Set<Long> originalIds = _getActivitiesIds(originalActivities);
+		Set<Long> originalActivitiesIds = _getActivitiesIds(originalActivities);
+		String originalTitle = _getFirstActivityTitle(originalActivities);
 
 		List<SocialActivity> activities = getActivities();
 
 		Assert.assertFalse(activities.toString(), activities.isEmpty());
 
 		for (SocialActivity activity : activities) {
-			if (!originalIds.contains(activity.getActivityId())) {
+			if (!originalActivitiesIds.contains(activity.getActivityId())) {
 				String title = activity.getExtraDataValue(
 					"title", serviceContext.getLocale());
 
@@ -276,25 +276,25 @@ public abstract class BaseSocialActivityInterpreterTestCase {
 		}
 	}
 
-	private String _getActivitiesFirstTitle(
-			List<SocialActivity> originalActivities)
+	private String _getFirstActivityTitle(
+			List<SocialActivity> activities)
 		throws Exception {
 
-		SocialActivity activity = originalActivities.get(0);
+		SocialActivity activity = activities.get(0);
 
 		return activity.getExtraDataValue("title", serviceContext.getLocale());
 	}
 
 	private Set<Long> _getActivitiesIds(
-		List<SocialActivity> originalActivities) {
+		List<SocialActivity> activities) {
 
-		Set<Long> originalIds = new HashSet<>();
+		Set<Long> activitiesIds = new HashSet<>();
 
-		for (SocialActivity activity : originalActivities) {
-			originalIds.add(activity.getActivityId());
+		for (SocialActivity activity : activities) {
+			activitiesIds.add(activity.getActivityId());
 		}
 
-		return originalIds;
+		return activitiesIds;
 	}
 
 }

--- a/modules/apps/social/social-activity-test-util/src/main/java/com/liferay/social/activity/test/util/BaseSocialActivityInterpreterTestCase.java
+++ b/modules/apps/social/social-activity-test-util/src/main/java/com/liferay/social/activity/test/util/BaseSocialActivityInterpreterTestCase.java
@@ -276,18 +276,7 @@ public abstract class BaseSocialActivityInterpreterTestCase {
 		}
 	}
 
-	private String _getFirstActivityTitle(
-			List<SocialActivity> activities)
-		throws Exception {
-
-		SocialActivity activity = activities.get(0);
-
-		return activity.getExtraDataValue("title", serviceContext.getLocale());
-	}
-
-	private Set<Long> _getActivitiesIds(
-		List<SocialActivity> activities) {
-
+	private Set<Long> _getActivitiesIds(List<SocialActivity> activities) {
 		Set<Long> activitiesIds = new HashSet<>();
 
 		for (SocialActivity activity : activities) {
@@ -295,6 +284,14 @@ public abstract class BaseSocialActivityInterpreterTestCase {
 		}
 
 		return activitiesIds;
+	}
+
+	private String _getFirstActivityTitle(List<SocialActivity> activities)
+		throws Exception {
+
+		SocialActivity activity = activities.get(0);
+
+		return activity.getExtraDataValue("title", serviceContext.getLocale());
 	}
 
 }

--- a/modules/apps/social/social-activity-test-util/src/main/java/com/liferay/social/activity/test/util/BaseSocialActivityInterpreterTestCase.java
+++ b/modules/apps/social/social-activity-test-util/src/main/java/com/liferay/social/activity/test/util/BaseSocialActivityInterpreterTestCase.java
@@ -33,7 +33,9 @@ import com.liferay.social.kernel.service.SocialActivityLocalServiceUtil;
 import com.liferay.trash.TrashHelper;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import javax.portlet.PortletURL;
 
@@ -80,9 +82,18 @@ public abstract class BaseSocialActivityInterpreterTestCase {
 	public void testActivityInterpreter() throws Exception {
 		addActivities();
 
+		String originalTitle = null;
+		Set<Long> originalActivitiesIds = new HashSet<>();
+
+		for (SocialActivity activity : getActivities()) {
+			originalActivitiesIds.add(activity.getActivityId());
+			originalTitle = activity.getExtraDataValue(
+				"title", serviceContext.getLocale());
+		}
+
 		renameModels();
 
-		checkRenaming();
+		checkRenaming(originalTitle, originalActivitiesIds);
 
 		if (isSupportsTrash()) {
 			moveModelsToTrash();
@@ -154,24 +165,25 @@ public abstract class BaseSocialActivityInterpreterTestCase {
 		}
 	}
 
-	protected void checkRenaming() throws Exception {
+	protected void checkRenaming(
+			String originalTitle, Set<Long> originalActivitiesIds)
+		throws Exception {
+
 		List<SocialActivity> activities = getActivities();
 
 		Assert.assertFalse(activities.toString(), activities.isEmpty());
 
-		String previousTitle = null;
-
 		for (SocialActivity activity : activities) {
-			String title = activity.getExtraDataValue(
-				"title", serviceContext.getLocale());
+			if (!originalActivitiesIds.contains(activity.getActivityId())) {
+				String title = activity.getExtraDataValue(
+					"title", serviceContext.getLocale());
 
-			if (isSupportsRename(activity.getClassName()) &&
-				Validator.isNotNull(title)) {
+				if (isSupportsRename(activity.getClassName()) &&
+					Validator.isNotNull(title)) {
 
-				Assert.assertNotEquals(previousTitle, title);
+					Assert.assertNotEquals(originalTitle, title);
+				}
 			}
-
-			previousTitle = title;
 		}
 	}
 

--- a/modules/apps/social/social-activity-test-util/src/main/java/com/liferay/social/activity/test/util/BaseSocialActivityInterpreterTestCase.java
+++ b/modules/apps/social/social-activity-test-util/src/main/java/com/liferay/social/activity/test/util/BaseSocialActivityInterpreterTestCase.java
@@ -82,18 +82,11 @@ public abstract class BaseSocialActivityInterpreterTestCase {
 	public void testActivityInterpreter() throws Exception {
 		addActivities();
 
-		String originalTitle = null;
-		Set<Long> originalActivitiesIds = new HashSet<>();
-
-		for (SocialActivity activity : getActivities()) {
-			originalActivitiesIds.add(activity.getActivityId());
-			originalTitle = activity.getExtraDataValue(
-				"title", serviceContext.getLocale());
-		}
+		List<SocialActivity> originalActivities = getActivities();
 
 		renameModels();
 
-		checkRenaming(originalTitle, originalActivitiesIds);
+		checkRenaming(originalActivities);
 
 		if (isSupportsTrash()) {
 			moveModelsToTrash();
@@ -165,16 +158,21 @@ public abstract class BaseSocialActivityInterpreterTestCase {
 		}
 	}
 
-	protected void checkRenaming(
-			String originalTitle, Set<Long> originalActivitiesIds)
+	protected void checkRenaming(List<SocialActivity> originalActivities)
 		throws Exception {
+
+		Assert.assertFalse(
+			originalActivities.toString(), originalActivities.isEmpty());
+
+		String originalTitle = _getActivitiesFirstTitle(originalActivities);
+		Set<Long> originalIds = _getActivitiesIds(originalActivities);
 
 		List<SocialActivity> activities = getActivities();
 
 		Assert.assertFalse(activities.toString(), activities.isEmpty());
 
 		for (SocialActivity activity : activities) {
-			if (!originalActivitiesIds.contains(activity.getActivityId())) {
+			if (!originalIds.contains(activity.getActivityId())) {
 				String title = activity.getExtraDataValue(
 					"title", serviceContext.getLocale());
 
@@ -277,5 +275,26 @@ public abstract class BaseSocialActivityInterpreterTestCase {
 
 	@Inject
 	protected TrashHelper trashHelper;
+
+	private String _getActivitiesFirstTitle(
+			List<SocialActivity> originalActivities)
+		throws Exception {
+
+		SocialActivity activity = originalActivities.get(0);
+
+		return activity.getExtraDataValue("title", serviceContext.getLocale());
+	}
+
+	private Set<Long> _getActivitiesIds(
+		List<SocialActivity> originalActivities) {
+
+		Set<Long> originalIds = new HashSet<>();
+
+		for (SocialActivity activity : originalActivities) {
+			originalIds.add(activity.getActivityId());
+		}
+
+		return originalIds;
+	}
 
 }

--- a/modules/apps/social/social-activity-test-util/src/main/resources/com/liferay/social/activity/test/util/packageinfo
+++ b/modules/apps/social/social-activity-test-util/src/main/resources/com/liferay/social/activity/test/util/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 3.0.0


### PR DESCRIPTION
- LPS-155149 Removed use of time and refactored check of renaming
- LPS-155149 Passing info of original activities to better check renaming
- LPS-155149 Fix: the implemented method addActivities() should effectively add activities
- LPS-155149 Simplified main test method

The original code relied on the time of inserted records. I wanted to avoid this as it could been the source of the intermittent errors. At the same time I've corrected another test using the fixed based class, as it wasn't adding activities in the implemented method addActivities(). I've corrected this method based on 2 similar implementations: `DLFolderActivityInterpreterTest` and `JournalFolderActivityInterpreterTest`.  When creating a "folder" no activity is added, so a simple way to add activities is to move to trash and restore from trash. As an example see the implementation for the `JournalFolderActivityInterpreterTest` below:

https://github.com/liferay/liferay-portal/blob/3da9eed4d2559fd367ddbd08534bea4bc1ee05fd/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/social/test/JournalFolderActivityInterpreterTest.java#L49