### PR TITLE
LPS-163295 Workflow tasks not created in virtual instances when the database is partitioned

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/petra/executor/GraphWalkerPortalExecutor.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/petra/executor/GraphWalkerPortalExecutor.java
@@ -24,9 +24,12 @@ import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.NamedThreadFactory;
 import com.liferay.portal.kernel.util.PortalClassLoaderUtil;
 import com.liferay.portal.kernel.util.PortalRunMode;
+import com.liferay.portal.workflow.kaleo.runtime.ExecutionContext;
 import com.liferay.portal.workflow.kaleo.runtime.graph.GraphWalker;
 import com.liferay.portal.workflow.kaleo.runtime.graph.PathElement;
 
@@ -59,13 +62,22 @@ public class GraphWalkerPortalExecutor {
 			return;
 		}
 
+		ExecutionContext executionContext = pathElement.getExecutionContext();
+
+		ServiceContext serviceContext = executionContext.getServiceContext();
+
+		long companyId = serviceContext.getCompanyId();
+
 		long ctCollectionId = CTCollectionThreadLocal.getCTCollectionId();
 
 		if (waitForCompletion) {
 			NoticeableFuture<?> noticeableFuture =
 				_noticeableExecutorService.submit(
 					() -> {
-						try (SafeCloseable safeCloseable =
+						try (SafeCloseable safeCloseable1 =
+								CompanyThreadLocal.setWithSafeCloseable(
+									companyId);
+							SafeCloseable safeCloseable2 =
 								CTCollectionThreadLocal.
 									setCTCollectionIdWithSafeCloseable(
 										ctCollectionId)) {
@@ -87,7 +99,9 @@ public class GraphWalkerPortalExecutor {
 		else {
 			_noticeableExecutorService.submit(
 				() -> {
-					try (SafeCloseable safeCloseable =
+					try (SafeCloseable safeCloseable1 =
+							CompanyThreadLocal.setWithSafeCloseable(companyId);
+						SafeCloseable safeCloseable2 =
 							CTCollectionThreadLocal.
 								setCTCollectionIdWithSafeCloseable(
 									ctCollectionId)) {

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/petra/executor/GraphWalkerPortalExecutor.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/petra/executor/GraphWalkerPortalExecutor.java
@@ -74,13 +74,9 @@ public class GraphWalkerPortalExecutor {
 			NoticeableFuture<?> noticeableFuture =
 				_noticeableExecutorService.submit(
 					() -> {
-						try (SafeCloseable safeCloseable1 =
+						try (SafeCloseable safeCloseable =
 								CompanyThreadLocal.setWithSafeCloseable(
-									companyId);
-							SafeCloseable safeCloseable2 =
-								CTCollectionThreadLocal.
-									setCTCollectionIdWithSafeCloseable(
-										ctCollectionId)) {
+									companyId, ctCollectionId)) {
 
 							_walk(pathElement);
 						}
@@ -99,12 +95,9 @@ public class GraphWalkerPortalExecutor {
 		else {
 			_noticeableExecutorService.submit(
 				() -> {
-					try (SafeCloseable safeCloseable1 =
-							CompanyThreadLocal.setWithSafeCloseable(companyId);
-						SafeCloseable safeCloseable2 =
-							CTCollectionThreadLocal.
-								setCTCollectionIdWithSafeCloseable(
-									ctCollectionId)) {
+					try (SafeCloseable safeCloseable =
+							CompanyThreadLocal.setWithSafeCloseable(
+								companyId, ctCollectionId)) {
 
 						_walk(pathElement);
 					}

--- a/portal-kernel/src/com/liferay/portal/kernel/change/tracking/CTCollectionThreadLocal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/change/tracking/CTCollectionThreadLocal.java
@@ -23,12 +23,14 @@ import com.liferay.portal.kernel.util.ServiceProxyFactory;
  */
 public class CTCollectionThreadLocal {
 
+	public static final long CT_COLLECTION_ID_PRODUCTION = 0;
+
 	public static long getCTCollectionId() {
 		return _ctCollectionId.get();
 	}
 
 	public static boolean isProductionMode() {
-		if (_ctCollectionId.get() == _CT_COLLECTION_ID_PRODUCTION) {
+		if (_ctCollectionId.get() == CT_COLLECTION_ID_PRODUCTION) {
 			return true;
 		}
 
@@ -46,14 +48,14 @@ public class CTCollectionThreadLocal {
 	}
 
 	public static SafeCloseable setProductionModeWithSafeCloseable() {
-		return setCTCollectionIdWithSafeCloseable(_CT_COLLECTION_ID_PRODUCTION);
+		return setCTCollectionIdWithSafeCloseable(CT_COLLECTION_ID_PRODUCTION);
 	}
 
 	private static long _getCTCollectionId() {
 		CTCollectionIdSupplier ctCollectionIdSupplier = _ctCollectionIdSupplier;
 
 		if (ctCollectionIdSupplier == null) {
-			return _CT_COLLECTION_ID_PRODUCTION;
+			return CT_COLLECTION_ID_PRODUCTION;
 		}
 
 		return ctCollectionIdSupplier.getCTCollectionId();
@@ -61,8 +63,6 @@ public class CTCollectionThreadLocal {
 
 	private CTCollectionThreadLocal() {
 	}
-
-	private static final int _CT_COLLECTION_ID_PRODUCTION = 0;
 
 	private static final CentralizedThreadLocal<Long> _ctCollectionId =
 		new CentralizedThreadLocal<>(

--- a/portal-kernel/src/com/liferay/portal/kernel/change/tracking/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/change/tracking/packageinfo
@@ -1,1 +1,1 @@
-version 2.1.0
+version 2.2.0

--- a/portal-kernel/src/com/liferay/portal/kernel/security/auth/CompanyThreadLocal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/auth/CompanyThreadLocal.java
@@ -100,6 +100,13 @@ public class CompanyThreadLocal {
 	}
 
 	public static SafeCloseable setWithSafeCloseable(Long companyId) {
+		return setWithSafeCloseable(
+			companyId, CTCollectionThreadLocal.CT_COLLECTION_ID_PRODUCTION);
+	}
+
+	public static SafeCloseable setWithSafeCloseable(
+		Long companyId, Long ctCollectionId) {
+
 		long currentCompanyId = _companyId.get();
 		Locale defaultLocale = LocaleThreadLocal.getDefaultLocale();
 		TimeZone defaultTimeZone = TimeZoneThreadLocal.getDefaultTimeZone();
@@ -107,7 +114,8 @@ public class CompanyThreadLocal {
 		_setCompanyId(companyId);
 
 		SafeCloseable ctCollectionSafeCloseable =
-			CTCollectionThreadLocal.setProductionModeWithSafeCloseable();
+			CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+				ctCollectionId);
 
 		return () -> {
 			_companyId.set(currentCompanyId);

--- a/portal-kernel/src/com/liferay/portal/kernel/security/auth/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/auth/packageinfo
@@ -1,1 +1,1 @@
-version 5.0.0
+version 5.1.0


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-163295

Manually forwarding since `ci:relevant` fails due to unrelated failures. `publications`, `workflow`, and `sf` test suites don't contain any unique failures either (https://github.com/xbrianlee/liferay-portal/pull/986).