### PR TITLE
LPS-166798 Object definitions were leaking to other Companies on the OAuth Scopes Page

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -274,6 +274,9 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 			Arrays.asList(
 				_objectEntryApplicationComponentFactory.newInstance(
 					HashMapDictionaryBuilder.<String, Object>put(
+						"companyId",
+						String.valueOf(objectDefinition.getCompanyId())
+					).put(
 						"liferay.jackson", false
 					).put(
 						"osgi.jaxrs.application.base",


### PR DESCRIPTION
Manually forwarding due to unrelated ci failures based on @carolmariaabb's comment [here](https://github.com/liferay-objects/liferay-portal/pull/1276#issuecomment-1293622786).

https://issues.liferay.com/browse/LPS-166798

Sets the `companyId` property to take advantage of the existing filter on companyId in the OAuth Service Tracker [here](https://github.com/liferay/liferay-portal/blob/05589ddef153203dbdbff32dc459afac2f90963d/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/liferay/ScopedServiceTrackerMapFactoryImpl.java#L101)

Also see this comment that I left on the original pull request:

> Hi @gabrielwas,
> 
> We had a "companyId" pattern already that was being used by the OAuth module.
> 
> When I did [LPS-163914](https://issues.liferay.com/browse/LPS-163914) a few weeks ago, I added it as "company.id" instead of "companyId", because I wasn't aware of the existing "companyId" pattern at that time (and "company.id" seemed to match better with the other property names which were period-delimited).
> 
> We probably should standardize them at some point.