### PR TITLE
LPS-165034 Don't show version tab for document types that don't have versions

### DIFF
--- a/modules/apps/content-dashboard/content-dashboard-api/bnd.bnd
+++ b/modules/apps/content-dashboard/content-dashboard-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Content Dashboard API
 Bundle-SymbolicName: com.liferay.content.dashboard.api
-Bundle-Version: 4.0.1
+Bundle-Version: 4.1.0
 Export-Package:\
 	com.liferay.content.dashboard.info.item,\
 	com.liferay.content.dashboard.item,\

--- a/modules/apps/content-dashboard/content-dashboard-api/src/main/java/com/liferay/content/dashboard/item/VersionableContentDashboardItem.java
+++ b/modules/apps/content-dashboard/content-dashboard-api/src/main/java/com/liferay/content/dashboard/item/VersionableContentDashboardItem.java
@@ -29,4 +29,10 @@ public interface VersionableContentDashboardItem<T>
 
 	public String getViewVersionsURL(HttpServletRequest httpServletRequest);
 
+	public default boolean isShowContentDashboardItemVersions(
+		HttpServletRequest httpServletRequest) {
+
+		return true;
+	}
+
 }

--- a/modules/apps/content-dashboard/content-dashboard-api/src/main/resources/com/liferay/content/dashboard/item/packageinfo
+++ b/modules/apps/content-dashboard/content-dashboard-api/src/main/resources/com/liferay/content/dashboard/item/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0

--- a/modules/apps/content-dashboard/content-dashboard-document-library-impl/build.gradle
+++ b/modules/apps/content-dashboard/content-dashboard-document-library-impl/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 	compileOnly project(":apps:asset:asset-display-page-api")
 	compileOnly project(":apps:content-dashboard:content-dashboard-api")
 	compileOnly project(":apps:document-library:document-library-api")
+	compileOnly project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-react")

--- a/modules/apps/content-dashboard/content-dashboard-document-library-impl/src/main/java/com/liferay/content/dashboard/document/library/internal/item/FileEntryContentDashboardItem.java
+++ b/modules/apps/content-dashboard/content-dashboard-document-library-impl/src/main/java/com/liferay/content/dashboard/document/library/internal/item/FileEntryContentDashboardItem.java
@@ -27,6 +27,8 @@ import com.liferay.content.dashboard.item.action.exception.ContentDashboardItemV
 import com.liferay.content.dashboard.item.action.provider.ContentDashboardItemActionProvider;
 import com.liferay.content.dashboard.item.action.provider.ContentDashboardItemVersionActionProvider;
 import com.liferay.content.dashboard.item.type.ContentDashboardItemSubtype;
+import com.liferay.document.library.display.context.DLDisplayContextProvider;
+import com.liferay.document.library.display.context.DLEditFileEntryDisplayContext;
 import com.liferay.document.library.util.DLURLHelper;
 import com.liferay.info.field.InfoFieldValue;
 import com.liferay.info.item.InfoItemClassDetails;
@@ -85,6 +87,7 @@ public class FileEntryContentDashboardItem
 		ContentDashboardItemVersionActionProviderTracker
 			contentDashboardItemVersionActionProviderTracker,
 		ContentDashboardItemSubtype contentDashboardItemSubtype,
+		DLDisplayContextProvider dlDisplayContextProvider,
 		DLURLHelper dlURLHelper, FileEntry fileEntry, Group group,
 		InfoItemFieldValuesProvider<FileEntry> infoItemFieldValuesProvider,
 		Language language, Portal portal) {
@@ -108,6 +111,7 @@ public class FileEntryContentDashboardItem
 		_contentDashboardItemVersionActionProviderTracker =
 			contentDashboardItemVersionActionProviderTracker;
 		_contentDashboardItemSubtype = contentDashboardItemSubtype;
+		_dlDisplayContextProvider = dlDisplayContextProvider;
 		_dlURLHelper = dlURLHelper;
 		_fileEntry = fileEntry;
 		_group = group;
@@ -436,6 +440,28 @@ public class FileEntryContentDashboardItem
 	}
 
 	@Override
