### PR TITLE
LPS-164650 Add the Expire Action to the Version History for Web Content

### DIFF
--- a/modules/apps/content-dashboard/content-dashboard-api/bnd.bnd
+++ b/modules/apps/content-dashboard/content-dashboard-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Content Dashboard API
 Bundle-SymbolicName: com.liferay.content.dashboard.api
-Bundle-Version: 3.1.1
+Bundle-Version: 4.0.0
 Export-Package:\
 	com.liferay.content.dashboard.info.item,\
 	com.liferay.content.dashboard.item,\

--- a/modules/apps/content-dashboard/content-dashboard-api/src/main/java/com/liferay/content/dashboard/item/ContentDashboardItemVersion.java
+++ b/modules/apps/content-dashboard/content-dashboard-api/src/main/java/com/liferay/content/dashboard/item/ContentDashboardItemVersion.java
@@ -14,10 +14,17 @@
 
 package com.liferay.content.dashboard.item;
 
+import com.liferay.content.dashboard.item.action.ContentDashboardItemVersionAction;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.util.ListUtil;
 
+import java.util.Collections;
 import java.util.Date;
+import java.util.List;
+import java.util.Locale;
 
 /**
  * @author Jürgen Kappler
@@ -25,12 +32,18 @@ import java.util.Date;
 public class ContentDashboardItemVersion {
 
 	public ContentDashboardItemVersion(
-		String changeLog, Date createDate, String label, String style,
+		String changeLog,
+		List<ContentDashboardItemVersionAction>
+			contentDashboardItemVersionActions,
+		Date createDate, String label, Locale locale, String style,
 		String userName, String version) {
 
 		_changeLog = changeLog;
+		_contentDashboardItemVersionActions =
+			contentDashboardItemVersionActions;
 		_createDate = createDate;
 		_label = label;
+		_locale = locale;
 		_style = style;
 		_userName = userName;
 		_version = version;
@@ -38,6 +51,13 @@ public class ContentDashboardItemVersion {
 
 	public String getChangeLog() {
 		return _changeLog;
+	}
+
+	public List<ContentDashboardItemVersionAction>
+		getContentDashboardItemVersionActions() {
+
+		return Collections.unmodifiableList(
+			_contentDashboardItemVersionActions);
 	}
 
 	public Date getCreateDate() {
@@ -62,6 +82,8 @@ public class ContentDashboardItemVersion {
 
 	public JSONObject toJSONObject() {
 		return JSONUtil.put(
+			"actions", _getContentDashboardItemVersionActionsJSONArray()
+		).put(
 			"changeLog", getChangeLog()
 		).put(
 			"createDate", getCreateDate()
@@ -76,9 +98,42 @@ public class ContentDashboardItemVersion {
 		);
 	}
 
+	private JSONArray _getContentDashboardItemVersionActionsJSONArray() {
+		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
+
+		if (ListUtil.isEmpty(_contentDashboardItemVersionActions)) {
+			return jsonArray;
+		}
+
+		for (ContentDashboardItemVersionAction
+				contentDashboardItemVersionAction :
+					_contentDashboardItemVersionActions) {
+
+			if (contentDashboardItemVersionAction == null) {
+				continue;
+			}
+
+			jsonArray.put(
+				JSONUtil.put(
+					"icon", contentDashboardItemVersionAction.getIcon()
+				).put(
+					"label", contentDashboardItemVersionAction.getLabel(_locale)
+				).put(
+					"name", contentDashboardItemVersionAction.getName()
+				).put(
+					"url", contentDashboardItemVersionAction.getURL()
+				));
+		}
+
+		return jsonArray;
+	}
+
 	private final String _changeLog;
+	private final List<ContentDashboardItemVersionAction>
+		_contentDashboardItemVersionActions;
 	private final Date _createDate;
 	private final String _label;
+	private final Locale _locale;
 	private final String _style;
 	private final String _userName;
 	private final String _version;

--- a/modules/apps/content-dashboard/content-dashboard-api/src/main/java/com/liferay/content/dashboard/item/VersionableContentDashboardItem.java
+++ b/modules/apps/content-dashboard/content-dashboard-api/src/main/java/com/liferay/content/dashboard/item/VersionableContentDashboardItem.java
@@ -14,8 +14,6 @@
 
 package com.liferay.content.dashboard.item;
 
-import com.liferay.portal.kernel.theme.ThemeDisplay;
-
 import java.util.List;
 
 import javax.servlet.http.HttpServletRequest;
@@ -27,7 +25,7 @@ public interface VersionableContentDashboardItem<T>
 	extends ContentDashboardItem<T> {
 
 	public List<ContentDashboardItemVersion> getAllContentDashboardItemVersions(
-		ThemeDisplay themeDisplay);
+		HttpServletRequest httpServletRequest);
 
 	public String getViewVersionsURL(HttpServletRequest httpServletRequest);
 

--- a/modules/apps/content-dashboard/content-dashboard-api/src/main/java/com/liferay/content/dashboard/item/action/ContentDashboardItemVersionAction.java
+++ b/modules/apps/content-dashboard/content-dashboard-api/src/main/java/com/liferay/content/dashboard/item/action/ContentDashboardItemVersionAction.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.content.dashboard.item.action;
+
+import java.util.Locale;
+
+/**
+ * @author Stefan Tanasie
+ */
+public interface ContentDashboardItemVersionAction {
+
+	public String getIcon();
+
+	public String getLabel(Locale locale);
+
+	public String getName();
+
+	public String getURL();
+
+}

--- a/modules/apps/content-dashboard/content-dashboard-api/src/main/java/com/liferay/content/dashboard/item/action/ContentDashboardItemVersionActionProviderTracker.java
+++ b/modules/apps/content-dashboard/content-dashboard-api/src/main/java/com/liferay/content/dashboard/item/action/ContentDashboardItemVersionActionProviderTracker.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.content.dashboard.item.action;
+
+import com.liferay.content.dashboard.item.action.provider.ContentDashboardItemVersionActionProvider;
+
+import java.util.List;
+
+/**
+ * @author Stefan Tanasie
+ */
+public interface ContentDashboardItemVersionActionProviderTracker {
+
+	public List<ContentDashboardItemVersionActionProvider>
+		getContentDashboardItemVersionActionProviders(String className);
+
+}

--- a/modules/apps/content-dashboard/content-dashboard-api/src/main/java/com/liferay/content/dashboard/item/action/exception/ContentDashboardItemVersionActionException.java
+++ b/modules/apps/content-dashboard/content-dashboard-api/src/main/java/com/liferay/content/dashboard/item/action/exception/ContentDashboardItemVersionActionException.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.content.dashboard.item.action.exception;
+
+/**
+ * @author Stefan Tanasie
+ */
+public class ContentDashboardItemVersionActionException extends Exception {
+
+	public ContentDashboardItemVersionActionException(String msg) {
+		super(msg);
+	}
+
+	public ContentDashboardItemVersionActionException(
+		String msg, Throwable throwable) {
+
+		super(msg, throwable);
+	}
+
+	public ContentDashboardItemVersionActionException(Throwable throwable) {
+		super(throwable);
+	}
+
+}

