### PR TITLE
LPS-152126 Changes to existing SAML modules (Exception naming & sort)

### DIFF
--- a/modules/dxp/apps/saml/saml-api/bnd.bnd
+++ b/modules/dxp/apps/saml/saml-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay SAML API
 Bundle-SymbolicName: com.liferay.saml.api
-Bundle-Version: 6.0.14
+Bundle-Version: 6.1.0
 Export-Package:\
 	com.liferay.saml.constants,\
 	com.liferay.saml.runtime,\

--- a/modules/dxp/apps/saml/saml-api/src/main/java/com/liferay/saml/runtime/exception/CredentialAuthException.java
+++ b/modules/dxp/apps/saml/saml-api/src/main/java/com/liferay/saml/runtime/exception/CredentialAuthException.java
@@ -31,17 +31,6 @@ public class CredentialAuthException extends SecurityException {
 			generalSecurityException);
 	}
 
-	public static class InvalidKeyStore
-		extends CredentialAuthException {
-
-		public InvalidKeyStore(
-			String message, GeneralSecurityException generalSecurityException) {
-
-			super(message, generalSecurityException);
-		}
-
-	}
-
 	public static class InvalidCredentialPassword
 		extends CredentialAuthException {
 
@@ -50,6 +39,16 @@ public class CredentialAuthException extends SecurityException {
 			UnrecoverableKeyException unrecoverableKeyException) {
 
 			super(message, unrecoverableKeyException);
+		}
+
+	}
+
+	public static class InvalidKeyStore extends CredentialAuthException {
+
+		public InvalidKeyStore(
+			String message, GeneralSecurityException generalSecurityException) {
+
+			super(message, generalSecurityException);
 		}
 
 	}

--- a/modules/dxp/apps/saml/saml-api/src/main/java/com/liferay/saml/runtime/exception/CredentialAuthException.java
+++ b/modules/dxp/apps/saml/saml-api/src/main/java/com/liferay/saml/runtime/exception/CredentialAuthException.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.saml.runtime.exception;
+
+import java.security.GeneralSecurityException;
+import java.security.UnrecoverableKeyException;
+
+/**
+ * @author Stian Sigvartsen
+ */
+public class CredentialAuthException extends SecurityException {
+
+	public CredentialAuthException(
+		String message, GeneralSecurityException generalSecurityException) {
+
+		super(
+			String.format(
+				"%s. %s", message, generalSecurityException.getMessage()),
+			generalSecurityException);
+	}
+
+	public static class CannotLoadKeyStore extends CredentialAuthException {
+
+		public CannotLoadKeyStore(
+			String message, GeneralSecurityException generalSecurityException) {
+
+			super(message, generalSecurityException);
+		}
+
+	}
+
+	public static class CredentialPasswordIncorrect
+		extends CredentialAuthException {
+
+		public CredentialPasswordIncorrect(
+			String message,
+			UnrecoverableKeyException unrecoverableKeyException) {
+
+			super(message, unrecoverableKeyException);
+		}
+
+	}
+
+	public static class KeyStorePasswordIncorrect
+		extends CredentialAuthException {
+
+		public KeyStorePasswordIncorrect(
+			String message,
+			UnrecoverableKeyException unrecoverableKeyException) {
+
+			super(message, unrecoverableKeyException);
+		}
+
+	}
+
+}

--- a/modules/dxp/apps/saml/saml-api/src/main/java/com/liferay/saml/runtime/exception/CredentialAuthException.java
+++ b/modules/dxp/apps/saml/saml-api/src/main/java/com/liferay/saml/runtime/exception/CredentialAuthException.java
@@ -31,9 +31,10 @@ public class CredentialAuthException extends SecurityException {
 			generalSecurityException);
 	}
 
