### PR TITLE
LPS-164290: Expose (update, delete) batch actions in the Objects headless APIs

### DIFF
--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectActionResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectActionResourceImpl.java
@@ -75,11 +75,23 @@ public class ObjectActionResourceImpl
 					com.liferay.object.model.ObjectDefinition.class.getName(),
 					objectDefinitionId)
 			).put(
+				"deleteBatch",
+				addAction(
+					ActionKeys.DELETE, "deleteObjectActionBatch",
+					com.liferay.object.model.ObjectDefinition.class.getName(),
+					null)
+			).put(
 				"get",
 				addAction(
 					ActionKeys.VIEW, "getObjectDefinitionObjectActionsPage",
 					com.liferay.object.model.ObjectDefinition.class.getName(),
 					objectDefinitionId)
+			).put(
+				"updateBatch",
+				addAction(
+					ActionKeys.UPDATE, "putObjectActionBatch",
+					com.liferay.object.model.ObjectDefinition.class.getName(),
+					null)
 			).build(),
 			booleanQuery -> {
 			},

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectDefinitionResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectDefinitionResourceImpl.java
@@ -142,11 +142,21 @@ public class ObjectDefinitionResourceImpl
 					"postObjectDefinitionBatch", ObjectConstants.RESOURCE_NAME,
 					contextCompany.getCompanyId())
 			).put(
+				"deleteBatch",
+				addAction(
+					ActionKeys.DELETE, "deleteObjectDefinitionBatch",
+					ObjectConstants.RESOURCE_NAME, null)
+			).put(
 				"get",
 				addAction(
 					ActionKeys.VIEW, "getObjectDefinitionsPage",
 					ObjectConstants.RESOURCE_NAME,
 					contextCompany.getCompanyId())
+			).put(
+				"updateBatch",
+				addAction(
+					ActionKeys.UPDATE, "putObjectDefinitionBatch",
+					ObjectConstants.RESOURCE_NAME, null)
 			).build(),
 			booleanQuery -> {
 			},

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectFieldResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectFieldResourceImpl.java
@@ -97,11 +97,23 @@ public class ObjectFieldResourceImpl
 					com.liferay.object.model.ObjectDefinition.class.getName(),
 					objectDefinitionId)
 			).put(
+				"deleteBatch",
+				addAction(
+					ActionKeys.DELETE, "deleteObjectFieldBatch",
+					com.liferay.object.model.ObjectDefinition.class.getName(),
+					null)
+			).put(
 				"get",
 				addAction(
 					ActionKeys.VIEW, "getObjectDefinitionObjectFieldsPage",
 					com.liferay.object.model.ObjectDefinition.class.getName(),
 					objectDefinitionId)
+			).put(
+				"updateBatch",
+				addAction(
+					ActionKeys.UPDATE, "putObjectFieldBatch",
+					com.liferay.object.model.ObjectDefinition.class.getName(),
+					null)
 			).build(),
 			booleanQuery -> {
 			},

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectLayoutResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectLayoutResourceImpl.java
@@ -81,10 +81,20 @@ public class ObjectLayoutResourceImpl
 					ActionKeys.UPDATE, "postObjectDefinitionObjectLayoutBatch",
 					ObjectDefinition.class.getName(), objectDefinitionId)
 			).put(
+				"deleteBatch",
+				addAction(
+					ActionKeys.DELETE, "deleteObjectLayoutBatch",
+					ObjectDefinition.class.getName(), null)
+			).put(
 				"get",
 				addAction(
 					ActionKeys.VIEW, "getObjectDefinitionObjectLayoutsPage",
 					ObjectDefinition.class.getName(), objectDefinitionId)
+			).put(
+				"updateBatch",
+				addAction(
+					ActionKeys.UPDATE, "putObjectLayoutBatch",
+					ObjectDefinition.class.getName(), null)
 			).build(),
 			booleanQuery -> {
 			},

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectRelationshipResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectRelationshipResourceImpl.java
@@ -87,6 +87,18 @@ public class ObjectRelationshipResourceImpl
 					"postObjectDefinitionObjectRelationshipBatch",
 					com.liferay.object.model.ObjectDefinition.class.getName(),
 					objectDefinitionId)