--- a/modules/apps/content-dashboard/content-dashboard-api/src/main/java/com/liferay/content/dashboard/item/action/provider/ContentDashboardItemVersionActionProvider.java
+++ b/modules/apps/content-dashboard/content-dashboard-api/src/main/java/com/liferay/content/dashboard/item/action/provider/ContentDashboardItemVersionActionProvider.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.content.dashboard.item.action.provider;
+
+import com.liferay.content.dashboard.item.action.ContentDashboardItemVersionAction;
+import com.liferay.content.dashboard.item.action.exception.ContentDashboardItemVersionActionException;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * @author Stefan Tanasie
+ */
+public interface ContentDashboardItemVersionActionProvider<T> {
+
+	public ContentDashboardItemVersionAction
+			getContentDashboardItemVersionAction(
+				T t, HttpServletRequest httpServletRequest)
+		throws ContentDashboardItemVersionActionException;
+
+	public boolean isShow(T t, HttpServletRequest httpServletRequest);
+
+}

--- a/modules/apps/content-dashboard/content-dashboard-api/src/main/resources/com/liferay/content/dashboard/item/action/exception/packageinfo
+++ b/modules/apps/content-dashboard/content-dashboard-api/src/main/resources/com/liferay/content/dashboard/item/action/exception/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/apps/content-dashboard/content-dashboard-api/src/main/resources/com/liferay/content/dashboard/item/action/packageinfo
+++ b/modules/apps/content-dashboard/content-dashboard-api/src/main/resources/com/liferay/content/dashboard/item/action/packageinfo
@@ -1,1 +1,1 @@
-version 1.5.0
+version 1.6.0

--- a/modules/apps/content-dashboard/content-dashboard-api/src/main/resources/com/liferay/content/dashboard/item/action/provider/packageinfo
+++ b/modules/apps/content-dashboard/content-dashboard-api/src/main/resources/com/liferay/content/dashboard/item/action/provider/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/apps/content-dashboard/content-dashboard-api/src/main/resources/com/liferay/content/dashboard/item/packageinfo
+++ b/modules/apps/content-dashboard/content-dashboard-api/src/main/resources/com/liferay/content/dashboard/item/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 2.0.0

--- a/modules/apps/content-dashboard/content-dashboard-blogs-impl/src/main/java/com/liferay/content/dashboard/blogs/internal/item/BlogsEntryContentDashboardItem.java
+++ b/modules/apps/content-dashboard/content-dashboard-blogs-impl/src/main/java/com/liferay/content/dashboard/blogs/internal/item/BlogsEntryContentDashboardItem.java
@@ -256,11 +256,11 @@ public class BlogsEntryContentDashboardItem
 
 		return Collections.singletonList(
 			new ContentDashboardItemVersion(
-				null, _blogsEntry.getCreateDate(),
+				null, null, _blogsEntry.getCreateDate(),
 				_language.get(
 					locale,
 					WorkflowConstants.getStatusLabel(_blogsEntry.getStatus())),
-				WorkflowConstants.getStatusStyle(_blogsEntry.getStatus()),
+				null, WorkflowConstants.getStatusStyle(_blogsEntry.getStatus()),
 				_blogsEntry.getUserName(), "1.0"));
 	}
 

