### PR TITLE
LPS-165823 Add test to sort headless resources inside of widget template

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/HeadlessResourceTemplates.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/HeadlessResourceTemplates.testcase
@@ -1,0 +1,74 @@
+@component-name = "portal-headless"
+definition {
+
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.main.component.name = "Headless";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginPG();
+	}
+
+	tearDown {
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
+
+		if ("${testPortalInstance}" == "true") {
+			PortalInstances.tearDownCP();
+		}
+		else {
+			BlogPostingAPI.deleteAllBlogPostings();
+
+			PagesAdmin.tearDownCP();
+
+			ApplicationDisplayTemplates.openWidgetTemplatesAdmin(siteURLKey = "guest");
+
+			ApplicationDisplayTemplates.deleteCP(widgetTemplateName = "Blogs Test ADT");
+		}
+	}
+
+	@priority = "4"
+	test CanUseServicesInsideTemplates {
+		property portal.acceptance = "true";
+
+		task ("Given three blog postings created") {
+			BlogPostingAPI.getIdOfCreateNBlogPostingBatchEngineImportTask(
+				createStrategy = "UPSERT",
+				numberOfBlogPostings = "3");
+		}
+
+		task ("And Given a template that will print the blog postings headlines sorted desc and filtered by creator name") {
+			ApplicationDisplayTemplates.openWidgetTemplatesAdmin(siteURLKey = "guest");
+
+			ApplicationDisplayTemplates.addCP(
+				adtFile = "adt_blogs_sort.ftl",
+				adtType = "Blogs");
+		}
+
+		task ("When adding a template to a widget page") {
+			JSONLayout.addPublicLayout(
+				groupName = "Guest",
+				layoutName = "Blogs Page");
+
+			JSONLayout.addWidgetToPublicLayout(
+				groupName = "Guest",
+				layoutName = "Blogs Page",
+				widgetName = "Blogs");
+
+			Navigator.gotoPage(pageName = "Blogs Page");
+
+			ApplicationDisplayTemplates.selectPortletADT(
+				portletName = "Blogs",
+				templateName = "Blogs Test ADT");
+		}
+
+		task ("Then blog posting headlines are visible and in the correct order") {
+			AssertTextEquals(
+				key_portletName = "Blogs",
+				locator1 = "Portlet#BODY",
+				value1 = "headline2 headline1 headline0");
+		}
+	}
+
+}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/HeadlessResourceTemplates.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/HeadlessResourceTemplates.testcase
@@ -25,6 +25,10 @@ definition {
 			ApplicationDisplayTemplates.openWidgetTemplatesAdmin(siteURLKey = "guest");
 
 			ApplicationDisplayTemplates.deleteCP(widgetTemplateName = "Blogs Test ADT");
+
+			JSONLayout.deletePublicLayout(
+				groupName = "Guest",
+				layoutName = "Blogs Page");
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/dependencies/adt_blogs_sort.ftl
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/dependencies/adt_blogs_sort.ftl
@@ -1,0 +1,5 @@
+<#assign blogPostingResource = resourceLocator.locate("/headless-delivery/v1.0", "BlogPosting")siteBlogPostingsPage = blogPostingResource.getSiteBlogPostingsPage(groupId, null, null, blogPostingResource.toFilter("creatorName eq Test"), null, blogPostingResource.toSorts("headline:desc"))blogPostings = siteBlogPostingsPage.getItems() />
+
+<#list blogPostings as blogPosting>
+	<h1>${blogPosting.headline}</h1>
+</#list>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/dependencies/adt_blogs_sort.ftl
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/dependencies/adt_blogs_sort.ftl
@@ -1,4 +1,4 @@
-<#assign blogPostingResource = resourceLocator.locate("/headless-delivery/v1.0", "BlogPosting")siteBlogPostingsPage = blogPostingResource.getSiteBlogPostingsPage(groupId, null, null, blogPostingResource.toFilter("creatorName eq Test"), null, blogPostingResource.toSorts("headline:desc"))blogPostings = siteBlogPostingsPage.getItems() />
+<#assign blogPostingResource = resourceLocator.locate("/headless-delivery/v1.0", "BlogPosting")siteBlogPostingsPage = blogPostingResource.getSiteBlogPostingsPage(groupId, null, null, blogPostingResource.toFilter("creatorId ne 0"), null, blogPostingResource.toSorts("headline:desc"))blogPostings = siteBlogPostingsPage.getItems() />
 
 <#list blogPostings as blogPosting>
 	<h1>${blogPosting.headline}</h1>


### PR DESCRIPTION
Manual forwarding, see here: https://github.com/liferay-headless/liferay-portal/pull/816

**Background**:
Add test to sort headless resources inside of widget template
(Check points for poshi tests:
add widget template through UI since I haven't find a way to add it through headless api
add widget template using exsiting file adt_blogs_sort.ftl to avoid autocompletion when set scripts through poshi type.sendKeys
update example to filter by creator name instead of creator id which should not make any differences to the key function)

**Test Plan:**
Given three blog postings created
And Given a template that will print the blog postings headlines sorted desc and filtered by creator name
When adding a template to a widget page
Then blog posting headlines are visible and in the correct order

**Jira Ticket:**
https://issues.liferay.com/browse/LPS-165823