### PR TITLE
Lps 163007 Condition with custom integers not working correctly on Expression Builder

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-evaluator-impl/src/main/java/com/liferay/dynamic/data/mapping/form/evaluator/internal/function/EqualsFunction.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-evaluator-impl/src/main/java/com/liferay/dynamic/data/mapping/form/evaluator/internal/function/EqualsFunction.java
@@ -39,7 +39,7 @@ public class EqualsFunction
 		Object value1 = _getValue(object1);
 		Object value2 = _getValue(object2);
 
-		if (!Objects.equals(value1.getClass(), value2.getClass())) {
+		if (!Objects.equals(_getClassName(value1), _getClassName(value2))) {
 			if (object1 instanceof BigDecimal) {
 				value1 = _convertValue(value2, value1);
 			}
@@ -68,6 +68,16 @@ public class EqualsFunction
 		}
 
 		return value2;
+	}
+
+	private String _getClassName(Object object) {
+		if (Objects.nonNull(object)) {
+			Class<?> classType = object.getClass();
+
+			return classType.getName();
+		}
+
+		return null;
 	}
 
 	private Object _getValue(Object object) {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-evaluator-impl/src/test/java/com/liferay/dynamic/data/mapping/form/evaluator/internal/function/EqualsFunctionTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-evaluator-impl/src/test/java/com/liferay/dynamic/data/mapping/form/evaluator/internal/function/EqualsFunctionTest.java
@@ -40,8 +40,22 @@ public class EqualsFunctionTest {
 		Assert.assertFalse(equalsFunction.apply("FORMS", "forms"));
 		Assert.assertFalse(equalsFunction.apply(null, "forms"));
 		Assert.assertFalse(equalsFunction.apply("forms&#39;", "forms'"));
+		Assert.assertFalse(equalsFunction.apply(null, new BigDecimal(1)));
+		Assert.assertFalse(
+			equalsFunction.apply(Double.valueOf(2), new BigDecimal(1)));
+		Assert.assertFalse(
+			equalsFunction.apply(Integer.valueOf(2), new BigDecimal(1)));
+		Assert.assertFalse(
+			equalsFunction.apply(Long.valueOf(2), new BigDecimal(1)));
+
 		Assert.assertTrue(equalsFunction.apply("1", new BigDecimal(1)));
 		Assert.assertTrue(equalsFunction.apply("forms", "forms"));
+		Assert.assertTrue(
+			equalsFunction.apply(Double.valueOf(1), new BigDecimal(1)));
+		Assert.assertTrue(
+			equalsFunction.apply(Integer.valueOf(1), new BigDecimal(1)));
+		Assert.assertTrue(
+			equalsFunction.apply(Long.valueOf(1), new BigDecimal(1)));
 	}
 
 }


### PR DESCRIPTION
@brianchandotcom 
Follow up PR for https://github.com/brianchandotcom/liferay-portal/pull/124069
After reviewing this unit test file, I see the input can be a null value, so I update code to handle this case.
The unit test also was implemented. 
However, I have taken a look on the function [visitEqualsExpression](https://github.com/liferay/liferay-portal/blob/master/modules/apps/dynamic-data-mapping/dynamic-data-mapping-expression/src/main/java/com/liferay/dynamic/data/mapping/expression/internal/DDMExpressionEvaluatorVisitor.java#L130-L144). Someone has change the logic here and it makes a regresstion bug if comparing between String object and Decimal object.

Thanks,
Thien