### PR TITLE
LPS-161364 Use new pattern for batch engine

### DIFF
--- a/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/FieldResourceImpl.java
+++ b/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/FieldResourceImpl.java
@@ -19,6 +19,7 @@ import com.liferay.batch.planner.rest.internal.vulcan.batch.engine.FieldProvider
 import com.liferay.batch.planner.rest.resource.v1_0.FieldResource;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.vulcan.pagination.Page;
 
 import java.util.Comparator;
@@ -71,7 +72,9 @@ public class FieldResourceImpl extends BaseFieldResourceImpl {
 			return _fieldProvider.getFields(internalClassName);
 		}
 
-		String objectDefinitionName = internalClassName.substring(idx + 1);
+		String objectDefinitionName = StringUtil.replaceLast(
+			internalClassName.substring(idx + 1),
+			String.valueOf(contextCompany.getCompanyId()), "");
 
 		return _fieldProvider.getFields(
 			contextCompany.getCompanyId(), objectDefinitionName,

--- a/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/display/context/EditBatchPlannerPlanDisplayContext.java
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/display/context/EditBatchPlannerPlanDisplayContext.java
@@ -20,6 +20,7 @@ import com.liferay.batch.planner.model.BatchPlannerPlan;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.SelectOption;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.util.StringUtil;
 
 import java.util.ArrayList;
@@ -197,7 +198,9 @@ public class EditBatchPlannerPlanDisplayContext {
 			return internalClassName;
 		}
 
-		return internalClassName.substring(index + 1);
+		return StringUtil.replaceLast(
+			internalClassName.substring(index + 1),
+			String.valueOf(CompanyThreadLocal.getCompanyId()), "");
 	}
 
 	private final List<SelectOption> _internalClassNameSelectOptions;

--- a/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/helper/BatchPlannerPlanHelper.java
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/helper/BatchPlannerPlanHelper.java
@@ -356,7 +356,7 @@ public class BatchPlannerPlanHelper {
 			return taskItemDelegateName;
 		}
 
-		return internalClassName.substring(index + 3);
+		return internalClassName.substring(index + 1);
 	}
 
 	private BatchPlannerPlan _updateBatchPlannerPlan(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -368,8 +368,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 						"api.version", "v1.0"
 					).put(
 						"batch.engine.entity.class.name",
-						ObjectEntry.class.getName() + "#" +
-							objectDefinition.getName()
+						ObjectEntry.class.getName() + "#" + osgiJaxRsName
 					).put(
 						"batch.engine.task.item.delegate", "true"
 					).put(
@@ -380,8 +379,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 						"batch.planner.import.enabled", "true"
 					).put(
 						"entity.class.name",
-						ObjectEntry.class.getName() + "#" +
-							objectDefinition.getName()
+						ObjectEntry.class.getName() + "#" + osgiJaxRsName
 					).put(
 						"osgi.jaxrs.application.select",
 						"(osgi.jaxrs.name=" + osgiJaxRsName + ")"


### PR DESCRIPTION
Forwarded from https://github.com/liferay-headless/liferay-portal/pull/817
___
Original description:
Related ticket [LPS-166128](https://issues.liferay.com/browse/LPS-166128)
____
## Purpose of this PR
In [this PR](https://github.com/brianchandotcom/liferay-portal/pull/124524) we changed the way that we register the new object JAXR applications breaking the import/export center as the taskItemDelegate has a different name.

With this PR we solved it using the new pattern.

## How to deploy it
Deploy de following modules:
* `object-rest-impl`
* `batch-planner-web`
* `batch-planner-rest-impl`