### PR TITLE
LPS-156658 Keep file entry type permissions in sync with its ddm structure

### DIFF
--- a/modules/apps/document-library/document-library-service/bnd.bnd
+++ b/modules/apps/document-library/document-library-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Document Library Service
 Bundle-SymbolicName: com.liferay.document.library.service
 Bundle-Version: 6.0.67
-Liferay-Require-SchemaVersion: 3.2.4
+Liferay-Require-SchemaVersion: 3.2.5
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/security/permission/DLFileEntryTypePermissionUpdateHandler.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/security/permission/DLFileEntryTypePermissionUpdateHandler.java
@@ -14,6 +14,7 @@
 
 package com.liferay.document.library.internal.security.permission;
 
+import com.liferay.document.library.internal.util.DLFileEntryTypePermissionUtil;
 import com.liferay.document.library.kernel.model.DLFileEntryMetadata;
 import com.liferay.document.library.kernel.model.DLFileEntryType;
 import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalService;
@@ -28,12 +29,9 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 
-import java.util.ArrayList;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import org.osgi.service.component.annotations.Component;
@@ -68,10 +66,6 @@ public class DLFileEntryTypePermissionUpdateHandler
 				_ddmPermissionSupport.getStructureModelResourceName(
 					DLFileEntryMetadata.class.getName());
 
-			List<ResourceAction> dlFileEntryTypeResourceActions =
-				_resourceActionLocalService.getResourceActions(
-					DLFileEntryType.class.getName());
-
 			List<ResourceAction> dlFileEntryMetadataResourceActions =
 				_resourceActionLocalService.getResourceActions(
 					dlFileEntryMetadataResourceName);
@@ -91,36 +85,15 @@ public class DLFileEntryTypePermissionUpdateHandler
 					ResourceConstants.SCOPE_INDIVIDUAL,
 					String.valueOf(dlFileEntryType.getFileEntryTypeId()));
 