+	public boolean isShowContentDashboardItemVersions(
+		HttpServletRequest httpServletRequest) {
+
+		DLEditFileEntryDisplayContext dlEditFileEntryDisplayContext =
+			_dlDisplayContextProvider.getDLEditFileEntryDisplayContext(
+				httpServletRequest, null, _fileEntry);
+
+		try {
+			if (!dlEditFileEntryDisplayContext.isVersionInfoVisible()) {
+				return false;
+			}
+		}
+		catch (PortalException portalException) {
+			_log.error(portalException);
+
+			return false;
+		}
+
+		return true;
+	}
+
+	@Override
 	public boolean isViewable(HttpServletRequest httpServletRequest) {
 		if (ListUtil.isEmpty(
 				_fileEntry.getFileVersions(
@@ -644,6 +670,7 @@ public class FileEntryContentDashboardItem
 	private final ContentDashboardItemSubtype _contentDashboardItemSubtype;
 	private final ContentDashboardItemVersionActionProviderTracker
 		_contentDashboardItemVersionActionProviderTracker;
+	private final DLDisplayContextProvider _dlDisplayContextProvider;
 	private final DLURLHelper _dlURLHelper;
 	private final FileEntry _fileEntry;
 	private final Group _group;

--- a/modules/apps/content-dashboard/content-dashboard-document-library-impl/src/main/java/com/liferay/content/dashboard/document/library/internal/item/FileEntryContentDashboardItemFactory.java
+++ b/modules/apps/content-dashboard/content-dashboard-document-library-impl/src/main/java/com/liferay/content/dashboard/document/library/internal/item/FileEntryContentDashboardItemFactory.java
@@ -22,6 +22,7 @@ import com.liferay.content.dashboard.item.action.ContentDashboardItemActionProvi
 import com.liferay.content.dashboard.item.action.ContentDashboardItemVersionActionProviderTracker;
 import com.liferay.content.dashboard.item.type.ContentDashboardItemSubtypeFactory;
 import com.liferay.content.dashboard.item.type.ContentDashboardItemSubtypeFactoryTracker;
+import com.liferay.document.library.display.context.DLDisplayContextProvider;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFileEntryType;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
@@ -83,7 +84,7 @@ public class FileEntryContentDashboardItemFactory
 			_contentDashboardItemVersionActionProviderTracker,
 			contentDashboardItemSubtypeFactory.create(
 				dlFileEntry.getFileEntryTypeId(), dlFileEntry.getFileEntryId()),
-			_dlURLHelper, fileEntry,
+			_dlDisplayContextProvider, _dlURLHelper, fileEntry,
 			_groupLocalService.fetchGroup(fileEntry.getGroupId()),
 			infoItemFieldValuesProvider, _language, _portal);
 	}
@@ -117,6 +118,9 @@ public class FileEntryContentDashboardItemFactory
 
 	@Reference
 	private DLAppLocalService _dlAppLocalService;
+
+	@Reference
+	private DLDisplayContextProvider _dlDisplayContextProvider;
 
 	@Reference
 	private DLURLHelper _dlURLHelper;

--- a/modules/apps/content-dashboard/content-dashboard-document-library-impl/src/test/java/com/liferay/content/dashboard/document/library/internal/item/FileEntryContentDashboardItemTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-document-library-impl/src/test/java/com/liferay/content/dashboard/document/library/internal/item/FileEntryContentDashboardItemTest.java
@@ -24,6 +24,8 @@ import com.liferay.content.dashboard.item.action.ContentDashboardItemVersionActi
 import com.liferay.content.dashboard.item.action.provider.ContentDashboardItemActionProvider;
 import com.liferay.content.dashboard.item.action.provider.ContentDashboardItemVersionActionProvider;
 import com.liferay.content.dashboard.item.type.ContentDashboardItemSubtype;
+import com.liferay.document.library.display.context.DLDisplayContextProvider;
+import com.liferay.document.library.display.context.DLEditFileEntryDisplayContext;
 import com.liferay.info.field.InfoField;
 import com.liferay.info.field.InfoFieldValue;
 import com.liferay.info.field.type.DateInfoFieldType;
@@ -486,6 +488,28 @@ public class FileEntryContentDashboardItemTest {
 	}
 
 	@Test
+	public void testIsShowContentDashboardItemVersions() throws Exception {
+		FileEntryContentDashboardItem fileEntryContentDashboardItem =
+			_getFileEntryContentDashboardItemWithDLDisplayContext(true);
+
+		Assert.assertTrue(
+			fileEntryContentDashboardItem.isShowContentDashboardItemVersions(
+				Mockito.mock(HttpServletRequest.class)));
+	}
+
+	@Test
+	public void testIsShowContentDashboardItemVersionsForUnsupportedFileEntry()
+		throws Exception {
+
+		FileEntryContentDashboardItem fileEntryContentDashboardItem =
+			_getFileEntryContentDashboardItemWithDLDisplayContext(false);
+
+		Assert.assertFalse(
+			fileEntryContentDashboardItem.isShowContentDashboardItemVersions(
+				Mockito.mock(HttpServletRequest.class)));
+	}
+
+	@Test
 	public void testIsViewable() throws Exception {
 		FileEntry fileEntry = _getFileEntry();
 
@@ -759,6 +783,37 @@ public class FileEntryContentDashboardItemTest {
 		);
 
 		return fileEntry;
+	}
+
+	private FileEntryContentDashboardItem
+			_getFileEntryContentDashboardItemWithDLDisplayContext(
+				boolean showVersionInfoVisible)
+		throws Exception {
+
+		FileEntry fileEntry = _getFileEntry();
+
+		DLEditFileEntryDisplayContext dlEditFileEntryDisplayContext =
+			Mockito.mock(DLEditFileEntryDisplayContext.class);
+
+		Mockito.when(
+			dlEditFileEntryDisplayContext.isVersionInfoVisible()
+		).thenReturn(
+			showVersionInfoVisible
+		);
+
+		DLDisplayContextProvider dlDisplayContextProvider = Mockito.mock(
+			DLDisplayContextProvider.class);
+
+		Mockito.when(
+			dlDisplayContextProvider.getDLEditFileEntryDisplayContext(
+				Mockito.any(), Mockito.any(), Mockito.any(FileEntry.class))
+		).thenReturn(
+			dlEditFileEntryDisplayContext
+		);
+
+		return new FileEntryContentDashboardItem(
+			null, null, null, null, null, dlDisplayContextProvider, null,
+			fileEntry, null, null, null, null);
 	}
 
 	private HttpServletRequest _getHttpServletRequest(long userId)

--- a/modules/apps/content-dashboard/content-dashboard-document-library-impl/src/test/java/com/liferay/content/dashboard/document/library/internal/item/FileEntryContentDashboardItemTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-document-library-impl/src/test/java/com/liferay/content/dashboard/document/library/internal/item/FileEntryContentDashboardItemTest.java
@@ -101,7 +101,7 @@ public class FileEntryContentDashboardItemTest {
 		FileEntryContentDashboardItem fileEntryContentDashboardItem =
 			new FileEntryContentDashboardItem(
 				Collections.singletonList(assetCategory), null, null, null,
-				null, null, fileEntry, null, null, null, null);
+				null, null, null, fileEntry, null, null, null, null);
 
 		Assert.assertEquals(
 			Collections.singletonList(assetCategory),
@@ -123,7 +123,7 @@ public class FileEntryContentDashboardItemTest {
 		FileEntryContentDashboardItem fileEntryContentDashboardItem =
 			new FileEntryContentDashboardItem(
 				Collections.singletonList(assetCategory), null, null, null,
-				null, null, fileEntry, null, null, null, null);
+				null, null, null, fileEntry, null, null, null, null);
 
 		Assert.assertEquals(
 			Collections.singletonList(assetCategory),
@@ -137,8 +137,8 @@ public class FileEntryContentDashboardItemTest {
 
 		FileEntryContentDashboardItem fileEntryContentDashboardItem =
 			new FileEntryContentDashboardItem(
-				null, null, null, null, null, null, fileEntry, null, null, null,
-				null);
+				null, null, null, null, null, null, null, fileEntry, null, null,
+				null, null);
 
 		Assert.assertEquals(
 			Collections.emptyList(),
@@ -160,7 +160,7 @@ public class FileEntryContentDashboardItemTest {
 		FileEntryContentDashboardItem fileEntryContentDashboardItem =
 			new FileEntryContentDashboardItem(
 				Collections.singletonList(assetCategory), null, null, null,
-				null, null, fileEntry, null, null, null, null);
+				null, null, null, fileEntry, null, null, null, null);
 
 		Assert.assertEquals(
 			Collections.emptyList(),
@@ -177,7 +177,7 @@ public class FileEntryContentDashboardItemTest {
 		FileEntryContentDashboardItem fileEntryContentDashboardItem =
 			new FileEntryContentDashboardItem(
 				null, Collections.singletonList(assetTag), null, null, null,
-				null, fileEntry, null, null, null, null);
+				null, null, fileEntry, null, null, null, null);
 
 		Assert.assertEquals(
 			Collections.singletonList(assetTag),
@@ -205,7 +205,7 @@ public class FileEntryContentDashboardItemTest {
 						contentDashboardItemVersionAction1, true),
 					_getContentDashboardItemVersionActionProvider(
 						contentDashboardItemVersionAction2, true)),
-				null, null, fileEntry, null, null, _getLanguage(), null);
+				null, null, null, fileEntry, null, null, _getLanguage(), null);
 
 		List<ContentDashboardItemVersion> contentDashboardItemVersions =
 			fileEntryContentDashboardItem.getAllContentDashboardItemVersions(
@@ -246,7 +246,7 @@ public class FileEntryContentDashboardItemTest {
 			new FileEntryContentDashboardItem(
 				null, null, null,
 				_getContentDashboardItemVersionActionProviderTracker(), null,
-				null, fileEntry, null, null, _getLanguage(), null);
+				null, null, fileEntry, null, null, _getLanguage(), null);
 
 		List<ContentDashboardItemVersion> contentDashboardItemVersions =
 			fileEntryContentDashboardItem.getAllContentDashboardItemVersions(
@@ -304,7 +304,7 @@ public class FileEntryContentDashboardItemTest {
 
 		FileEntryContentDashboardItem fileEntryContentDashboardItem =
 			new FileEntryContentDashboardItem(
-				null, null, null, null, null, null, fileEntry, null,
+				null, null, null, null, null, null, null, fileEntry, null,
 				infoItemFieldValuesProvider, null, null);
 
 		Assert.assertEquals(
@@ -318,8 +318,8 @@ public class FileEntryContentDashboardItemTest {
 
 		FileEntryContentDashboardItem fileEntryContentDashboardItem =
 			new FileEntryContentDashboardItem(
-				null, null, null, null, null, null, fileEntry, null, null, null,
-				null);
+				null, null, null, null, null, null, null, fileEntry, null, null,
+				null, null);
 
 		Assert.assertEquals(
 			fileEntry.getModifiedDate(),
@@ -340,8 +340,8 @@ public class FileEntryContentDashboardItemTest {
 
 		FileEntryContentDashboardItem fileEntryContentDashboardItem =
 			new FileEntryContentDashboardItem(
-				null, null, null, null, null, null, fileEntry, group, null,
-				null, null);
+				null, null, null, null, null, null, null, fileEntry, group,
+				null, null, null);
 
 		Assert.assertEquals(
 			"scopeName",
@@ -378,7 +378,7 @@ public class FileEntryContentDashboardItemTest {
 					}
 
 				},
-				null, fileEntry, null, null, null, null);
+				null, null, fileEntry, null, null, null, null);
 
 		ContentDashboardItemSubtype contentDashboardItemType =
 			fileEntryContentDashboardItem.getContentDashboardItemSubtype();
@@ -393,8 +393,8 @@ public class FileEntryContentDashboardItemTest {
 
 		FileEntryContentDashboardItem fileEntryContentDashboardItem =
 			new FileEntryContentDashboardItem(
-				null, null, null, null, null, null, fileEntry, null, null, null,
-				null);
+				null, null, null, null, null, null, null, fileEntry, null, null,
+				null, null);
 
 		Assert.assertEquals(
 			fileEntry.getTitle(),
@@ -413,8 +413,8 @@ public class FileEntryContentDashboardItemTest {
 
 		FileEntryContentDashboardItem fileEntryContentDashboardItem =
 			new FileEntryContentDashboardItem(
-				null, null, null, null, null, null, fileEntry, null, null, null,
-				null);
+				null, null, null, null, null, null, null, fileEntry, null, null,
+				null, null);
 
 		Assert.assertEquals(
 			fileEntry.getUserId(), fileEntryContentDashboardItem.getUserId());
@@ -432,8 +432,8 @@ public class FileEntryContentDashboardItemTest {
 
 		FileEntryContentDashboardItem fileEntryContentDashboardItem =
 			new FileEntryContentDashboardItem(
-				null, null, null, null, null, null, fileEntry, null, null, null,
-				null);
+				null, null, null, null, null, null, null, fileEntry, null, null,
+				null, null);
 
 		Assert.assertEquals(
 			fileEntry.getUserId(), fileEntryContentDashboardItem.getUserId());
@@ -458,7 +458,7 @@ public class FileEntryContentDashboardItemTest {
 					_getContentDashboardItemVersionActionProvider(
 						contentDashboardItemVersionAction, true),
 					_getContentDashboardItemVersionActionProvider(null, false)),
-				null, null, fileEntry, null, null, _getLanguage(), null);
+				null, null, null, fileEntry, null, null, _getLanguage(), null);
 
 		List<ContentDashboardItemVersion> contentDashboardItemVersions =
 			fileEntryContentDashboardItem.getAllContentDashboardItemVersions(
@@ -507,7 +507,8 @@ public class FileEntryContentDashboardItemTest {
 					_getContentDashboardItemActionProvider(
 						ContentDashboardItemAction.Type.VIEW,
 						"http://localhost:8080/view")),
-				null, null, null, fileEntry, null, null, _getLanguage(), null);
+				null, null, null, null, fileEntry, null, null, _getLanguage(),
+				null);
 
 		Assert.assertTrue(
 			fileEntryContentDashboardItem.isViewable(

--- a/modules/apps/content-dashboard/content-dashboard-test/src/testIntegration/java/com/liferay/content/dashboard/web/internal/portlet/action/test/GetContentDashboardItemVersionsResourceCommandTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-test/src/testIntegration/java/com/liferay/content/dashboard/web/internal/portlet/action/test/GetContentDashboardItemVersionsResourceCommandTest.java
@@ -25,7 +25,6 @@ import com.liferay.content.dashboard.item.action.ContentDashboardItemAction;
 import com.liferay.content.dashboard.item.type.ContentDashboardItemSubtype;
 import com.liferay.content.dashboard.item.type.ContentDashboardItemSubtypeFactory;
 import com.liferay.info.item.InfoItemReference;
-import com.liferay.petra.function.UnsafeRunnable;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -77,128 +76,135 @@ public class GetContentDashboardItemVersionsResourceCommandTest {
 			PermissionCheckerMethodTestRule.INSTANCE);
 
 	@Test
-	public void testGetContentDashboardItemVersions() throws Exception {
+	public void testGetContentDashboardItemVersions() {
 		int versionsCount = 15;
 
-		_withTestItemContentDashboardItemFactoryRegistered(
-			() -> {
-				MockLiferayResourceRequest mockLiferayResourceRequest =
-					_getMockLiferayPortletResourceRequest();
+		ServiceRegistration<ContentDashboardItemFactory> serviceRegistration =
+			_getServiceRegistration(versionsCount);
 
-				mockLiferayResourceRequest.setParameter(
-					"className", TestItem.class.getName());
-				mockLiferayResourceRequest.setParameter("classPK", "0");
+		try {
+			MockLiferayResourceRequest mockLiferayResourceRequest =
+				_getMockLiferayPortletResourceRequest();
 
-				JSONObject jsonObject = ReflectionTestUtil.invoke(
-					_mvcResourceCommand,
-					"_getContentDashboardItemVersionsJSONObject",
-					new Class<?>[] {ResourceRequest.class},
-					mockLiferayResourceRequest);
+			mockLiferayResourceRequest.setParameter(
+				"className", TestItem.class.getName());
+			mockLiferayResourceRequest.setParameter("classPK", "0");
 
-				Assert.assertNotNull(jsonObject);
+			JSONObject jsonObject = ReflectionTestUtil.invoke(
+				_mvcResourceCommand,
+				"_getContentDashboardItemVersionsJSONObject",
+				new Class<?>[] {ResourceRequest.class},
+				mockLiferayResourceRequest);
 
-				String viewVersionsURL = jsonObject.getString(
-					"viewVersionsURL");
+			Assert.assertNotNull(jsonObject);
 
-				Assert.assertEquals(_VIEW_VERSIONS_URL, viewVersionsURL);
+			String viewVersionsURL = jsonObject.getString("viewVersionsURL");
 
-				_assertVersions(jsonObject, 10, versionsCount);
-			},
-			versionsCount);
+			Assert.assertEquals(_VIEW_VERSIONS_URL, viewVersionsURL);
+
+			_assertVersions(jsonObject, 10, versionsCount);
+		}
+		finally {
+			serviceRegistration.unregister();
+		}
 	}
 
 	@Test
-	public void testGetContentDashboardItemVersionsForInvalidClassName()
-		throws Exception {
+	public void testGetContentDashboardItemVersionsForInvalidClassName() {
+		ServiceRegistration<ContentDashboardItemFactory> serviceRegistration =
+			_getServiceRegistration(15);
 
-		_withTestItemContentDashboardItemFactoryRegistered(
-			() -> {
-				MockLiferayResourceRequest mockLiferayResourceRequest =
-					_getMockLiferayPortletResourceRequest();
+		try {
+			MockLiferayResourceRequest mockLiferayResourceRequest =
+				_getMockLiferayPortletResourceRequest();
 
-				mockLiferayResourceRequest.setParameter(
-					"className", RandomTestUtil.randomString());
+			mockLiferayResourceRequest.setParameter(
+				"className", RandomTestUtil.randomString());
 
-				JSONObject jsonObject = ReflectionTestUtil.invoke(
-					_mvcResourceCommand,
-					"_getContentDashboardItemVersionsJSONObject",
-					new Class<?>[] {ResourceRequest.class},
-					mockLiferayResourceRequest);
+			JSONObject jsonObject = ReflectionTestUtil.invoke(
+				_mvcResourceCommand,
+				"_getContentDashboardItemVersionsJSONObject",
+				new Class<?>[] {ResourceRequest.class},
+				mockLiferayResourceRequest);
 
-				Assert.assertNotNull(jsonObject);
-				Assert.assertEquals(0, jsonObject.length());
-			},
-			15);
+			Assert.assertNotNull(jsonObject);
+			Assert.assertEquals(0, jsonObject.length());
+		}
+		finally {
+			serviceRegistration.unregister();
+		}
 	}
 
 	@Test
-	public void testGetContentDashboardItemVersionsWithLimit()
-		throws Exception {
-
+	public void testGetContentDashboardItemVersionsWithLimit() {
 		int versionsCount = 15;
 
-		_withTestItemContentDashboardItemFactoryRegistered(
-			() -> {
-				int maxDisplayVersions = 5;
+		ServiceRegistration<ContentDashboardItemFactory> serviceRegistration =
+			_getServiceRegistration(versionsCount);
 
-				MockLiferayResourceRequest mockLiferayResourceRequest =
-					_getMockLiferayPortletResourceRequest();
+		try {
+			int maxDisplayVersions = 5;
 
-				mockLiferayResourceRequest.setParameter(
-					"className", TestItem.class.getName());
-				mockLiferayResourceRequest.setParameter("classPK", "0");
-				mockLiferayResourceRequest.setParameter(
-					"maxDisplayVersions", String.valueOf(maxDisplayVersions));
+			MockLiferayResourceRequest mockLiferayResourceRequest =
+				_getMockLiferayPortletResourceRequest();
 
-				JSONObject jsonObject = ReflectionTestUtil.invoke(
-					_mvcResourceCommand,
-					"_getContentDashboardItemVersionsJSONObject",
-					new Class<?>[] {ResourceRequest.class},
-					mockLiferayResourceRequest);
+			mockLiferayResourceRequest.setParameter(
+				"className", TestItem.class.getName());
+			mockLiferayResourceRequest.setParameter("classPK", "0");
+			mockLiferayResourceRequest.setParameter(
+				"maxDisplayVersions", String.valueOf(maxDisplayVersions));
 
-				Assert.assertNotNull(jsonObject);
+			JSONObject jsonObject = ReflectionTestUtil.invoke(
+				_mvcResourceCommand,
+				"_getContentDashboardItemVersionsJSONObject",
+				new Class<?>[] {ResourceRequest.class},
+				mockLiferayResourceRequest);
 
-				String viewVersionsURL = jsonObject.getString(
-					"viewVersionsURL");
+			Assert.assertNotNull(jsonObject);
 
-				Assert.assertEquals(_VIEW_VERSIONS_URL, viewVersionsURL);
+			String viewVersionsURL = jsonObject.getString("viewVersionsURL");
 
-				_assertVersions(jsonObject, maxDisplayVersions, versionsCount);
-			},
-			versionsCount);
+			Assert.assertEquals(_VIEW_VERSIONS_URL, viewVersionsURL);
+
+			_assertVersions(jsonObject, maxDisplayVersions, versionsCount);
+		}
+		finally {
+			serviceRegistration.unregister();
+		}
 	}
 
 	@Test
-	public void testGetContentDashboardItemVersionsWithoutViewVersionURL()
-		throws Exception {
-
+	public void testGetContentDashboardItemVersionsWithoutViewVersionURL() {
 		int versionsCount = 5;
 
-		_withTestItemContentDashboardItemFactoryRegistered(
-			() -> {
-				MockLiferayResourceRequest mockLiferayResourceRequest =
-					_getMockLiferayPortletResourceRequest();
+		ServiceRegistration<ContentDashboardItemFactory> serviceRegistration =
+			_getServiceRegistration(versionsCount);
 
-				mockLiferayResourceRequest.setParameter(
-					"className", TestItem.class.getName());
-				mockLiferayResourceRequest.setParameter("classPK", "0");
+		try {
+			MockLiferayResourceRequest mockLiferayResourceRequest =
+				_getMockLiferayPortletResourceRequest();
 
-				JSONObject jsonObject = ReflectionTestUtil.invoke(
-					_mvcResourceCommand,
-					"_getContentDashboardItemVersionsJSONObject",
-					new Class<?>[] {ResourceRequest.class},
-					mockLiferayResourceRequest);
+			mockLiferayResourceRequest.setParameter(
+				"className", TestItem.class.getName());
+			mockLiferayResourceRequest.setParameter("classPK", "0");
 
-				Assert.assertNotNull(jsonObject);
+			JSONObject jsonObject = ReflectionTestUtil.invoke(
+				_mvcResourceCommand,
+				"_getContentDashboardItemVersionsJSONObject",
+				new Class<?>[] {ResourceRequest.class},
+				mockLiferayResourceRequest);
 
-				String viewVersionsURL = jsonObject.getString(
-					"viewVersionsURL");
+			Assert.assertNotNull(jsonObject);
 
-				Assert.assertEquals(StringPool.BLANK, viewVersionsURL);
+			String viewVersionsURL = jsonObject.getString("viewVersionsURL");
 
-				_assertVersions(jsonObject, versionsCount, versionsCount);
-			},
-			versionsCount);
+			Assert.assertEquals(StringPool.BLANK, viewVersionsURL);
+
+			_assertVersions(jsonObject, versionsCount, versionsCount);
+		}
+		finally {
+			serviceRegistration.unregister();
+		}
 	}
 
 	private void _assertVersions(
@@ -231,26 +237,17 @@ public class GetContentDashboardItemVersionsResourceCommandTest {
 		return mockLiferayResourceRequest;
 	}
 
-	private void _withTestItemContentDashboardItemFactoryRegistered(
-			UnsafeRunnable<Exception> unsafeRunnable, int versionsCount)
-		throws Exception {
+	private ServiceRegistration<ContentDashboardItemFactory>
+		_getServiceRegistration(int versionsCount) {
 
 		Bundle bundle = FrameworkUtil.getBundle(
 			GetContentDashboardItemVersionsResourceCommandTest.class);
 
 		BundleContext bundleContext = bundle.getBundleContext();
 
-		ServiceRegistration<ContentDashboardItemFactory> serviceRegistration =
-			bundleContext.registerService(
-				ContentDashboardItemFactory.class,
-				new TestItemContentDashboardItemFactory(versionsCount), null);
-
-		try {
-			unsafeRunnable.run();
-		}
-		finally {
-			serviceRegistration.unregister();
-		}
+		return bundleContext.registerService(
+			ContentDashboardItemFactory.class,
+			new TestItemContentDashboardItemFactory(versionsCount), null);
 	}
 
 	private static final String _VIEW_VERSIONS_URL = "view_versions_url";

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/portlet/action/GetContentDashboardItemInfoMVCResourceCommand.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/portlet/action/GetContentDashboardItemInfoMVCResourceCommand.java
@@ -158,6 +158,18 @@ public class GetContentDashboardItemInfoMVCResourceCommand
 							return null;
 						}
 
+						VersionableContentDashboardItem
+							versionableContentDashboardItem =
+								(VersionableContentDashboardItem)
+									contentDashboardItem;
+
+						if (!versionableContentDashboardItem.
+								isShowContentDashboardItemVersions(
+									httpServletRequest)) {
+
+							return null;
+						}
+
 						return ResourceURLBuilder.createResourceURL(
 							resourceResponse
 						).setParameter(
@@ -182,6 +194,24 @@ public class GetContentDashboardItemInfoMVCResourceCommand
 					"preview",
 					_getPreviewJSONObject(
 						contentDashboardItem, httpServletRequest)
+				).put(
+					"showItemVersions",
+					() -> {
+						if (!(contentDashboardItem instanceof
+								VersionableContentDashboardItem)) {
+
+							return false;
+						}
+
+						VersionableContentDashboardItem
+							versionableContentDashboardItem =
+								(VersionableContentDashboardItem)
+									contentDashboardItem;
+
+						return versionableContentDashboardItem.
+							isShowContentDashboardItemVersions(
+								httpServletRequest);
+					}
 				).put(
 					"specificFields",
 					_getSpecificFieldsJSONObject(contentDashboardItem, locale)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/portlet/action/GetContentDashboardItemVersionsMVCResourceCommand.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/portlet/action/GetContentDashboardItemVersionsMVCResourceCommand.java
@@ -90,14 +90,10 @@ public class GetContentDashboardItemVersionsMVCResourceCommand
 	}
 
 	private JSONArray _getContentDashboardItemVersionsJSONArray(
-		int displayVersions, HttpServletRequest httpServletRequest,
-		VersionableContentDashboardItem versionableContentDashboardItem) {
+		List<ContentDashboardItemVersion> contentDashboardItemVersions,
+		int displayVersions) {
 
 		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
-
-		List<ContentDashboardItemVersion> contentDashboardItemVersions =
-			versionableContentDashboardItem.getAllContentDashboardItemVersions(
-				httpServletRequest);
 
 		if (ListUtil.isEmpty(contentDashboardItemVersions)) {
 			return jsonArray;
@@ -158,8 +154,7 @@ public class GetContentDashboardItemVersionsMVCResourceCommand
 		return JSONUtil.put(
 			"versions",
 			_getContentDashboardItemVersionsJSONArray(
-				displayVersions, httpServletRequest,
-				versionableContentDashboardItem)
+				contentDashboardItemVersions, displayVersions)
 		).put(
 			"viewVersionsURL",
 			() -> {

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/SidebarPanelInfoView.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/SidebarPanelInfoView.js
@@ -236,13 +236,15 @@ const SidebarPanelInfoView = ({
 							/>
 						</ClayTabs.TabPane>
 
-						<ClayTabs.TabPane aria-labelledby="tab-2">
-							<VersionsContent
-								getItemVersionsURL={getItemVersionsURL}
-								languageTag={languageTag}
-								onError={handleError}
-							/>
-						</ClayTabs.TabPane>
+						{showTabs && (
+							<ClayTabs.TabPane aria-labelledby="tab-2">
+								<VersionsContent
+									getItemVersionsURL={getItemVersionsURL}
+									languageTag={languageTag}
+									onError={handleError}
+								/>
+							</ClayTabs.TabPane>
+						)}
 					</ClayTabs.Content>
 				</div>
 			</Sidebar.Body>

--- a/modules/apps/content-dashboard/content-dashboard-web/test/js/components/SidebarPanelInfoView/__snapshots__/SidebarPanelInfoView.test.js.snap
+++ b/modules/apps/content-dashboard/content-dashboard-web/test/js/components/SidebarPanelInfoView/__snapshots__/SidebarPanelInfoView.test.js.snap
@@ -1358,15 +1358,6 @@ exports[`SidebarPanelInfoView renders 1`] = `
                 </div>
               </div>
             </div>
-            <div
-              aria-labelledby="tab-2"
-              class="tab-pane fade"
-              role="tabpanel"
-            >
-              <ul
-                class="list-group sidebar-list-group"
-              />
-            </div>
           </div>
         </div>
       </div>

--- a/modules/apps/content-dashboard/content-dashboard-web/test/js/mocks/props.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/test/js/mocks/props.js
@@ -214,6 +214,7 @@ export const mockedProps = {
 		},
 	],
 	modifiedDate: '2020-07-27T10:56:56.027',
+	singlePageApplicationEnabled: false,
 	specificFields: {
 		'display-date': {
 			title: 'Display Date',


### PR DESCRIPTION
## Motivation

[Link to story](https://issues.liferay.com/browse/LPS-165034)

There are cases were some types of documents don't have history, so we don't want to show the histories tab in the Info Panel in Content Dashboard

## Proposed solution

* Add a new method in VersionableContentDashboardItem to control this. By default it's set to true and decide each model how to implement it.


## Change summary:

* Add new method to control visibility of version items
* Adapt parameters that are passed to the front to control visibility
* Fix an issue were the content of versions was included even though we don't show the tab
* Improve performance when retrieving the versions
* Unit test for FileEntryContentDashboardItem
* Change integration test to make it more readable for future developers

## How to test

* Add a new document of type "External Video Shortcut"
* Provide a URL for a youtube video or any type of video
* Go to Content Dashboard
* Click on the i icon to open the Info Panel
* Versions tab will not be shown, just as with the attached gif

![versions](https://user-images.githubusercontent.com/4267448/195587968-0f0cd938-eef8-4193-8302-ad56aaa88dea.gif)


