### PR TITLE
LPS-166947 Shrink quartz thread pool size to 1. Quartz only runs Mess…

### DIFF
--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -8195,7 +8195,7 @@
     # Env: LIFERAY_MEMORY_PERIOD_SCHEDULER_PERIOD_ORG_PERIOD_QUARTZ_PERIOD_THREAD_UPPERCASEP_OOL_PERIOD_THREAD_UPPERCASEC_OUNT
     # Env: LIFERAY_MEMORY_PERIOD_SCHEDULER_PERIOD_ORG_PERIOD_QUARTZ_PERIOD_THREAD_UPPERCASEP_OOL_PERIOD_THREAD_UPPERCASEP_RIORITY
     #
-    memory.scheduler.org.quartz.threadPool.threadCount=5
+    memory.scheduler.org.quartz.threadPool.threadCount=1
     memory.scheduler.org.quartz.threadPool.threadPriority=5
 
     #
@@ -8283,7 +8283,7 @@
     # Env: LIFERAY_PERSISTED_PERIOD_SCHEDULER_PERIOD_ORG_PERIOD_QUARTZ_PERIOD_THREAD_UPPERCASEP_OOL_PERIOD_THREAD_UPPERCASEC_OUNT
     # Env: LIFERAY_PERSISTED_PERIOD_SCHEDULER_PERIOD_ORG_PERIOD_QUARTZ_PERIOD_THREAD_UPPERCASEP_OOL_PERIOD_THREAD_UPPERCASEP_RIORITY
     #
-    persisted.scheduler.org.quartz.threadPool.threadCount=5
+    persisted.scheduler.org.quartz.threadPool.threadCount=1
     persisted.scheduler.org.quartz.threadPool.threadPriority=5
 
 ##


### PR DESCRIPTION
…ageSenderJob which is just sending a message to an async messagebus destination. The main work load is handled by the message bus thread, not quartz thread. Having one thread per storge type is enough.