--- a/modules/apps/content-dashboard/content-dashboard-document-library-impl/src/main/java/com/liferay/content/dashboard/document/library/internal/item/FileEntryContentDashboardItem.java
+++ b/modules/apps/content-dashboard/content-dashboard-document-library-impl/src/main/java/com/liferay/content/dashboard/document/library/internal/item/FileEntryContentDashboardItem.java
@@ -110,9 +110,13 @@ public class FileEntryContentDashboardItem
 
 	@Override
 	public List<ContentDashboardItemVersion> getAllContentDashboardItemVersions(
-		ThemeDisplay themeDisplay) {
+		HttpServletRequest httpServletRequest) {
 
 		int status = WorkflowConstants.STATUS_APPROVED;
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
 
 		PermissionChecker permissionChecker =
 			themeDisplay.getPermissionChecker();

--- a/modules/apps/content-dashboard/content-dashboard-document-library-impl/src/main/java/com/liferay/content/dashboard/document/library/internal/item/FileEntryContentDashboardItem.java
+++ b/modules/apps/content-dashboard/content-dashboard-document-library-impl/src/main/java/com/liferay/content/dashboard/document/library/internal/item/FileEntryContentDashboardItem.java
@@ -136,11 +136,11 @@ public class FileEntryContentDashboardItem
 
 		return stream.map(
 			fileVersion -> new ContentDashboardItemVersion(
-				fileVersion.getChangeLog(), fileVersion.getCreateDate(),
+				fileVersion.getChangeLog(), null, fileVersion.getCreateDate(),
 				_language.get(
 					themeDisplay.getLocale(),
 					WorkflowConstants.getStatusLabel(fileVersion.getStatus())),
-				WorkflowConstants.getStatusStyle(fileVersion.getStatus()),
+				null, WorkflowConstants.getStatusStyle(fileVersion.getStatus()),
 				fileVersion.getUserName(),
 				String.valueOf(fileVersion.getVersion()))
 		).collect(
@@ -565,11 +565,13 @@ public class FileEntryContentDashboardItem
 			fileVersion
 		).map(
 			curFileVersion -> new ContentDashboardItemVersion(
-				curFileVersion.getChangeLog(), curFileVersion.getCreateDate(),
+				curFileVersion.getChangeLog(), null,
+				curFileVersion.getCreateDate(),
 				_language.get(
 					locale,
 					WorkflowConstants.getStatusLabel(
 						curFileVersion.getStatus())),
+				null,
 				WorkflowConstants.getStatusStyle(curFileVersion.getStatus()),
 				curFileVersion.getUserName(), curFileVersion.getVersion())
 		);

--- a/modules/apps/content-dashboard/content-dashboard-document-library-impl/src/main/java/com/liferay/content/dashboard/document/library/internal/item/FileEntryContentDashboardItemFactory.java
+++ b/modules/apps/content-dashboard/content-dashboard-document-library-impl/src/main/java/com/liferay/content/dashboard/document/library/internal/item/FileEntryContentDashboardItemFactory.java
@@ -19,6 +19,7 @@ import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.content.dashboard.item.ContentDashboardItem;
 import com.liferay.content.dashboard.item.ContentDashboardItemFactory;
 import com.liferay.content.dashboard.item.action.ContentDashboardItemActionProviderTracker;
+import com.liferay.content.dashboard.item.action.ContentDashboardItemVersionActionProviderTracker;
 import com.liferay.content.dashboard.item.type.ContentDashboardItemSubtypeFactory;
 import com.liferay.content.dashboard.item.type.ContentDashboardItemSubtypeFactoryTracker;
 import com.liferay.document.library.kernel.model.DLFileEntry;
@@ -79,6 +80,7 @@ public class FileEntryContentDashboardItemFactory
 		return new FileEntryContentDashboardItem(
 			assetEntry.getCategories(), assetEntry.getTags(),
 			_contentDashboardItemActionProviderTracker,
+			_contentDashboardItemVersionActionProviderTracker,
 			contentDashboardItemSubtypeFactory.create(
 				dlFileEntry.getFileEntryTypeId(), dlFileEntry.getFileEntryId()),
 			_dlURLHelper, fileEntry,
@@ -108,6 +110,10 @@ public class FileEntryContentDashboardItemFactory
 	@Reference
 	private ContentDashboardItemSubtypeFactoryTracker
 		_contentDashboardItemSubtypeFactoryTracker;
+
+	@Reference
+	private ContentDashboardItemVersionActionProviderTracker
+		_contentDashboardItemVersionActionProviderTracker;
 
 	@Reference
 	private DLAppLocalService _dlAppLocalService;

--- a/modules/apps/content-dashboard/content-dashboard-document-library-impl/src/main/java/com/liferay/content/dashboard/document/library/internal/item/action/ViewFileVersionContentDashboardItemVersionAction.java
+++ b/modules/apps/content-dashboard/content-dashboard-document-library-impl/src/main/java/com/liferay/content/dashboard/document/library/internal/item/action/ViewFileVersionContentDashboardItemVersionAction.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.content.dashboard.document.library.internal.item.action;
+
+import com.liferay.content.dashboard.item.action.ContentDashboardItemVersionAction;
+import com.liferay.document.library.constants.DLPortletKeys;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
+import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
+import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
+import com.liferay.portal.kernel.repository.model.FileVersion;
+import com.liferay.portal.kernel.util.JavaConstants;
+import com.liferay.portal.kernel.util.PortalUtil;
+
+import java.util.Locale;
+
+import javax.portlet.PortletResponse;
+import javax.portlet.PortletURL;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * @author Jürgen Kappler
+ */
+public class ViewFileVersionContentDashboardItemVersionAction
+	implements ContentDashboardItemVersionAction {
+
+	public ViewFileVersionContentDashboardItemVersionAction(
+		FileVersion fileVersion, HttpServletRequest httpServletRequest,
+		Language language,
+		RequestBackedPortletURLFactory requestBackedPortletURLFactory) {
+
+		_fileVersion = fileVersion;
+		_httpServletRequest = httpServletRequest;
+		_language = language;
+		_requestBackedPortletURLFactory = requestBackedPortletURLFactory;
+	}
+
+	@Override
+	public String getIcon() {
+		return "view";
+	}
+
+	@Override
+	public String getLabel(Locale locale) {
+		return _language.get(locale, "view");
+	}
+
+	@Override
+	public String getName() {
+		return "view";
+	}
+
+	@Override
+	public String getURL() {
+		LiferayPortletResponse liferayPortletResponse =
+			PortalUtil.getLiferayPortletResponse(
+				(PortletResponse)_httpServletRequest.getAttribute(
+					JavaConstants.JAVAX_PORTLET_RESPONSE));
+
+		PortletURL portletURL = liferayPortletResponse.createRenderURL();
+
+		return PortletURLBuilder.create(
+			_requestBackedPortletURLFactory.createActionURL(
+				DLPortletKeys.DOCUMENT_LIBRARY_ADMIN)
+		).setMVCRenderCommandName(
+			"/document_library/view_file_entry"
+		).setRedirect(
+			portletURL
+		).setBackURL(
+			portletURL.toString()
+		).setParameter(
+			"fileEntryId", _fileVersion.getFileEntryId()
+		).setParameter(
+			"version", _fileVersion.getVersion()
+		).buildString();
+	}
+
+	private final FileVersion _fileVersion;
+	private final HttpServletRequest _httpServletRequest;
+	private final Language _language;
+	private final RequestBackedPortletURLFactory
+		_requestBackedPortletURLFactory;
+
+}

--- a/modules/apps/content-dashboard/content-dashboard-document-library-impl/src/main/java/com/liferay/content/dashboard/document/library/internal/item/action/provider/ViewFileVersionContentDashboardItemVersionActionProvider.java
+++ b/modules/apps/content-dashboard/content-dashboard-document-library-impl/src/main/java/com/liferay/content/dashboard/document/library/internal/item/action/provider/ViewFileVersionContentDashboardItemVersionActionProvider.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.content.dashboard.document.library.internal.item.action.provider;
+
+import com.liferay.content.dashboard.document.library.internal.item.action.ViewFileVersionContentDashboardItemVersionAction;
+import com.liferay.content.dashboard.item.action.ContentDashboardItemVersionAction;
+import com.liferay.content.dashboard.item.action.provider.ContentDashboardItemVersionActionProvider;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil;
+import com.liferay.portal.kernel.repository.model.FileVersion;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Jürgen Kappler
+ */
+@Component(service = ContentDashboardItemVersionActionProvider.class)
+public class ViewFileVersionContentDashboardItemVersionActionProvider
+	implements ContentDashboardItemVersionActionProvider<FileVersion> {
+
+	@Override
+	public ContentDashboardItemVersionAction
+		getContentDashboardItemVersionAction(
+			FileVersion fileVersion, HttpServletRequest httpServletRequest) {
+
+		if (!isShow(fileVersion, httpServletRequest)) {
+			return null;
+		}
+
+		return new ViewFileVersionContentDashboardItemVersionAction(
+			fileVersion, httpServletRequest, _language,
+			RequestBackedPortletURLFactoryUtil.create(httpServletRequest));
+	}
+
+	@Override
+	public boolean isShow(
+		FileVersion fileVersion, HttpServletRequest httpServletRequest) {
+
+		return true;
+	}
+
+	@Reference
+	private Language _language;
+
+}

--- a/modules/apps/content-dashboard/content-dashboard-document-library-impl/src/test/java/com/liferay/content/dashboard/document/library/internal/item/FileEntryContentDashboardItemTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-document-library-impl/src/test/java/com/liferay/content/dashboard/document/library/internal/item/FileEntryContentDashboardItemTest.java
@@ -93,7 +93,7 @@ public class FileEntryContentDashboardItemTest {
 		FileEntryContentDashboardItem fileEntryContentDashboardItem =
 			new FileEntryContentDashboardItem(
 				Collections.singletonList(assetCategory), null, null, null,
-				null, fileEntry, null, null, null, null);
+				null, null, fileEntry, null, null, null, null);
 
 		Assert.assertEquals(
 			Collections.singletonList(assetCategory),
@@ -115,7 +115,7 @@ public class FileEntryContentDashboardItemTest {
 		FileEntryContentDashboardItem fileEntryContentDashboardItem =
 			new FileEntryContentDashboardItem(
 				Collections.singletonList(assetCategory), null, null, null,
-				null, fileEntry, null, null, null, null);
+				null, null, fileEntry, null, null, null, null);
 
 		Assert.assertEquals(
 			Collections.singletonList(assetCategory),
@@ -129,7 +129,7 @@ public class FileEntryContentDashboardItemTest {
 
 		FileEntryContentDashboardItem fileEntryContentDashboardItem =
 			new FileEntryContentDashboardItem(
-				null, null, null, null, null, fileEntry, null, null, null,
+				null, null, null, null, null, null, fileEntry, null, null, null,
 				null);
 
 		Assert.assertEquals(
@@ -152,7 +152,7 @@ public class FileEntryContentDashboardItemTest {
 		FileEntryContentDashboardItem fileEntryContentDashboardItem =
 			new FileEntryContentDashboardItem(
 				Collections.singletonList(assetCategory), null, null, null,
-				null, fileEntry, null, null, null, null);
+				null, null, fileEntry, null, null, null, null);
 
 		Assert.assertEquals(
 			Collections.emptyList(),
@@ -169,7 +169,7 @@ public class FileEntryContentDashboardItemTest {
 		FileEntryContentDashboardItem fileEntryContentDashboardItem =
 			new FileEntryContentDashboardItem(
 				null, Collections.singletonList(assetTag), null, null, null,
-				fileEntry, null, null, null, null);
+				null, fileEntry, null, null, null, null);
 
 		Assert.assertEquals(
 			Collections.singletonList(assetTag),
@@ -211,7 +211,7 @@ public class FileEntryContentDashboardItemTest {
 
 		FileEntryContentDashboardItem fileEntryContentDashboardItem =
 			new FileEntryContentDashboardItem(
-				null, null, null, null, null, fileEntry, null,
+				null, null, null, null, null, null, fileEntry, null,
 				infoItemFieldValuesProvider, null, null);
 
 		Assert.assertEquals(
@@ -225,7 +225,7 @@ public class FileEntryContentDashboardItemTest {
 
 		FileEntryContentDashboardItem fileEntryContentDashboardItem =
 			new FileEntryContentDashboardItem(
-				null, null, null, null, null, fileEntry, null, null, null,
+				null, null, null, null, null, null, fileEntry, null, null, null,
 				null);
 
 		Assert.assertEquals(
@@ -247,8 +247,8 @@ public class FileEntryContentDashboardItemTest {
 
 		FileEntryContentDashboardItem fileEntryContentDashboardItem =
 			new FileEntryContentDashboardItem(
-				null, null, null, null, null, fileEntry, group, null, null,
-				null);
+				null, null, null, null, null, null, fileEntry, group, null,
+				null, null);
 
 		Assert.assertEquals(
 			"scopeName",
@@ -261,7 +261,7 @@ public class FileEntryContentDashboardItemTest {
 
 		FileEntryContentDashboardItem fileEntryContentDashboardItem =
 			new FileEntryContentDashboardItem(
-				null, null, null,
+				null, null, null, null,
 				new ContentDashboardItemSubtype() {
 
 					@Override
@@ -300,7 +300,7 @@ public class FileEntryContentDashboardItemTest {
 
 		FileEntryContentDashboardItem fileEntryContentDashboardItem =
 			new FileEntryContentDashboardItem(
-				null, null, null, null, null, fileEntry, null, null, null,
+				null, null, null, null, null, null, fileEntry, null, null, null,
 				null);
 
 		Assert.assertEquals(
@@ -320,7 +320,7 @@ public class FileEntryContentDashboardItemTest {
 
 		FileEntryContentDashboardItem fileEntryContentDashboardItem =
 			new FileEntryContentDashboardItem(
-				null, null, null, null, null, fileEntry, null, null, null,
+				null, null, null, null, null, null, fileEntry, null, null, null,
 				null);
 
 		Assert.assertEquals(
@@ -339,7 +339,7 @@ public class FileEntryContentDashboardItemTest {
 
 		FileEntryContentDashboardItem fileEntryContentDashboardItem =
 			new FileEntryContentDashboardItem(
-				null, null, null, null, null, fileEntry, null, null, null,
+				null, null, null, null, null, null, fileEntry, null, null, null,
 				null);
 
 		Assert.assertEquals(
@@ -368,7 +368,7 @@ public class FileEntryContentDashboardItemTest {
 					_getContentDashboardItemActionProvider(
 						ContentDashboardItemAction.Type.VIEW,
 						"http://localhost:8080/view")),
-				null, null, fileEntry, null, null, _getLanguage(), null);
+				null, null, null, fileEntry, null, null, _getLanguage(), null);
 
 		Assert.assertTrue(
 			fileEntryContentDashboardItem.isViewable(

--- a/modules/apps/content-dashboard/content-dashboard-journal-impl/src/main/java/com/liferay/content/dashboard/journal/internal/item/JournalArticleContentDashboardItem.java
+++ b/modules/apps/content-dashboard/content-dashboard-journal-impl/src/main/java/com/liferay/content/dashboard/journal/internal/item/JournalArticleContentDashboardItem.java
@@ -50,6 +50,7 @@ import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
 import java.util.Collections;
@@ -119,9 +120,13 @@ public class JournalArticleContentDashboardItem
 
 	@Override
 	public List<ContentDashboardItemVersion> getAllContentDashboardItemVersions(
-		ThemeDisplay themeDisplay) {
+		HttpServletRequest httpServletRequest) {
 
 		int status = WorkflowConstants.STATUS_APPROVED;
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
 
 		PermissionChecker permissionChecker =
 			themeDisplay.getPermissionChecker();

--- a/modules/apps/content-dashboard/content-dashboard-journal-impl/src/main/java/com/liferay/content/dashboard/journal/internal/item/JournalArticleContentDashboardItem.java
+++ b/modules/apps/content-dashboard/content-dashboard-journal-impl/src/main/java/com/liferay/content/dashboard/journal/internal/item/JournalArticleContentDashboardItem.java
@@ -149,11 +149,12 @@ public class JournalArticleContentDashboardItem
 		return ListUtil.toList(
 			journalArticles,
 			journalArticle -> new ContentDashboardItemVersion(
-				null, journalArticle.getStatusDate(),
+				null, null, journalArticle.getStatusDate(),
 				_language.get(
 					themeDisplay.getLocale(),
 					WorkflowConstants.getStatusLabel(
 						journalArticle.getStatus())),
+				null,
 				WorkflowConstants.getStatusStyle(journalArticle.getStatus()),
 				journalArticle.getUserName(),
 				String.valueOf(journalArticle.getVersion())));
@@ -508,11 +509,12 @@ public class JournalArticleContentDashboardItem
 			journalArticle
 		).map(
 			curJournalArticle -> new ContentDashboardItemVersion(
-				null, curJournalArticle.getCreateDate(),
+				null, null, curJournalArticle.getCreateDate(),
 				_language.get(
 					locale,
 					WorkflowConstants.getStatusLabel(
 						curJournalArticle.getStatus())),
+				null,
 				WorkflowConstants.getStatusStyle(curJournalArticle.getStatus()),
 				curJournalArticle.getUserName(),
 				String.valueOf(curJournalArticle.getVersion()))

--- a/modules/apps/content-dashboard/content-dashboard-journal-impl/src/main/java/com/liferay/content/dashboard/journal/internal/item/JournalArticleContentDashboardItemFactory.java
+++ b/modules/apps/content-dashboard/content-dashboard-journal-impl/src/main/java/com/liferay/content/dashboard/journal/internal/item/JournalArticleContentDashboardItemFactory.java
@@ -19,6 +19,7 @@ import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.content.dashboard.item.ContentDashboardItem;
 import com.liferay.content.dashboard.item.ContentDashboardItemFactory;
 import com.liferay.content.dashboard.item.action.ContentDashboardItemActionProviderTracker;
+import com.liferay.content.dashboard.item.action.ContentDashboardItemVersionActionProviderTracker;
 import com.liferay.content.dashboard.item.type.ContentDashboardItemSubtypeFactory;
 import com.liferay.content.dashboard.item.type.ContentDashboardItemSubtypeFactoryTracker;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
@@ -100,6 +101,7 @@ public class JournalArticleContentDashboardItemFactory
 		return new JournalArticleContentDashboardItem(
 			assetEntry.getCategories(), assetEntry.getTags(),
 			_contentDashboardItemActionProviderTracker,
+			_contentDashboardItemVersionActionProviderTracker,
 			contentDashboardItemSubtypeFactory.create(
 				ddmStructure.getStructureId(),
 				journalArticle.getResourcePrimKey()),
@@ -130,6 +132,10 @@ public class JournalArticleContentDashboardItemFactory
 	@Reference
 	private ContentDashboardItemSubtypeFactoryTracker
 		_contentDashboardItemSubtypeFactoryTracker;
+
+	@Reference
+	private ContentDashboardItemVersionActionProviderTracker
+		_contentDashboardItemVersionActionProviderTracker;
 
 	@Reference
 	private GroupLocalService _groupLocalService;

--- a/modules/apps/content-dashboard/content-dashboard-journal-impl/src/main/java/com/liferay/content/dashboard/journal/internal/item/action/ExpireJournalArticleContentDashboardItemVersionAction.java
+++ b/modules/apps/content-dashboard/content-dashboard-journal-impl/src/main/java/com/liferay/content/dashboard/journal/internal/item/action/ExpireJournalArticleContentDashboardItemVersionAction.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.content.dashboard.journal.internal.item.action;
+
+import com.liferay.content.dashboard.item.action.ContentDashboardItemVersionAction;
+import com.liferay.journal.constants.JournalPortletKeys;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
+import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
+import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
+import com.liferay.portal.kernel.util.JavaConstants;
+import com.liferay.portal.kernel.util.PortalUtil;
+
+import java.util.Locale;
+
+import javax.portlet.PortletResponse;
+import javax.portlet.PortletURL;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * @author Jürgen Kappler
+ */
+public class ExpireJournalArticleContentDashboardItemVersionAction
+	implements ContentDashboardItemVersionAction {
+
+	public ExpireJournalArticleContentDashboardItemVersionAction(
+		HttpServletRequest httpServletRequest, JournalArticle journalArticle,
+		Language language,
+		RequestBackedPortletURLFactory requestBackedPortletURLFactory) {
+
+		_httpServletRequest = httpServletRequest;
+		_journalArticle = journalArticle;
+		_language = language;
+		_requestBackedPortletURLFactory = requestBackedPortletURLFactory;
+	}
+
+	@Override
+	public String getIcon() {
+		return "time";
+	}
+
+	@Override
+	public String getLabel(Locale locale) {
+		return _language.get(locale, "expire");
+	}
+
+	@Override
+	public String getName() {
+		return "expire";
+	}
+
+	@Override
+	public String getURL() {
+		LiferayPortletResponse liferayPortletResponse =
+			PortalUtil.getLiferayPortletResponse(
+				(PortletResponse)_httpServletRequest.getAttribute(
+					JavaConstants.JAVAX_PORTLET_RESPONSE));
+
+		PortletURL portletURL = liferayPortletResponse.createRenderURL();
+
+		return PortletURLBuilder.create(
+			_requestBackedPortletURLFactory.createActionURL(
+				JournalPortletKeys.JOURNAL)
+		).setActionName(
+			"/journal/expire_articles"
+		).setRedirect(
+			portletURL
+		).setBackURL(
+			portletURL.toString()
+		).setParameter(
+			"articleId",
+			_journalArticle.getArticleId() + _VERSION_SEPARATOR +
+				_journalArticle.getVersion()
+		).setParameter(
+			"groupId", _journalArticle.getGroupId()
+		).buildString();
+	}
+
+	private static final String _VERSION_SEPARATOR = "_version_";
+
+	private final HttpServletRequest _httpServletRequest;
+	private final JournalArticle _journalArticle;
+	private final Language _language;
+	private final RequestBackedPortletURLFactory
+		_requestBackedPortletURLFactory;
+
+}

--- a/modules/apps/content-dashboard/content-dashboard-journal-impl/src/main/java/com/liferay/content/dashboard/journal/internal/item/action/provider/ExpireJournalArticleContentDashboardItemVersionActionProvider.java
+++ b/modules/apps/content-dashboard/content-dashboard-journal-impl/src/main/java/com/liferay/content/dashboard/journal/internal/item/action/provider/ExpireJournalArticleContentDashboardItemVersionActionProvider.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.content.dashboard.journal.internal.item.action.provider;
+
+import com.liferay.content.dashboard.item.action.ContentDashboardItemVersionAction;
+import com.liferay.content.dashboard.item.action.provider.ContentDashboardItemVersionActionProvider;
+import com.liferay.content.dashboard.journal.internal.item.action.ExpireJournalArticleContentDashboardItemVersionAction;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.service.JournalArticleService;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Jürgen Kappler
+ */
+@Component(service = ContentDashboardItemVersionActionProvider.class)
+public class ExpireJournalArticleContentDashboardItemVersionActionProvider
+	implements ContentDashboardItemVersionActionProvider<JournalArticle> {
+
+	@Override
+	public ContentDashboardItemVersionAction
+		getContentDashboardItemVersionAction(
+			JournalArticle journalArticle,
+			HttpServletRequest httpServletRequest) {
+
+		if (!isShow(journalArticle, httpServletRequest)) {
+			return null;
+		}
+
+		return new ExpireJournalArticleContentDashboardItemVersionAction(
+			httpServletRequest, journalArticle, _language,
+			RequestBackedPortletURLFactoryUtil.create(httpServletRequest));
+	}
+
+	@Override
+	public boolean isShow(
+		JournalArticle journalArticle, HttpServletRequest httpServletRequest) {
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		try {
+			if (_modelResourcePermission.contains(
+					themeDisplay.getPermissionChecker(), journalArticle,
+					ActionKeys.EXPIRE) &&
+				((journalArticle.getStatus() ==
+					WorkflowConstants.STATUS_APPROVED) ||
+				 (journalArticle.getStatus() ==
+					 WorkflowConstants.STATUS_SCHEDULED))) {
+
+				return true;
+			}
+
+			return false;
+		}
+		catch (PortalException portalException) {
+			_log.error(portalException);
+
+			return false;
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		ExpireJournalArticleContentDashboardItemVersionActionProvider.class);
+
+	@Reference
+	private JournalArticleService _journalArticleService;
+
+	@Reference
+	private Language _language;
+
+	@Reference(
+		target = "(model.class.name=com.liferay.journal.model.JournalArticle)"
+	)
+	private ModelResourcePermission<JournalArticle> _modelResourcePermission;
+
+}

--- a/modules/apps/content-dashboard/content-dashboard-journal-impl/src/test/java/com/liferay/content/dashboard/journal/internal/item/JournalArticleContentDashboardItemTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-journal-impl/src/test/java/com/liferay/content/dashboard/journal/internal/item/JournalArticleContentDashboardItemTest.java
@@ -89,7 +89,7 @@ public class JournalArticleContentDashboardItemTest {
 		JournalArticleContentDashboardItem journalArticleContentDashboardItem =
 			new JournalArticleContentDashboardItem(
 				Collections.singletonList(assetCategory), null, null, null,
-				null, null, journalArticle, null, null, null, null);
+				null, null, null, journalArticle, null, null, null, null);
 
 		Assert.assertEquals(
 			Collections.singletonList(assetCategory),
@@ -111,7 +111,7 @@ public class JournalArticleContentDashboardItemTest {
 		JournalArticleContentDashboardItem journalArticleContentDashboardItem =
 			new JournalArticleContentDashboardItem(
 				Collections.singletonList(assetCategory), null, null, null,
-				null, null, journalArticle, null, null, null, null);
+				null, null, null, journalArticle, null, null, null, null);
 
 		Assert.assertEquals(
 			Collections.singletonList(assetCategory),
@@ -125,8 +125,8 @@ public class JournalArticleContentDashboardItemTest {
 
 		JournalArticleContentDashboardItem journalArticleContentDashboardItem =
 			new JournalArticleContentDashboardItem(
-				null, null, null, null, null, null, journalArticle, null, null,
-				null, null);
+				null, null, null, null, null, null, null, journalArticle, null,
+				null, null, null);
 
 		Assert.assertEquals(
 			Collections.emptyList(),
@@ -149,7 +149,7 @@ public class JournalArticleContentDashboardItemTest {
 		JournalArticleContentDashboardItem journalArticleContentDashboardItem =
 			new JournalArticleContentDashboardItem(
 				Collections.singletonList(assetCategory), null, null, null,
-				null, null, journalArticle, null, null, null, null);
+				null, null, null, journalArticle, null, null, null, null);
 
 		Assert.assertEquals(
 			Collections.emptyList(),
@@ -166,7 +166,7 @@ public class JournalArticleContentDashboardItemTest {
 		JournalArticleContentDashboardItem journalArticleContentDashboardItem =
 			new JournalArticleContentDashboardItem(
 				null, Collections.singletonList(assetTag), null, null, null,
-				null, journalArticle, null, null, null, null);
+				null, null, journalArticle, null, null, null, null);
 
 		Assert.assertEquals(
 			Collections.singletonList(assetTag),
@@ -190,8 +190,8 @@ public class JournalArticleContentDashboardItemTest {
 					_getContentDashboardItemActionProvider(
 						ContentDashboardItemAction.Type.VIEW,
 						"http://localhost:8080/view")),
-				null, null, null, journalArticle, null, new LanguageImpl(),
-				null, new PortalImpl());
+				null, null, null, null, journalArticle, null,
+				new LanguageImpl(), null, new PortalImpl());
 
 		ContentDashboardItemAction contentDashboardItemAction =
 			journalArticleContentDashboardItem.
@@ -238,8 +238,8 @@ public class JournalArticleContentDashboardItemTest {
 					_getContentDashboardItemActionProvider(
 						ContentDashboardItemAction.Type.EDIT,
 						"http://localhost:8080/edit")),
-				null, null, null, journalArticle1, null, new LanguageImpl(),
-				journalArticle2, new PortalImpl());
+				null, null, null, null, journalArticle1, null,
+				new LanguageImpl(), journalArticle2, new PortalImpl());
 
 		ContentDashboardItemAction contentDashboardItemAction =
 			journalArticleContentDashboardItem.
@@ -298,8 +298,8 @@ public class JournalArticleContentDashboardItemTest {
 					_getContentDashboardItemActionProvider(
 						ContentDashboardItemAction.Type.EDIT,
 						"http://localhost:8080/edit")),
-				null, null, null, journalArticle1, null, new LanguageImpl(),
-				journalArticle2, new PortalImpl());
+				null, null, null, null, journalArticle1, null,
+				new LanguageImpl(), journalArticle2, new PortalImpl());
 
 		ContentDashboardItemAction contentDashboardItemAction =
 			journalArticleContentDashboardItem.
@@ -339,8 +339,8 @@ public class JournalArticleContentDashboardItemTest {
 		JournalArticleContentDashboardItem journalArticleContentDashboardItem =
 			new JournalArticleContentDashboardItem(
 				null, null, _getContentDashboardItemActionProviderTracker(null),
-				null, null, null, journalArticle1, null, new LanguageImpl(),
-				journalArticle2, new PortalImpl());
+				null, null, null, null, journalArticle1, null,
+				new LanguageImpl(), journalArticle2, new PortalImpl());
 
 		ContentDashboardItemAction contentDashboardItemAction =
 			journalArticleContentDashboardItem.
@@ -356,8 +356,8 @@ public class JournalArticleContentDashboardItemTest {
 
 		JournalArticleContentDashboardItem journalArticleContentDashboardItem =
 			new JournalArticleContentDashboardItem(
-				null, null, null, null, null, null, journalArticle, null, null,
-				null, null);
+				null, null, null, null, null, null, null, journalArticle, null,
+				null, null, null);
 
 		Assert.assertEquals(
 			journalArticle.getModifiedDate(),
@@ -378,8 +378,8 @@ public class JournalArticleContentDashboardItemTest {
 
 		JournalArticleContentDashboardItem journalArticleContentDashboardItem =
 			new JournalArticleContentDashboardItem(
-				null, null, null, null, group, null, journalArticle, null, null,
-				null, null);
+				null, null, null, null, null, group, null, journalArticle, null,
+				null, null, null);
 
 		Assert.assertEquals(
 			"scopeName",
@@ -392,7 +392,7 @@ public class JournalArticleContentDashboardItemTest {
 
 		JournalArticleContentDashboardItem journalArticleContentDashboardItem =
 			new JournalArticleContentDashboardItem(
-				null, null, null,
+				null, null, null, null,
 				new ContentDashboardItemSubtype() {
 
 					@Override
@@ -431,8 +431,8 @@ public class JournalArticleContentDashboardItemTest {
 
 		JournalArticleContentDashboardItem journalArticleContentDashboardItem =
 			new JournalArticleContentDashboardItem(
-				null, null, null, null, null, null, journalArticle, null, null,
-				null, null);
+				null, null, null, null, null, null, null, journalArticle, null,
+				null, null, null);
 
 		Assert.assertEquals(
 			journalArticle.getTitle(LocaleUtil.US),
@@ -451,8 +451,8 @@ public class JournalArticleContentDashboardItemTest {
 
 		JournalArticleContentDashboardItem journalArticleContentDashboardItem =
 			new JournalArticleContentDashboardItem(
-				null, null, null, null, null, null, journalArticle, null, null,
-				null, null);
+				null, null, null, null, null, null, null, journalArticle, null,
+				null, null, null);
 
 		Assert.assertEquals(
 			journalArticle.getUserId(),
@@ -479,8 +479,8 @@ public class JournalArticleContentDashboardItemTest {
 
 		JournalArticleContentDashboardItem journalArticleContentDashboardItem =
 			new JournalArticleContentDashboardItem(
-				null, null, null, null, null, null, journalArticle1, null, null,
-				journalArticle2, null);
+				null, null, null, null, null, null, null, journalArticle1, null,
+				null, journalArticle2, null);
 
 		Assert.assertEquals(
 			journalArticle2.getUserId(),
@@ -499,8 +499,8 @@ public class JournalArticleContentDashboardItemTest {
 
 		JournalArticleContentDashboardItem journalArticleContentDashboardItem =
 			new JournalArticleContentDashboardItem(
-				null, null, null, null, null, null, journalArticle, null, null,
-				null, null);
+				null, null, null, null, null, null, null, journalArticle, null,
+				null, null, null);
 
 		Assert.assertEquals(
 			journalArticle.getUserId(),
@@ -527,8 +527,8 @@ public class JournalArticleContentDashboardItemTest {
 
 		JournalArticleContentDashboardItem journalArticleContentDashboardItem =
 			new JournalArticleContentDashboardItem(
-				null, null, null, null, null, null, journalArticle1, null, null,
-				journalArticle2, null);
+				null, null, null, null, null, null, null, journalArticle1, null,
+				null, journalArticle2, null);
 
 		Assert.assertEquals(
 			journalArticle2.getUserId(),
@@ -547,7 +547,7 @@ public class JournalArticleContentDashboardItemTest {
 
 		JournalArticleContentDashboardItem journalArticleContentDashboardItem =
 			new JournalArticleContentDashboardItem(
-				null, null, null, null, null, null, journalArticle, null,
+				null, null, null, null, null, null, null, journalArticle, null,
 				_getLanguage(), null, null);
 
 		List<ContentDashboardItemVersion> contentDashboardItemVersions =
@@ -599,7 +599,7 @@ public class JournalArticleContentDashboardItemTest {
 
 		JournalArticleContentDashboardItem journalArticleContentDashboardItem =
 			new JournalArticleContentDashboardItem(
-				null, null, null, null, null, null, journalArticle1, null,
+				null, null, null, null, null, null, null, journalArticle1, null,
 				_getLanguage(), journalArticle2, null);
 
 		List<ContentDashboardItemVersion> contentDashboardItemVersions =
@@ -639,8 +639,8 @@ public class JournalArticleContentDashboardItemTest {
 					_getContentDashboardItemActionProvider(
 						ContentDashboardItemAction.Type.VIEW,
 						"http://localhost:8080/view")),
-				null, null, null, journalArticle, null, _getLanguage(), null,
-				null);
+				null, null, null, null, journalArticle, null, _getLanguage(),
+				null, null);
 
 		Assert.assertTrue(
 			journalArticleContentDashboardItem.isViewable(

--- a/modules/apps/content-dashboard/content-dashboard-test/src/testIntegration/java/com/liferay/content/dashboard/web/internal/portlet/action/test/GetContentDashboardItemVersionsResourceCommandTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-test/src/testIntegration/java/com/liferay/content/dashboard/web/internal/portlet/action/test/GetContentDashboardItemVersionsResourceCommandTest.java
@@ -216,7 +216,7 @@ public class GetContentDashboardItemVersionsResourceCommandTest {
 			for (int i = _VERSIONS_COUNT; i > 0; i--) {
 				contentDashboardItemVersions.add(
 					new ContentDashboardItemVersion(
-						null, null, RandomTestUtil.randomString(),
+						null, null, null, RandomTestUtil.randomString(), null,
 						RandomTestUtil.randomString(),
 						RandomTestUtil.randomString(), String.valueOf(i)));
 			}

--- a/modules/apps/content-dashboard/content-dashboard-test/src/testIntegration/java/com/liferay/content/dashboard/web/internal/portlet/action/test/GetContentDashboardItemVersionsResourceCommandTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-test/src/testIntegration/java/com/liferay/content/dashboard/web/internal/portlet/action/test/GetContentDashboardItemVersionsResourceCommandTest.java
@@ -33,7 +33,6 @@ import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.portlet.MockLiferayResourceRequest;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
-import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -208,7 +207,8 @@ public class GetContentDashboardItemVersionsResourceCommandTest {
 
 		@Override
 		public List<ContentDashboardItemVersion>
-			getAllContentDashboardItemVersions(ThemeDisplay themeDisplay) {
+			getAllContentDashboardItemVersions(
+				HttpServletRequest httpServletRequest) {
 
 			List<ContentDashboardItemVersion> contentDashboardItemVersions =
 				new ArrayList<>();

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/item/action/ContentDashboardItemVersionActionProviderTrackerImpl.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/item/action/ContentDashboardItemVersionActionProviderTrackerImpl.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.content.dashboard.web.internal.item.action;
+
+import com.liferay.content.dashboard.item.action.ContentDashboardItemVersionActionProviderTracker;
+import com.liferay.content.dashboard.item.action.provider.ContentDashboardItemVersionActionProvider;
+import com.liferay.osgi.service.tracker.collections.map.PropertyServiceReferenceComparator;
+import com.liferay.osgi.service.tracker.collections.map.ServiceReferenceMapperFactory;
+import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
+import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
+import com.liferay.petra.reflect.GenericUtil;
+import com.liferay.portal.kernel.util.ListUtil;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+
+/**
+ * @author Stefan Tanasie
+ */
+@Component(service = ContentDashboardItemVersionActionProviderTracker.class)
+public class ContentDashboardItemVersionActionProviderTrackerImpl
+	implements ContentDashboardItemVersionActionProviderTracker {
+
+	@Override
+	public List<ContentDashboardItemVersionActionProvider>
+		getContentDashboardItemVersionActionProviders(String className) {
+
+		List<ContentDashboardItemVersionActionProvider>
+			contentDashboardItemVersionActionProviders =
+				_serviceTrackerMap.getService(className);
+
+		if (ListUtil.isEmpty(contentDashboardItemVersionActionProviders)) {
+			return Collections.emptyList();
+		}
+
+		return contentDashboardItemVersionActionProviders;
+	}
+
+	@Activate
+	protected void activate(BundleContext bundleContext) {
+		_serviceTrackerMap = ServiceTrackerMapFactory.openMultiValueMap(
+			bundleContext, ContentDashboardItemVersionActionProvider.class,
+			null,
+			ServiceReferenceMapperFactory.create(
+				bundleContext,
+				(contentDashboardItemVersionAction, emitter) -> emitter.emit(
+					GenericUtil.getGenericClassName(
+						contentDashboardItemVersionAction))),
+			new PropertyServiceReferenceComparator<>("service.ranking"));
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		_serviceTrackerMap.close();
+	}
+
+	private ServiceTrackerMap
+		<String, List<ContentDashboardItemVersionActionProvider>>
+			_serviceTrackerMap;
+
+}

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/portlet/action/GetContentDashboardItemVersionsMVCResourceCommand.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/portlet/action/GetContentDashboardItemVersionsMVCResourceCommand.java
@@ -31,13 +31,11 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.portlet.JSONPortletResponseUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCResourceCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
-import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
-import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.List;
 
@@ -97,13 +95,9 @@ public class GetContentDashboardItemVersionsMVCResourceCommand
 
 		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
 
-		ThemeDisplay themeDisplay =
-			(ThemeDisplay)httpServletRequest.getAttribute(
-				WebKeys.THEME_DISPLAY);
-
 		List<ContentDashboardItemVersion> contentDashboardItemVersions =
 			versionableContentDashboardItem.getAllContentDashboardItemVersions(
-				themeDisplay);
+				httpServletRequest);
 
 		if (ListUtil.isEmpty(contentDashboardItemVersions)) {
 			return jsonArray;
@@ -151,10 +145,6 @@ public class GetContentDashboardItemVersionsMVCResourceCommand
 		HttpServletRequest httpServletRequest = _portal.getHttpServletRequest(
 			resourceRequest);
 
-		ThemeDisplay themeDisplay =
-			(ThemeDisplay)httpServletRequest.getAttribute(
-				WebKeys.THEME_DISPLAY);
-
 		int displayVersions = ParamUtil.getInteger(
 			resourceRequest, "maxDisplayVersions", 10);
 
@@ -163,7 +153,7 @@ public class GetContentDashboardItemVersionsMVCResourceCommand
 
 		List<ContentDashboardItemVersion> contentDashboardItemVersions =
 			versionableContentDashboardItem.getAllContentDashboardItemVersions(
-				themeDisplay);
+				httpServletRequest);
 
 		return JSONUtil.put(
 			"versions",

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/VersionActions.tsx
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/VersionActions.tsx
@@ -18,13 +18,9 @@ import ClayIcon from '@clayui/icon';
 import React from 'react';
 
 const VersionActions = ({actions}: IProps) => {
-	const handleActionClick = ({
-		actionURL: _actionURL,
-		title: _title,
-	}: {
-		actionURL: string;
-		title: string;
-	}): void => {};
+	const handleActionClick = ({url}: {url: string}): void => {
+		window.submitForm((document as IDocument).hrefFm, url);
+	};
 
 	return (
 		<ClayDropDown
@@ -41,20 +37,16 @@ const VersionActions = ({actions}: IProps) => {
 			}
 		>
 			<ClayDropDown.ItemList>
-				{actions.map(
-					({action, actionLabel, actionURL, icon, title}) => (
-						<ClayDropDown.Item
-							key={action}
-							onClick={() =>
-								handleActionClick({actionURL, title})
-							}
-						>
-							<ClayIcon symbol={icon || ''} />
+				{actions.map(({icon, label, name, url}) => (
+					<ClayDropDown.Item
+						key={name}
+						onClick={() => handleActionClick({url})}
+					>
+						<ClayIcon symbol={icon || ''} />
 
-							<span className="pl-3">{actionLabel}</span>
-						</ClayDropDown.Item>
-					)
-				)}
+						<span className="pl-3">{label}</span>
+					</ClayDropDown.Item>
+				))}
 			</ClayDropDown.ItemList>
 		</ClayDropDown>
 	);
@@ -64,12 +56,21 @@ interface IProps {
 	actions: IAction[];
 }
 
-interface IAction {
-	action: string;
-	actionLabel: string;
-	actionURL: string;
+export interface IAction {
 	icon?: string;
-	title: string;
+	label: string;
+	name: string;
+	url: string;
+}
+
+declare global {
+	interface Window {
+		submitForm: (form: HTMLElement, url: string) => void;
+	}
+
+	interface IDocument extends Document {
+		hrefFm: HTMLElement;
+	}
 }
 
 export default VersionActions;

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/VersionsContent.tsx
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/VersionsContent.tsx
@@ -18,6 +18,7 @@ import ClayLoadingIndicator from '@clayui/loading-indicator';
 import {fetch, sub} from 'frontend-js-web';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 
+import VersionActions, {IAction} from './VersionActions';
 import formatDate from './utils/formatDate';
 
 const useIsFirstRender = (): boolean => {
@@ -92,19 +93,25 @@ const VersionsContent = ({
 				</div>
 			) : (
 				<>
-					{versions && (
-						<ul className="list-group sidebar-list-group">
-							{versions.map((version) => (
+					<ul className="list-group sidebar-list-group">
+						{versions.map(
+							({
+								actions,
+								changeLog,
+								createDate,
+								userName,
+								version,
+							}) => (
 								<li
-									className="list-group-item list-group-item-flex p-0"
-									key={version.version}
+									className="list-group-item list-group-item-flex"
+									key={version}
 								>
 									<ClayLayout.ContentCol expand>
 										<div className="list-group-title">
 											{Liferay.Language.get('version') +
 												' '}
 
-											{version.version}
+											{version}
 										</div>
 
 										<div className="list-group-subtitle">
@@ -112,27 +119,30 @@ const VersionsContent = ({
 												Liferay.Language.get('x-by-x'),
 												[
 													formatDate(
-														version.createDate,
+														createDate,
 														languageTag
 													),
-													version.userName,
+													userName,
 												]
 											)}
 										</div>
 
 										<div className="list-group-subtext">
-											{version.changeLog
-												? version.changeLog
+											{changeLog
+												? changeLog
 												: Liferay.Language.get(
 														'no-change-log'
 												  )}
 										</div>
 									</ClayLayout.ContentCol>
-								</li>
-							))}
-						</ul>
-					)}
 
+									{actions && !!actions.length && (
+										<VersionActions actions={actions} />
+									)}
+								</li>
+							)
+						)}
+					</ul>
 					{viewVersionsURL && (
 						<div className="d-flex justify-content-center">
 							<ClayLink
@@ -162,6 +172,7 @@ interface IProps {
 }
 
 interface IVersion {
+	actions: IAction[];
 	changeLog?: string;
 	createDate: string;
 	statusLabel: string;

--- a/modules/apps/content-dashboard/content-dashboard-web/src/test/java/com/liferay/content/dashboard/web/internal/portlet/action/GetContentDashboardItemInfoMVCResourceCommandTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/test/java/com/liferay/content/dashboard/web/internal/portlet/action/GetContentDashboardItemInfoMVCResourceCommandTest.java
@@ -816,7 +816,8 @@ public class GetContentDashboardItemInfoMVCResourceCommandTest {
 
 					return Collections.singletonList(
 						new ContentDashboardItemVersion(
-							null, null, "version", "style", "user", "0.1"));
+							null, null, null, "version", null, "style", "user",
+							"0.1"));
 				}
 
 				@Override

--- a/modules/apps/content-dashboard/content-dashboard-web/types/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/Categorization.d.ts
+++ b/modules/apps/content-dashboard/content-dashboard-web/types/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/Categorization.d.ts
@@ -12,8 +12,6 @@
  * details.
  */
 
-/// <reference types="react" />
-
 declare const Categorization: ({
 	tags,
 	vocabularies,

--- a/modules/apps/content-dashboard/content-dashboard-web/types/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/PreviewActionsDescriptionSection.d.ts
+++ b/modules/apps/content-dashboard/content-dashboard-web/types/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/PreviewActionsDescriptionSection.d.ts
@@ -12,8 +12,6 @@
  * details.
  */
 
-/// <reference types="react" />
-
 declare const PreviewActionsDescriptionSection: ({
 	description,
 	downloadURL,

--- a/modules/apps/content-dashboard/content-dashboard-web/types/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/VersionActions.d.ts
+++ b/modules/apps/content-dashboard/content-dashboard-web/types/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/VersionActions.d.ts
@@ -12,17 +12,22 @@
  * details.
  */
 
-/// <reference types="react" />
-
 declare const VersionActions: ({actions}: IProps) => JSX.Element;
 interface IProps {
 	actions: IAction[];
 }
-interface IAction {
-	action: string;
-	actionLabel: string;
-	actionURL: string;
+export interface IAction {
 	icon?: string;
-	title: string;
+	label: string;
+	name: string;
+	url: string;
+}
+declare global {
+	interface Window {
+		submitForm: (form: HTMLElement, url: string) => void;
+	}
+	interface IDocument extends Document {
+		hrefFm: HTMLElement;
+	}
 }
 export default VersionActions;


### PR DESCRIPTION
## Motivation

[Link to ticket](https://issues.liferay.com/browse/LPS-164650)
[Link to ticket (frontend)](https://issues.liferay.com/browse/LPS-162827)

Tango Team is working on improving the information panel in content dashboard, and one of these improvements is adding the version history of the elements in the sidebar. Each version can have actions available to the user, such as viewing, downloading, sharing, i.e.


## Change summary:

* Replicate the logic that we already have for content dashboard item action (action, provider and tracker), and leave only the barebone
* Change signature so that we pass the version
* Add a new method in content dashboard item to retrieve the actions by version
* Change the resource command to include the actions for each version

