### PR TITLE
LPS-165611 Add the correct related Custom Object schema and modify references in the OpenAPI

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/openapi/v1_0/ObjectEntryOpenAPIResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/openapi/v1_0/ObjectEntryOpenAPIResourceImpl.java
@@ -133,7 +133,7 @@ public class ObjectEntryOpenAPIResourceImpl
 
 		return _openAPIResource.getOpenAPI(
 			new ObjectEntryOpenAPIContributor(
-				_objectDefinition, _objectDefinitionLocalService,
+				_objectDefinition, _objectDefinitionLocalService, this,
 				_objectRelationshipLocalService),
 			_getOpenAPISchemaFilter(_objectDefinition.getRESTContextPath()),
 			new HashSet<Class<?>>() {

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/openapi/contributor/ObjectEntryOpenAPIContributor.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/openapi/contributor/ObjectEntryOpenAPIContributor.java
@@ -80,12 +80,15 @@ public class ObjectEntryOpenAPIContributor implements OpenAPIContributor {
 
 				ObjectDefinition relatedObjectDefinition = entry.getValue();
 
-				if (uriInfo != null) {
-					_addSchema(relatedObjectDefinition, openAPI);
-				}
+				if (!relatedObjectDefinition.isSystem()) {
+					if (uriInfo != null) {
+						_addSchema(relatedObjectDefinition, openAPI);
+					}
 
-				_addRelationshipPaths(
-					key, relatedObjectDefinition, objectRelationship, paths);
+					_addRelationshipPaths(
+						key, relatedObjectDefinition, objectRelationship,
+						paths);
+				}
 
 				openAPI.getComponents(
 				).getSchemas(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/openapi/contributor/util/OpenAPIContributorUtil.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/openapi/contributor/util/OpenAPIContributorUtil.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.rest.internal.vulcan.openapi.contributor.util;
+
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.rest.openapi.v1_0.ObjectEntryOpenAPIResource;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.media.Schema;
+
+import java.util.Map;
+
+import javax.ws.rs.core.Response;
+
+/**
+ * @author Carlos Correa
+ */
+public class OpenAPIContributorUtil {
+
+	public static void copySchemas(
+		ObjectDefinition objectDefinition, OpenAPI sourceOpenAPI,
+		OpenAPI targetOpenAPI) {
+
+		_copySchema(
+			getSchemaName(objectDefinition), sourceOpenAPI, targetOpenAPI);
+		_copySchema(
+			getPageSchemaName(objectDefinition), sourceOpenAPI, targetOpenAPI);
+	}
+
+	public static OpenAPI getObjectEntryOpenAPI(
+			ObjectDefinition objectDefinition,
+			ObjectEntryOpenAPIResource objectEntryOpenAPIResource)
+		throws Exception {
+
+		Response response = objectEntryOpenAPIResource.getOpenAPI(
+			objectDefinition, "json", null);
+
+		return (OpenAPI)response.getEntity();
+	}
+
+	public static String getPageSchemaName(ObjectDefinition objectDefinition) {
+		return "Page" + getSchemaName(objectDefinition);
+	}
+
+	public static String getSchemaName(ObjectDefinition objectDefinition) {
+		return objectDefinition.getShortName();
+	}
+
+	private static void _copySchema(
+		String schemaName, OpenAPI sourceOpenAPI, OpenAPI targetOpenAPI) {
+
+		Components components = sourceOpenAPI.getComponents();
+
+		Map<String, Schema> schemas = components.getSchemas();
+
+		targetOpenAPI.schema(schemaName, schemas.get(schemaName));
+	}
+
+}

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/openapi/contributor/util/OpenAPIContributorUtil.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/openapi/contributor/util/OpenAPIContributorUtil.java
@@ -35,9 +35,9 @@ public class OpenAPIContributorUtil {
 		OpenAPI targetOpenAPI) {
 
 		_copySchema(
-			getSchemaName(objectDefinition), sourceOpenAPI, targetOpenAPI);
-		_copySchema(
 			getPageSchemaName(objectDefinition), sourceOpenAPI, targetOpenAPI);
+		_copySchema(
+			getSchemaName(objectDefinition), sourceOpenAPI, targetOpenAPI);
 	}
 
 	public static OpenAPI getObjectEntryOpenAPI(


### PR DESCRIPTION
PR forwarded manually from: https://github.com/liferay-headless/liferay-portal/pull/804

This PR contains the code to fix the following issues:

- Assign the correct Custom Object related to the Custom Object in the OpenAPI file.
- Hide the System Object related endpoints of a Custom Object in the OpenAPI file as **the functionalityi is still not available**.

---

For example, given the following Custom Objects:

- `MyObjectDefinition1`
- `MyObjectDefinition2`

and a Many to Many relationship between them called `m2m`.

**Before the PR**:

The OpenAPI contains the relationship endpoints with an incorrect reference, plus the `MyObjectDefinition2` schema does not exist:

```yaml
  /{myObjectDefinition1Id}/m2m:
    get:
      tags:
      - MyObjectDefinition1
      operationId: getMyObjectDefinition1M2mMyObjectDefinition2
      [...]
      responses:
        default:
          description: default response
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/PageMyObjectDefinition1'
            application/xml:
              schema:
                $ref: '#/components/schemas/PageMyObjectDefinition1'
```

```yaml
  /{myObjectDefinition1Id}/m2m/{myObjectDefinition2Id}:
    put:
      tags:
      - MyObjectDefinition1
      operationId: putMyObjectDefinition1M2mMyObjectDefinition2
      [...]
      responses:
        default:
          description: default response
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/MyObjectDefinition1'
            application/xml:
              schema:
                $ref: '#/components/schemas/MyObjectDefinition1'
```

**After the PR**:

```yaml
components:
  schemas:
  [...]
    MyObjectDefinition2:
      type: object
      [...]
    PageMyObjectDefinition2:
      type: object
      [...]
```
```yaml
  /{myObjectDefinition1Id}/m2m:
    get:
      tags:
      - MyObjectDefinition1
      operationId: getMyObjectDefinition1M2mMyObjectDefinition2
      [...]
      responses:
        default:
          description: default response
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/PageMyObjectDefinition2'
            application/xml:
              schema:
                $ref: '#/components/schemas/PageMyObjectDefinition2'
```

```yaml
  /{myObjectDefinition1Id}/m2m/{myObjectDefinition2Id}:
    put:
      tags:
      - MyObjectDefinition1
      operationId: putMyObjectDefinition1M2mMyObjectDefinition2
      [...]
      responses:
        default:
          description: default response
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/MyObjectDefinition2'
            application/xml:
              schema:
                $ref: '#/components/schemas/MyObjectDefinition2'
```
