### PR TITLE
LPS-164067 Display the Active and Inactive Labels in the Control Menu

### DIFF
--- a/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/product/navigation/control/menu/SegmentsExperienceSelectorProductNavigationControlMenuEntry.java
+++ b/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/product/navigation/control/menu/SegmentsExperienceSelectorProductNavigationControlMenuEntry.java
@@ -18,6 +18,8 @@ import com.liferay.layout.content.page.editor.constants.ContentPageEditorWebKeys
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.security.permission.resource.LayoutContentModelResourcePermission;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
@@ -35,7 +37,10 @@ import com.liferay.product.navigation.control.menu.BaseJSPProductNavigationContr
 import com.liferay.product.navigation.control.menu.ProductNavigationControlMenuEntry;
 import com.liferay.product.navigation.control.menu.constants.ProductNavigationControlMenuCategoryKeys;
 import com.liferay.segments.manager.SegmentsExperienceManager;
+import com.liferay.segments.service.SegmentsEntryLocalService;
 import com.liferay.segments.service.SegmentsExperienceLocalService;
+import com.liferay.segments.service.SegmentsExperimentLocalService;
+import com.liferay.segments.service.SegmentsExperimentRelLocalService;
 import com.liferay.segments.web.internal.display.context.SegmentsExperienceSelectorDisplayContext;
 import com.liferay.sites.kernel.util.Sites;
 
@@ -157,15 +162,24 @@ public class SegmentsExperienceSelectorProductNavigationControlMenuEntry
 		httpServletRequest.setAttribute(
 			SegmentsExperienceSelectorDisplayContext.class.getName(),
 			new SegmentsExperienceSelectorDisplayContext(
-				httpServletRequest,
-				new SegmentsExperienceManager(
-					_segmentsExperienceLocalService)));
+				httpServletRequest, _jsonFactory, _language, _portal,
+				_segmentsEntryLocalService,
+				new SegmentsExperienceManager(_segmentsExperienceLocalService),
+				_segmentsExperienceLocalService,
+				_segmentsExperimentLocalService,
+				_segmentsExperimentRelLocalService));
 
 		return super.include(httpServletRequest, httpServletResponse, jspPath);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		SegmentsExperienceSelectorProductNavigationControlMenuEntry.class);
+
+	@Reference
+	private JSONFactory _jsonFactory;
+
+	@Reference
+	private Language _language;
 
 	@Reference
 	private LayoutLocalService _layoutLocalService;
@@ -180,7 +194,17 @@ public class SegmentsExperienceSelectorProductNavigationControlMenuEntry
 	private Portal _portal;
 
 	@Reference
+	private SegmentsEntryLocalService _segmentsEntryLocalService;
+
+	@Reference
 	private SegmentsExperienceLocalService _segmentsExperienceLocalService;
+
+	@Reference
+	private SegmentsExperimentLocalService _segmentsExperimentLocalService;
+
+	@Reference
+	private SegmentsExperimentRelLocalService
+		_segmentsExperimentRelLocalService;
 
 	@Reference(target = "(osgi.web.symbolicname=com.liferay.segments.web)")
 	private ServletContext _servletContext;

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/segments_experience_selector.jsp
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/segments_experience_selector.jsp
@@ -24,9 +24,22 @@ SegmentsExperienceSelectorDisplayContext segmentsExperienceSelectorDisplayContex
 	<div class="dropdown">
 		<button aria-expanded="false" aria-haspopup="true" class="btn btn-sm btn-unstyled dropdown-toggle" id="<portlet:namespace />dropdownToggle" type="button">
 			<span class="align-items-center c-inner d-flex" tabindex="-1">
-				<span class="lfr-portal-tooltip mr-2 text-truncate" title="<%= HtmlUtil.escapeAttribute(segmentsExperienceSelectorDisplayContext.getSelectedSegmentsExperienceName()) %>">
-					<%= segmentsExperienceSelectorDisplayContext.getSelectedSegmentsExperienceName() %>
+
+				<%
+				JSONObject segmentsExperienceSelectedJSONObject = segmentsExperienceSelectorDisplayContext.getSegmentsExperienceSelectedJSONObject();
+				%>
+
+				<span class="lfr-portal-tooltip mr-2 text-truncate" title="<%= HtmlUtil.escapeAttribute(segmentsExperienceSelectedJSONObject.getString("segmentsExperienceName")) %>">
+					<%= segmentsExperienceSelectedJSONObject.getString("segmentsExperienceName") %>
 				</span>
+
+				<div class="autofit-col">
+					<span class="label label-<%= segmentsExperienceSelectedJSONObject.getBoolean("active")?"success":"secondary" %> bg-transparent m-0">
+						<span class="label-item label-item-expand">
+							<%= segmentsExperienceSelectedJSONObject.getString("statusLabel") %>
+						</span>
+					</span>
+				</div>
 
 				<clay:icon
 					cssClass="flex-shrink-0"
@@ -56,15 +69,13 @@ SegmentsExperienceSelectorDisplayContext segmentsExperienceSelectorDisplayContex
 							</p>
 						</div>
 
-						<c:if test='<%= segmentsExperiencesJSONObject.getBoolean("active") %>'>
-							<div class="autofit-col">
-								<span class="label label-success m-0">
-									<span class="label-item label-item-expand">
-										<liferay-ui:message key="active" />
-									</span>
+						<div class="autofit-col">
+							<span class="label label-<%= segmentsExperiencesJSONObject.getBoolean("active")?"success":"secondary" %> bg-transparent m-0">
+								<span class="label-item label-item-expand">
+									<%= segmentsExperiencesJSONObject.getString("statusLabel") %>
 								</span>
-							</div>
-						</c:if>
+							</span>
+						</div>
 					</a>
 				</li>
 


### PR DESCRIPTION
Motivation
=======
As a marketer, I want to see the Active / Inactive labels while in view mode, so that I can easily understand the status of an experience I am currently viewing. 
[Link to story or ticket](https://issues.liferay.com/browse/LPS-154188)

Proposed Solution
========
Added Active / Inactive labels to the control menu in view mode.

<img width="1667" alt="image" src="https://user-images.githubusercontent.com/46810560/194047406-53b5c4e2-33d2-43b7-9880-81ca5007c1c9.png">


Steps to Verify:
----------------
1-Go to People / Segment management.
2-Add some segments.
3-Go to a content page.
4-Add some experiences related to the same segment.
5-Order created experiences and you will see the labels.