### PR TITLE
LPS-165827 Add ics to the custom mimeTypes

### DIFF
--- a/modules/apps/portal/portal-tika/src/main/resources/com/liferay/portal/tika/internal/mime/dependencies/custom-mimetypes.xml
+++ b/modules/apps/portal/portal-tika/src/main/resources/com/liferay/portal/tika/internal/mime/dependencies/custom-mimetypes.xml
@@ -4,4 +4,7 @@
 	<mime-type type="application/zip">
 		<glob pattern="*.lar" />
 	</mime-type>
+	<mime-type type="text/calendar">
+		<glob pattern="*.ics" />
+	</mime-type>
 </mime-info>


### PR DESCRIPTION
Original PR comment:

> Hi Team,
> 
> https://issues.liferay.com/browse/LPS-165827
> 
> **Issue:**
> When we upload a .ics file to Documents and Media that has HTML tags in X-ALT-DESC part, Tika can't parse it correctly and detects it as HTML content. And the mimeType is saved as text/html in the dlfileentry table. But it should be saved as text/calendar to be useable afterwards.
> 
> **Solution:**
> I added the missing .ics mimeType to our custom mimeTypes, then I deployed the portlet and it worked as expected, the file was saved as text/ics.
> 
> Please review my PR!
> 
> Best regards,
> Évi

@brianchandotcom resending this pull directly to you since after a few retries we confirmed this pull is not related to any of the failing tests in https://github.com/liferay-lima/liferay-portal/pull/3604, thanks!