-			Map<Long, String[]> roleIdsToActionIds = new HashMap<>();
-
-			for (ResourcePermission resourcePermission : resourcePermissions) {
-				long actionIds = resourcePermission.getActionIds();
-
-				List<String> resourcePermissionActionIds = new ArrayList<>();
-
-				for (ResourceAction resourceAction :
-						dlFileEntryTypeResourceActions) {
-
-					String actionId = resourceAction.getActionId();
-
-					if (((actionIds & resourceAction.getBitwiseValue()) ==
-							resourceAction.getBitwiseValue()) &&
-						dlFileEntryMetadataActionIds.contains(actionId)) {
-
-						resourcePermissionActionIds.add(actionId);
-					}
-				}
-
-				roleIdsToActionIds.put(
-					resourcePermission.getRoleId(),
-					resourcePermissionActionIds.toArray(new String[0]));
-			}
-
 			_resourcePermissionLocalService.setResourcePermissions(
 				dlFileEntryType.getCompanyId(), dlFileEntryMetadataResourceName,
 				ResourceConstants.SCOPE_INDIVIDUAL,
 				String.valueOf(dlFileEntryType.getDataDefinitionId()),
-				roleIdsToActionIds);
+				DLFileEntryTypePermissionUtil.getRoleIdsToActionIds(
+					_resourceActionLocalService.getResourceActions(
+						DLFileEntryType.class.getName()),
+					resourcePermissions,
+					dlFileEntryMetadataActionIds::contains));
 		}
 		catch (PortalException portalException) {
 			ReflectionUtil.throwException(portalException);

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/security/permission/DLFileEntryTypePermissionUpdateHandler.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/security/permission/DLFileEntryTypePermissionUpdateHandler.java
@@ -15,11 +15,26 @@
 package com.liferay.document.library.internal.security.permission;
 
 import com.liferay.document.library.kernel.model.DLFileEntryType;
+import com.liferay.document.library.kernel.model.DLFileEntryMetadata;
 import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalService;
+import com.liferay.dynamic.data.mapping.security.permission.DDMPermissionSupport;
+import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.security.permission.PermissionUpdateHandler;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -47,9 +62,78 @@ public class DLFileEntryTypePermissionUpdateHandler
 		dlFileEntryType.setModifiedDate(new Date());
 
 		_dLFileEntryTypeLocalService.updateDLFileEntryType(dlFileEntryType);
+
+                // Each DLFileEntryType is tied to a DDM structure, that holds
+                // the metadata definitions defined in the document type itself.
+                // The upload forms (and most probably other code) checks the
+                // permissions on the DDM structure to determine if the fields
+                // may be viewed/entered by a user. So the permissions on the
+                // structure need to be sychronized with the DLFilEntryType.
+                // This covers the updating case. Adding is handled in
+                // portal-impl
+                // DLFileEntryTypeLocalServiceImpl.addFileEntryTypeResources
+
+                try {
+
+                    String metadataResourceName = _ddmPermissionSupport
+                            .getStructureModelResourceName(DLFileEntryMetadata.class.getName());
+
+                    List<ResourceAction> fileEntryTypeActions = _resourceActionLocalService
+                            .getResourceActions(DLFileEntryType.class.getName());
+
+                    List<ResourceAction> mataDataResourceActions = _resourceActionLocalService
+                            .getResourceActions(metadataResourceName);
+
+                    Set<String> fileEntryMetadataActions =  mataDataResourceActions
+                            .stream()
+                            .map(ra -> ra.getActionId())
+                            .collect(Collectors.toSet());
+
+                    List<ResourcePermission> permissions = _resourcePermissionLocalService.getResourcePermissions(
+                            dlFileEntryType.getCompanyId(),
+                            DLFileEntryType.class.getName(),
+                            ResourceConstants.SCOPE_INDIVIDUAL,
+                            Long.toString(dlFileEntryType.getFileEntryTypeId())
+                    );
+
+                    Map<Long, String[]> roleIdsToActionIds = new HashMap<>();
+
+                    for (ResourcePermission permission: permissions) {
+                            long actionIds = permission.getActionIds();
+                            List<String> actionIdList = new ArrayList<>();
+
+                            for (ResourceAction ra: fileEntryTypeActions) {
+                                String actionId = ra.getActionId();
+                                if((actionIds & ra.getBitwiseValue()) == ra.getBitwiseValue()
+                                        && fileEntryMetadataActions.contains(actionId)) {
+                                    actionIdList.add(actionId);
+                                }
+                            }
+                            roleIdsToActionIds.put(permission.getRoleId(), actionIdList.toArray(new String[0]));
+                    }
+
+                    _resourcePermissionLocalService.setResourcePermissions(
+                            dlFileEntryType.getCompanyId(),
+                            metadataResourceName,
+                            ResourceConstants.SCOPE_INDIVIDUAL,
+                            Long.toString(dlFileEntryType.getDataDefinitionId()),
+                            roleIdsToActionIds
+                    );
+                }
+                catch (PortalException portalException) {
+			ReflectionUtil.throwException(portalException);
+		}
 	}
+
+        @Reference
+        private DDMPermissionSupport _ddmPermissionSupport;
 
 	@Reference
 	private DLFileEntryTypeLocalService _dLFileEntryTypeLocalService;
 
+        @Reference
+	private ResourceActionLocalService _resourceActionLocalService;
+
+        @Reference
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
 }

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/registry/DLServiceUpgradeStepRegistrator.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/registry/DLServiceUpgradeStepRegistrator.java
@@ -25,10 +25,14 @@ import com.liferay.document.library.internal.upgrade.v2_0_0.UpgradeCompanyId;
 import com.liferay.document.library.internal.upgrade.v3_2_1.DDMStructureLinkUpgradeProcess;
 import com.liferay.document.library.internal.upgrade.v3_2_2.DLFileEntryUpgradeProcess;
 import com.liferay.document.library.internal.upgrade.v3_2_4.UpgradeDLSizeLimitConfiguration;
+import com.liferay.document.library.internal.upgrade.v3_2_5.SyncDLFileEntryTypesDDMStructurePermissions;
 import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.dynamic.data.mapping.security.permission.DDMPermissionSupport;
 import com.liferay.portal.configuration.upgrade.PrefsPropsToConfigurationUpgradeHelper;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourceLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.upgrade.CTModelUpgradeProcess;
 import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
 import com.liferay.portal.kernel.upgrade.MVCCVersionUpgradeProcess;
