### PR TITLE
LPS-164967 Inject resources into templates

### DIFF
--- a/modules/apps/analytics/analytics-settings-rest-impl/src/main/java/com/liferay/analytics/settings/rest/internal/resource/v1_0/factory/DataSourceResourceFactoryImpl.java
+++ b/modules/apps/analytics/analytics-settings-rest-impl/src/main/java/com/liferay/analytics/settings/rest/internal/resource/v1_0/factory/DataSourceResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Riccardo Ferrari
  * @generated
  */
-@Component(immediate = true, service = DataSourceResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/analytics-settings-rest/v1.0/DataSource",
+	service = DataSourceResource.Factory.class
+)
 @Generated("")
 public class DataSourceResourceFactoryImpl
 	implements DataSourceResource.Factory {

--- a/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/factory/FieldResourceFactoryImpl.java
+++ b/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/factory/FieldResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Matija Petanjek
  * @generated
  */
-@Component(immediate = true, service = FieldResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/batch-planner/v1.0/Field",
+	service = FieldResource.Factory.class
+)
 @Generated("")
 public class FieldResourceFactoryImpl implements FieldResource.Factory {
 

--- a/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/factory/PlanResourceFactoryImpl.java
+++ b/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/factory/PlanResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Matija Petanjek
  * @generated
  */
-@Component(immediate = true, service = PlanResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/batch-planner/v1.0/Plan",
+	service = PlanResource.Factory.class
+)
 @Generated("")
 public class PlanResourceFactoryImpl implements PlanResource.Factory {
 

--- a/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/factory/SiteScopeResourceFactoryImpl.java
+++ b/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/factory/SiteScopeResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Matija Petanjek
  * @generated
  */
-@Component(immediate = true, service = SiteScopeResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/batch-planner/v1.0/SiteScope",
+	service = SiteScopeResource.Factory.class
+)
 @Generated("")
 public class SiteScopeResourceFactoryImpl implements SiteScopeResource.Factory {
 

--- a/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/factory/KeywordResourceFactoryImpl.java
+++ b/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/factory/KeywordResourceFactoryImpl.java
@@ -62,7 +62,10 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Alejandro Tardín
  * @generated
  */
-@Component(immediate = true, service = KeywordResource.Factory.class)
+@Component(
+	immediate = true, property = "resource.locator.key=/bulk/v1.0/Keyword",
+	service = KeywordResource.Factory.class
+)
 @Generated("")
 public class KeywordResourceFactoryImpl implements KeywordResource.Factory {
 

--- a/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/factory/SelectionResourceFactoryImpl.java
+++ b/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/factory/SelectionResourceFactoryImpl.java
@@ -62,7 +62,10 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Alejandro Tardín
  * @generated
  */
-@Component(immediate = true, service = SelectionResource.Factory.class)
+@Component(
+	immediate = true, property = "resource.locator.key=/bulk/v1.0/Selection",
+	service = SelectionResource.Factory.class
+)
 @Generated("")
 public class SelectionResourceFactoryImpl implements SelectionResource.Factory {
 

--- a/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/factory/StatusResourceFactoryImpl.java
+++ b/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/factory/StatusResourceFactoryImpl.java
@@ -62,7 +62,10 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Alejandro Tardín
  * @generated
  */
-@Component(immediate = true, service = StatusResource.Factory.class)
+@Component(
+	immediate = true, property = "resource.locator.key=/bulk/v1.0/Status",
+	service = StatusResource.Factory.class
+)
 @Generated("")
 public class StatusResourceFactoryImpl implements StatusResource.Factory {
 

--- a/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/factory/TaxonomyCategoryResourceFactoryImpl.java
+++ b/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/factory/TaxonomyCategoryResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Alejandro Tardín
  * @generated
  */
-@Component(immediate = true, service = TaxonomyCategoryResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/bulk/v1.0/TaxonomyCategory",
+	service = TaxonomyCategoryResource.Factory.class
+)
 @Generated("")
 public class TaxonomyCategoryResourceFactoryImpl
 	implements TaxonomyCategoryResource.Factory {

--- a/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/factory/TaxonomyVocabularyResourceFactoryImpl.java
+++ b/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/factory/TaxonomyVocabularyResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Alejandro Tardín
  * @generated
  */
-@Component(immediate = true, service = TaxonomyVocabularyResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/bulk/v1.0/TaxonomyVocabulary",
+	service = TaxonomyVocabularyResource.Factory.class
+)
 @Generated("")
 public class TaxonomyVocabularyResourceFactoryImpl
 	implements TaxonomyVocabularyResource.Factory {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/factory/AccountAddressResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/factory/AccountAddressResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-account/v1.0/AccountAddress",
 	service = AccountAddressResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/factory/AccountGroupResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/factory/AccountGroupResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-account/v1.0/AccountGroup",
 	service = AccountGroupResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/factory/AccountMemberResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/factory/AccountMemberResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-account/v1.0/AccountMember",
 	service = AccountMemberResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/factory/AccountOrganizationResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/factory/AccountOrganizationResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-account/v1.0/AccountOrganization",
 	service = AccountOrganizationResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/factory/AccountResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/factory/AccountResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	enabled = false, immediate = true, service = AccountResource.Factory.class
+	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-account/v1.0/Account",
+	service = AccountResource.Factory.class
 )
 @Generated("")
 public class AccountResourceFactoryImpl implements AccountResource.Factory {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/factory/UserResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/factory/UserResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	enabled = false, immediate = true, service = UserResource.Factory.class
+	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-account/v1.0/User",
+	service = UserResource.Factory.class
 )
 @Generated("")
 public class UserResourceFactoryImpl implements UserResource.Factory {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/factory/AttachmentResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/factory/AttachmentResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-catalog/v1.0/Attachment",
 	service = AttachmentResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/factory/CatalogResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/factory/CatalogResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	enabled = false, immediate = true, service = CatalogResource.Factory.class
+	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-catalog/v1.0/Catalog",
+	service = CatalogResource.Factory.class
 )
 @Generated("")
 public class CatalogResourceFactoryImpl implements CatalogResource.Factory {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/factory/CategoryResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/factory/CategoryResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	enabled = false, immediate = true, service = CategoryResource.Factory.class
+	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-catalog/v1.0/Category",
+	service = CategoryResource.Factory.class
 )
 @Generated("")
 public class CategoryResourceFactoryImpl implements CategoryResource.Factory {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/factory/DiagramResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/factory/DiagramResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	enabled = false, immediate = true, service = DiagramResource.Factory.class
+	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-catalog/v1.0/Diagram",
+	service = DiagramResource.Factory.class
 )
 @Generated("")
 public class DiagramResourceFactoryImpl implements DiagramResource.Factory {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/factory/MappedProductResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/factory/MappedProductResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-catalog/v1.0/MappedProduct",
 	service = MappedProductResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/factory/OptionCategoryResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/factory/OptionCategoryResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-catalog/v1.0/OptionCategory",
 	service = OptionCategoryResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/factory/OptionResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/factory/OptionResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	enabled = false, immediate = true, service = OptionResource.Factory.class
+	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-catalog/v1.0/Option",
+	service = OptionResource.Factory.class
 )
 @Generated("")
 public class OptionResourceFactoryImpl implements OptionResource.Factory {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/factory/OptionValueResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/factory/OptionValueResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-catalog/v1.0/OptionValue",
 	service = OptionValueResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/factory/PinResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/factory/PinResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	enabled = false, immediate = true, service = PinResource.Factory.class
+	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-catalog/v1.0/Pin",
+	service = PinResource.Factory.class
 )
 @Generated("")
 public class PinResourceFactoryImpl implements PinResource.Factory {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/factory/ProductAccountGroupResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/factory/ProductAccountGroupResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-catalog/v1.0/ProductAccountGroup",
 	service = ProductAccountGroupResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/factory/ProductChannelResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/factory/ProductChannelResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-catalog/v1.0/ProductChannel",
 	service = ProductChannelResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/factory/ProductConfigurationResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/factory/ProductConfigurationResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-catalog/v1.0/ProductConfiguration",
 	service = ProductConfigurationResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/factory/ProductGroupProductResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/factory/ProductGroupProductResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-catalog/v1.0/ProductGroupProduct",
 	service = ProductGroupProductResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/factory/ProductGroupResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/factory/ProductGroupResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-catalog/v1.0/ProductGroup",
 	service = ProductGroupResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/factory/ProductOptionResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/factory/ProductOptionResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-catalog/v1.0/ProductOption",
 	service = ProductOptionResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/factory/ProductOptionValueResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/factory/ProductOptionValueResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-catalog/v1.0/ProductOptionValue",
 	service = ProductOptionValueResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/factory/ProductResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/factory/ProductResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	enabled = false, immediate = true, service = ProductResource.Factory.class
+	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-catalog/v1.0/Product",
+	service = ProductResource.Factory.class
 )
 @Generated("")
 public class ProductResourceFactoryImpl implements ProductResource.Factory {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/factory/ProductShippingConfigurationResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/factory/ProductShippingConfigurationResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-catalog/v1.0/ProductShippingConfiguration",
 	service = ProductShippingConfigurationResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/factory/ProductSpecificationResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/factory/ProductSpecificationResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-catalog/v1.0/ProductSpecification",
 	service = ProductSpecificationResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/factory/ProductSubscriptionConfigurationResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/factory/ProductSubscriptionConfigurationResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-catalog/v1.0/ProductSubscriptionConfiguration",
 	service = ProductSubscriptionConfigurationResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/factory/ProductTaxConfigurationResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/factory/ProductTaxConfigurationResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-catalog/v1.0/ProductTaxConfiguration",
 	service = ProductTaxConfigurationResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/factory/RelatedProductResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/factory/RelatedProductResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-catalog/v1.0/RelatedProduct",
 	service = RelatedProductResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/factory/SkuResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/factory/SkuResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	enabled = false, immediate = true, service = SkuResource.Factory.class
+	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-catalog/v1.0/Sku",
+	service = SkuResource.Factory.class
 )
 @Generated("")
 public class SkuResourceFactoryImpl implements SkuResource.Factory {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/factory/SpecificationResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/factory/SpecificationResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-catalog/v1.0/Specification",
 	service = SpecificationResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/factory/ChannelResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/factory/ChannelResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	enabled = false, immediate = true, service = ChannelResource.Factory.class
+	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-channel/v1.0/Channel",
+	service = ChannelResource.Factory.class
 )
 @Generated("")
 public class ChannelResourceFactoryImpl implements ChannelResource.Factory {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/factory/OrderTypeResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/factory/OrderTypeResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	enabled = false, immediate = true, service = OrderTypeResource.Factory.class
+	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-channel/v1.0/OrderType",
+	service = OrderTypeResource.Factory.class
 )
 @Generated("")
 public class OrderTypeResourceFactoryImpl implements OrderTypeResource.Factory {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/factory/PaymentMethodGroupRelOrderTypeResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/factory/PaymentMethodGroupRelOrderTypeResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-channel/v1.0/PaymentMethodGroupRelOrderType",
 	service = PaymentMethodGroupRelOrderTypeResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/factory/PaymentMethodGroupRelTermResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/factory/PaymentMethodGroupRelTermResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-channel/v1.0/PaymentMethodGroupRelTerm",
 	service = PaymentMethodGroupRelTermResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/factory/ShippingFixedOptionOrderTypeResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/factory/ShippingFixedOptionOrderTypeResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-channel/v1.0/ShippingFixedOptionOrderType",
 	service = ShippingFixedOptionOrderTypeResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/factory/ShippingFixedOptionTermResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/factory/ShippingFixedOptionTermResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-channel/v1.0/ShippingFixedOptionTerm",
 	service = ShippingFixedOptionTermResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/factory/ShippingMethodResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/factory/ShippingMethodResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-channel/v1.0/ShippingMethod",
 	service = ShippingMethodResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/factory/TaxCategoryResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/factory/TaxCategoryResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-channel/v1.0/TaxCategory",
 	service = TaxCategoryResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/factory/TermResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/factory/TermResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	enabled = false, immediate = true, service = TermResource.Factory.class
+	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-channel/v1.0/Term",
+	service = TermResource.Factory.class
 )
 @Generated("")
 public class TermResourceFactoryImpl implements TermResource.Factory {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/factory/ChannelResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/factory/ChannelResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	enabled = false, immediate = true, service = ChannelResource.Factory.class
+	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-inventory/v1.0/Channel",
+	service = ChannelResource.Factory.class
 )
 @Generated("")
 public class ChannelResourceFactoryImpl implements ChannelResource.Factory {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/factory/OrderTypeResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/factory/OrderTypeResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	enabled = false, immediate = true, service = OrderTypeResource.Factory.class
+	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-inventory/v1.0/OrderType",
+	service = OrderTypeResource.Factory.class
 )
 @Generated("")
 public class OrderTypeResourceFactoryImpl implements OrderTypeResource.Factory {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/factory/ReplenishmentItemResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/factory/ReplenishmentItemResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-inventory/v1.0/ReplenishmentItem",
 	service = ReplenishmentItemResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/factory/WarehouseChannelResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/factory/WarehouseChannelResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-inventory/v1.0/WarehouseChannel",
 	service = WarehouseChannelResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/factory/WarehouseItemResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/factory/WarehouseItemResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-inventory/v1.0/WarehouseItem",
 	service = WarehouseItemResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/factory/WarehouseOrderTypeResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/factory/WarehouseOrderTypeResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-inventory/v1.0/WarehouseOrderType",
 	service = WarehouseOrderTypeResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/factory/WarehouseResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/factory/WarehouseResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	enabled = false, immediate = true, service = WarehouseResource.Factory.class
+	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-inventory/v1.0/Warehouse",
+	service = WarehouseResource.Factory.class
 )
 @Generated("")
 public class WarehouseResourceFactoryImpl implements WarehouseResource.Factory {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/factory/AccountGroupResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/factory/AccountGroupResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-order/v1.0/AccountGroup",
 	service = AccountGroupResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/factory/AccountResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/factory/AccountResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	enabled = false, immediate = true, service = AccountResource.Factory.class
+	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-order/v1.0/Account",
+	service = AccountResource.Factory.class
 )
 @Generated("")
 public class AccountResourceFactoryImpl implements AccountResource.Factory {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/factory/BillingAddressResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/factory/BillingAddressResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-order/v1.0/BillingAddress",
 	service = BillingAddressResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/factory/ChannelResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/factory/ChannelResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	enabled = false, immediate = true, service = ChannelResource.Factory.class
+	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-order/v1.0/Channel",
+	service = ChannelResource.Factory.class
 )
 @Generated("")
 public class ChannelResourceFactoryImpl implements ChannelResource.Factory {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/factory/OrderItemResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/factory/OrderItemResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	enabled = false, immediate = true, service = OrderItemResource.Factory.class
+	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-order/v1.0/OrderItem",
+	service = OrderItemResource.Factory.class
 )
 @Generated("")
 public class OrderItemResourceFactoryImpl implements OrderItemResource.Factory {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/factory/OrderNoteResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/factory/OrderNoteResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	enabled = false, immediate = true, service = OrderNoteResource.Factory.class
+	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-order/v1.0/OrderNote",
+	service = OrderNoteResource.Factory.class
 )
 @Generated("")
 public class OrderNoteResourceFactoryImpl implements OrderNoteResource.Factory {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/factory/OrderResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/factory/OrderResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	enabled = false, immediate = true, service = OrderResource.Factory.class
+	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-order/v1.0/Order",
+	service = OrderResource.Factory.class
 )
 @Generated("")
 public class OrderResourceFactoryImpl implements OrderResource.Factory {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/factory/OrderRuleAccountGroupResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/factory/OrderRuleAccountGroupResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-order/v1.0/OrderRuleAccountGroup",
 	service = OrderRuleAccountGroupResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/factory/OrderRuleAccountResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/factory/OrderRuleAccountResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-order/v1.0/OrderRuleAccount",
 	service = OrderRuleAccountResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/factory/OrderRuleChannelResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/factory/OrderRuleChannelResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-order/v1.0/OrderRuleChannel",
 	service = OrderRuleChannelResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/factory/OrderRuleOrderTypeResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/factory/OrderRuleOrderTypeResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-order/v1.0/OrderRuleOrderType",
 	service = OrderRuleOrderTypeResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/factory/OrderRuleResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/factory/OrderRuleResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	enabled = false, immediate = true, service = OrderRuleResource.Factory.class
+	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-order/v1.0/OrderRule",
+	service = OrderRuleResource.Factory.class
 )
 @Generated("")
 public class OrderRuleResourceFactoryImpl implements OrderRuleResource.Factory {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/factory/OrderTypeChannelResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/factory/OrderTypeChannelResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-order/v1.0/OrderTypeChannel",
 	service = OrderTypeChannelResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/factory/OrderTypeResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/factory/OrderTypeResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	enabled = false, immediate = true, service = OrderTypeResource.Factory.class
+	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-order/v1.0/OrderType",
+	service = OrderTypeResource.Factory.class
 )
 @Generated("")
 public class OrderTypeResourceFactoryImpl implements OrderTypeResource.Factory {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/factory/ShippingAddressResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/factory/ShippingAddressResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-order/v1.0/ShippingAddress",
 	service = ShippingAddressResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/factory/TermOrderTypeResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/factory/TermOrderTypeResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-order/v1.0/TermOrderType",
 	service = TermOrderTypeResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/factory/TermResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/factory/TermResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	enabled = false, immediate = true, service = TermResource.Factory.class
+	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-order/v1.0/Term",
+	service = TermResource.Factory.class
 )
 @Generated("")
 public class TermResourceFactoryImpl implements TermResource.Factory {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/factory/DiscountAccountGroupResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/factory/DiscountAccountGroupResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-pricing/v1.0/DiscountAccountGroup",
 	service = DiscountAccountGroupResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/factory/DiscountCategoryResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/factory/DiscountCategoryResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-pricing/v1.0/DiscountCategory",
 	service = DiscountCategoryResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/factory/DiscountProductResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/factory/DiscountProductResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-pricing/v1.0/DiscountProduct",
 	service = DiscountProductResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/factory/DiscountResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/factory/DiscountResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	enabled = false, immediate = true, service = DiscountResource.Factory.class
+	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-pricing/v1.0/Discount",
+	service = DiscountResource.Factory.class
 )
 @Generated("")
 public class DiscountResourceFactoryImpl implements DiscountResource.Factory {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/factory/DiscountRuleResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/factory/DiscountRuleResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-pricing/v1.0/DiscountRule",
 	service = DiscountRuleResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/factory/PriceEntryResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/factory/PriceEntryResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-pricing/v1.0/PriceEntry",
 	service = PriceEntryResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/factory/PriceListAccountGroupResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/factory/PriceListAccountGroupResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-pricing/v1.0/PriceListAccountGroup",
 	service = PriceListAccountGroupResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/factory/PriceListResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/factory/PriceListResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	enabled = false, immediate = true, service = PriceListResource.Factory.class
+	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-pricing/v1.0/PriceList",
+	service = PriceListResource.Factory.class
 )
 @Generated("")
 public class PriceListResourceFactoryImpl implements PriceListResource.Factory {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/factory/TierPriceResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/factory/TierPriceResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	enabled = false, immediate = true, service = TierPriceResource.Factory.class
+	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-pricing/v1.0/TierPrice",
+	service = TierPriceResource.Factory.class
 )
 @Generated("")
 public class TierPriceResourceFactoryImpl implements TierPriceResource.Factory {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/AccountGroupResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/AccountGroupResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-pricing/v2.0/AccountGroup",
 	service = AccountGroupResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/AccountResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/AccountResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	enabled = false, immediate = true, service = AccountResource.Factory.class
+	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-pricing/v2.0/Account",
+	service = AccountResource.Factory.class
 )
 @Generated("")
 public class AccountResourceFactoryImpl implements AccountResource.Factory {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/CategoryResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/CategoryResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	enabled = false, immediate = true, service = CategoryResource.Factory.class
+	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-pricing/v2.0/Category",
+	service = CategoryResource.Factory.class
 )
 @Generated("")
 public class CategoryResourceFactoryImpl implements CategoryResource.Factory {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/ChannelResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/ChannelResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	enabled = false, immediate = true, service = ChannelResource.Factory.class
+	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-pricing/v2.0/Channel",
+	service = ChannelResource.Factory.class
 )
 @Generated("")
 public class ChannelResourceFactoryImpl implements ChannelResource.Factory {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/DiscountAccountGroupResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/DiscountAccountGroupResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-pricing/v2.0/DiscountAccountGroup",
 	service = DiscountAccountGroupResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/DiscountAccountResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/DiscountAccountResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-pricing/v2.0/DiscountAccount",
 	service = DiscountAccountResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/DiscountCategoryResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/DiscountCategoryResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-pricing/v2.0/DiscountCategory",
 	service = DiscountCategoryResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/DiscountChannelResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/DiscountChannelResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-pricing/v2.0/DiscountChannel",
 	service = DiscountChannelResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/DiscountOrderTypeResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/DiscountOrderTypeResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-pricing/v2.0/DiscountOrderType",
 	service = DiscountOrderTypeResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/DiscountProductGroupResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/DiscountProductGroupResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-pricing/v2.0/DiscountProductGroup",
 	service = DiscountProductGroupResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/DiscountProductResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/DiscountProductResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-pricing/v2.0/DiscountProduct",
 	service = DiscountProductResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/DiscountResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/DiscountResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	enabled = false, immediate = true, service = DiscountResource.Factory.class
+	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-pricing/v2.0/Discount",
+	service = DiscountResource.Factory.class
 )
 @Generated("")
 public class DiscountResourceFactoryImpl implements DiscountResource.Factory {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/DiscountRuleResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/DiscountRuleResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-pricing/v2.0/DiscountRule",
 	service = DiscountRuleResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/DiscountSkuResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/DiscountSkuResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-pricing/v2.0/DiscountSku",
 	service = DiscountSkuResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/OrderTypeResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/OrderTypeResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	enabled = false, immediate = true, service = OrderTypeResource.Factory.class
+	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-pricing/v2.0/OrderType",
+	service = OrderTypeResource.Factory.class
 )
 @Generated("")
 public class OrderTypeResourceFactoryImpl implements OrderTypeResource.Factory {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/PriceEntryResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/PriceEntryResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-pricing/v2.0/PriceEntry",
 	service = PriceEntryResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/PriceListAccountGroupResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/PriceListAccountGroupResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-pricing/v2.0/PriceListAccountGroup",
 	service = PriceListAccountGroupResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/PriceListAccountResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/PriceListAccountResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-pricing/v2.0/PriceListAccount",
 	service = PriceListAccountResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/PriceListChannelResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/PriceListChannelResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-pricing/v2.0/PriceListChannel",
 	service = PriceListChannelResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/PriceListDiscountResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/PriceListDiscountResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-pricing/v2.0/PriceListDiscount",
 	service = PriceListDiscountResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/PriceListOrderTypeResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/PriceListOrderTypeResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-pricing/v2.0/PriceListOrderType",
 	service = PriceListOrderTypeResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/PriceListResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/PriceListResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	enabled = false, immediate = true, service = PriceListResource.Factory.class
+	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-pricing/v2.0/PriceList",
+	service = PriceListResource.Factory.class
 )
 @Generated("")
 public class PriceListResourceFactoryImpl implements PriceListResource.Factory {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/PriceModifierCategoryResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/PriceModifierCategoryResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-pricing/v2.0/PriceModifierCategory",
 	service = PriceModifierCategoryResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/PriceModifierProductGroupResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/PriceModifierProductGroupResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-pricing/v2.0/PriceModifierProductGroup",
 	service = PriceModifierProductGroupResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/PriceModifierProductResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/PriceModifierProductResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-pricing/v2.0/PriceModifierProduct",
 	service = PriceModifierProductResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/PriceModifierResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/PriceModifierResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-pricing/v2.0/PriceModifier",
 	service = PriceModifierResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/ProductGroupResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/ProductGroupResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-pricing/v2.0/ProductGroup",
 	service = ProductGroupResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/ProductResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/ProductResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	enabled = false, immediate = true, service = ProductResource.Factory.class
+	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-pricing/v2.0/Product",
+	service = ProductResource.Factory.class
 )
 @Generated("")
 public class ProductResourceFactoryImpl implements ProductResource.Factory {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/SkuResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/SkuResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	enabled = false, immediate = true, service = SkuResource.Factory.class
+	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-pricing/v2.0/Sku",
+	service = SkuResource.Factory.class
 )
 @Generated("")
 public class SkuResourceFactoryImpl implements SkuResource.Factory {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/TierPriceResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/factory/TierPriceResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	enabled = false, immediate = true, service = TierPriceResource.Factory.class
+	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-pricing/v2.0/TierPrice",
+	service = TierPriceResource.Factory.class
 )
 @Generated("")
 public class TierPriceResourceFactoryImpl implements TierPriceResource.Factory {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/factory/ShipmentItemResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/factory/ShipmentItemResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-shipment/v1.0/ShipmentItem",
 	service = ShipmentItemResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/factory/ShipmentResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/factory/ShipmentResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	enabled = false, immediate = true, service = ShipmentResource.Factory.class
+	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-shipment/v1.0/Shipment",
+	service = ShipmentResource.Factory.class
 )
 @Generated("")
 public class ShipmentResourceFactoryImpl implements ShipmentResource.Factory {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/factory/ShippingAddressResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/factory/ShippingAddressResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-shipment/v1.0/ShippingAddress",
 	service = ShippingAddressResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/factory/AvailabilityEstimateResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/factory/AvailabilityEstimateResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-site-setting/v1.0/AvailabilityEstimate",
 	service = AvailabilityEstimateResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/factory/MeasurementUnitResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/factory/MeasurementUnitResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-site-setting/v1.0/MeasurementUnit",
 	service = MeasurementUnitResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/factory/TaxCategoryResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/factory/TaxCategoryResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-site-setting/v1.0/TaxCategory",
 	service = TaxCategoryResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/factory/WarehouseResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/factory/WarehouseResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	enabled = false, immediate = true, service = WarehouseResource.Factory.class
+	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-admin-site-setting/v1.0/Warehouse",
+	service = WarehouseResource.Factory.class
 )
 @Generated("")
 public class WarehouseResourceFactoryImpl implements WarehouseResource.Factory {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/factory/AddressResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/factory/AddressResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	enabled = false, immediate = true, service = AddressResource.Factory.class
+	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-delivery-cart/v1.0/Address",
+	service = AddressResource.Factory.class
 )
 @Generated("")
 public class AddressResourceFactoryImpl implements AddressResource.Factory {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/factory/CartCommentResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/factory/CartCommentResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-delivery-cart/v1.0/CartComment",
 	service = CartCommentResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/factory/CartItemResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/factory/CartItemResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	enabled = false, immediate = true, service = CartItemResource.Factory.class
+	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-delivery-cart/v1.0/CartItem",
+	service = CartItemResource.Factory.class
 )
 @Generated("")
 public class CartItemResourceFactoryImpl implements CartItemResource.Factory {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/factory/CartResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/factory/CartResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	enabled = false, immediate = true, service = CartResource.Factory.class
+	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-delivery-cart/v1.0/Cart",
+	service = CartResource.Factory.class
 )
 @Generated("")
 public class CartResourceFactoryImpl implements CartResource.Factory {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/factory/PaymentMethodResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/factory/PaymentMethodResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-delivery-cart/v1.0/PaymentMethod",
 	service = PaymentMethodResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/factory/ShippingMethodResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/factory/ShippingMethodResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-delivery-cart/v1.0/ShippingMethod",
 	service = ShippingMethodResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/factory/AttachmentResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/factory/AttachmentResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-delivery-catalog/v1.0/Attachment",
 	service = AttachmentResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/factory/CategoryResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/factory/CategoryResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	enabled = false, immediate = true, service = CategoryResource.Factory.class
+	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-delivery-catalog/v1.0/Category",
+	service = CategoryResource.Factory.class
 )
 @Generated("")
 public class CategoryResourceFactoryImpl implements CategoryResource.Factory {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/factory/ChannelResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/factory/ChannelResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	enabled = false, immediate = true, service = ChannelResource.Factory.class
+	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-delivery-catalog/v1.0/Channel",
+	service = ChannelResource.Factory.class
 )
 @Generated("")
 public class ChannelResourceFactoryImpl implements ChannelResource.Factory {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/factory/MappedProductResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/factory/MappedProductResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-delivery-catalog/v1.0/MappedProduct",
 	service = MappedProductResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/factory/PinResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/factory/PinResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	enabled = false, immediate = true, service = PinResource.Factory.class
+	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-delivery-catalog/v1.0/Pin",
+	service = PinResource.Factory.class
 )
 @Generated("")
 public class PinResourceFactoryImpl implements PinResource.Factory {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/factory/ProductOptionResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/factory/ProductOptionResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-delivery-catalog/v1.0/ProductOption",
 	service = ProductOptionResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/factory/ProductResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/factory/ProductResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	enabled = false, immediate = true, service = ProductResource.Factory.class
+	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-delivery-catalog/v1.0/Product",
+	service = ProductResource.Factory.class
 )
 @Generated("")
 public class ProductResourceFactoryImpl implements ProductResource.Factory {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/factory/ProductSpecificationResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/factory/ProductSpecificationResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-delivery-catalog/v1.0/ProductSpecification",
 	service = ProductSpecificationResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/factory/RelatedProductResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/factory/RelatedProductResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-delivery-catalog/v1.0/RelatedProduct",
 	service = RelatedProductResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/factory/SkuResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/factory/SkuResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	enabled = false, immediate = true, service = SkuResource.Factory.class
+	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-delivery-catalog/v1.0/Sku",
+	service = SkuResource.Factory.class
 )
 @Generated("")
 public class SkuResourceFactoryImpl implements SkuResource.Factory {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/factory/PlacedOrderAddressResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/factory/PlacedOrderAddressResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-delivery-order/v1.0/PlacedOrderAddress",
 	service = PlacedOrderAddressResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/factory/PlacedOrderCommentResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/factory/PlacedOrderCommentResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-delivery-order/v1.0/PlacedOrderComment",
 	service = PlacedOrderCommentResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/factory/PlacedOrderItemResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/factory/PlacedOrderItemResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-delivery-order/v1.0/PlacedOrderItem",
 	service = PlacedOrderItemResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/factory/PlacedOrderItemShipmentResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/factory/PlacedOrderItemShipmentResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-delivery-order/v1.0/PlacedOrderItemShipment",
 	service = PlacedOrderItemShipmentResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/factory/PlacedOrderResourceFactoryImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/factory/PlacedOrderResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-delivery-order/v1.0/PlacedOrder",
 	service = PlacedOrderResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/factory/DataDefinitionFieldLinkResourceFactoryImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/factory/DataDefinitionFieldLinkResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	immediate = true, service = DataDefinitionFieldLinkResource.Factory.class
+	immediate = true,
+	property = "resource.locator.key=/data-engine/v2.0/DataDefinitionFieldLink",
+	service = DataDefinitionFieldLinkResource.Factory.class
 )
 @Generated("")
 public class DataDefinitionFieldLinkResourceFactoryImpl

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/factory/DataDefinitionResourceFactoryImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/factory/DataDefinitionResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Jeyvison Nascimento
  * @generated
  */
-@Component(immediate = true, service = DataDefinitionResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/data-engine/v2.0/DataDefinition",
+	service = DataDefinitionResource.Factory.class
+)
 @Generated("")
 public class DataDefinitionResourceFactoryImpl
 	implements DataDefinitionResource.Factory {

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/factory/DataLayoutResourceFactoryImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/factory/DataLayoutResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Jeyvison Nascimento
  * @generated
  */
-@Component(immediate = true, service = DataLayoutResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/data-engine/v2.0/DataLayout",
+	service = DataLayoutResource.Factory.class
+)
 @Generated("")
 public class DataLayoutResourceFactoryImpl
 	implements DataLayoutResource.Factory {

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/factory/DataListViewResourceFactoryImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/factory/DataListViewResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Jeyvison Nascimento
  * @generated
  */
-@Component(immediate = true, service = DataListViewResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/data-engine/v2.0/DataListView",
+	service = DataListViewResource.Factory.class
+)
 @Generated("")
 public class DataListViewResourceFactoryImpl
 	implements DataListViewResource.Factory {

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/factory/DataRecordCollectionResourceFactoryImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/factory/DataRecordCollectionResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	immediate = true, service = DataRecordCollectionResource.Factory.class
+	immediate = true,
+	property = "resource.locator.key=/data-engine/v2.0/DataRecordCollection",
+	service = DataRecordCollectionResource.Factory.class
 )
 @Generated("")
 public class DataRecordCollectionResourceFactoryImpl

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/factory/DataRecordResourceFactoryImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/factory/DataRecordResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Jeyvison Nascimento
  * @generated
  */
-@Component(immediate = true, service = DataRecordResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/data-engine/v2.0/DataRecord",
+	service = DataRecordResource.Factory.class
+)
 @Generated("")
 public class DataRecordResourceFactoryImpl
 	implements DataRecordResource.Factory {

--- a/modules/apps/digital-signature/digital-signature-rest-impl/src/main/java/com/liferay/digital/signature/rest/internal/resource/v1_0/factory/DSEnvelopeResourceFactoryImpl.java
+++ b/modules/apps/digital-signature/digital-signature-rest-impl/src/main/java/com/liferay/digital/signature/rest/internal/resource/v1_0/factory/DSEnvelopeResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author José Abelenda
  * @generated
  */
-@Component(immediate = true, service = DSEnvelopeResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/digital-signature-rest/v1.0/DSEnvelope",
+	service = DSEnvelopeResource.Factory.class
+)
 @Generated("")
 public class DSEnvelopeResourceFactoryImpl
 	implements DSEnvelopeResource.Factory {

--- a/modules/apps/frontend-view-state/frontend-view-state-rest-impl/src/main/java/com/liferay/frontend/view/state/rest/internal/resource/v1_0/factory/ActiveViewResourceFactoryImpl.java
+++ b/modules/apps/frontend-view-state/frontend-view-state-rest-impl/src/main/java/com/liferay/frontend/view/state/rest/internal/resource/v1_0/factory/ActiveViewResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Javier Gamarra
  * @generated
  */
-@Component(immediate = true, service = ActiveViewResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/frontend-view-state/v1.0/ActiveView",
+	service = ActiveViewResource.Factory.class
+)
 @Generated("")
 public class ActiveViewResourceFactoryImpl
 	implements ActiveViewResource.Factory {

--- a/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/java/com/liferay/headless/admin/address/internal/resource/v1_0/factory/CountryResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/java/com/liferay/headless/admin/address/internal/resource/v1_0/factory/CountryResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Drew Brokke
  * @generated
  */
-@Component(immediate = true, service = CountryResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/headless-admin-address/v1.0/Country",
+	service = CountryResource.Factory.class
+)
 @Generated("")
 public class CountryResourceFactoryImpl implements CountryResource.Factory {
 

--- a/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/java/com/liferay/headless/admin/address/internal/resource/v1_0/factory/RegionResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/java/com/liferay/headless/admin/address/internal/resource/v1_0/factory/RegionResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Drew Brokke
  * @generated
  */
-@Component(immediate = true, service = RegionResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/headless-admin-address/v1.0/Region",
+	service = RegionResource.Factory.class
+)
 @Generated("")
 public class RegionResourceFactoryImpl implements RegionResource.Factory {
 

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/resource/v1_0/factory/DisplayPageTemplateResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/resource/v1_0/factory/DisplayPageTemplateResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	immediate = true, service = DisplayPageTemplateResource.Factory.class
+	immediate = true,
+	property = "resource.locator.key=/headless-admin-content/v1.0/DisplayPageTemplate",
+	service = DisplayPageTemplateResource.Factory.class
 )
 @Generated("")
 public class DisplayPageTemplateResourceFactoryImpl

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/resource/v1_0/factory/PageDefinitionResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/resource/v1_0/factory/PageDefinitionResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Javier Gamarra
  * @generated
  */
-@Component(immediate = true, service = PageDefinitionResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/headless-admin-content/v1.0/PageDefinition",
+	service = PageDefinitionResource.Factory.class
+)
 @Generated("")
 public class PageDefinitionResourceFactoryImpl
 	implements PageDefinitionResource.Factory {

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/resource/v1_0/factory/StructuredContentResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/resource/v1_0/factory/StructuredContentResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Javier Gamarra
  * @generated
  */
-@Component(immediate = true, service = StructuredContentResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/headless-admin-content/v1.0/StructuredContent",
+	service = StructuredContentResource.Factory.class
+)
 @Generated("")
 public class StructuredContentResourceFactoryImpl
 	implements StructuredContentResource.Factory {

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/resource/v1_0/factory/ListTypeDefinitionResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/resource/v1_0/factory/ListTypeDefinitionResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Gabriel Albuquerque
  * @generated
  */
-@Component(immediate = true, service = ListTypeDefinitionResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/headless-admin-list-type/v1.0/ListTypeDefinition",
+	service = ListTypeDefinitionResource.Factory.class
+)
 @Generated("")
 public class ListTypeDefinitionResourceFactoryImpl
 	implements ListTypeDefinitionResource.Factory {

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/resource/v1_0/factory/ListTypeEntryResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/resource/v1_0/factory/ListTypeEntryResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Gabriel Albuquerque
  * @generated
  */
-@Component(immediate = true, service = ListTypeEntryResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/headless-admin-list-type/v1.0/ListTypeEntry",
+	service = ListTypeEntryResource.Factory.class
+)
 @Generated("")
 public class ListTypeEntryResourceFactoryImpl
 	implements ListTypeEntryResource.Factory {

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/factory/KeywordResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/factory/KeywordResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Javier Gamarra
  * @generated
  */
-@Component(immediate = true, service = KeywordResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/headless-admin-taxonomy/v1.0/Keyword",
+	service = KeywordResource.Factory.class
+)
 @Generated("")
 public class KeywordResourceFactoryImpl implements KeywordResource.Factory {
 

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/factory/TaxonomyCategoryResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/factory/TaxonomyCategoryResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Javier Gamarra
  * @generated
  */
-@Component(immediate = true, service = TaxonomyCategoryResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/headless-admin-taxonomy/v1.0/TaxonomyCategory",
+	service = TaxonomyCategoryResource.Factory.class
+)
 @Generated("")
 public class TaxonomyCategoryResourceFactoryImpl
 	implements TaxonomyCategoryResource.Factory {

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/factory/TaxonomyVocabularyResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/factory/TaxonomyVocabularyResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Javier Gamarra
  * @generated
  */
-@Component(immediate = true, service = TaxonomyVocabularyResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/headless-admin-taxonomy/v1.0/TaxonomyVocabulary",
+	service = TaxonomyVocabularyResource.Factory.class
+)
 @Generated("")
 public class TaxonomyVocabularyResourceFactoryImpl
 	implements TaxonomyVocabularyResource.Factory {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml
@@ -1071,7 +1071,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.admin.user.client', and version '4.0.30'."
+        'com.liferay.headless.admin.user.client', and version '4.0.32'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.user.client', and version '4.0.30'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin User", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.user.client', and version '4.0.32'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin User", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/factory/AccountResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/factory/AccountResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Javier Gamarra
  * @generated
  */
-@Component(immediate = true, service = AccountResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/headless-admin-user/v1.0/Account",
+	service = AccountResource.Factory.class
+)
 @Generated("")
 public class AccountResourceFactoryImpl implements AccountResource.Factory {
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/factory/AccountRoleResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/factory/AccountRoleResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Javier Gamarra
  * @generated
  */
-@Component(immediate = true, service = AccountRoleResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/headless-admin-user/v1.0/AccountRole",
+	service = AccountRoleResource.Factory.class
+)
 @Generated("")
 public class AccountRoleResourceFactoryImpl
 	implements AccountRoleResource.Factory {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/factory/EmailAddressResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/factory/EmailAddressResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Javier Gamarra
  * @generated
  */
-@Component(immediate = true, service = EmailAddressResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/headless-admin-user/v1.0/EmailAddress",
+	service = EmailAddressResource.Factory.class
+)
 @Generated("")
 public class EmailAddressResourceFactoryImpl
 	implements EmailAddressResource.Factory {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/factory/OrganizationResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/factory/OrganizationResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Javier Gamarra
  * @generated
  */
-@Component(immediate = true, service = OrganizationResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/headless-admin-user/v1.0/Organization",
+	service = OrganizationResource.Factory.class
+)
 @Generated("")
 public class OrganizationResourceFactoryImpl
 	implements OrganizationResource.Factory {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/factory/PhoneResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/factory/PhoneResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Javier Gamarra
  * @generated
  */
-@Component(immediate = true, service = PhoneResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/headless-admin-user/v1.0/Phone",
+	service = PhoneResource.Factory.class
+)
 @Generated("")
 public class PhoneResourceFactoryImpl implements PhoneResource.Factory {
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/factory/PostalAddressResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/factory/PostalAddressResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Javier Gamarra
  * @generated
  */
-@Component(immediate = true, service = PostalAddressResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/headless-admin-user/v1.0/PostalAddress",
+	service = PostalAddressResource.Factory.class
+)
 @Generated("")
 public class PostalAddressResourceFactoryImpl
 	implements PostalAddressResource.Factory {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/factory/RoleResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/factory/RoleResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Javier Gamarra
  * @generated
  */
-@Component(immediate = true, service = RoleResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/headless-admin-user/v1.0/Role",
+	service = RoleResource.Factory.class
+)
 @Generated("")
 public class RoleResourceFactoryImpl implements RoleResource.Factory {
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/factory/SegmentResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/factory/SegmentResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Javier Gamarra
  * @generated
  */
-@Component(immediate = true, service = SegmentResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/headless-admin-user/v1.0/Segment",
+	service = SegmentResource.Factory.class
+)
 @Generated("")
 public class SegmentResourceFactoryImpl implements SegmentResource.Factory {
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/factory/SegmentUserResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/factory/SegmentUserResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Javier Gamarra
  * @generated
  */
-@Component(immediate = true, service = SegmentUserResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/headless-admin-user/v1.0/SegmentUser",
+	service = SegmentUserResource.Factory.class
+)
 @Generated("")
 public class SegmentUserResourceFactoryImpl
 	implements SegmentUserResource.Factory {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/factory/SiteResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/factory/SiteResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Javier Gamarra
  * @generated
  */
-@Component(immediate = true, service = SiteResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/headless-admin-user/v1.0/Site",
+	service = SiteResource.Factory.class
+)
 @Generated("")
 public class SiteResourceFactoryImpl implements SiteResource.Factory {
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/factory/SubscriptionResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/factory/SubscriptionResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Javier Gamarra
  * @generated
  */
-@Component(immediate = true, service = SubscriptionResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/headless-admin-user/v1.0/Subscription",
+	service = SubscriptionResource.Factory.class
+)
 @Generated("")
 public class SubscriptionResourceFactoryImpl
 	implements SubscriptionResource.Factory {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/factory/UserAccountResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/factory/UserAccountResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Javier Gamarra
  * @generated
  */
-@Component(immediate = true, service = UserAccountResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/headless-admin-user/v1.0/UserAccount",
+	service = UserAccountResource.Factory.class
+)
 @Generated("")
 public class UserAccountResourceFactoryImpl
 	implements UserAccountResource.Factory {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/factory/UserGroupResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/factory/UserGroupResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Javier Gamarra
  * @generated
  */
-@Component(immediate = true, service = UserGroupResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/headless-admin-user/v1.0/UserGroup",
+	service = UserGroupResource.Factory.class
+)
 @Generated("")
 public class UserGroupResourceFactoryImpl implements UserGroupResource.Factory {
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/factory/WebUrlResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/factory/WebUrlResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Javier Gamarra
  * @generated
  */
-@Component(immediate = true, service = WebUrlResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/headless-admin-user/v1.0/WebUrl",
+	service = WebUrlResource.Factory.class
+)
 @Generated("")
 public class WebUrlResourceFactoryImpl implements WebUrlResource.Factory {
 

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/factory/AssigneeResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/factory/AssigneeResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Javier Gamarra
  * @generated
  */
-@Component(immediate = true, service = AssigneeResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/headless-admin-workflow/v1.0/Assignee",
+	service = AssigneeResource.Factory.class
+)
 @Generated("")
 public class AssigneeResourceFactoryImpl implements AssigneeResource.Factory {
 

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/factory/TransitionResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/factory/TransitionResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Javier Gamarra
  * @generated
  */
-@Component(immediate = true, service = TransitionResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/headless-admin-workflow/v1.0/Transition",
+	service = TransitionResource.Factory.class
+)
 @Generated("")
 public class TransitionResourceFactoryImpl
 	implements TransitionResource.Factory {

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/factory/WorkflowDefinitionResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/factory/WorkflowDefinitionResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Javier Gamarra
  * @generated
  */
-@Component(immediate = true, service = WorkflowDefinitionResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/headless-admin-workflow/v1.0/WorkflowDefinition",
+	service = WorkflowDefinitionResource.Factory.class
+)
 @Generated("")
 public class WorkflowDefinitionResourceFactoryImpl
 	implements WorkflowDefinitionResource.Factory {

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/factory/WorkflowInstanceResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/factory/WorkflowInstanceResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Javier Gamarra
  * @generated
  */
-@Component(immediate = true, service = WorkflowInstanceResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/headless-admin-workflow/v1.0/WorkflowInstance",
+	service = WorkflowInstanceResource.Factory.class
+)
 @Generated("")
 public class WorkflowInstanceResourceFactoryImpl
 	implements WorkflowInstanceResource.Factory {

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/factory/WorkflowLogResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/factory/WorkflowLogResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Javier Gamarra
  * @generated
  */
-@Component(immediate = true, service = WorkflowLogResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/headless-admin-workflow/v1.0/WorkflowLog",
+	service = WorkflowLogResource.Factory.class
+)
 @Generated("")
 public class WorkflowLogResourceFactoryImpl
 	implements WorkflowLogResource.Factory {

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/factory/WorkflowTaskAssignableUsersResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/factory/WorkflowTaskAssignableUsersResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	immediate = true,
+	property = "resource.locator.key=/headless-admin-workflow/v1.0/WorkflowTaskAssignableUsers",
 	service = WorkflowTaskAssignableUsersResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/factory/WorkflowTaskResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/factory/WorkflowTaskResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Javier Gamarra
  * @generated
  */
-@Component(immediate = true, service = WorkflowTaskResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/headless-admin-workflow/v1.0/WorkflowTask",
+	service = WorkflowTaskResource.Factory.class
+)
 @Generated("")
 public class WorkflowTaskResourceFactoryImpl
 	implements WorkflowTaskResource.Factory {

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/factory/WorkflowTaskTransitionsResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/factory/WorkflowTaskTransitionsResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	immediate = true, service = WorkflowTaskTransitionsResource.Factory.class
+	immediate = true,
+	property = "resource.locator.key=/headless-admin-workflow/v1.0/WorkflowTaskTransitions",
+	service = WorkflowTaskTransitionsResource.Factory.class
 )
 @Generated("")
 public class WorkflowTaskTransitionsResourceFactoryImpl

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/src/main/java/com/liferay/headless/batch/engine/internal/resource/v1_0/factory/ExportTaskResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/src/main/java/com/liferay/headless/batch/engine/internal/resource/v1_0/factory/ExportTaskResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Ivica Cardic
  * @generated
  */
-@Component(immediate = true, service = ExportTaskResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/headless-batch-engine/v1.0/ExportTask",
+	service = ExportTaskResource.Factory.class
+)
 @Generated("")
 public class ExportTaskResourceFactoryImpl
 	implements ExportTaskResource.Factory {

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/src/main/java/com/liferay/headless/batch/engine/internal/resource/v1_0/factory/ImportTaskResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/src/main/java/com/liferay/headless/batch/engine/internal/resource/v1_0/factory/ImportTaskResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Ivica Cardic
  * @generated
  */
-@Component(immediate = true, service = ImportTaskResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/headless-batch-engine/v1.0/ImportTask",
+	service = ImportTaskResource.Factory.class
+)
 @Generated("")
 public class ImportTaskResourceFactoryImpl
 	implements ImportTaskResource.Factory {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -5319,7 +5319,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.delivery.client', and version '4.0.40'."
+        'com.liferay.headless.delivery.client', and version '4.0.41'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.delivery.client', and version '4.0.40'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Delivery", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.delivery.client', and version '4.0.41'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Delivery", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/factory/BlogPostingImageResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/factory/BlogPostingImageResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Javier Gamarra
  * @generated
  */
-@Component(immediate = true, service = BlogPostingImageResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/headless-delivery/v1.0/BlogPostingImage",
+	service = BlogPostingImageResource.Factory.class
+)
 @Generated("")
 public class BlogPostingImageResourceFactoryImpl
 	implements BlogPostingImageResource.Factory {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/factory/BlogPostingResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/factory/BlogPostingResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Javier Gamarra
  * @generated
  */
-@Component(immediate = true, service = BlogPostingResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/headless-delivery/v1.0/BlogPosting",
+	service = BlogPostingResource.Factory.class
+)
 @Generated("")
 public class BlogPostingResourceFactoryImpl
 	implements BlogPostingResource.Factory {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/factory/CommentResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/factory/CommentResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Javier Gamarra
  * @generated
  */
-@Component(immediate = true, service = CommentResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/headless-delivery/v1.0/Comment",
+	service = CommentResource.Factory.class
+)
 @Generated("")
 public class CommentResourceFactoryImpl implements CommentResource.Factory {
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/factory/ContentElementResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/factory/ContentElementResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Javier Gamarra
  * @generated
  */
-@Component(immediate = true, service = ContentElementResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/headless-delivery/v1.0/ContentElement",
+	service = ContentElementResource.Factory.class
+)
 @Generated("")
 public class ContentElementResourceFactoryImpl
 	implements ContentElementResource.Factory {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/factory/ContentSetElementResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/factory/ContentSetElementResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Javier Gamarra
  * @generated
  */
-@Component(immediate = true, service = ContentSetElementResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/headless-delivery/v1.0/ContentSetElement",
+	service = ContentSetElementResource.Factory.class
+)
 @Generated("")
 public class ContentSetElementResourceFactoryImpl
 	implements ContentSetElementResource.Factory {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/factory/ContentStructureResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/factory/ContentStructureResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Javier Gamarra
  * @generated
  */
-@Component(immediate = true, service = ContentStructureResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/headless-delivery/v1.0/ContentStructure",
+	service = ContentStructureResource.Factory.class
+)
 @Generated("")
 public class ContentStructureResourceFactoryImpl
 	implements ContentStructureResource.Factory {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/factory/ContentTemplateResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/factory/ContentTemplateResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Javier Gamarra
  * @generated
  */
-@Component(immediate = true, service = ContentTemplateResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/headless-delivery/v1.0/ContentTemplate",
+	service = ContentTemplateResource.Factory.class
+)
 @Generated("")
 public class ContentTemplateResourceFactoryImpl
 	implements ContentTemplateResource.Factory {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/factory/DocumentFolderResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/factory/DocumentFolderResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Javier Gamarra
  * @generated
  */
-@Component(immediate = true, service = DocumentFolderResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/headless-delivery/v1.0/DocumentFolder",
+	service = DocumentFolderResource.Factory.class
+)
 @Generated("")
 public class DocumentFolderResourceFactoryImpl
 	implements DocumentFolderResource.Factory {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/factory/DocumentResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/factory/DocumentResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Javier Gamarra
  * @generated
  */
-@Component(immediate = true, service = DocumentResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/headless-delivery/v1.0/Document",
+	service = DocumentResource.Factory.class
+)
 @Generated("")
 public class DocumentResourceFactoryImpl implements DocumentResource.Factory {
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/factory/KnowledgeBaseArticleResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/factory/KnowledgeBaseArticleResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	immediate = true, service = KnowledgeBaseArticleResource.Factory.class
+	immediate = true,
+	property = "resource.locator.key=/headless-delivery/v1.0/KnowledgeBaseArticle",
+	service = KnowledgeBaseArticleResource.Factory.class
 )
 @Generated("")
 public class KnowledgeBaseArticleResourceFactoryImpl

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/factory/KnowledgeBaseAttachmentResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/factory/KnowledgeBaseAttachmentResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	immediate = true, service = KnowledgeBaseAttachmentResource.Factory.class
+	immediate = true,
+	property = "resource.locator.key=/headless-delivery/v1.0/KnowledgeBaseAttachment",
+	service = KnowledgeBaseAttachmentResource.Factory.class
 )
 @Generated("")
 public class KnowledgeBaseAttachmentResourceFactoryImpl

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/factory/KnowledgeBaseFolderResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/factory/KnowledgeBaseFolderResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	immediate = true, service = KnowledgeBaseFolderResource.Factory.class
+	immediate = true,
+	property = "resource.locator.key=/headless-delivery/v1.0/KnowledgeBaseFolder",
+	service = KnowledgeBaseFolderResource.Factory.class
 )
 @Generated("")
 public class KnowledgeBaseFolderResourceFactoryImpl

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/factory/LanguageResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/factory/LanguageResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Javier Gamarra
  * @generated
  */
-@Component(immediate = true, service = LanguageResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/headless-delivery/v1.0/Language",
+	service = LanguageResource.Factory.class
+)
 @Generated("")
 public class LanguageResourceFactoryImpl implements LanguageResource.Factory {
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/factory/MessageBoardAttachmentResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/factory/MessageBoardAttachmentResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	immediate = true, service = MessageBoardAttachmentResource.Factory.class
+	immediate = true,
+	property = "resource.locator.key=/headless-delivery/v1.0/MessageBoardAttachment",
+	service = MessageBoardAttachmentResource.Factory.class
 )
 @Generated("")
 public class MessageBoardAttachmentResourceFactoryImpl

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/factory/MessageBoardMessageResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/factory/MessageBoardMessageResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	immediate = true, service = MessageBoardMessageResource.Factory.class
+	immediate = true,
+	property = "resource.locator.key=/headless-delivery/v1.0/MessageBoardMessage",
+	service = MessageBoardMessageResource.Factory.class
 )
 @Generated("")
 public class MessageBoardMessageResourceFactoryImpl

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/factory/MessageBoardSectionResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/factory/MessageBoardSectionResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	immediate = true, service = MessageBoardSectionResource.Factory.class
+	immediate = true,
+	property = "resource.locator.key=/headless-delivery/v1.0/MessageBoardSection",
+	service = MessageBoardSectionResource.Factory.class
 )
 @Generated("")
 public class MessageBoardSectionResourceFactoryImpl

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/factory/MessageBoardThreadResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/factory/MessageBoardThreadResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Javier Gamarra
  * @generated
  */
-@Component(immediate = true, service = MessageBoardThreadResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/headless-delivery/v1.0/MessageBoardThread",
+	service = MessageBoardThreadResource.Factory.class
+)
 @Generated("")
 public class MessageBoardThreadResourceFactoryImpl
 	implements MessageBoardThreadResource.Factory {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/factory/NavigationMenuResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/factory/NavigationMenuResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Javier Gamarra
  * @generated
  */
-@Component(immediate = true, service = NavigationMenuResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/headless-delivery/v1.0/NavigationMenu",
+	service = NavigationMenuResource.Factory.class
+)
 @Generated("")
 public class NavigationMenuResourceFactoryImpl
 	implements NavigationMenuResource.Factory {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/factory/SitePageResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/factory/SitePageResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Javier Gamarra
  * @generated
  */
-@Component(immediate = true, service = SitePageResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/headless-delivery/v1.0/SitePage",
+	service = SitePageResource.Factory.class
+)
 @Generated("")
 public class SitePageResourceFactoryImpl implements SitePageResource.Factory {
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/factory/StructuredContentFolderResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/factory/StructuredContentFolderResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	immediate = true, service = StructuredContentFolderResource.Factory.class
+	immediate = true,
+	property = "resource.locator.key=/headless-delivery/v1.0/StructuredContentFolder",
+	service = StructuredContentFolderResource.Factory.class
 )
 @Generated("")
 public class StructuredContentFolderResourceFactoryImpl

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/factory/StructuredContentResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/factory/StructuredContentResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Javier Gamarra
  * @generated
  */
-@Component(immediate = true, service = StructuredContentResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/headless-delivery/v1.0/StructuredContent",
+	service = StructuredContentResource.Factory.class
+)
 @Generated("")
 public class StructuredContentResourceFactoryImpl
 	implements StructuredContentResource.Factory {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/factory/WikiNodeResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/factory/WikiNodeResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Javier Gamarra
  * @generated
  */
-@Component(immediate = true, service = WikiNodeResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/headless-delivery/v1.0/WikiNode",
+	service = WikiNodeResource.Factory.class
+)
 @Generated("")
 public class WikiNodeResourceFactoryImpl implements WikiNodeResource.Factory {
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/factory/WikiPageAttachmentResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/factory/WikiPageAttachmentResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Javier Gamarra
  * @generated
  */
-@Component(immediate = true, service = WikiPageAttachmentResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/headless-delivery/v1.0/WikiPageAttachment",
+	service = WikiPageAttachmentResource.Factory.class
+)
 @Generated("")
 public class WikiPageAttachmentResourceFactoryImpl
 	implements WikiPageAttachmentResource.Factory {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/factory/WikiPageResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/factory/WikiPageResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Javier Gamarra
  * @generated
  */
-@Component(immediate = true, service = WikiPageResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/headless-delivery/v1.0/WikiPage",
+	service = WikiPageResource.Factory.class
+)
 @Generated("")
 public class WikiPageResourceFactoryImpl implements WikiPageResource.Factory {
 

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/factory/FormDocumentResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/factory/FormDocumentResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Javier Gamarra
  * @generated
  */
-@Component(immediate = true, service = FormDocumentResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/headless-form/v1.0/FormDocument",
+	service = FormDocumentResource.Factory.class
+)
 @Generated("")
 public class FormDocumentResourceFactoryImpl
 	implements FormDocumentResource.Factory {

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/factory/FormRecordResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/factory/FormRecordResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Javier Gamarra
  * @generated
  */
-@Component(immediate = true, service = FormRecordResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/headless-form/v1.0/FormRecord",
+	service = FormRecordResource.Factory.class
+)
 @Generated("")
 public class FormRecordResourceFactoryImpl
 	implements FormRecordResource.Factory {

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/factory/FormResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/factory/FormResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Javier Gamarra
  * @generated
  */
-@Component(immediate = true, service = FormResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/headless-form/v1.0/Form",
+	service = FormResource.Factory.class
+)
 @Generated("")
 public class FormResourceFactoryImpl implements FormResource.Factory {
 

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/factory/FormStructureResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/factory/FormStructureResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Javier Gamarra
  * @generated
  */
-@Component(immediate = true, service = FormStructureResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/headless-form/v1.0/FormStructure",
+	service = FormStructureResource.Factory.class
+)
 @Generated("")
 public class FormStructureResourceFactoryImpl
 	implements FormStructureResource.Factory {

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/src/main/java/com/liferay/headless/portal/instances/internal/resource/v1_0/factory/PortalInstanceResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/src/main/java/com/liferay/headless/portal/instances/internal/resource/v1_0/factory/PortalInstanceResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Alberto Chaparro
  * @generated
  */
-@Component(immediate = true, service = PortalInstanceResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/headless-portal-instances/v1.0/PortalInstance",
+	service = PortalInstanceResource.Factory.class
+)
 @Generated("")
 public class PortalInstanceResourceFactoryImpl
 	implements PortalInstanceResource.Factory {

--- a/modules/apps/notification/notification-rest-impl/rest-openapi.yaml
+++ b/modules/apps/notification/notification-rest-impl/rest-openapi.yaml
@@ -112,7 +112,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.notification.rest.client', and version '1.0.8'."
+        'com.liferay.notification.rest.client', and version '1.0.9'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/notification/notification-rest-impl/src/main/java/com/liferay/notification/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/notification/notification-rest-impl/src/main/java/com/liferay/notification/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.notification.rest.client', and version '1.0.8'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.notification.rest.client', and version '1.0.9'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/notification/notification-rest-impl/src/main/java/com/liferay/notification/rest/internal/resource/v1_0/factory/NotificationQueueEntryResourceFactoryImpl.java
+++ b/modules/apps/notification/notification-rest-impl/src/main/java/com/liferay/notification/rest/internal/resource/v1_0/factory/NotificationQueueEntryResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	immediate = true, service = NotificationQueueEntryResource.Factory.class
+	immediate = true,
+	property = "resource.locator.key=/notification/v1.0/NotificationQueueEntry",
+	service = NotificationQueueEntryResource.Factory.class
 )
 @Generated("")
 public class NotificationQueueEntryResourceFactoryImpl

--- a/modules/apps/notification/notification-rest-impl/src/main/java/com/liferay/notification/rest/internal/resource/v1_0/factory/NotificationTemplateResourceFactoryImpl.java
+++ b/modules/apps/notification/notification-rest-impl/src/main/java/com/liferay/notification/rest/internal/resource/v1_0/factory/NotificationTemplateResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	immediate = true, service = NotificationTemplateResource.Factory.class
+	immediate = true,
+	property = "resource.locator.key=/notification/v1.0/NotificationTemplate",
+	service = NotificationTemplateResource.Factory.class
 )
 @Generated("")
 public class NotificationTemplateResourceFactoryImpl

--- a/modules/apps/object/object-admin-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-admin-rest-impl/rest-openapi.yaml
@@ -511,7 +511,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.object.admin.rest.client', and version '1.0.38'."
+        'com.liferay.object.admin.rest.client', and version '1.0.39'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.object.admin.rest.client', and version '1.0.38'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Object", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.object.admin.rest.client', and version '1.0.39'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Object", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/factory/ObjectActionResourceFactoryImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/factory/ObjectActionResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Javier Gamarra
  * @generated
  */
-@Component(immediate = true, service = ObjectActionResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/object-admin/v1.0/ObjectAction",
+	service = ObjectActionResource.Factory.class
+)
 @Generated("")
 public class ObjectActionResourceFactoryImpl
 	implements ObjectActionResource.Factory {

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/factory/ObjectDefinitionResourceFactoryImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/factory/ObjectDefinitionResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Javier Gamarra
  * @generated
  */
-@Component(immediate = true, service = ObjectDefinitionResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/object-admin/v1.0/ObjectDefinition",
+	service = ObjectDefinitionResource.Factory.class
+)
 @Generated("")
 public class ObjectDefinitionResourceFactoryImpl
 	implements ObjectDefinitionResource.Factory {

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/factory/ObjectFieldResourceFactoryImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/factory/ObjectFieldResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Javier Gamarra
  * @generated
  */
-@Component(immediate = true, service = ObjectFieldResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/object-admin/v1.0/ObjectField",
+	service = ObjectFieldResource.Factory.class
+)
 @Generated("")
 public class ObjectFieldResourceFactoryImpl
 	implements ObjectFieldResource.Factory {

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/factory/ObjectLayoutResourceFactoryImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/factory/ObjectLayoutResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Javier Gamarra
  * @generated
  */
-@Component(immediate = true, service = ObjectLayoutResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/object-admin/v1.0/ObjectLayout",
+	service = ObjectLayoutResource.Factory.class
+)
 @Generated("")
 public class ObjectLayoutResourceFactoryImpl
 	implements ObjectLayoutResource.Factory {

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/factory/ObjectRelationshipResourceFactoryImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/factory/ObjectRelationshipResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Javier Gamarra
  * @generated
  */
-@Component(immediate = true, service = ObjectRelationshipResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/object-admin/v1.0/ObjectRelationship",
+	service = ObjectRelationshipResource.Factory.class
+)
 @Generated("")
 public class ObjectRelationshipResourceFactoryImpl
 	implements ObjectRelationshipResource.Factory {

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/factory/ObjectValidationRuleResourceFactoryImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/factory/ObjectValidationRuleResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	immediate = true, service = ObjectValidationRuleResource.Factory.class
+	immediate = true,
+	property = "resource.locator.key=/object-admin/v1.0/ObjectValidationRule",
+	service = ObjectValidationRuleResource.Factory.class
 )
 @Generated("")
 public class ObjectValidationRuleResourceFactoryImpl

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/factory/ObjectViewResourceFactoryImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/factory/ObjectViewResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Javier Gamarra
  * @generated
  */
-@Component(immediate = true, service = ObjectViewResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/object-admin/v1.0/ObjectView",
+	service = ObjectViewResource.Factory.class
+)
 @Generated("")
 public class ObjectViewResourceFactoryImpl
 	implements ObjectViewResource.Factory {

--- a/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/resource/v1_0/factory/SuggestionResourceFactoryImpl.java
+++ b/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/resource/v1_0/factory/SuggestionResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Petteri Karttunen
  * @generated
  */
-@Component(immediate = true, service = SuggestionResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/portal-search-rest/v1.0/Suggestion",
+	service = SuggestionResource.Factory.class
+)
 @Generated("")
 public class SuggestionResourceFactoryImpl
 	implements SuggestionResource.Factory {

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/resource/ResourceLocator.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/resource/ResourceLocator.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.vulcan.resource;
+
+/**
+ * @author Shuyang Zhou
+ */
+public interface ResourceLocator {
+
+	public Object locate(String resourceName);
+
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/resource/ResourceLocator.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/resource/ResourceLocator.java
@@ -19,6 +19,6 @@ package com.liferay.portal.vulcan.resource;
  */
 public interface ResourceLocator {
 
-	public Object locate(String resourceLocatorKey);
+	public Object locate(String restContextPath, String resourceName);
 
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/resource/ResourceLocator.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/resource/ResourceLocator.java
@@ -19,6 +19,6 @@ package com.liferay.portal.vulcan.resource;
  */
 public interface ResourceLocator {
 
-	public Object locate(String resourceName);
+	public Object locate(String resourceLocatorKey);
 
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/resource/ResourceLocatorFactory.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/resource/ResourceLocatorFactory.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.vulcan.resource;
+
+import com.liferay.portal.kernel.model.User;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * @author Shuyang Zhou
+ */
+public interface ResourceLocatorFactory {
+
+	public ResourceLocator create(
+		HttpServletRequest httpServletRequest, User user);
+
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/resource/ResourceLocatorFactoryImpl.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/resource/ResourceLocatorFactoryImpl.java
@@ -16,6 +16,7 @@ package com.liferay.portal.vulcan.internal.resource;
 
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.User;
@@ -47,12 +48,12 @@ public class ResourceLocatorFactoryImpl implements ResourceLocatorFactory {
 		return new ResourceLocator() {
 
 			@Override
-			public Object locate(String resourceLocatorKey) {
+			public Object locate(String restContextPath, String resourceName) {
 				ServiceTrackerMap<String, Builder> serviceTrackerMap =
 					_getServiceTrackerMap();
 
 				Builder builder = serviceTrackerMap.getService(
-					resourceLocatorKey);
+					restContextPath + StringPool.SLASH + resourceName);
 
 				if (builder == null) {
 					return null;

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/resource/ResourceLocatorFactoryImpl.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/resource/ResourceLocatorFactoryImpl.java
@@ -1,0 +1,244 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.vulcan.internal.resource;
+
+import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
+import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.vulcan.resource.ResourceLocator;
+import com.liferay.portal.vulcan.resource.ResourceLocatorFactory;
+
+import java.lang.reflect.Method;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.util.tracker.ServiceTrackerCustomizer;
+
+/**
+ * @author Shuyang Zhou
+ */
+@Component(service = ResourceLocatorFactory.class)
+public class ResourceLocatorFactoryImpl implements ResourceLocatorFactory {
+
+	@Override
+	public ResourceLocator create(
+		HttpServletRequest httpServletRequest, User user) {
+
+		return new ResourceLocator() {
+
+			@Override
+			public Object locate(String resourceName) {
+				ServiceTrackerMap<String, Builder> serviceTrackerMap =
+					_getServiceTrackerMap();
+
+				Builder builder = serviceTrackerMap.getService(resourceName);
+
+				if (builder == null) {
+					return null;
+				}
+
+				return builder.build(httpServletRequest, user);
+			}
+
+		};
+	}
+
+	@Activate
+	protected void activate(BundleContext bundleContext) {
+		_bundleContext = bundleContext;
+	}
+
+	@Deactivate
+	protected synchronized void deactivate() {
+		ServiceTrackerMap<String, Builder> serviceTrackerMap =
+			_serviceTrackerMap;
+
+		if (serviceTrackerMap != null) {
+			serviceTrackerMap.close();
+		}
+	}
+
+	private ServiceTrackerMap<String, Builder> _getServiceTrackerMap() {
+		ServiceTrackerMap<String, Builder> serviceTrackerMap =
+			_serviceTrackerMap;
+
+		if (serviceTrackerMap != null) {
+			return _serviceTrackerMap;
+		}
+
+		synchronized (this) {
+			if (_serviceTrackerMap != null) {
+				return _serviceTrackerMap;
+			}
+
+			serviceTrackerMap = ServiceTrackerMapFactory.openSingleValueMap(
+				_bundleContext, null, "(component.name=*)",
+				(serviceReference, emitter) -> {
+					String componentName = (String)serviceReference.getProperty(
+						"component.name");
+
+					if (!componentName.endsWith("ResourceFactoryImpl")) {
+						return;
+					}
+
+					Object service = _bundleContext.getService(
+						serviceReference);
+
+					try {
+						Class<?> clazz = service.getClass();
+
+						Class<?>[] interfaces = clazz.getInterfaces();
+
+						if (interfaces.length != 1) {
+							return;
+						}
+
+						Class<?> interfaceClazz = interfaces[0];
+
+						String interfaceName = interfaceClazz.getName();
+
+						if (!interfaceName.endsWith("Resource$Factory")) {
+							return;
+						}
+
+						Class<?> resourceInterface =
+							interfaceClazz.getEnclosingClass();
+
+						emitter.emit(resourceInterface.getName());
+					}
+					finally {
+						_bundleContext.ungetService(serviceReference);
+					}
+				},
+				new ServiceTrackerCustomizer<Object, Builder>() {
+
+					@Override
+					public Builder addingService(
+						ServiceReference<Object> serviceReference) {
+
+						Object factoryImpl = _bundleContext.getService(
+							serviceReference);
+
+						Class<?> resourceFactoryImplClass =
+							factoryImpl.getClass();
+
+						try {
+							Method createMethod =
+								resourceFactoryImplClass.getMethod("create");
+
+							Class<?> resourceBuilderInterface =
+								createMethod.getReturnType();
+
+							return new Builder(
+								factoryImpl, createMethod,
+								resourceBuilderInterface.getMethod("build"),
+								resourceBuilderInterface.getMethod(
+									"httpServletRequest",
+									HttpServletRequest.class),
+								resourceBuilderInterface.getMethod(
+									"user", User.class));
+						}
+						catch (NoSuchMethodException noSuchMethodException) {
+							_log.error(noSuchMethodException);
+
+							return null;
+						}
+					}
+
+					@Override
+					public void modifiedService(
+						ServiceReference<Object> serviceReference,
+						Builder builder) {
+					}
+
+					@Override
+					public void removedService(
+						ServiceReference<Object> serviceReference,
+						Builder builder) {
+
+						_bundleContext.ungetService(serviceReference);
+					}
+
+				});
+
+			_serviceTrackerMap = serviceTrackerMap;
+		}
+
+		return serviceTrackerMap;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		ResourceLocatorFactoryImpl.class);
+
+	private BundleContext _bundleContext;
+	private volatile ServiceTrackerMap<String, Builder> _serviceTrackerMap;
+
+	private static class Builder {
+
+		public Object build(HttpServletRequest httpServletRequest, User user) {
+			try {
+				Object builder = _createMethod.invoke(_factoryImpl);
+
+				if (httpServletRequest != null) {
+					_httpServletRequestMethod.invoke(
+						builder, httpServletRequest);
+				}
+
+				if (user != null) {
+					_userMethod.invoke(builder, user);
+				}
+
+				return _buildMethod.invoke(builder);
+			}
+			catch (ReflectiveOperationException reflectiveOperationException) {
+				_log.error(reflectiveOperationException);
+
+				return null;
+			}
+		}
+
+		private Builder(
+			Object factoryImpl, Method createMethod, Method buildMethod,
+			Method httpServletRequestMethod, Method userMethod) {
+
+			_factoryImpl = factoryImpl;
+
+			_createMethod = createMethod;
+			_buildMethod = buildMethod;
+			_httpServletRequestMethod = httpServletRequestMethod;
+			_userMethod = userMethod;
+
+			_createMethod.setAccessible(true);
+			_buildMethod.setAccessible(true);
+			_httpServletRequestMethod.setAccessible(true);
+			_userMethod.setAccessible(true);
+		}
+
+		private final Method _buildMethod;
+		private final Method _createMethod;
+		private final Object _factoryImpl;
+		private final Method _httpServletRequestMethod;
+		private final Method _userMethod;
+
+	}
+
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/resource/ResourceLocatorFactoryImpl.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/resource/ResourceLocatorFactoryImpl.java
@@ -35,6 +35,7 @@ import org.osgi.util.tracker.ServiceTrackerCustomizer;
 
 /**
  * @author Shuyang Zhou
+ * @author Alejandro Tardín
  */
 @Component(service = ResourceLocatorFactory.class)
 public class ResourceLocatorFactoryImpl implements ResourceLocatorFactory {
@@ -46,11 +47,12 @@ public class ResourceLocatorFactoryImpl implements ResourceLocatorFactory {
 		return new ResourceLocator() {
 
 			@Override
-			public Object locate(String resourceName) {
+			public Object locate(String resourceLocatorKey) {
 				ServiceTrackerMap<String, Builder> serviceTrackerMap =
 					_getServiceTrackerMap();
 
-				Builder builder = serviceTrackerMap.getService(resourceName);
+				Builder builder = serviceTrackerMap.getService(
+					resourceLocatorKey);
 
 				if (builder == null) {
 					return null;
@@ -91,44 +93,7 @@ public class ResourceLocatorFactoryImpl implements ResourceLocatorFactory {
 			}
 
 			serviceTrackerMap = ServiceTrackerMapFactory.openSingleValueMap(
-				_bundleContext, null, "(component.name=*)",
-				(serviceReference, emitter) -> {
-					String componentName = (String)serviceReference.getProperty(
-						"component.name");
-
-					if (!componentName.endsWith("ResourceFactoryImpl")) {
-						return;
-					}
-
-					Object service = _bundleContext.getService(
-						serviceReference);
-
-					try {
-						Class<?> clazz = service.getClass();
-
-						Class<?>[] interfaces = clazz.getInterfaces();
-
-						if (interfaces.length != 1) {
-							return;
-						}
-
-						Class<?> interfaceClazz = interfaces[0];
-
-						String interfaceName = interfaceClazz.getName();
-
-						if (!interfaceName.endsWith("Resource$Factory")) {
-							return;
-						}
-
-						Class<?> resourceInterface =
-							interfaceClazz.getEnclosingClass();
-
-						emitter.emit(resourceInterface.getName());
-					}
-					finally {
-						_bundleContext.ungetService(serviceReference);
-					}
-				},
+				_bundleContext, null, "resource.locator.key",
 				new ServiceTrackerCustomizer<Object, Builder>() {
 
 					@Override

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/template/ResourceTemplateContextContributor.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/template/ResourceTemplateContextContributor.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.vulcan.internal.template;
+
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.template.TemplateContextContributor;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.vulcan.resource.ResourceLocator;
+import com.liferay.portal.vulcan.resource.ResourceLocatorFactory;
+
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Shuyang Zhou
+ */
+@Component(
+	property = "type=" + TemplateContextContributor.TYPE_GLOBAL,
+	service = TemplateContextContributor.class
+)
+public class ResourceTemplateContextContributor
+	implements TemplateContextContributor {
+
+	@Override
+	public void prepare(
+		Map<String, Object> contextObjects,
+		HttpServletRequest httpServletRequest) {
+
+		try {
+			User user = _portal.getUser(httpServletRequest);
+
+			if (user == null) {
+				user = _userLocalService.getDefaultUser(
+					_portal.getCompanyId(httpServletRequest));
+			}
+
+			ResourceLocator resourceLocator = _resourceLocatorFactory.create(
+				httpServletRequest, user);
+
+			contextObjects.put("resourceLocator", resourceLocator);
+		}
+		catch (PortalException portalException) {
+			_log.error(portalException);
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		ResourceTemplateContextContributor.class);
+
+	@Reference
+	private Portal _portal;
+
+	@Reference
+	private ResourceLocatorFactory _resourceLocatorFactory;
+
+	@Reference
+	private UserLocalService _userLocalService;
+
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-test/build.gradle
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/build.gradle
@@ -3,6 +3,7 @@ dependencies {
 	testIntegrationCompile group: "javax.ws.rs", name: "javax.ws.rs-api", version: "2.1"
 	testIntegrationCompile group: "org.apache.cxf", name: "cxf-core", version: "3.4.4"
 	testIntegrationCompile group: "org.apache.cxf", name: "cxf-rt-frontend-jaxrs", version: "3.4.4"
+	testIntegrationCompile group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	testIntegrationCompile group: "org.springframework", name: "spring-test", version: "5.2.22.RELEASE"
 	testIntegrationCompile project(":apps:portal-odata:portal-odata-api")
 	testIntegrationCompile project(":apps:portal-vulcan:portal-vulcan-api")

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/resource/test/ResourceLocatorFactoryTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/resource/test/ResourceLocatorFactoryTest.java
@@ -69,7 +69,7 @@ public class ResourceLocatorFactoryTest {
 			ResourceLocator resourceLocator = _resourceLocatorFactory.create(
 				httpServletRequest, user);
 
-			Object testResource = resourceLocator.locate("/test/v1.0/Test");
+			Object testResource = resourceLocator.locate("/test/v1.0", "Test");
 
 			Assert.assertSame(TestResourceImpl.class, testResource.getClass());
 

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/resource/test/ResourceLocatorFactoryTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/resource/test/ResourceLocatorFactoryTest.java
@@ -58,7 +58,7 @@ public class ResourceLocatorFactoryTest {
 			bundleContext.registerService(
 				TestResource.Factory.class, new TestResourceFactoryImpl(),
 				MapUtil.singletonDictionary(
-					"component.name", TestResourceFactoryImpl.class.getName()));
+					"resource.locator.key", "/test/v1.0/Test"));
 
 		try {
 			HttpServletRequest httpServletRequest =
@@ -69,8 +69,7 @@ public class ResourceLocatorFactoryTest {
 			ResourceLocator resourceLocator = _resourceLocatorFactory.create(
 				httpServletRequest, user);
 
-			Object testResource = resourceLocator.locate(
-				TestResource.class.getName());
+			Object testResource = resourceLocator.locate("/test/v1.0/Test");
 
 			Assert.assertSame(TestResourceImpl.class, testResource.getClass());
 

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/resource/test/ResourceLocatorFactoryTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/resource/test/ResourceLocatorFactoryTest.java
@@ -1,0 +1,162 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.vulcan.internal.resource.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.ProxyFactory;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.vulcan.resource.ResourceLocator;
+import com.liferay.portal.vulcan.resource.ResourceLocatorFactory;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceRegistration;
+
+/**
+ * @author Shuyang Zhou
+ */
+@RunWith(Arquillian.class)
+public class ResourceLocatorFactoryTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testResourceLocator() {
+		Bundle bundle = FrameworkUtil.getBundle(
+			ResourceLocatorFactoryTest.class);
+
+		BundleContext bundleContext = bundle.getBundleContext();
+
+		ServiceRegistration<?> serviceRegistration =
+			bundleContext.registerService(
+				TestResource.Factory.class, new TestResourceFactoryImpl(),
+				MapUtil.singletonDictionary(
+					"component.name", TestResourceFactoryImpl.class.getName()));
+
+		try {
+			HttpServletRequest httpServletRequest =
+				ProxyFactory.newDummyInstance(HttpServletRequest.class);
+
+			User user = ProxyFactory.newDummyInstance(User.class);
+
+			ResourceLocator resourceLocator = _resourceLocatorFactory.create(
+				httpServletRequest, user);
+
+			Object testResource = resourceLocator.locate(
+				TestResource.class.getName());
+
+			Assert.assertSame(TestResourceImpl.class, testResource.getClass());
+
+			TestResourceImpl testResourceImpl = (TestResourceImpl)testResource;
+
+			Assert.assertSame(
+				httpServletRequest, testResourceImpl._httpServletRequest);
+			Assert.assertSame(user, testResourceImpl._user);
+		}
+		finally {
+			serviceRegistration.unregister();
+		}
+	}
+
+	@Inject
+	private ResourceLocatorFactory _resourceLocatorFactory;
+
+	private static class TestResourceFactoryImpl
+		implements TestResource.Factory {
+
+		@Override
+		public TestResource.Builder create() {
+			return new TestResource.Builder() {
+
+				@Override
+				public TestResource build() {
+					return new TestResourceImpl(_httpServletRequest, _user);
+				}
+
+				@Override
+				public TestResource.Builder httpServletRequest(
+					HttpServletRequest httpServletRequest) {
+
+					_httpServletRequest = httpServletRequest;
+
+					return this;
+				}
+
+				@Override
+				public TestResource.Builder user(User user) {
+					_user = user;
+
+					return this;
+				}
+
+				private HttpServletRequest _httpServletRequest;
+				private User _user;
+
+			};
+		}
+
+	}
+
+	private static class TestResourceImpl implements TestResource {
+
+		private TestResourceImpl(
+			HttpServletRequest httpServletRequest, User user) {
+
+			_httpServletRequest = httpServletRequest;
+			_user = user;
+		}
+
+		private final HttpServletRequest _httpServletRequest;
+		private final User _user;
+
+	}
+
+	private interface TestResource {
+
+		public interface Builder {
+
+			public TestResource build();
+
+			public Builder httpServletRequest(
+				HttpServletRequest httpServletRequest);
+
+			public Builder user(User user);
+
+		}
+
+		public interface Factory {
+
+			public Builder create();
+
+		}
+
+	}
+
+}

--- a/modules/core/osgi-service-tracker-collections/src/main/java/com/liferay/osgi/service/tracker/collections/internal/map/ServiceTrackerMapImpl.java
+++ b/modules/core/osgi-service-tracker-collections/src/main/java/com/liferay/osgi/service/tracker/collections/internal/map/ServiceTrackerMapImpl.java
@@ -57,7 +57,12 @@ public class ServiceTrackerMapImpl<K, SR, TS, R>
 			bundleContext, clazz, filterString,
 			new ServiceReferenceServiceTrackerCustomizer());
 
-		_serviceTracker.open();
+		if (clazz == null) {
+			_serviceTracker.open(true);
+		}
+		else {
+			_serviceTracker.open();
+		}
 	}
 
 	@Override

--- a/modules/dxp/apps/commerce-punchout/headless/headless-commerce-punchout-impl/src/main/java/com/liferay/headless/commerce/punchout/internal/resource/v1_0/factory/PunchOutSessionResourceFactoryImpl.java
+++ b/modules/dxp/apps/commerce-punchout/headless/headless-commerce-punchout-impl/src/main/java/com/liferay/headless/commerce/punchout/internal/resource/v1_0/factory/PunchOutSessionResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-punchout/v1.0/PunchOutSession",
 	service = PunchOutSessionResource.Factory.class
 )
 @Generated("")

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/factory/AccountCategoryForecastResourceFactoryImpl.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/factory/AccountCategoryForecastResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-machine-learning/v1.0/AccountCategoryForecast",
 	service = AccountCategoryForecastResource.Factory.class
 )
 @Generated("")

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/factory/AccountForecastResourceFactoryImpl.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/factory/AccountForecastResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-machine-learning/v1.0/AccountForecast",
 	service = AccountForecastResource.Factory.class
 )
 @Generated("")

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/factory/SkuForecastResourceFactoryImpl.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/factory/SkuForecastResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	enabled = false, immediate = true,
+	property = "resource.locator.key=/headless-commerce-machine-learning/v1.0/SkuForecast",
 	service = SkuForecastResource.Factory.class
 )
 @Generated("")

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/factory/AssigneeMetricResourceFactoryImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/factory/AssigneeMetricResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Rafael Praxedes
  * @generated
  */
-@Component(immediate = true, service = AssigneeMetricResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/portal-workflow-metrics/v1.0/AssigneeMetric",
+	service = AssigneeMetricResource.Factory.class
+)
 @Generated("")
 public class AssigneeMetricResourceFactoryImpl
 	implements AssigneeMetricResource.Factory {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/factory/AssigneeResourceFactoryImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/factory/AssigneeResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Rafael Praxedes
  * @generated
  */
-@Component(immediate = true, service = AssigneeResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/portal-workflow-metrics/v1.0/Assignee",
+	service = AssigneeResource.Factory.class
+)
 @Generated("")
 public class AssigneeResourceFactoryImpl implements AssigneeResource.Factory {
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/factory/CalendarResourceFactoryImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/factory/CalendarResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Rafael Praxedes
  * @generated
  */
-@Component(immediate = true, service = CalendarResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/portal-workflow-metrics/v1.0/Calendar",
+	service = CalendarResource.Factory.class
+)
 @Generated("")
 public class CalendarResourceFactoryImpl implements CalendarResource.Factory {
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/factory/HistogramMetricResourceFactoryImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/factory/HistogramMetricResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Rafael Praxedes
  * @generated
  */
-@Component(immediate = true, service = HistogramMetricResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/portal-workflow-metrics/v1.0/HistogramMetric",
+	service = HistogramMetricResource.Factory.class
+)
 @Generated("")
 public class HistogramMetricResourceFactoryImpl
 	implements HistogramMetricResource.Factory {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/factory/IndexResourceFactoryImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/factory/IndexResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Rafael Praxedes
  * @generated
  */
-@Component(immediate = true, service = IndexResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/portal-workflow-metrics/v1.0/Index",
+	service = IndexResource.Factory.class
+)
 @Generated("")
 public class IndexResourceFactoryImpl implements IndexResource.Factory {
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/factory/InstanceResourceFactoryImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/factory/InstanceResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Rafael Praxedes
  * @generated
  */
-@Component(immediate = true, service = InstanceResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/portal-workflow-metrics/v1.0/Instance",
+	service = InstanceResource.Factory.class
+)
 @Generated("")
 public class InstanceResourceFactoryImpl implements InstanceResource.Factory {
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/factory/NodeMetricResourceFactoryImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/factory/NodeMetricResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Rafael Praxedes
  * @generated
  */
-@Component(immediate = true, service = NodeMetricResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/portal-workflow-metrics/v1.0/NodeMetric",
+	service = NodeMetricResource.Factory.class
+)
 @Generated("")
 public class NodeMetricResourceFactoryImpl
 	implements NodeMetricResource.Factory {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/factory/NodeResourceFactoryImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/factory/NodeResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Rafael Praxedes
  * @generated
  */
-@Component(immediate = true, service = NodeResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/portal-workflow-metrics/v1.0/Node",
+	service = NodeResource.Factory.class
+)
 @Generated("")
 public class NodeResourceFactoryImpl implements NodeResource.Factory {
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/factory/ProcessMetricResourceFactoryImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/factory/ProcessMetricResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Rafael Praxedes
  * @generated
  */
-@Component(immediate = true, service = ProcessMetricResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/portal-workflow-metrics/v1.0/ProcessMetric",
+	service = ProcessMetricResource.Factory.class
+)
 @Generated("")
 public class ProcessMetricResourceFactoryImpl
 	implements ProcessMetricResource.Factory {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/factory/ProcessResourceFactoryImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/factory/ProcessResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Rafael Praxedes
  * @generated
  */
-@Component(immediate = true, service = ProcessResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/portal-workflow-metrics/v1.0/Process",
+	service = ProcessResource.Factory.class
+)
 @Generated("")
 public class ProcessResourceFactoryImpl implements ProcessResource.Factory {
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/factory/ProcessVersionResourceFactoryImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/factory/ProcessVersionResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Rafael Praxedes
  * @generated
  */
-@Component(immediate = true, service = ProcessVersionResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/portal-workflow-metrics/v1.0/ProcessVersion",
+	service = ProcessVersionResource.Factory.class
+)
 @Generated("")
 public class ProcessVersionResourceFactoryImpl
 	implements ProcessVersionResource.Factory {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/factory/ReindexStatusResourceFactoryImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/factory/ReindexStatusResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Rafael Praxedes
  * @generated
  */
-@Component(immediate = true, service = ReindexStatusResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/portal-workflow-metrics/v1.0/ReindexStatus",
+	service = ReindexStatusResource.Factory.class
+)
 @Generated("")
 public class ReindexStatusResourceFactoryImpl
 	implements ReindexStatusResource.Factory {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/factory/RoleResourceFactoryImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/factory/RoleResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Rafael Praxedes
  * @generated
  */
-@Component(immediate = true, service = RoleResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/portal-workflow-metrics/v1.0/Role",
+	service = RoleResource.Factory.class
+)
 @Generated("")
 public class RoleResourceFactoryImpl implements RoleResource.Factory {
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/factory/SLAResourceFactoryImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/factory/SLAResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Rafael Praxedes
  * @generated
  */
-@Component(immediate = true, service = SLAResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/portal-workflow-metrics/v1.0/SLA",
+	service = SLAResource.Factory.class
+)
 @Generated("")
 public class SLAResourceFactoryImpl implements SLAResource.Factory {
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/factory/SLAResultResourceFactoryImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/factory/SLAResultResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Rafael Praxedes
  * @generated
  */
-@Component(immediate = true, service = SLAResultResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/portal-workflow-metrics/v1.0/SLAResult",
+	service = SLAResultResource.Factory.class
+)
 @Generated("")
 public class SLAResultResourceFactoryImpl implements SLAResultResource.Factory {
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/factory/TaskResourceFactoryImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/factory/TaskResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Rafael Praxedes
  * @generated
  */
-@Component(immediate = true, service = TaskResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/portal-workflow-metrics/v1.0/Task",
+	service = TaskResource.Factory.class
+)
 @Generated("")
 public class TaskResourceFactoryImpl implements TaskResource.Factory {
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/factory/TimeRangeResourceFactoryImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/factory/TimeRangeResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Rafael Praxedes
  * @generated
  */
-@Component(immediate = true, service = TimeRangeResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/portal-workflow-metrics/v1.0/TimeRange",
+	service = TimeRangeResource.Factory.class
+)
 @Generated("")
 public class TimeRangeResourceFactoryImpl implements TimeRangeResource.Factory {
 

--- a/modules/dxp/apps/saml/saml-admin-rest-impl/src/main/java/com/liferay/saml/admin/rest/internal/resource/v1_0/factory/SamlProviderResourceFactoryImpl.java
+++ b/modules/dxp/apps/saml/saml-admin-rest-impl/src/main/java/com/liferay/saml/admin/rest/internal/resource/v1_0/factory/SamlProviderResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Stian Sigvartsen
  * @generated
  */
-@Component(immediate = true, service = SamlProviderResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/saml-admin/v1.0/SamlProvider",
+	service = SamlProviderResource.Factory.class
+)
 @Generated("")
 public class SamlProviderResourceFactoryImpl
 	implements SamlProviderResource.Factory {

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/factory/FieldMappingInfoResourceFactoryImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/factory/FieldMappingInfoResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Brian Wing Shun Chan
  * @generated
  */
-@Component(immediate = true, service = FieldMappingInfoResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/search-experiences-rest/v1.0/FieldMappingInfo",
+	service = FieldMappingInfoResource.Factory.class
+)
 @Generated("")
 public class FieldMappingInfoResourceFactoryImpl
 	implements FieldMappingInfoResource.Factory {

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/factory/KeywordQueryContributorResourceFactoryImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/factory/KeywordQueryContributorResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	immediate = true, service = KeywordQueryContributorResource.Factory.class
+	immediate = true,
+	property = "resource.locator.key=/search-experiences-rest/v1.0/KeywordQueryContributor",
+	service = KeywordQueryContributorResource.Factory.class
 )
 @Generated("")
 public class KeywordQueryContributorResourceFactoryImpl

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/factory/ModelPrefilterContributorResourceFactoryImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/factory/ModelPrefilterContributorResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	immediate = true, service = ModelPrefilterContributorResource.Factory.class
+	immediate = true,
+	property = "resource.locator.key=/search-experiences-rest/v1.0/ModelPrefilterContributor",
+	service = ModelPrefilterContributorResource.Factory.class
 )
 @Generated("")
 public class ModelPrefilterContributorResourceFactoryImpl

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/factory/QueryPrefilterContributorResourceFactoryImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/factory/QueryPrefilterContributorResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	immediate = true, service = QueryPrefilterContributorResource.Factory.class
+	immediate = true,
+	property = "resource.locator.key=/search-experiences-rest/v1.0/QueryPrefilterContributor",
+	service = QueryPrefilterContributorResource.Factory.class
 )
 @Generated("")
 public class QueryPrefilterContributorResourceFactoryImpl

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/factory/SXPBlueprintResourceFactoryImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/factory/SXPBlueprintResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Brian Wing Shun Chan
  * @generated
  */
-@Component(immediate = true, service = SXPBlueprintResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/search-experiences-rest/v1.0/SXPBlueprint",
+	service = SXPBlueprintResource.Factory.class
+)
 @Generated("")
 public class SXPBlueprintResourceFactoryImpl
 	implements SXPBlueprintResource.Factory {

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/factory/SXPElementResourceFactoryImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/factory/SXPElementResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Brian Wing Shun Chan
  * @generated
  */
-@Component(immediate = true, service = SXPElementResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/search-experiences-rest/v1.0/SXPElement",
+	service = SXPElementResource.Factory.class
+)
 @Generated("")
 public class SXPElementResourceFactoryImpl
 	implements SXPElementResource.Factory {

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/factory/SXPParameterContributorDefinitionResourceFactoryImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/factory/SXPParameterContributorDefinitionResourceFactoryImpl.java
@@ -64,6 +64,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  */
 @Component(
 	immediate = true,
+	property = "resource.locator.key=/search-experiences-rest/v1.0/SXPParameterContributorDefinition",
 	service = SXPParameterContributorDefinitionResource.Factory.class
 )
 @Generated("")

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/factory/SearchResponseResourceFactoryImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/factory/SearchResponseResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Brian Wing Shun Chan
  * @generated
  */
-@Component(immediate = true, service = SearchResponseResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/search-experiences-rest/v1.0/SearchResponse",
+	service = SearchResponseResource.Factory.class
+)
 @Generated("")
 public class SearchResponseResourceFactoryImpl
 	implements SearchResponseResource.Factory {

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/factory/SearchableAssetNameDisplayResourceFactoryImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/factory/SearchableAssetNameDisplayResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	immediate = true, service = SearchableAssetNameDisplayResource.Factory.class
+	immediate = true,
+	property = "resource.locator.key=/search-experiences-rest/v1.0/SearchableAssetNameDisplay",
+	service = SearchableAssetNameDisplayResource.Factory.class
 )
 @Generated("")
 public class SearchableAssetNameDisplayResourceFactoryImpl

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/factory/SearchableAssetNameResourceFactoryImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/factory/SearchableAssetNameResourceFactoryImpl.java
@@ -63,7 +63,9 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	immediate = true, service = SearchableAssetNameResource.Factory.class
+	immediate = true,
+	property = "resource.locator.key=/search-experiences-rest/v1.0/SearchableAssetName",
+	service = SearchableAssetNameResource.Factory.class
 )
 @Generated("")
 public class SearchableAssetNameResourceFactoryImpl

--- a/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/factory/ExperimentResourceFactoryImpl.java
+++ b/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/factory/ExperimentResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Javier Gamarra
  * @generated
  */
-@Component(immediate = true, service = ExperimentResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/segments-asah/v1.0/Experiment",
+	service = ExperimentResource.Factory.class
+)
 @Generated("")
 public class ExperimentResourceFactoryImpl
 	implements ExperimentResource.Factory {

--- a/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/factory/ExperimentRunResourceFactoryImpl.java
+++ b/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/factory/ExperimentRunResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Javier Gamarra
  * @generated
  */
-@Component(immediate = true, service = ExperimentRunResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/segments-asah/v1.0/ExperimentRun",
+	service = ExperimentRunResource.Factory.class
+)
 @Generated("")
 public class ExperimentRunResourceFactoryImpl
 	implements ExperimentRunResource.Factory {

--- a/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/factory/StatusResourceFactoryImpl.java
+++ b/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/factory/StatusResourceFactoryImpl.java
@@ -62,7 +62,11 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author Javier Gamarra
  * @generated
  */
-@Component(immediate = true, service = StatusResource.Factory.class)
+@Component(
+	immediate = true,
+	property = "resource.locator.key=/segments-asah/v1.0/Status",
+	service = StatusResource.Factory.class
+)
 @Generated("")
 public class StatusResourceFactoryImpl implements StatusResource.Factory {
 

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/resource_factory_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/resource_factory_impl.ftl
@@ -50,7 +50,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @author ${configYAML.author}
  * @generated
  */
-@Component(<#if configYAML.liferayEnterpriseApp>enabled = false,</#if> immediate = true, service = ${schemaName}Resource.Factory.class)
+@Component(<#if configYAML.liferayEnterpriseApp>enabled = false,</#if> immediate = true, service = ${schemaName}Resource.Factory.class,property="resource.locator.key=${configYAML.application.baseURI}/${openAPIYAML.info.version}/${schemaName}")
 @Generated("")
 public class ${schemaName}ResourceFactoryImpl implements ${schemaName}Resource.Factory {
 


### PR DESCRIPTION
With these changes we can inject headless resources into templates. 

```
${resourceLocator.locate("/headless-delivery/v1.0", "BlogPosting").getBlogPosting(44505)}
```

To test it:

1. Go to `Design -> Templates -> Widget Templates`
2. Create a `Blogs Template`.
3. Add the Blogs Widget to the page.
4. In the configuration of the widget, under `Display Template`, select the template created in step 2.
5. Create a blog entry and copy its id.
6. Edit the template from step 2 and add this:
```
${resourceLocator.locate("/headless-delivery/v1.0", "BlogPosting").getBlogPosting(<the id from step 5>)}
```
7. Render the homepage and you should see the json:
<img width="850" alt="Screenshot 2022-10-07 at 14 31 22" src="https://user-images.githubusercontent.com/1937354/194553868-706f527d-8e3e-4390-a30a-ffed374b2616.png">

**Pending things:**
1. Objects support. We will create a separate ticket for it and plan it for the future.

