### PR TITLE
LPS-166044: Fix wrong names for actions in Objects entries APIs

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -902,7 +902,17 @@ public class DefaultObjectEntryManagerImpl
 				"permissions",
 				ActionUtil.addAction(
 					ActionKeys.PERMISSIONS, ObjectEntryResourceImpl.class,
-					objectEntry.getObjectEntryId(), "patchObjectEntry", null,
+					objectEntry.getObjectEntryId(),
+					"getObjectEntryPermissionsPage", null,
+					objectEntry.getUserId(),
+					_getObjectEntryPermissionName(
+						objectEntry.getObjectDefinitionId()),
+					objectEntry.getGroupId(), dtoConverterContext.getUriInfo())
+			).put(
+				"replace",
+				ActionUtil.addAction(
+					ActionKeys.UPDATE, ObjectEntryResourceImpl.class,
+					objectEntry.getObjectEntryId(), "putObjectEntry", null,
 					objectEntry.getUserId(),
 					_getObjectEntryPermissionName(
 						objectEntry.getObjectDefinitionId()),
@@ -911,7 +921,7 @@ public class DefaultObjectEntryManagerImpl
 				"update",
 				ActionUtil.addAction(
 					ActionKeys.UPDATE, ObjectEntryResourceImpl.class,
-					objectEntry.getObjectEntryId(), "putObjectEntry", null,
+					objectEntry.getObjectEntryId(), "patchObjectEntry", null,
 					objectEntry.getUserId(),
 					_getObjectEntryPermissionName(
 						objectEntry.getObjectDefinitionId()),


### PR DESCRIPTION
**What is new?**
- Update `"replace"` action using PUT method and `"update"` action using PATCH method.
- Update `"permission"` action using GET method.

**Before PR**
```json
"actions": {
    "permissions": {
      "method": "PATCH",
      "href": "http://localhost:8080/o/c/universities/45606"
    },
    "get": {
      "method": "GET",
      "href": "http://localhost:8080/o/c/universities/45606"
    },
    "update": {
      "method": "PUT",
      "href": "http://localhost:8080/o/c/universities/45606"
    },
    "delete": {
      "method": "DELETE",
      "href": "http://localhost:8080/o/c/universities/45606"
    }
  }
```

**After PR**
```json
 "actions": {
    "permissions": {
      "method": "GET",
      "href": "http://localhost:8080/o/c/universities/45606/permissions"
    },
    "get": {
      "method": "GET",
      "href": "http://localhost:8080/o/c/universities/45606"
    },
    "replace": {
      "method": "PUT",
      "href": "http://localhost:8080/o/c/universities/45606"
    },
    "update": {
      "method": "PATCH",
      "href": "http://localhost:8080/o/c/universities/45606"
    },
    "delete": {
      "method": "DELETE",
      "href": "http://localhost:8080/o/c/universities/45606"
    }
  }
```

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-166044