@@ -120,6 +124,13 @@ public class DLServiceUpgradeStepRegistrator implements UpgradeStepRegistrator {
 		registry.register(
 			"3.2.3", "3.2.4",
 			new UpgradeDLSizeLimitConfiguration(_configurationAdmin));
+
+		registry.register(
+			"3.2.4", "3.2.5",
+			new SyncDLFileEntryTypesDDMStructurePermissions(
+                                _ddmPermissionSupport,
+                                _resourceActionLocalService,
+                                _resourcePermissionLocalService));
 	}
 
 	@Reference
@@ -128,12 +139,21 @@ public class DLServiceUpgradeStepRegistrator implements UpgradeStepRegistrator {
 	@Reference
 	private ConfigurationAdmin _configurationAdmin;
 
+        @Reference
+        private DDMPermissionSupport _ddmPermissionSupport;
+
 	@Reference
 	private PrefsPropsToConfigurationUpgradeHelper
 		_prefsPropsToConfigurationUpgradeHelper;
 
 	@Reference
+	private ResourceActionLocalService _resourceActionLocalService;
+
+        @Reference
 	private ResourceLocalService _resourceLocalService;
+
+        @Reference
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
 
 	@Reference(target = "(dl.store.impl.enabled=true)")
 	private StoreFactory _storeFactory;

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/registry/DLServiceUpgradeStepRegistrator.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/registry/DLServiceUpgradeStepRegistrator.java
@@ -25,7 +25,7 @@ import com.liferay.document.library.internal.upgrade.v2_0_0.UpgradeCompanyId;
 import com.liferay.document.library.internal.upgrade.v3_2_1.DDMStructureLinkUpgradeProcess;
 import com.liferay.document.library.internal.upgrade.v3_2_2.DLFileEntryUpgradeProcess;
 import com.liferay.document.library.internal.upgrade.v3_2_4.UpgradeDLSizeLimitConfiguration;
-import com.liferay.document.library.internal.upgrade.v3_2_5.SyncDLFileEntryTypesDDMStructurePermissions;
+import com.liferay.document.library.internal.upgrade.v3_2_5.DLFileEntryTypesDDMStructureUpgradeProcess;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.dynamic.data.mapping.security.permission.DDMPermissionSupport;
 import com.liferay.portal.configuration.upgrade.PrefsPropsToConfigurationUpgradeHelper;
@@ -127,7 +127,7 @@ public class DLServiceUpgradeStepRegistrator implements UpgradeStepRegistrator {
 
 		registry.register(
 			"3.2.4", "3.2.5",
-			new SyncDLFileEntryTypesDDMStructurePermissions(
+			new DLFileEntryTypesDDMStructureUpgradeProcess(
 				_ddmPermissionSupport, _resourceActionLocalService,
 				_resourcePermissionLocalService));
 	}

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/registry/DLServiceUpgradeStepRegistrator.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/registry/DLServiceUpgradeStepRegistrator.java
@@ -128,9 +128,8 @@ public class DLServiceUpgradeStepRegistrator implements UpgradeStepRegistrator {
 		registry.register(
 			"3.2.4", "3.2.5",
 			new SyncDLFileEntryTypesDDMStructurePermissions(
-                                _ddmPermissionSupport,
-                                _resourceActionLocalService,
-                                _resourcePermissionLocalService));
+				_ddmPermissionSupport, _resourceActionLocalService,
+				_resourcePermissionLocalService));
 	}
 
 	@Reference
