### PR TITLE
LPS-165248 - Screen Reader announcing extra information for fieldset elements

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/fieldset/start.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/fieldset/start.jsp
@@ -43,6 +43,10 @@ else if (collapsible) {
 
 			<c:choose>
 				<c:when test="<%= collapsible %>">
+					<legend class="sr-only">
+						<%= header %>
+					</legend>
+
 					<a aria-controls="<%= id %>Content" aria-expanded="<%= !collapsed %>" class="collapse-icon <%= collapsed ? "collapsed" : StringPool.BLANK %> sheet-subtitle" data-toggle="liferay-collapse" href="#<%= id %>Content" role="button">
 						<span>
 							<%= header %>

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/fieldset/start.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/fieldset/start.jsp
@@ -43,12 +43,8 @@ else if (collapsible) {
 
 			<c:choose>
 				<c:when test="<%= collapsible %>">
-					<legend class="sr-only">
-						<%= header %>
-					</legend>
-
 					<a aria-controls="<%= id %>Content" aria-expanded="<%= !collapsed %>" class="collapse-icon <%= collapsed ? "collapsed" : StringPool.BLANK %> sheet-subtitle" data-toggle="liferay-collapse" href="#<%= id %>Content" role="button">
-						<span aria-hidden="true">
+						<span>
 							<%= header %>
 						</span>
 

--- a/portal-web/docroot/html/taglib/aui/fieldset/start.jsp
+++ b/portal-web/docroot/html/taglib/aui/fieldset/start.jsp
@@ -51,13 +51,9 @@ if (Validator.isNull(panelHeaderLinkCssClass)) {
 
 			<c:choose>
 				<c:when test="<%= collapsible %>">
-					<legend class="sr-only">
-						<%= header %>
-					</legend>
-
 					<a aria-controls="<%= id %>Content" aria-expanded="<%= !collapsed %>" class="collapse-icon collapse-icon-middle <%= panelHeaderLinkCssClass %> <%= collapsed ? "collapsed" : StringPool.BLANK %>" data-toggle="liferay-collapse" href="#<%= id %>Content" role="button">
 						<span class="c-inner" tabindex="-1">
-							<span aria-hidden="true">
+							<span>
 								<%= header %>
 							</span>
 

--- a/portal-web/docroot/html/taglib/aui/fieldset/start.jsp
+++ b/portal-web/docroot/html/taglib/aui/fieldset/start.jsp
@@ -51,6 +51,10 @@ if (Validator.isNull(panelHeaderLinkCssClass)) {
 
 			<c:choose>
 				<c:when test="<%= collapsible %>">
+					<legend class="sr-only">
+						<%= header %>
+					</legend>
+
 					<a aria-controls="<%= id %>Content" aria-expanded="<%= !collapsed %>" class="collapse-icon collapse-icon-middle <%= panelHeaderLinkCssClass %> <%= collapsed ? "collapsed" : StringPool.BLANK %>" data-toggle="liferay-collapse" href="#<%= id %>Content" role="button">
 						<span class="c-inner" tabindex="-1">
 							<span>


### PR DESCRIPTION
Forced forward due to [unrelated CI failures](https://liferay.slack.com/archives/C19PWQ74J/p1665674670871589?thread_ts=1665657841.291949&cid=C19PWQ74J).

Forwarded from https://github.com/ethib137/liferay-portal/pull/69

For the toggle button of our collapse panels, the screen reader is announcing the href instead of a human understandable label. This is because the label within had the `aria-hidden="true"` attribute added as a part of [this ticket](https://issues.liferay.com/browse/LPS-134141). 

The `aria-hidden` attribute was added to "avoid redundancy"
> Since the label of collapsible fieldsets are shown inside an <a> element, it's necessary for the <legend> to include an sr-only label and for the header to include aria-hidden="true" to avoid redundancy.

This is not actually avoiding redundancy though, because the <legend> and the label inside the anchor have different purposes and are announced differently by screen readers. The legend indicates the start and purpose of a group of fields inside a fieldset. The label inside the anchor is announced as a toggle button to open and close the entire fieldset.