### PR TITLE
LPS-165222 Avoid calling toEntityModel()/toCacheModel() in MVCCSynchr…

### DIFF
--- a/modules/apps/portal-cache/portal-cache-impl/src/main/java/com/liferay/portal/cache/internal/dao/orm/EntityCacheImpl.java
+++ b/modules/apps/portal-cache/portal-cache-impl/src/main/java/com/liferay/portal/cache/internal/dao/orm/EntityCacheImpl.java
@@ -100,6 +100,22 @@ public class EntityCacheImpl
 	}
 
 	@Override
+	public Serializable getLocalCacheResult(
+		Class<?> clazz, Serializable primaryKey) {
+
+		if (_isLocalCacheEnabled()) {
+			Map<Serializable, Serializable> localCache = _localCache.get();
+
+			Serializable localCacheKey = new LocalCacheKey(
+				clazz.getName(), primaryKey);
+
+			return localCache.get(localCacheKey);
+		}
+
+		return null;
+	}
+
+	@Override
 	public PortalCache<Serializable, Serializable> getPortalCache(
 		Class<?> clazz) {
 

--- a/portal-kernel/bnd.bnd
+++ b/portal-kernel/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 79.0.1
+Bundle-Version: 79.1.0
 Export-Package:\
 	!com.liferay.portal.kernel.internal.*,\
 	!com.liferay.portal.kernel.module.util,\

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/orm/EntityCache.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/orm/EntityCache.java
@@ -33,6 +33,9 @@ public interface EntityCache {
 
 	public void clearLocalCache();
 
+	public Serializable getLocalCacheResult(
+		Class<?> clazz, Serializable primaryKey);
+
 	public PortalCache<Serializable, Serializable> getPortalCache(
 		Class<?> clazz);
 

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/orm/EntityCacheUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/orm/EntityCacheUtil.java
@@ -41,6 +41,12 @@ public class EntityCacheUtil {
 		return _entityCache;
 	}
 
+	public static Serializable getLocalCacheResult(
+		Class<?> clazz, Serializable primaryKey) {
+
+		return _entityCache.getLocalCacheResult(clazz, primaryKey);
+	}
+
 	public static PortalCache<Serializable, Serializable> getPortalCache(
 		Class<?> clazz) {
 

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/orm/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/orm/packageinfo
@@ -1,1 +1,1 @@
-version 11.0.0
+version 11.1.0


### PR DESCRIPTION
…onizerPostUpdateEventListener which would cause service calls with db modification that further leads to ConcurrentModificationException in hibernate ActionQueue