### PR TITLE
LPS-164646 Package for class implementing 'InfoPermissionProvider' should end with 'info.permission.provider'

### DIFF
--- a/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/exception/NoSuchLayoutClassedModelUsageException.java
+++ b/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/exception/NoSuchLayoutClassedModelUsageException.java
@@ -11,6 +11,7 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
+
 package com.liferay.layout.exception;
 
 import com.liferay.portal.kernel.exception.NoSuchModelException;
@@ -18,7 +19,8 @@ import com.liferay.portal.kernel.exception.NoSuchModelException;
 /**
  * @author Brian Wing Shun Chan
  */
-public class NoSuchLayoutClassedModelUsageException extends NoSuchModelException {
+public class NoSuchLayoutClassedModelUsageException
+	extends NoSuchModelException {
 
 	public NoSuchLayoutClassedModelUsageException() {
 	}
@@ -27,7 +29,9 @@ public class NoSuchLayoutClassedModelUsageException extends NoSuchModelException
 		super(msg);
 	}
 
-	public NoSuchLayoutClassedModelUsageException(String msg, Throwable throwable) {
+	public NoSuchLayoutClassedModelUsageException(
+		String msg, Throwable throwable) {
+
 		super(msg, throwable);
 	}
 

--- a/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/exception/NoSuchLayoutLocalizationException.java
+++ b/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/exception/NoSuchLayoutLocalizationException.java
@@ -11,6 +11,7 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
+
 package com.liferay.layout.exception;
 
 import com.liferay.portal.kernel.exception.NoSuchModelException;

--- a/modules/source-formatter.properties
+++ b/modules/source-formatter.properties
@@ -168,6 +168,7 @@
         ExportImportContentProcessor,\
         ExportImportPortletPreferencesProcessor,\
         FormNavigatorCategory,\
+        InfoPermissionProvider,\
         KeywordQueryContributor,\
         ManagedServiceFactory,\
         ModelDocumentContributor,\
@@ -200,6 +201,7 @@
         ExportImportPortletPreferencesProcessor:exportimport.portlet.preferences.processor,\
         FormNavigatorCategory:frontend.taglib.form.navigator,\
         FormNavigatorEntry:frontend.taglib.form.navigator,\
+        InfoPermissionProvider:info.permission.provider,\
         KeywordQueryContributor:search.spi.model.query.contributor,\
         ManagedServiceFactory:configuration.admin.service,\
         ModelDocumentContributor:search.spi.model.index.contributor,\


### PR DESCRIPTION
SF issue: https://github.com/liferay/liferay-portal/commit/44acc6d2d67d94f6ad88a74ab7740eb5c031ea2e
https://issues.liferay.com/browse/LPS-164646

Tested [here](https://github.com/ling-alan-huang/liferay-portal/pull/1416), unrelated failures.