-	public static class CannotLoadKeyStore extends CredentialAuthException {
+	public static class InvalidKeyStore
+		extends CredentialAuthException {
 
-		public CannotLoadKeyStore(
+		public InvalidKeyStore(
 			String message, GeneralSecurityException generalSecurityException) {
 
 			super(message, generalSecurityException);
@@ -41,10 +42,10 @@ public class CredentialAuthException extends SecurityException {
 
 	}
 
-	public static class CredentialPasswordIncorrect
+	public static class InvalidCredentialPassword
 		extends CredentialAuthException {
 
-		public CredentialPasswordIncorrect(
+		public InvalidCredentialPassword(
 			String message,
 			UnrecoverableKeyException unrecoverableKeyException) {
 
@@ -53,10 +54,10 @@ public class CredentialAuthException extends SecurityException {
 
 	}
 
-	public static class KeyStorePasswordIncorrect
+	public static class InvalidKeyStorePassword
 		extends CredentialAuthException {
 
-		public KeyStorePasswordIncorrect(
+		public InvalidKeyStorePassword(
 			String message,
 			UnrecoverableKeyException unrecoverableKeyException) {
 

--- a/modules/dxp/apps/saml/saml-api/src/main/java/com/liferay/saml/runtime/metadata/LocalEntityManager.java
+++ b/modules/dxp/apps/saml/saml-api/src/main/java/com/liferay/saml/runtime/metadata/LocalEntityManager.java
@@ -15,6 +15,8 @@
 package com.liferay.saml.runtime.metadata;
 
 import com.liferay.saml.runtime.SamlException;
+import com.liferay.saml.runtime.exception.CredentialAuthException;
+import com.liferay.saml.runtime.exception.CredentialException;
 
 import java.security.KeyStoreException;
 import java.security.PrivateKey;
@@ -24,6 +26,11 @@ import java.security.cert.X509Certificate;
  * @author Michael C. Han
  */
 public interface LocalEntityManager {
+
+	public void authenticateLocalEntityCertificate(
+			String certificateKeyPassword, CertificateUsage certificateUsage,
+			String entityId)
+		throws CredentialAuthException, CredentialException;
 
 	public void deleteLocalEntityCertificate(CertificateUsage certificateUsage)
 		throws KeyStoreException;

--- a/modules/dxp/apps/saml/saml-api/src/main/java/com/liferay/saml/runtime/metadata/LocalEntityManager.java
+++ b/modules/dxp/apps/saml/saml-api/src/main/java/com/liferay/saml/runtime/metadata/LocalEntityManager.java
@@ -22,9 +22,12 @@ import java.security.KeyStoreException;
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
 
+import org.osgi.annotation.versioning.ProviderType;
+
 /**
  * @author Michael C. Han
  */
+@ProviderType
 public interface LocalEntityManager {
 
 	public void authenticateLocalEntityCertificate(

--- a/modules/dxp/apps/saml/saml-api/src/main/resources/com/liferay/saml/runtime/exception/packageinfo
+++ b/modules/dxp/apps/saml/saml-api/src/main/resources/com/liferay/saml/runtime/exception/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 1.2.0

--- a/modules/dxp/apps/saml/saml-api/src/main/resources/com/liferay/saml/runtime/metadata/packageinfo
+++ b/modules/dxp/apps/saml/saml-api/src/main/resources/com/liferay/saml/runtime/metadata/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0

--- a/modules/dxp/apps/saml/saml-impl/src/main/java/com/liferay/saml/internal/configuration/SamlProviderConfigurationHelperImpl.java
+++ b/modules/dxp/apps/saml/saml-impl/src/main/java/com/liferay/saml/internal/configuration/SamlProviderConfigurationHelperImpl.java
@@ -160,7 +160,19 @@ public class SamlProviderConfigurationHelperImpl
 			samlProviderConfiguration, pid);
 
 		_configurationHolderByCompanyId.put(companyId, configurationHolder);
-		_configurationHolderByPid.put(pid, configurationHolder);
+
+		ConfigurationHolder oldConfigurationHolder =
+			_configurationHolderByPid.put(pid, configurationHolder);
+
+		if (oldConfigurationHolder != null) {
+			SamlProviderConfiguration oldSamlProviderConfiguration =
+				oldConfigurationHolder.getSamlProviderConfiguration();
+
+			if (oldSamlProviderConfiguration.companyId() != companyId) {
+				_configurationHolderByCompanyId.remove(
+					oldSamlProviderConfiguration.companyId());
+			}
+		}
 	}
 
 	@Override

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/credential/KeyStoreCredentialResolver.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/credential/KeyStoreCredentialResolver.java
@@ -337,7 +337,7 @@ public class KeyStoreCredentialResolver
 						UnrecoverableKeyException.class);
 
 				if (unrecoverableKeyException != null) {
-					throw new CredentialAuthException.KeyStorePasswordIncorrect(
+					throw new CredentialAuthException.InvalidKeyStorePassword(
 						String.format(
 							"Company %s used an incorrect password to access " +
 								"the KeyStore provided by %s",
@@ -345,7 +345,7 @@ public class KeyStoreCredentialResolver
 						unrecoverableKeyException);
 				}
 
-				throw new CredentialAuthException.CannotLoadKeyStore(
+				throw new CredentialAuthException.InvalidKeyStore(
 					String.format(
 						"Company %s could not load the SAML KeyStore " +
 							"provided by %s",
@@ -354,7 +354,7 @@ public class KeyStoreCredentialResolver
 			}
 
 			if (generalSecurityException instanceof UnrecoverableKeyException) {
-				throw new CredentialAuthException.CredentialPasswordIncorrect(
+				throw new CredentialAuthException.InvalidCredentialPassword(
 					String.format(
 						"Company %s used an incorrect key credential " +
 							"password to an entry in the SAML KeyStore " +

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/credential/KeyStoreCredentialResolver.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/credential/KeyStoreCredentialResolver.java
@@ -187,57 +187,48 @@ public class KeyStoreCredentialResolver
 	public Iterable<Credential> resolve(CriteriaSet criteriaSet)
 		throws SecurityException {
 
-		try {
-			_checkCriteriaRequirements(criteriaSet);
+		_checkCriteriaRequirements(criteriaSet);
 
-			EntityIdCriterion entityIDCriterion = criteriaSet.get(
-				EntityIdCriterion.class);
+		EntityIdCriterion entityIDCriterion = criteriaSet.get(
+			EntityIdCriterion.class);
 
-			String entityId = entityIDCriterion.getEntityId();
+		String entityId = entityIDCriterion.getEntityId();
 
-			SamlProviderConfiguration samlProviderConfiguration =
-				_samlProviderConfigurationHelper.getSamlProviderConfiguration();
+		SamlProviderConfiguration samlProviderConfiguration =
+			_samlProviderConfigurationHelper.getSamlProviderConfiguration();
 
-			UsageCriterion usageCriterion = criteriaSet.get(UsageCriterion.class);
+		UsageCriterion usageCriterion = criteriaSet.get(UsageCriterion.class);
 
-			UsageType usageType = UsageType.UNSPECIFIED;
+		UsageType usageType = UsageType.UNSPECIFIED;
 
-			if (usageCriterion != null) {
-				usageType = usageCriterion.getUsage();
-			}
-
-			String keyStoreCredentialPassword = null;
-
-			if (entityId.equals(samlProviderConfiguration.entityId())) {
-				if (usageType == UsageType.ENCRYPTION) {
-					keyStoreCredentialPassword =
-						samlProviderConfiguration.
-							keyStoreEncryptionCredentialPassword();
-				}
-				else {
-					keyStoreCredentialPassword =
-						samlProviderConfiguration.keyStoreCredentialPassword();
-				}
-			}
-
-			KeyStore.Entry entry = _getKeyStoreEntry(
-				_getAlias(entityId, usageType), keyStoreCredentialPassword);
-
-			if (entry == null) {
-				return Collections.emptySet();
-			}
-
-			Credential credential = _buildCredential(
-				entry, entityId, usageType);
-
-			return Collections.singleton(credential);
+		if (usageCriterion != null) {
+			usageType = usageCriterion.getUsage();
 		}
-		catch (RuntimeException runtimeException) {
-			throw new SecurityException(runtimeException);
+
+		String keyStoreCredentialPassword = null;
+
+		if (entityId.equals(samlProviderConfiguration.entityId())) {
+			if (usageType == UsageType.ENCRYPTION) {
+				keyStoreCredentialPassword =
+					samlProviderConfiguration.
+						keyStoreEncryptionCredentialPassword();
+			}
+			else {
+				keyStoreCredentialPassword =
+					samlProviderConfiguration.keyStoreCredentialPassword();
+			}
 		}
-		catch (Exception exception) {
-			throw new SecurityException(exception);
+
+		KeyStore.Entry entry = _getKeyStoreEntry(
+			_getAlias(entityId, usageType), keyStoreCredentialPassword);
+
+		if (entry == null) {
+			return Collections.emptySet();
 		}
+
+		Credential credential = _buildCredential(entry, entityId, usageType);
+
+		return Collections.singleton(credential);
 	}
 
 	@Override

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/credential/KeyStoreCredentialResolver.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/credential/KeyStoreCredentialResolver.java
@@ -22,12 +22,16 @@ import com.liferay.saml.runtime.SamlException;
 import com.liferay.saml.runtime.configuration.SamlProviderConfiguration;
 import com.liferay.saml.runtime.configuration.SamlProviderConfigurationHelper;
 import com.liferay.saml.runtime.credential.KeyStoreManager;
+import com.liferay.saml.runtime.exception.CredentialAuthException;
+import com.liferay.saml.runtime.exception.CredentialException;
 import com.liferay.saml.runtime.exception.EntityIdException;
 import com.liferay.saml.runtime.metadata.LocalEntityManager;
 
+import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.PrivateKey;
+import java.security.UnrecoverableKeyException;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
@@ -56,6 +60,7 @@ import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Mika Koivisto
+ * @author Stian Sigvartsen
  */
 @Component(
 	configurationPid = "com.liferay.saml.runtime.configuration.SamlKeyStoreManagerConfiguration",
@@ -64,6 +69,28 @@ import org.osgi.service.component.annotations.Reference;
 )
 public class KeyStoreCredentialResolver
 	extends AbstractCredentialResolver implements LocalEntityManager {
+
+	public void authenticateLocalEntityCertificate(
+			String certificateKeyPassword, CertificateUsage certificateUsage,
+			String entityId)
+		throws CredentialAuthException, CredentialException {
+
+		KeyStore.Entry entry = null;
+
+		if (certificateUsage == CertificateUsage.ENCRYPTION) {
+			entry = _getKeyStoreEntry(
+				_getAlias(entityId, UsageType.ENCRYPTION),
+				certificateKeyPassword);
+		}
+		else {
+			entry = _getKeyStoreEntry(
+				_getAlias(entityId, UsageType.SIGNING), certificateKeyPassword);
+		}
+
+		if (entry == null) {
+			throw new CredentialException("Certificate not found");
+		}
+	}
 
 	@Override
 	public void deleteLocalEntityCertificate(CertificateUsage certificateUsage)
@@ -168,13 +195,10 @@ public class KeyStoreCredentialResolver
 
 			String entityId = entityIDCriterion.getEntityId();
 
-			KeyStore.PasswordProtection keyStorePasswordProtection = null;
-
 			SamlProviderConfiguration samlProviderConfiguration =
 				_samlProviderConfigurationHelper.getSamlProviderConfiguration();
 
-			UsageCriterion usageCriterion = criteriaSet.get(
-				UsageCriterion.class);
+			UsageCriterion usageCriterion = criteriaSet.get(UsageCriterion.class);
 
 			UsageType usageType = UsageType.UNSPECIFIED;
 
@@ -182,9 +206,9 @@ public class KeyStoreCredentialResolver
 				usageType = usageCriterion.getUsage();
 			}
 
-			if (entityId.equals(samlProviderConfiguration.entityId())) {
-				String keyStoreCredentialPassword = null;
+			String keyStoreCredentialPassword = null;
 
+			if (entityId.equals(samlProviderConfiguration.entityId())) {
 				if (usageType == UsageType.ENCRYPTION) {
 					keyStoreCredentialPassword =
 						samlProviderConfiguration.
@@ -194,18 +218,10 @@ public class KeyStoreCredentialResolver
 					keyStoreCredentialPassword =
 						samlProviderConfiguration.keyStoreCredentialPassword();
 				}
-
-				if (keyStoreCredentialPassword != null) {
-					keyStorePasswordProtection =
-						new KeyStore.PasswordProtection(
-							keyStoreCredentialPassword.toCharArray());
-				}
 			}
 
-			KeyStore keyStore = _keyStoreManager.getKeyStore();
-
-			KeyStore.Entry entry = keyStore.getEntry(
-				_getAlias(entityId, usageType), keyStorePasswordProtection);
+			KeyStore.Entry entry = _getKeyStoreEntry(
+				_getAlias(entityId, usageType), keyStoreCredentialPassword);
 
 			if (entry == null) {
 				return Collections.emptySet();
@@ -280,6 +296,88 @@ public class KeyStoreCredentialResolver
 		}
 
 		return entityId;
+	}
+
+	private <T> T _getCauseThrowable(
+		Throwable throwable, Class<T> exceptionType) {
+
+		if (throwable == null) {
+			return null;
+		}
+
+		Throwable causeThrowable = throwable.getCause();
+
+		while (causeThrowable != null) {
+			if (exceptionType.isInstance(causeThrowable)) {
+				return (T)causeThrowable;
+			}
+
+			causeThrowable = causeThrowable.getCause();
+		}
+
+		return null;
+	}
+
+	private KeyStore.Entry _getKeyStoreEntry(
+			String alias, String certificateKeyPassword)
+		throws CredentialAuthException {
+
+		KeyStore.PasswordProtection keyStorePasswordProtection = null;
+
+		if (certificateKeyPassword != null) {
+			keyStorePasswordProtection = new KeyStore.PasswordProtection(
+				certificateKeyPassword.toCharArray());
+		}
+
+		try {
+			KeyStore keyStore = _keyStoreManager.getKeyStore();
+
+			return keyStore.getEntry(alias, keyStorePasswordProtection);
+		}
+		catch (GeneralSecurityException generalSecurityException) {
+			Class<? extends KeyStoreManager> clazz =
+				_keyStoreManager.getClass();
+			long companyId = CompanyThreadLocal.getCompanyId();
+
+			if (generalSecurityException instanceof KeyStoreException) {
+				UnrecoverableKeyException unrecoverableKeyException =
+					_getCauseThrowable(
+						generalSecurityException,
+						UnrecoverableKeyException.class);
+
+				if (unrecoverableKeyException != null) {
+					throw new CredentialAuthException.KeyStorePasswordIncorrect(
+						String.format(
+							"Company %s used an incorrect password to access " +
+								"the KeyStore provided by %s",
+							companyId, clazz.getSimpleName()),
+						unrecoverableKeyException);
+				}
+
+				throw new CredentialAuthException.CannotLoadKeyStore(
+					String.format(
+						"Company %s could not load the SAML KeyStore " +
+							"provided by %s",
+						companyId, clazz.getSimpleName()),
+					generalSecurityException);
+			}
+
+			if (generalSecurityException instanceof UnrecoverableKeyException) {
+				throw new CredentialAuthException.CredentialPasswordIncorrect(
+					String.format(
+						"Company %s used an incorrect key credential " +
+							"password to an entry in the SAML KeyStore " +
+								"provided by %s",
+						companyId, clazz.getSimpleName()),
+					(UnrecoverableKeyException)generalSecurityException);
+			}
+
+			throw new CredentialAuthException(
+				String.format(
+					"Unknown Exception occurred for company %s using %s",
+					companyId, clazz.getSimpleName()),
+				generalSecurityException);
+		}
 	}
 
 	private SamlProviderConfiguration _getSamlProviderConfiguration() {

--- a/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/display/context/GeneralTabDefaultViewDisplayContext.java
+++ b/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/display/context/GeneralTabDefaultViewDisplayContext.java
@@ -99,7 +99,7 @@ public class GeneralTabDefaultViewDisplayContext {
 			return new X509CertificateStatus(
 				null, X509CertificateStatus.Status.UNBOUND);
 		}
-		catch (CredentialAuthException.KeyStorePasswordIncorrect
+		catch (CredentialAuthException.InvalidKeyStorePassword
 					credentialAuthException) {
 
 			return _buildX509CertificateStatus(
@@ -107,14 +107,14 @@ public class GeneralTabDefaultViewDisplayContext {
 				X509CertificateStatus.Status.SAML_KEYSTORE_PASSWORD_INCORRECT,
 				true);
 		}
-		catch (CredentialAuthException.CannotLoadKeyStore
+		catch (CredentialAuthException.InvalidKeyStore
 					credentialAuthException) {
 
 			return _buildX509CertificateStatus(
 				credentialAuthException,
 				X509CertificateStatus.Status.SAML_KEYSTORE_EXCEPTION, true);
 		}
-		catch (CredentialAuthException.CredentialPasswordIncorrect
+		catch (CredentialAuthException.InvalidCredentialPassword
 					credentialAuthException) {
 
 			return _buildX509CertificateStatus(

--- a/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/display/context/GeneralTabDefaultViewDisplayContext.java
+++ b/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/display/context/GeneralTabDefaultViewDisplayContext.java
@@ -99,6 +99,21 @@ public class GeneralTabDefaultViewDisplayContext {
 			return new X509CertificateStatus(
 				null, X509CertificateStatus.Status.UNBOUND);
 		}
+		catch (CredentialAuthException.InvalidCredentialPassword
+			credentialAuthException) {
+
+			return _buildX509CertificateStatus(
+				credentialAuthException,
+				X509CertificateStatus.Status.SAML_X509_CERTIFICATE_AUTH_NEEDED,
+				false);
+		}
+		catch (CredentialAuthException.InvalidKeyStore
+			credentialAuthException) {
+
+			return _buildX509CertificateStatus(
+				credentialAuthException,
+				X509CertificateStatus.Status.SAML_KEYSTORE_EXCEPTION, true);
+		}
 		catch (CredentialAuthException.InvalidKeyStorePassword
 					credentialAuthException) {
 
@@ -106,21 +121,6 @@ public class GeneralTabDefaultViewDisplayContext {
 				credentialAuthException,
 				X509CertificateStatus.Status.SAML_KEYSTORE_PASSWORD_INCORRECT,
 				true);
-		}
-		catch (CredentialAuthException.InvalidKeyStore
-					credentialAuthException) {
-
-			return _buildX509CertificateStatus(
-				credentialAuthException,
-				X509CertificateStatus.Status.SAML_KEYSTORE_EXCEPTION, true);
-		}
-		catch (CredentialAuthException.InvalidCredentialPassword
-					credentialAuthException) {
-
-			return _buildX509CertificateStatus(
-				credentialAuthException,
-				X509CertificateStatus.Status.SAML_X509_CERTIFICATE_AUTH_NEEDED,
-				false);
 		}
 		catch (CredentialAuthException credentialAuthException) {
 			return _buildX509CertificateStatus(

--- a/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/display/context/GeneralTabDefaultViewDisplayContext.java
+++ b/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/display/context/GeneralTabDefaultViewDisplayContext.java
@@ -100,23 +100,25 @@ public class GeneralTabDefaultViewDisplayContext {
 				null, X509CertificateStatus.Status.UNBOUND);
 		}
 		catch (CredentialAuthException.KeyStorePasswordIncorrect
-					keyStorePasswordIncorrect) {
+					credentialAuthException) {
 
 			return _buildX509CertificateStatus(
-				keyStorePasswordIncorrect,
+				credentialAuthException,
 				X509CertificateStatus.Status.SAML_KEYSTORE_PASSWORD_INCORRECT,
 				true);
 		}
-		catch (CredentialAuthException.CannotLoadKeyStore cannotLoadKeyStore) {
+		catch (CredentialAuthException.CannotLoadKeyStore
+					credentialAuthException) {
+
 			return _buildX509CertificateStatus(
-				cannotLoadKeyStore,
+				credentialAuthException,
 				X509CertificateStatus.Status.SAML_KEYSTORE_EXCEPTION, true);
 		}
 		catch (CredentialAuthException.CredentialPasswordIncorrect
-					credentialPasswordIncorrect) {
+					credentialAuthException) {
 
 			return _buildX509CertificateStatus(
-				credentialPasswordIncorrect,
+				credentialAuthException,
 				X509CertificateStatus.Status.SAML_X509_CERTIFICATE_AUTH_NEEDED,
 				false);
 		}

--- a/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/display/context/GeneralTabDefaultViewDisplayContext.java
+++ b/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/display/context/GeneralTabDefaultViewDisplayContext.java
@@ -100,7 +100,7 @@ public class GeneralTabDefaultViewDisplayContext {
 				null, X509CertificateStatus.Status.UNBOUND);
 		}
 		catch (CredentialAuthException.InvalidCredentialPassword
-			credentialAuthException) {
+					credentialAuthException) {
 
 			return _buildX509CertificateStatus(
 				credentialAuthException,
@@ -108,7 +108,7 @@ public class GeneralTabDefaultViewDisplayContext {
 				false);
 		}
 		catch (CredentialAuthException.InvalidKeyStore
-			credentialAuthException) {
+					credentialAuthException) {
 
 			return _buildX509CertificateStatus(
 				credentialAuthException,

--- a/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/display/context/GeneralTabDefaultViewDisplayContext.java
+++ b/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/display/context/GeneralTabDefaultViewDisplayContext.java
@@ -48,83 +48,11 @@ public class GeneralTabDefaultViewDisplayContext {
 		LocalEntityManager.CertificateUsage certificateUsage) {
 
 		return _x509CertificateStatuses.computeIfAbsent(
-				certificateUsage,
-				this::doGetX509CertificateStatus);
-	}
-
-	protected X509CertificateStatus doGetX509CertificateStatus(
-		LocalEntityManager.CertificateUsage certificateUsage) {
-
-		try {
-			X509Certificate x509Certificate =
-				_localEntityManager.getLocalEntityCertificate(certificateUsage);
-
-			if (x509Certificate != null) {
-				return new X509CertificateStatus(
-					x509Certificate, X509CertificateStatus.Status.BOUND);
-			}
-			else {
-				return new X509CertificateStatus(
-					null, X509CertificateStatus.Status.UNBOUND);
-			}
-		}
-		catch (CredentialAuthException.KeyStorePasswordIncorrect
-				keyStorePasswordIncorrect) {
-			return _buildX509CertificateStatus(
-				keyStorePasswordIncorrect,
-				X509CertificateStatus.Status.SAML_KEYSTORE_PASSWORD_INCORRECT,
-				true);
-		}
-		catch (CredentialAuthException.CannotLoadKeyStore cannotLoadKeyStore) {
-			return _buildX509CertificateStatus(
-				cannotLoadKeyStore,
-				X509CertificateStatus.Status.SAML_KEYSTORE_EXCEPTION,
-				true);
-		}
-		catch (CredentialAuthException.CredentialPasswordIncorrect
-			credentialPasswordIncorrect) {
-			return _buildX509CertificateStatus(
-				credentialPasswordIncorrect,
-				X509CertificateStatus.Status.SAML_X509_CERTIFICATE_AUTH_NEEDED,
-				false);
-		}
-		catch (CredentialAuthException credentialAuthException) {
-			return _buildX509CertificateStatus(
-				credentialAuthException,
-				X509CertificateStatus.Status.UNKNOWN_EXCEPTION,
-				true);
-		}
-		catch (SamlException samlException) {
-			return _buildX509CertificateStatus(
-				samlException,
-				X509CertificateStatus.Status.UNBOUND,
-				false);
-		}
+			certificateUsage, this::doGetX509CertificateStatus);
 	}
 
 	public boolean isRoleIdPAvailable() {
 		return _samlConfiguration.idpRoleConfigurationEnabled();
-	}
-
-	private X509CertificateStatus _buildX509CertificateStatus(
-		Exception exception,
-		X509CertificateStatus.Status status, boolean logError) {
-
-		if (_log.isDebugEnabled()) {
-			_log.debug(
-				String.format(
-					"Unable to get local entity certificate: %s",
-					exception.getMessage()),
-				exception);
-		}
-		else if (logError && _log.isErrorEnabled()) {
-			_log.error(
-				String.format(
-					"Unable to get local entity certificate: %s",
-					exception.getMessage()));
-		}
-
-		return new X509CertificateStatus(null, status);
 	}
 
 	public static class X509CertificateStatus {
@@ -154,6 +82,74 @@ public class GeneralTabDefaultViewDisplayContext {
 		private final Status _status;
 		private final X509Certificate _x509Certificate;
 
+	}
+
+	protected X509CertificateStatus doGetX509CertificateStatus(
+		LocalEntityManager.CertificateUsage certificateUsage) {
+
+		try {
+			X509Certificate x509Certificate =
+				_localEntityManager.getLocalEntityCertificate(certificateUsage);
+
+			if (x509Certificate != null) {
+				return new X509CertificateStatus(
+					x509Certificate, X509CertificateStatus.Status.BOUND);
+			}
+
+			return new X509CertificateStatus(
+				null, X509CertificateStatus.Status.UNBOUND);
+		}
+		catch (CredentialAuthException.KeyStorePasswordIncorrect
+					keyStorePasswordIncorrect) {
+
+			return _buildX509CertificateStatus(
+				keyStorePasswordIncorrect,
+				X509CertificateStatus.Status.SAML_KEYSTORE_PASSWORD_INCORRECT,
+				true);
+		}
+		catch (CredentialAuthException.CannotLoadKeyStore cannotLoadKeyStore) {
+			return _buildX509CertificateStatus(
+				cannotLoadKeyStore,
+				X509CertificateStatus.Status.SAML_KEYSTORE_EXCEPTION, true);
+		}
+		catch (CredentialAuthException.CredentialPasswordIncorrect
+					credentialPasswordIncorrect) {
+
+			return _buildX509CertificateStatus(
+				credentialPasswordIncorrect,
+				X509CertificateStatus.Status.SAML_X509_CERTIFICATE_AUTH_NEEDED,
+				false);
+		}
+		catch (CredentialAuthException credentialAuthException) {
+			return _buildX509CertificateStatus(
+				credentialAuthException,
+				X509CertificateStatus.Status.UNKNOWN_EXCEPTION, true);
+		}
+		catch (SamlException samlException) {
+			return _buildX509CertificateStatus(
+				samlException, X509CertificateStatus.Status.UNBOUND, false);
+		}
+	}
+
+	private X509CertificateStatus _buildX509CertificateStatus(
+		Exception exception, X509CertificateStatus.Status status,
+		boolean logError) {
+
+		if (_log.isDebugEnabled()) {
+			_log.debug(
+				String.format(
+					"Unable to get local entity certificate: %s",
+					exception.getMessage()),
+				exception);
+		}
+		else if (logError) {
+			_log.error(
+				String.format(
+					"Unable to get local entity certificate: %s",
+					exception.getMessage()));
+		}
+
+		return new X509CertificateStatus(null, status);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(


### PR DESCRIPTION
Hi Brian. Following up on https://github.com/brianchandotcom/liferay-portal/pull/124292#issuecomment-1273412157 . 

I reviewed a lot of "public static class" naming and there are a lot of name prefixes used: Invalid, MustBe, Required etc.
I decided on "invalid" as it is generic and also does not imply any tense. i.e. validating configuration vs. invocation parameters.

I don't feel 100% comfortable replacing `CannotLoadKeyStore` with `InvalidKeyStore`, because loading covers mishandling by the actor doing the loading, as well as the thing being loaded. But if you are happy, then I am happy also.

I also noticed that in all the existing code I thought is similar to this, the outer type has a public constructor. So I left it public. It is possible I did not understand your intention correct (https://github.com/brianchandotcom/liferay-portal/pull/124134#issuecomment-1269975538).

Sent on top of https://github.com/brianchandotcom/liferay-portal/pull/124134.