@@ -139,8 +138,8 @@ public class DLServiceUpgradeStepRegistrator implements UpgradeStepRegistrator {
 	@Reference
 	private ConfigurationAdmin _configurationAdmin;
 
-        @Reference
-        private DDMPermissionSupport _ddmPermissionSupport;
+	@Reference
+	private DDMPermissionSupport _ddmPermissionSupport;
 
 	@Reference
 	private PrefsPropsToConfigurationUpgradeHelper
@@ -149,10 +148,10 @@ public class DLServiceUpgradeStepRegistrator implements UpgradeStepRegistrator {
 	@Reference
 	private ResourceActionLocalService _resourceActionLocalService;
 
-        @Reference
+	@Reference
 	private ResourceLocalService _resourceLocalService;
 
-        @Reference
+	@Reference
 	private ResourcePermissionLocalService _resourcePermissionLocalService;
 
 	@Reference(target = "(dl.store.impl.enabled=true)")

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/v3_2_5/DLFileEntryTypesDDMStructureUpgradeProcess.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/v3_2_5/DLFileEntryTypesDDMStructureUpgradeProcess.java
@@ -14,6 +14,7 @@
 
 package com.liferay.document.library.internal.upgrade.v3_2_5;
 
+import com.liferay.document.library.internal.util.DLFileEntryTypePermissionUtil;
 import com.liferay.document.library.kernel.model.DLFileEntryMetadata;
 import com.liferay.document.library.kernel.model.DLFileEntryType;
 import com.liferay.dynamic.data.mapping.security.permission.DDMPermissionSupport;
@@ -27,11 +28,8 @@ import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 /**
@@ -54,10 +52,6 @@ public class DLFileEntryTypesDDMStructureUpgradeProcess extends UpgradeProcess {
 		String dlFileEntryMetadataResourceName =
 			_ddmPermissionSupport.getStructureModelResourceName(
 				DLFileEntryMetadata.class.getName());
-
-		List<ResourceAction> dlFileEntryTypeResourceActions =
-			_resourceActionLocalService.getResourceActions(
-				DLFileEntryType.class.getName());
 
 		List<ResourceAction> dlFileEntryMetadataResourceAction =
 			_resourceActionLocalService.getResourceActions(
@@ -87,38 +81,15 @@ public class DLFileEntryTypesDDMStructureUpgradeProcess extends UpgradeProcess {
 						ResourceConstants.SCOPE_INDIVIDUAL,
 						String.valueOf(fileEntryTypeId));
 
-				Map<Long, String[]> roleIdsToActionIds = new HashMap<>();
-
-				for (ResourcePermission resourcePermission :
-						resourcePermissions) {
-
-					long actionIds = resourcePermission.getActionIds();
-
-					List<String> resourcePermissionActionIds =
-						new ArrayList<>();
-
-					for (ResourceAction resourceAction :
-							dlFileEntryTypeResourceActions) {
-
-						String actionId = resourceAction.getActionId();
-
-						if (((actionIds & resourceAction.getBitwiseValue()) ==
-								resourceAction.getBitwiseValue()) &&
-							dlFileEntryMetadataActionIds.contains(actionId)) {
-
-							resourcePermissionActionIds.add(actionId);
-						}
-					}
-
-					roleIdsToActionIds.put(
-						resourcePermission.getRoleId(),
-						resourcePermissionActionIds.toArray(new String[0]));
-				}
-
 				_resourcePermissionLocalService.setResourcePermissions(
 					companyId, dlFileEntryMetadataResourceName,
 					ResourceConstants.SCOPE_INDIVIDUAL,
-					String.valueOf(dataDefinitionId), roleIdsToActionIds);
+					String.valueOf(dataDefinitionId),
+					DLFileEntryTypePermissionUtil.getRoleIdsToActionIds(
+						_resourceActionLocalService.getResourceActions(
+							DLFileEntryType.class.getName()),
+						resourcePermissions,
+						dlFileEntryMetadataActionIds::contains));
 			}
 		}
 	}

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/v3_2_5/DLFileEntryTypesDDMStructureUpgradeProcess.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/v3_2_5/DLFileEntryTypesDDMStructureUpgradeProcess.java
@@ -37,10 +37,9 @@ import java.util.Set;
 /**
  * @author Matthias Bläsing
  */
-public class SyncDLFileEntryTypesDDMStructurePermissions
-	extends UpgradeProcess {
+public class DLFileEntryTypesDDMStructureUpgradeProcess extends UpgradeProcess {
 
-	public SyncDLFileEntryTypesDDMStructurePermissions(
+	public DLFileEntryTypesDDMStructureUpgradeProcess(
 		DDMPermissionSupport ddmPermissionSupport,
 		ResourceActionLocalService resourceActionLocalService,
 		ResourcePermissionLocalService resourcePermissionLocalService) {

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/v3_2_5/SyncDLFileEntryTypesDDMStructurePermissions.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/v3_2_5/SyncDLFileEntryTypesDDMStructurePermissions.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.document.library.internal.upgrade.v3_2_5;
+
+import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
+import com.liferay.document.library.kernel.model.DLFileEntryType;
+import com.liferay.document.library.kernel.model.DLFileEntryMetadata;
+import com.liferay.dynamic.data.mapping.security.permission.DDMPermissionSupport;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+/**
+ * @author Matthias Bläsing
+ */
+public class SyncDLFileEntryTypesDDMStructurePermissions extends UpgradeProcess {
+
+	public SyncDLFileEntryTypesDDMStructurePermissions(
+                DDMPermissionSupport ddmPermissionSupport,
+                ResourceActionLocalService resourceActionLocalService,
+		ResourcePermissionLocalService resourcePermissionLocalService) {
+
+                _ddmPermissionSupport = ddmPermissionSupport;
+                _resourceActionLocalService = resourceActionLocalService;
+		_resourcePermissionLocalService = resourcePermissionLocalService;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+                String metadataResourceName = _ddmPermissionSupport
+                        .getStructureModelResourceName(DLFileEntryMetadata.class.getName());
+
+                List<ResourceAction> fileEntryTypeActions = _resourceActionLocalService
+                        .getResourceActions(DLFileEntryType.class.getName());
+
+                Set<String> fileEntryMetadataActions = _resourceActionLocalService
+                        .getResourceActions(metadataResourceName)
+                        .stream()
+                        .map(ra -> ra.getActionId())
+                        .collect(Collectors.toSet());
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				"select companyId, fileEntryTypeId, dataDefinitionId from DLFileEntryType");
+			ResultSet resultSet = preparedStatement.executeQuery()) {
+
+			while (resultSet.next()) {
+				long companyId = resultSet.getLong("companyId");
+				long fileEntryTypeId = resultSet.getLong("fileEntryTypeId");
+				long dataDefinitionId = resultSet.getLong("dataDefinitionId");
+
+                                List<ResourcePermission> permissions = _resourcePermissionLocalService.getResourcePermissions(
+                                        companyId,
+                                        DLFileEntryType.class.getName(),
+                                        ResourceConstants.SCOPE_INDIVIDUAL,
+                                        Long.toString(fileEntryTypeId)
+                                );
+
+                                Map<Long,String[]> roleIdsToActionIds = new HashMap<>();
+
+                                for(ResourcePermission permission: permissions) {
+                                        long actionIds = permission.getActionIds();
+                                        List<String> actionIdList = new ArrayList<>();
+                                        for(ResourceAction ra: fileEntryTypeActions) {
+                                            String actionId = ra.getActionId();
+                                            if((actionIds & ra.getBitwiseValue()) == ra.getBitwiseValue() && fileEntryMetadataActions.contains(actionId)) {
+                                                actionIdList.add(actionId);
+                                            }
+                                        }
+                                        roleIdsToActionIds.put(permission.getRoleId(), actionIdList.toArray(new String[0]));
+                                }
+
+                                try {
+                                    _resourcePermissionLocalService.setResourcePermissions(
+                                            companyId,
+                                            metadataResourceName,
+                                            ResourceConstants.SCOPE_INDIVIDUAL,
+                                            Long.toString(dataDefinitionId),
+                                            roleIdsToActionIds
+                                    );
+                                }
+                                catch (PortalException portalException) {
+                                        ReflectionUtil.throwException(portalException);
+                                }
+			}
+		}
+	}
+
+	private final ResourceActionLocalService _resourceActionLocalService;
+
+	private final ResourcePermissionLocalService _resourcePermissionLocalService;
+
+        private final DDMPermissionSupport _ddmPermissionSupport;
+}

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/util/DLFileEntryTypePermissionUtil.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/util/DLFileEntryTypePermissionUtil.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.document.library.internal.util;
+
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourcePermission;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class DLFileEntryTypePermissionUtil {
+
+	public static Map<Long, String[]> getRoleIdsToActionIds(
+		List<ResourceAction> resourceActions,
+		List<ResourcePermission> resourcePermissions,
+		Predicate<String> predicate) {
+
+		Map<Long, String[]> roleIdsToActionIds = new HashMap<>();
+
+		for (ResourcePermission resourcePermission : resourcePermissions) {
+			long actionIds = resourcePermission.getActionIds();
+
+			List<String> resourcePermissionActionIds = new ArrayList<>();
+
+			for (ResourceAction resourceAction : resourceActions) {
+				String actionId = resourceAction.getActionId();
+
+				if (((actionIds & resourceAction.getBitwiseValue()) ==
+						resourceAction.getBitwiseValue()) &&
+					predicate.test(actionId)) {
+
+					resourcePermissionActionIds.add(actionId);
+				}
+			}
+
+			roleIdsToActionIds.put(
+				resourcePermission.getRoleId(),
+				resourcePermissionActionIds.toArray(new String[0]));
+		}
+
+		return roleIdsToActionIds;
+	}
+
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v1_0_0/DynamicDataMappingUpgradeProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v1_0_0/DynamicDataMappingUpgradeProcess.java
@@ -1225,22 +1225,19 @@ public class DynamicDataMappingUpgradeProcess extends UpgradeProcess {
 
 			String resourceName = _getStructureModelResourceName(classNameId);
 
-			// Check if the target permission already exists. For
-			// example the permissions for the structures backing
-			// DLFileEntryTypes are also updated through
-			// SyncDLFileEntryTypesDDMStructurePermissions in
-			// document-library-service. If this situation arises,
-			// don't try to rename the existing structure, but
-			// remove it, as the permissions were created in the
-			// second way.
+			// A permission with the correct resourceName may already exist.
+			// This means that Documents and Media has already migrated the
+			// structures for all its file entry types. In this case, we simply
+			// need to remove the old permission and continue with the upgrade
+			// process for the remaining resource permissions.
 
-			ResourcePermission existingPermission =
+			ResourcePermission existingResourcePermission =
 				_resourcePermissionLocalService.fetchResourcePermission(
 					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
 					String.valueOf(structureId),
 					resourcePermission.getRoleId());
 
-			if (existingPermission != null) {
+			if (existingResourcePermission != null) {
 				_resourcePermissionLocalService.deleteResourcePermission(
 					resourcePermission.getResourcePermissionId());
 			}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v1_0_0/DynamicDataMappingUpgradeProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v1_0_0/DynamicDataMappingUpgradeProcess.java
@@ -1225,10 +1225,31 @@ public class DynamicDataMappingUpgradeProcess extends UpgradeProcess {
 
 			String resourceName = _getStructureModelResourceName(classNameId);
 
-			resourcePermission.setName(resourceName);
+			// Check if the target permission already exists. For
+			// example the permissions for the structures backing
+			// DLFileEntryTypes are also updated through
+			// SyncDLFileEntryTypesDDMStructurePermissions in
+			// document-library-service. If this situation arises,
+			// don't try to rename the existing structure, but
+			// remove it, as the permissions were created in the
+			// second way.
 
-			_resourcePermissionLocalService.updateResourcePermission(
-				resourcePermission);
+			ResourcePermission existingPermission =
+				_resourcePermissionLocalService.fetchResourcePermission(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(structureId),
+					resourcePermission.getRoleId());
+
+			if (existingPermission != null) {
+				_resourcePermissionLocalService.deleteResourcePermission(
+					resourcePermission.getResourcePermissionId());
+			}
+			else {
+				resourcePermission.setName(resourceName);
+
+				_resourcePermissionLocalService.updateResourcePermission(
+					resourcePermission);
+			}
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryTypeLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryTypeLocalServiceImpl.java
@@ -773,21 +773,25 @@ public class DLFileEntryTypeLocalServiceImpl
                 // This covers the creation case. Updating is handled in
                 // com.liferay.document.library.internal.security.permission.DLFileEntryTypePermissionUpdateHandler
 
-                ModelPermissions structurePermissions = ModelPermissionsFactory.create(DDM_FILE_ENTRY_METADATA);
+                ModelPermissions structurePermissions = null;
 
-                Set<String> fileEntryMetadataActions = _resourceActionLocalService
-                        .getResourceActions(DDM_FILE_ENTRY_METADATA)
-                        .stream()
-                        .map(ra -> ra.getActionId())
-                        .collect(Collectors.toSet());
+                if (modelPermissions != null) {
+                        structurePermissions = ModelPermissionsFactory.create(DDM_FILE_ENTRY_METADATA);
 
-                for(String role: modelPermissions.getRoleNames()) {
-                    String[] structureActionIds = Arrays
-                            .stream(modelPermissions.getActionIds(role))
-                            .filter(actionId -> fileEntryMetadataActions.contains(actionId))
-                            .collect(Collectors.toList())
-                            .toArray(new String[0]);
-                    structurePermissions.addRolePermissions(role, structureActionIds);
+                        Set<String> fileEntryMetadataActions = _resourceActionLocalService
+                                .getResourceActions(DDM_FILE_ENTRY_METADATA)
+                                .stream()
+                                .map(ra -> ra.getActionId())
+                                .collect(Collectors.toSet());
+
+                        for (String role : modelPermissions.getRoleNames()) {
+                                String[] structureActionIds = Arrays
+                                        .stream(modelPermissions.getActionIds(role))
+                                        .filter(actionId -> fileEntryMetadataActions.contains(actionId))
+                                        .collect(Collectors.toList())
+                                        .toArray(new String[0]);
+                                structurePermissions.addRolePermissions(role, structureActionIds);
+                        }
                 }
 
 		_resourceLocalService.addModelResources(

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryTypeLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryTypeLocalServiceImpl.java
@@ -735,18 +735,10 @@ public class DLFileEntryTypeLocalServiceImpl
 			dlFileEntryType.getFileEntryTypeId(), false, addGroupPermissions,
 			addGuestPermissions);
 
-		// Each DLFileEntryType is tied to a DDM structure, that holds
-		// the metadata definitions defined in the document type itself.
-		// The upload forms (and most probably other code) checks the
-		// permissions on the DDM structure to determine if the fields
-		// may be viewed/entered by a user. So the permissions on the
-		// structure need to be sychronized with the DLFilEntryType.
-		// This covers the creation case. Updating is handled in
-		// document-library-service, DLFileEntryTypePermissionUpdateHandler
-
 		_resourceLocalService.addResources(
 			dlFileEntryType.getCompanyId(), dlFileEntryType.getGroupId(),
-			dlFileEntryType.getUserId(), _DDM_FILE_ENTRY_METADATA,
+			dlFileEntryType.getUserId(),
+			_DL_FILE_ENTRY_METADATA_DDM_STRUCTURE_CLASS_NAME,
 			dlFileEntryType.getDataDefinitionId(), false, addGroupPermissions,
 			addGuestPermissions);
 	}
@@ -760,49 +752,51 @@ public class DLFileEntryTypeLocalServiceImpl
 			dlFileEntryType.getUserId(), DLFileEntryType.class.getName(),
 			dlFileEntryType.getFileEntryTypeId(), modelPermissions);
 
-		// Each DLFileEntryType is tied to a DDM structure, that holds
-		// the metadata definitions defined in the document type itself.
-		// The upload forms (and most probably other code) checks the
-		// permissions on the DDM structure to determine if the fields
-		// may be viewed/entered by a user. So the permissions on the
-		// structure need to be sychronized with the DLFilEntryType.
-		// This covers the creation case. Updating is handled in
-		// document-library-service, DLFileEntryTypePermissionUpdateHandler
-
-		ModelPermissions structurePermissions = null;
+		ModelPermissions dlFileEntryMetadataDDMStructureModelPermissions = null;
 
 		if (modelPermissions != null) {
-			structurePermissions = ModelPermissionsFactory.create(
-				_DDM_FILE_ENTRY_METADATA);
+			dlFileEntryMetadataDDMStructureModelPermissions =
+				ModelPermissionsFactory.create(
+					_DL_FILE_ENTRY_METADATA_DDM_STRUCTURE_CLASS_NAME);
 
-			List<ResourceAction> fileEntryMetadataActions =
+			List<ResourceAction> dlFileEntryMetadataResourceActions =
 				_resourceActionLocalService.getResourceActions(
-					_DDM_FILE_ENTRY_METADATA);
+					_DL_FILE_ENTRY_METADATA_DDM_STRUCTURE_CLASS_NAME);
 
-			Set<String> fileEntryMetadataActionIds = new HashSet<>();
+			Set<String> dlFileEntryMetadataActionIds = new HashSet<>();
 
-			for (ResourceAction ra : fileEntryMetadataActions) {
-				fileEntryMetadataActionIds.add(ra.getActionId());
+			for (ResourceAction resourceAction :
+					dlFileEntryMetadataResourceActions) {
+
+				dlFileEntryMetadataActionIds.add(resourceAction.getActionId());
 			}
 
-			for (String role : modelPermissions.getRoleNames()) {
-				Set<String> structureActionIds = new HashSet<>();
+			for (String roleName : modelPermissions.getRoleNames()) {
+				Set<String> dlFileEntryMetadataDDMStructureActionIds =
+					new HashSet<>();
 
-				for (String actionId : modelPermissions.getActionIds(role)) {
-					if (fileEntryMetadataActionIds.contains(actionId)) {
-						structureActionIds.add(actionId);
+				for (String actionId :
+						modelPermissions.getActionIds(roleName)) {
+
+					if (dlFileEntryMetadataActionIds.contains(actionId)) {
+						dlFileEntryMetadataDDMStructureActionIds.add(actionId);
 					}
 				}
 
-				structurePermissions.addRolePermissions(
-					role, structureActionIds.toArray(new String[0]));
+				dlFileEntryMetadataDDMStructureModelPermissions.
+					addRolePermissions(
+						roleName,
+						dlFileEntryMetadataDDMStructureActionIds.toArray(
+							new String[0]));
 			}
 		}
 
 		_resourceLocalService.addModelResources(
 			dlFileEntryType.getCompanyId(), dlFileEntryType.getGroupId(),
-			dlFileEntryType.getUserId(), _DDM_FILE_ENTRY_METADATA,
-			dlFileEntryType.getDataDefinitionId(), structurePermissions);
+			dlFileEntryType.getUserId(),
+			_DL_FILE_ENTRY_METADATA_DDM_STRUCTURE_CLASS_NAME,
+			dlFileEntryType.getDataDefinitionId(),
+			dlFileEntryMetadataDDMStructureModelPermissions);
 	}
 
 	protected void cascadeFileEntryTypes(
@@ -1101,9 +1095,10 @@ public class DLFileEntryTypeLocalServiceImpl
 		}
 	}
 
-	private static final String _DDM_FILE_ENTRY_METADATA =
-		"com.liferay.document.library.kernel.model.DLFileEntryMetadata-" +
-			"com.liferay.dynamic.data.mapping.model.DDMStructure";
+	private static final String
+		_DL_FILE_ENTRY_METADATA_DDM_STRUCTURE_CLASS_NAME =
+			"com.liferay.document.library.kernel.model.DLFileEntryMetadata-" +
+				"com.liferay.dynamic.data.mapping.model.DDMStructure";
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		DLFileEntryTypeLocalServiceImpl.class);


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-156658
Original PR1 comment:

> Each DLFileEntryType is tied to a DDM structure, that holds the
> metadata definitions defined in the document type itself.
> 
> The upload forms (and most probably other code) checks the permissions
> on the DDM structure to determine if the fields may be viewed/entered
> by a user. So the permissions on the structure need to be sychronized
> with the DLFilEntryType.

Original PR2 comment:

> Hey @matthiasblaesing,
> 
> I've added a couple of commits on top of your changes. These are basically variable renames and other minor changes so that the PR conforms to our coding conventions.
> 
> Can you take a look at my changes to make sure everything is ok?
> 
> Thanks!

@brianchandotcom resending this pull directly to you since after a few retries we confirmed this pull is not related to any of the failing tests in https://github.com/liferay-lima/liferay-portal/pull/3623.