### PR TITLE
LPS-143205 When we are not running Staging, we should use the Scope GroupId

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/AddSegmentsExperienceMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/AddSegmentsExperienceMVCActionCommandTest.java
@@ -143,7 +143,11 @@ public class AddSegmentsExperienceMVCActionCommandTest {
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
 			new MockLiferayPortletActionRequest();
 
+		mockLiferayPortletActionRequest.addParameter(
+			"groupId", String.valueOf(_layout.getGroupId()));
 		mockLiferayPortletActionRequest.addParameter("name", name);
+		mockLiferayPortletActionRequest.addParameter(
+			"plid", String.valueOf(_layout.getPlid()));
 		mockLiferayPortletActionRequest.addParameter(
 			"segmentsEntryId", String.valueOf(segmentsEntryId));
 		mockLiferayPortletActionRequest.setAttribute(

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageLayoutEditorDisplayContext.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageLayoutEditorDisplayContext.java
@@ -56,6 +56,7 @@ import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -132,8 +133,13 @@ public class ContentPageLayoutEditorDisplayContext
 
 		configContext.put(
 			"addSegmentsExperienceURL",
-			getFragmentEntryActionURL(
-				"/layout_content_page_editor/add_segments_experience"));
+			HttpComponentsUtil.addParameter(
+				HttpComponentsUtil.addParameter(
+					getFragmentEntryActionURL(
+						"/layout_content_page_editor/add_segments_experience"),
+					getPortletNamespace() + "plid", themeDisplay.getPlid()),
+				getPortletNamespace() + "groupId",
+				themeDisplay.getScopeGroupId()));
 		configContext.put(
 			"availableSegmentsEntries", _getAvailableSegmentsEntries());
 		configContext.put(

--- a/modules/dxp/apps/segments/segments-experiment-web/build.gradle
+++ b/modules/dxp/apps/segments/segments-experiment-web/build.gradle
@@ -14,6 +14,7 @@ dependencies {
 	compileOnly project(":apps:portal-template:portal-template-react-renderer-api")
 	compileOnly project(":apps:product-navigation:product-navigation-control-menu-api")
 	compileOnly project(":apps:segments:segments-api")
+	compileOnly project(":apps:staging:staging-api")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-lang")

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/java/com/liferay/segments/experiment/web/internal/display/context/SegmentsExperimentDisplayContext.java
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/java/com/liferay/segments/experiment/web/internal/display/context/SegmentsExperimentDisplayContext.java
@@ -53,6 +53,7 @@ import com.liferay.segments.model.SegmentsExperimentRel;
 import com.liferay.segments.service.SegmentsExperienceService;
 import com.liferay.segments.service.SegmentsExperimentRelService;
 import com.liferay.segments.service.SegmentsExperimentService;
+import com.liferay.staging.StagingGroupHelper;
 
 import java.util.Arrays;
 import java.util.List;
@@ -82,7 +83,8 @@ public class SegmentsExperimentDisplayContext {
 		SegmentsExperienceService segmentsExperienceService,
 		SegmentsExperimentConfiguration segmentsExperimentConfiguration,
 		SegmentsExperimentRelService segmentsExperimentRelService,
-		SegmentsExperimentService segmentsExperimentService) {
+		SegmentsExperimentService segmentsExperimentService,
+		StagingGroupHelper stagingGroupHelper) {
 
 		_groupLocalService = groupLocalService;
 		_httpServletRequest = httpServletRequest;
@@ -95,6 +97,7 @@ public class SegmentsExperimentDisplayContext {
 		_segmentsExperimentConfiguration = segmentsExperimentConfiguration;
 		_segmentsExperimentRelService = segmentsExperimentRelService;
 		_segmentsExperimentService = segmentsExperimentService;
+		_stagingGroupHelper = stagingGroupHelper;
 
 		_themeDisplay = (ThemeDisplay)_httpServletRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
@@ -314,6 +317,17 @@ public class SegmentsExperimentDisplayContext {
 		return _pathToAssets + "/images";
 	}
 
+	private long _getLiveGroupId() throws Exception {
+		Group group = _groupLocalService.getGroup(
+			_themeDisplay.getScopeGroupId());
+
+		if (_stagingGroupHelper.isStagingGroup(group)) {
+			return group.getLiveGroupId();
+		}
+
+		return _themeDisplay.getScopeGroupId();
+	}
+
 	private Map<String, Object> _getPage() {
 		return HashMapBuilder.<String, Object>put(
 			"classNameId", PortalUtil.getClassNameId(Layout.class.getName())
@@ -334,13 +348,8 @@ public class SegmentsExperimentDisplayContext {
 
 		return HashMapBuilder.<String, Object>put(
 			"analyticsData",
-			() -> {
-				Group group = _groupLocalService.getGroup(
-					_themeDisplay.getScopeGroupId());
-
-				return _getAnalyticsDataJSONObject(
-					_themeDisplay.getCompanyId(), group.getLiveGroupId());
-			}
+			_getAnalyticsDataJSONObject(
+				_themeDisplay.getCompanyId(), _getLiveGroupId())
 		).put(
 			"hideSegmentsExperimentPanelURL",
 			PortletURLBuilder.create(
@@ -581,6 +590,7 @@ public class SegmentsExperimentDisplayContext {
 		_segmentsExperimentConfiguration;
 	private final SegmentsExperimentRelService _segmentsExperimentRelService;
 	private final SegmentsExperimentService _segmentsExperimentService;
+	private final StagingGroupHelper _stagingGroupHelper;
 	private final ThemeDisplay _themeDisplay;
 
 }

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/java/com/liferay/segments/experiment/web/internal/display/context/SegmentsExperimentDisplayContext.java
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/java/com/liferay/segments/experiment/web/internal/display/context/SegmentsExperimentDisplayContext.java
@@ -189,8 +189,14 @@ public class SegmentsExperimentDisplayContext {
 	}
 
 	private String _getCreateSegmentsVariantURL() {
-		return _getContentPageEditorActionURL(
-			"/layout_content_page_editor/add_segments_experience");
+		return HttpComponentsUtil.addParameter(
+			HttpComponentsUtil.addParameter(
+				_getContentPageEditorActionURL(
+					"/layout_content_page_editor/add_segments_experience"),
+				_getContentPageEditorPortletNamespace() + "plid",
+				_themeDisplay.getPlid()),
+			_getContentPageEditorPortletNamespace() + "groupId",
+			_themeDisplay.getScopeGroupId());
 	}
 
 	private String _getDeleteSegmentsExperimentURL() {

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/java/com/liferay/segments/experiment/web/internal/product/navigation/control/menu/SegmentsExperimentProductNavigationControlMenuEntry.java
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/java/com/liferay/segments/experiment/web/internal/product/navigation/control/menu/SegmentsExperimentProductNavigationControlMenuEntry.java
@@ -54,6 +54,7 @@ import com.liferay.segments.service.SegmentsExperienceLocalService;
 import com.liferay.segments.service.SegmentsExperienceService;
 import com.liferay.segments.service.SegmentsExperimentRelService;
 import com.liferay.segments.service.SegmentsExperimentService;
+import com.liferay.staging.StagingGroupHelper;
 import com.liferay.taglib.aui.IconTag;
 import com.liferay.taglib.util.BodyBottomTag;
 
@@ -352,7 +353,8 @@ public class SegmentsExperimentProductNavigationControlMenuEntry
 						_segmentsExperienceLocalService),
 					_segmentsExperienceService,
 					_segmentsExperimentConfiguration,
-					_segmentsExperimentRelService, _segmentsExperimentService);
+					_segmentsExperimentRelService, _segmentsExperimentService,
+					_stagingGroupHelper);
 
 			_reactRenderer.renderReact(
 				new ComponentDescriptor(
@@ -419,5 +421,8 @@ public class SegmentsExperimentProductNavigationControlMenuEntry
 		target = "(osgi.web.symbolicname=com.liferay.segments.experiment.web)"
 	)
 	private ServletContext _servletContext;
+
+	@Reference
+	private StagingGroupHelper _stagingGroupHelper;
 
 }


### PR DESCRIPTION
Sending directly to @brianchandotcom, because the CI is failing and QA has validated that the problem is not related with this PR,

Motivation
=======
A/B Testing Panel can't be opened in Staging Mode 
[Link to story or ticket](https://issues.liferay.com/browse/LPS-143205)

Proposed Solution
========
When the live group  is 0 then we need to use the scopeGroupId.

Still we need to handle with the publication of the A/B tests.

Steps to Verify:
----------------
1. Connect to Analytics Cloud.
1. DONT enable Staging
2. The A/B Testing panel should be connected

Screencaps:
----------------

<img width="1728" alt="Captura de pantalla 2022-10-05 a las 10 32 52" src="https://user-images.githubusercontent.com/5776822/194029187-64a51061-577b-45ae-aef3-bc3d65551750.png">

Note:
----------------

I haven't including integration/Unit tests, because I haven't seen a pattern I can follow in portal to test between live/staging group.

Continuation of https://github.com/brianchandotcom/liferay-portal/pull/124075#issuecomment-1267066270