+			).put(
+				"deleteBatch",
+				addAction(
+					ActionKeys.DELETE, "deleteObjectRelationshipBatch",
+					com.liferay.object.model.ObjectDefinition.class.getName(),
+					null)
+			).put(
+				"updateBatch",
+				addAction(
+					ActionKeys.UPDATE, "putObjectRelationshipBatch",
+					com.liferay.object.model.ObjectDefinition.class.getName(),
+					null)
 			).build(),
 			booleanQuery -> {
 			},

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectValidationRuleResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectValidationRuleResourceImpl.java
@@ -70,11 +70,21 @@ public class ObjectValidationRuleResourceImpl
 					"postObjectDefinitionObjectValidationRuleBatch",
 					ObjectDefinition.class.getName(), objectDefinitionId)
 			).put(
+				"deleteBatch",
+				addAction(
+					ActionKeys.DELETE, "deleteObjectValidationRuleBatch",
+					ObjectDefinition.class.getName(), null)
+			).put(
 				"get",
 				addAction(
 					ActionKeys.VIEW,
 					"getObjectDefinitionObjectValidationRulesPage",
 					ObjectDefinition.class.getName(), objectDefinitionId)
+			).put(
+				"updateBatch",
+				addAction(
+					ActionKeys.UPDATE, "putObjectValidationRuleBatch",
+					ObjectDefinition.class.getName(), null)
 			).build(),
 			booleanQuery -> {
 			},

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectViewResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectViewResourceImpl.java
@@ -79,10 +79,20 @@ public class ObjectViewResourceImpl
 					ActionKeys.UPDATE, "postObjectDefinitionObjectViewBatch",
 					ObjectDefinition.class.getName(), objectDefinitionId)
 			).put(
+				"deleteBatch",
+				addAction(
+					ActionKeys.DELETE, "deleteObjectViewBatch",
+					ObjectDefinition.class.getName(), null)
+			).put(
 				"get",
 				addAction(
 					ActionKeys.VIEW, "getObjectDefinitionObjectViewsPage",
 					ObjectDefinition.class.getName(), objectDefinitionId)
+			).put(
+				"updateBatch",
+				addAction(
+					ActionKeys.UPDATE, "putObjectViewBatch",
+					ObjectDefinition.class.getName(), null)
 			).build(),
 			booleanQuery -> {
 			},

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -403,10 +403,27 @@ public class DefaultObjectEntryManagerImpl
 						objectDefinition.getObjectDefinitionId()),
 					groupId, dtoConverterContext.getUriInfo())
 			).put(
+				"deleteBatch",
+				ActionUtil.addAction(
+					ActionKeys.DELETE, ObjectEntryResourceImpl.class, null,
+					"deleteObjectEntryBatch", null,
+					objectDefinition.getUserId(),
+					_getObjectEntriesPermissionName(
+						objectDefinition.getObjectDefinitionId()),
+					groupId, dtoConverterContext.getUriInfo())
+			).put(
 				"get",
 				ActionUtil.addAction(
 					ActionKeys.VIEW, ObjectEntryResourceImpl.class, 0L,
 					"getObjectEntriesPage", null, objectDefinition.getUserId(),
+					_getObjectEntriesPermissionName(
+						objectDefinition.getObjectDefinitionId()),
+					groupId, dtoConverterContext.getUriInfo())
+			).put(
+				"updateBatch",
+				ActionUtil.addAction(
+					ActionKeys.UPDATE, ObjectEntryResourceImpl.class, null,
+					"putObjectEntryBatch", null, objectDefinition.getUserId(),
 					_getObjectEntriesPermissionName(
 						objectDefinition.getObjectDefinitionId()),
 					groupId, dtoConverterContext.getUriInfo())


### PR DESCRIPTION
**What is new?**
- Expose `deleteBatch` and `updateBatch` actions in Objects Definition APIs.
- Expose `deleteBatch` and `updateBatch` actions in Objects Entries APIs (scope by `siteId` and `companyId`).

**NEW CHANGES**

```
  "actions": {
    "updateBatch": {
      "method": "PUT",
      "href": "http://localhost:8080/o/object-admin/v1.0/object-views/batch"
    },
    "get": {
      "method": "GET",
      "href": "http://localhost:8080/o/object-admin/v1.0/object-definitions/43722/object-views"
    },
    "create": {
      "method": "POST",
      "href": "http://localhost:8080/o/object-admin/v1.0/object-definitions/43722/object-views"
    },
    "createBatch": {
      "method": "POST",
      "href": "http://localhost:8080/o/object-admin/v1.0/object-definitions/43722/object-views/batch"
    },
    "deleteBatch": {
      "method": "DELETE",
      "href": "http://localhost:8080/o/object-admin/v1.0/object-views/batch"
    }
  },
```
**HOW TO REPRODUCE IT?**
1. Deploy `object-admin-rest-impl` and `object-rest-impl`
2. Go to `/o/api`

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-164290