### PR TITLE
LPS-162963: Allow developers to break a relationship between 2 objects

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -17,7 +17,6 @@ package com.liferay.object.rest.internal.manager.v1_0;
 import com.liferay.account.constants.AccountConstants;
 import com.liferay.account.model.AccountEntry;
 import com.liferay.account.service.AccountEntryLocalService;
-import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.object.constants.ObjectConstants;
 import com.liferay.object.constants.ObjectDefinitionConstants;
@@ -52,6 +51,8 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.PersistedModel;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.sanitizer.Sanitizer;
 import com.liferay.portal.kernel.sanitizer.SanitizerUtil;
@@ -62,6 +63,8 @@ import com.liferay.portal.kernel.search.filter.BooleanFilter;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.search.filter.TermFilter;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.service.PersistedModelLocalService;
+import com.liferay.portal.kernel.service.PersistedModelLocalServiceRegistryUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -695,14 +698,22 @@ public class DefaultObjectEntryManagerImpl
 			_systemObjectDefinitionMetadataTracker.
 				getSystemObjectDefinitionMetadata(objectDefinition.getName());
 
-		AssetEntry assetEntry = _assetEntryLocalService.getEntry(
-			systemObjectDefinitionMetadata.getModelClassName(), objectEntryId);
+		PersistedModelLocalService persistedModelLocalService =
+			PersistedModelLocalServiceRegistryUtil.
+				getPersistedModelLocalService(
+					systemObjectDefinitionMetadata.getModelClassName());
+
+		PersistedModel persistedModel =
+			persistedModelLocalService.getPersistedModel(objectEntryId);
 
 		if (Objects.equals(
 				systemObjectDefinitionMetadata.getScope(),
-				ObjectDefinitionConstants.SCOPE_SITE)) {
+				ObjectDefinitionConstants.SCOPE_SITE) &&
+			(persistedModel instanceof GroupedModel)) {
 
-			groupId = assetEntry.getGroupId();
+			GroupedModel groupedModel = (GroupedModel)persistedModel;
+
+			groupId = groupedModel.getGroupId();
 		}
 
 		return Page.of(
@@ -711,7 +722,7 @@ public class DefaultObjectEntryManagerImpl
 				dtoConverterContext,
 				objectRelatedModelsProvider.getRelatedModels(
 					groupId, objectRelationship.getObjectRelationshipId(),
-					assetEntry.getClassPK(), pagination.getStartPosition(),
+					objectEntryId, pagination.getStartPosition(),
 					pagination.getEndPosition())));
 	}
 

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseRelatedObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseRelatedObjectEntryResourceImpl.java
@@ -26,6 +26,7 @@ import io.swagger.v3.oas.annotations.tags.Tags;
 
 import javax.validation.constraints.NotNull;
 
+import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
@@ -38,6 +39,23 @@ import javax.ws.rs.core.Context;
  */
 @Path("/v1.0")
 public class BaseRelatedObjectEntryResourceImpl {
+
+	@DELETE
+	@Path(
+		"/{previousPath: [a-zA-Z0-9-]+}/{objectEntryId: \\d+}/{objectRelationshipName: [a-zA-Z0-9-]+}/{relatedObjectEntryId}"
+	)
+	@Produces({"application/json", "application/xml"})
+	public void deleteObjectRelationshipMappingTableValues(
+			@NotNull @Parameter(hidden = true) @PathParam("previousPath") String
+				previousPath,
+			@NotNull @Parameter(hidden = true) @PathParam("objectEntryId") Long
+				objectEntryId,
+			@NotNull @Parameter(hidden = true)
+			@PathParam("objectRelationshipName")
+			String objectRelationshipName,
+			@PathParam("relatedObjectEntryId") Long relatedObjectEntryId)
+		throws Exception {
+	}
 
 	@GET
 	@Parameters(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/RelatedObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/RelatedObjectEntryResourceImpl.java
@@ -27,6 +27,8 @@ import com.liferay.object.service.ObjectRelationshipService;
 import com.liferay.object.system.SystemObjectDefinitionMetadata;
 import com.liferay.object.system.SystemObjectDefinitionMetadataTracker;
 import com.liferay.portal.kernel.security.auth.GuestOrUserUtil;
+import com.liferay.portal.kernel.service.PersistedModelLocalService;
+import com.liferay.portal.kernel.service.PersistedModelLocalServiceRegistryUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -78,6 +80,8 @@ public class RelatedObjectEntryResourceImpl
 
 		_getRelatedObjectEntry(
 			objectRelationship, relatedObjectEntryId, systemObjectDefinition);
+
+		_checkSystemObjectEntry(objectEntryId, systemObjectDefinition);
 
 		ObjectRelatedModelsProvider objectRelatedModelsProvider =
 			_objectRelatedModelsProviderRegistry.getObjectRelatedModelsProvider(
@@ -166,6 +170,18 @@ public class RelatedObjectEntryResourceImpl
 
 		return _getRelatedObjectEntry(
 			objectRelationship, relatedObjectEntryId, systemObjectDefinition);
+	}
+
+	private void _checkSystemObjectEntry(
+			long objectEntryId, ObjectDefinition systemObjectDefinition)
+		throws Exception {
+
+		PersistedModelLocalService persistedModelLocalService =
+			PersistedModelLocalServiceRegistryUtil.
+				getPersistedModelLocalService(
+					systemObjectDefinition.getClassName());
+
+		persistedModelLocalService.getPersistedModel(objectEntryId);
 	}
 
 	private DefaultDTOConverterContext _getDefaultDTOConverterContext(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/RelatedObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/RelatedObjectEntryResourceTest.java
@@ -53,6 +53,7 @@ import com.liferay.portal.util.PropsUtil;
 
 import java.io.Serializable;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -107,47 +108,303 @@ public class RelatedObjectEntryResourceTest {
 			_systemObjectDefinitionMetadataTracker.
 				getSystemObjectDefinitionMetadata("User");
 
-		ObjectDefinition userSystemObjectDefinition =
+		_userSystemObjectDefinition =
 			_objectDefinitionLocalService.fetchSystemObjectDefinition(
 				_userSystemObjectDefinitionMetadata.getName());
 
-		_objectRelationship =
-			ObjectRelationshipLocalServiceUtil.addObjectRelationship(
-				TestPropsValues.getUserId(),
-				_objectDefinition.getObjectDefinitionId(),
-				userSystemObjectDefinition.getObjectDefinitionId(), 0,
-				ObjectRelationshipConstants.DELETION_TYPE_PREVENT,
-				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
-				StringUtil.randomId(),
-				ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
-
 		_user = TestPropsValues.getUser();
-
-		ObjectRelationshipLocalServiceUtil.
-			addObjectRelationshipMappingTableValues(
-				TestPropsValues.getUserId(),
-				_objectRelationship.getObjectRelationshipId(),
-				_objectEntry.getPrimaryKey(), _user.getUserId(),
-				ServiceContextTestUtil.getServiceContext());
 	}
 
 	@After
 	public void tearDown() throws Exception {
-		ObjectRelationshipLocalServiceUtil.
-			deleteObjectRelationshipMappingTableValues(
-				_objectRelationship.getObjectRelationshipId(),
-				_objectEntry.getPrimaryKey(), _user.getUserId());
-		ObjectRelationshipLocalServiceUtil.deleteObjectRelationship(
-			_objectRelationship);
+		for (ObjectRelationship objectRelationship : _objectRelationships) {
+			ObjectRelationshipLocalServiceUtil.
+				deleteObjectRelationshipMappingTableValues(
+					objectRelationship.getObjectRelationshipId(),
+					_user.getUserId(), _objectEntry.getPrimaryKey());
+
+			ObjectRelationshipLocalServiceUtil.deleteObjectRelationship(
+				objectRelationship);
+		}
 	}
 
 	@Test
-	public void testGetSystemObjectRelatedObjects() throws Exception {
+	public void testDeleteManyToManySystemObjectNotFoundRelatedObject()
+		throws Exception {
+
+		Long irrelevantUserId = RandomTestUtil.randomLong();
+
+		String name = StringUtil.randomId();
+
+		ObjectRelationship objectRelationship = _addObjectRelationship(
+			name, _objectDefinition.getObjectDefinitionId(),
+			_userSystemObjectDefinition.getObjectDefinitionId(),
+			_objectEntry.getPrimaryKey(), _user.getUserId(),
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		JSONObject jsonObject = _invoke(
+			StringBundler.concat(
+				_userSystemObjectDefinitionMetadata.getRESTContextPath(),
+				StringPool.SLASH, irrelevantUserId, StringPool.SLASH,
+				objectRelationship.getName(), StringPool.SLASH,
+				_objectEntry.getPrimaryKey()),
+			Http.Method.DELETE);
+
+		String statusCode = jsonObject.getString("status");
+
+		Assert.assertEquals("NOT_FOUND", statusCode);
+
+		jsonObject = _invoke(
+			StringBundler.concat(
+				_userSystemObjectDefinitionMetadata.getRESTContextPath(),
+				StringPool.SLASH, _user.getUserId(), StringPool.SLASH,
+				objectRelationship.getName()),
+			Http.Method.GET);
+
+		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
+
+		Assert.assertEquals(1, itemsJSONArray.length());
+	}
+
+	@Test
+	public void testDeleteManyToManySystemObjectRelatedObject()
+		throws Exception {
+
+		String name = StringUtil.randomId();
+
+		ObjectRelationship objectRelationship = _addObjectRelationship(
+			name, _objectDefinition.getObjectDefinitionId(),
+			_userSystemObjectDefinition.getObjectDefinitionId(),
+			_objectEntry.getPrimaryKey(), _user.getUserId(),
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
 		JSONObject jsonObject = _invoke(
 			StringBundler.concat(
 				_userSystemObjectDefinitionMetadata.getRESTContextPath(),
 				StringPool.SLASH, _user.getUserId(), StringPool.SLASH,
-				_objectRelationship.getName()),
+				objectRelationship.getName()),
+			Http.Method.GET);
+
+		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
+
+		Assert.assertEquals(1, itemsJSONArray.length());
+
+		_invoke(
+			StringBundler.concat(
+				_userSystemObjectDefinitionMetadata.getRESTContextPath(),
+				StringPool.SLASH, _user.getUserId(), StringPool.SLASH,
+				objectRelationship.getName(), StringPool.SLASH,
+				_objectEntry.getPrimaryKey()),
+			Http.Method.DELETE);
+
+		jsonObject = _invoke(
+			StringBundler.concat(
+				_userSystemObjectDefinitionMetadata.getRESTContextPath(),
+				StringPool.SLASH, _user.getUserId(), StringPool.SLASH,
+				objectRelationship.getName()),
+			Http.Method.GET);
+
+		itemsJSONArray = jsonObject.getJSONArray("items");
+
+		Assert.assertEquals(0, itemsJSONArray.length());
+	}
+
+	@Test
+	public void testDeleteManyToManySystemObjectRelatedObjectNotFound()
+		throws Exception {
+
+		Long irrelevantPrimaryKey = RandomTestUtil.randomLong();
+
+		String name = StringUtil.randomId();
+
+		ObjectRelationship objectRelationship = _addObjectRelationship(
+			name, _objectDefinition.getObjectDefinitionId(),
+			_userSystemObjectDefinition.getObjectDefinitionId(),
+			_objectEntry.getPrimaryKey(), _user.getUserId(),
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		JSONObject jsonObject = _invoke(
+			StringBundler.concat(
+				_userSystemObjectDefinitionMetadata.getRESTContextPath(),
+				StringPool.SLASH, _user.getUserId(), StringPool.SLASH,
+				objectRelationship.getName(), StringPool.SLASH,
+				irrelevantPrimaryKey),
+			Http.Method.DELETE);
+
+		String statusCode = jsonObject.getString("status");
+
+		Assert.assertEquals("NOT_FOUND", statusCode);
+
+		jsonObject = _invoke(
+			StringBundler.concat(
+				_userSystemObjectDefinitionMetadata.getRESTContextPath(),
+				StringPool.SLASH, _user.getUserId(), StringPool.SLASH,
+				objectRelationship.getName()),
+			Http.Method.GET);
+
+		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
+
+		Assert.assertEquals(1, itemsJSONArray.length());
+	}
+
+	@Test
+	public void testDeleteOneToManySystemObjectNotFoundRelatedObject()
+		throws Exception {
+
+		Long irrelevantUserId = RandomTestUtil.randomLong();
+
+		String name = StringUtil.randomId();
+
+		ObjectRelationship objectRelationship = _addObjectRelationship(
+			name, _userSystemObjectDefinition.getObjectDefinitionId(),
+			_objectDefinition.getObjectDefinitionId(), _user.getUserId(),
+			_objectEntry.getPrimaryKey(),
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		JSONObject jsonObject = _invoke(
+			StringBundler.concat(
+				_userSystemObjectDefinitionMetadata.getRESTContextPath(),
+				StringPool.SLASH, irrelevantUserId, StringPool.SLASH,
+				objectRelationship.getName(), StringPool.SLASH,
+				_objectEntry.getPrimaryKey()),
+			Http.Method.DELETE);
+
+		String statusCode = jsonObject.getString("status");
+
+		Assert.assertEquals("NOT_FOUND", statusCode);
+
+		jsonObject = _invoke(
+			StringBundler.concat(
+				_userSystemObjectDefinitionMetadata.getRESTContextPath(),
+				StringPool.SLASH, _user.getUserId(), StringPool.SLASH,
+				objectRelationship.getName()),
+			Http.Method.GET);
+
+		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
+
+		Assert.assertEquals(1, itemsJSONArray.length());
+	}
+
+	@Test
+	public void testDeleteOneToManySystemObjectRelatedObject()
+		throws Exception {
+
+		String name = StringUtil.randomId();
+
+		ObjectRelationship objectRelationship = _addObjectRelationship(
+			name, _userSystemObjectDefinition.getObjectDefinitionId(),
+			_objectDefinition.getObjectDefinitionId(), _user.getUserId(),
+			_objectEntry.getPrimaryKey(),
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		JSONObject jsonObject = _invoke(
+			StringBundler.concat(
+				_userSystemObjectDefinitionMetadata.getRESTContextPath(),
+				StringPool.SLASH, _user.getUserId(), StringPool.SLASH,
+				objectRelationship.getName()),
+			Http.Method.GET);
+
+		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
+
+		Assert.assertEquals(1, itemsJSONArray.length());
+
+		_invoke(
+			StringBundler.concat(
+				_userSystemObjectDefinitionMetadata.getRESTContextPath(),
+				StringPool.SLASH, _user.getUserId(), StringPool.SLASH,
+				objectRelationship.getName(), StringPool.SLASH,
+				_objectEntry.getPrimaryKey()),
+			Http.Method.DELETE);
+
+		jsonObject = _invoke(
+			StringBundler.concat(
+				_userSystemObjectDefinitionMetadata.getRESTContextPath(),
+				StringPool.SLASH, _user.getUserId(), StringPool.SLASH,
+				objectRelationship.getName()),
+			Http.Method.GET);
+
+		itemsJSONArray = jsonObject.getJSONArray("items");
+
+		Assert.assertEquals(0, itemsJSONArray.length());
+	}
+
+	@Test
+	public void testDeleteOneToManySystemObjectRelatedObjectNotFound()
+		throws Exception {
+
+		Long irrelevantPrimaryKey = RandomTestUtil.randomLong();
+
+		String name = StringUtil.randomId();
+
+		ObjectRelationship objectRelationship = _addObjectRelationship(
+			name, _userSystemObjectDefinition.getObjectDefinitionId(),
+			_objectDefinition.getObjectDefinitionId(), _user.getUserId(),
+			_objectEntry.getPrimaryKey(),
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		JSONObject jsonObject = _invoke(
+			StringBundler.concat(
+				_userSystemObjectDefinitionMetadata.getRESTContextPath(),
+				StringPool.SLASH, _user.getUserId(), StringPool.SLASH,
+				objectRelationship.getName(), StringPool.SLASH,
+				irrelevantPrimaryKey),
+			Http.Method.DELETE);
+
+		String statusCode = jsonObject.getString("status");
+
+		Assert.assertEquals("NOT_FOUND", statusCode);
+
+		jsonObject = _invoke(
+			StringBundler.concat(
+				_userSystemObjectDefinitionMetadata.getRESTContextPath(),
+				StringPool.SLASH, _user.getUserId(), StringPool.SLASH,
+				objectRelationship.getName()),
+			Http.Method.GET);
+
+		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
+
+		Assert.assertEquals(1, itemsJSONArray.length());
+	}
+
+	@Test
+	public void testGetSystemObjectNotFoundRelatedObjects() throws Exception {
+		Long irrelevantUserId = RandomTestUtil.randomLong();
+
+		String name = StringUtil.randomId();
+
+		ObjectRelationship objectRelationship = _addObjectRelationship(
+			name, _objectDefinition.getObjectDefinitionId(),
+			_userSystemObjectDefinition.getObjectDefinitionId(),
+			_objectEntry.getPrimaryKey(), _user.getUserId(),
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		JSONObject jsonObject = _invoke(
+			StringBundler.concat(
+				_userSystemObjectDefinitionMetadata.getRESTContextPath(),
+				StringPool.SLASH, irrelevantUserId, StringPool.SLASH,
+				objectRelationship.getName()),
+			Http.Method.GET);
+
+		String statusCode = jsonObject.getString("status");
+
+		Assert.assertEquals("NOT_FOUND", statusCode);
+	}
+
+	@Test
+	public void testGetSystemObjectRelatedObjects() throws Exception {
+		String name = StringUtil.randomId();
+
+		ObjectRelationship objectRelationship = _addObjectRelationship(
+			name, _objectDefinition.getObjectDefinitionId(),
+			_userSystemObjectDefinition.getObjectDefinitionId(),
+			_objectEntry.getPrimaryKey(), _user.getUserId(),
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		JSONObject jsonObject = _invoke(
+			StringBundler.concat(
+				_userSystemObjectDefinitionMetadata.getRESTContextPath(),
+				StringPool.SLASH, _user.getUserId(), StringPool.SLASH,
+				objectRelationship.getName()),
 			Http.Method.GET);
 
 		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
@@ -162,6 +419,14 @@ public class RelatedObjectEntryResourceTest {
 
 	@Test
 	public void testPutSystemObjectRelatedObject() throws Exception {
+		String name = StringUtil.randomId();
+
+		ObjectRelationship objectRelationship = _addObjectRelationship(
+			name, _objectDefinition.getObjectDefinitionId(),
+			_userSystemObjectDefinition.getObjectDefinitionId(),
+			_objectEntry.getPrimaryKey(), _user.getUserId(),
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
 		String objectFieldValue = RandomTestUtil.randomString();
 
 		ObjectEntry objectEntry = _addObjectEntry(objectFieldValue);
@@ -170,7 +435,7 @@ public class RelatedObjectEntryResourceTest {
 			StringBundler.concat(
 				_userSystemObjectDefinitionMetadata.getRESTContextPath(),
 				StringPool.SLASH, _user.getUserId(), StringPool.SLASH,
-				_objectRelationship.getName(), StringPool.SLASH,
+				objectRelationship.getName(), StringPool.SLASH,
 				objectEntry.getPrimaryKey()),
 			Http.Method.PUT);
 
@@ -181,12 +446,48 @@ public class RelatedObjectEntryResourceTest {
 			StringBundler.concat(
 				_userSystemObjectDefinitionMetadata.getRESTContextPath(),
 				StringPool.SLASH, _user.getUserId(), StringPool.SLASH,
-				_objectRelationship.getName()),
+				objectRelationship.getName()),
 			Http.Method.GET);
 
 		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
 
 		Assert.assertEquals(2, itemsJSONArray.length());
+	}
+
+	@Test
+	public void testPutSystemObjectRelatedObjectNotFound() throws Exception {
+		Long irrelevantPrimaryKey = RandomTestUtil.randomLong();
+
+		String name = StringUtil.randomId();
+
+		ObjectRelationship objectRelationship = _addObjectRelationship(
+			name, _objectDefinition.getObjectDefinitionId(),
+			_userSystemObjectDefinition.getObjectDefinitionId(),
+			_objectEntry.getPrimaryKey(), _user.getUserId(),
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		JSONObject jsonObject = _invoke(
+			StringBundler.concat(
+				_userSystemObjectDefinitionMetadata.getRESTContextPath(),
+				StringPool.SLASH, _user.getUserId(), StringPool.SLASH,
+				objectRelationship.getName(), StringPool.SLASH,
+				irrelevantPrimaryKey),
+			Http.Method.PUT);
+
+		String statusCode = jsonObject.getString("status");
+
+		Assert.assertEquals("NOT_FOUND", statusCode);
+
+		jsonObject = _invoke(
+			StringBundler.concat(
+				_userSystemObjectDefinitionMetadata.getRESTContextPath(),
+				StringPool.SLASH, _user.getUserId(), StringPool.SLASH,
+				objectRelationship.getName()),
+			Http.Method.GET);
+
+		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
+
+		Assert.assertEquals(1, itemsJSONArray.length());
 	}
 
 	private ObjectEntry _addObjectEntry(String objectFieldValue)
@@ -201,6 +502,29 @@ public class RelatedObjectEntryResourceTest {
 			ServiceContextTestUtil.getServiceContext());
 	}
 
+	private ObjectRelationship _addObjectRelationship(
+			String name, long objectDefinitionId1, long objectDefinitionId2,
+			long primaryKey1, long primaryKey2, String type)
+		throws Exception {
+
+		ObjectRelationship objectRelationship =
+			ObjectRelationshipLocalServiceUtil.addObjectRelationship(
+				_user.getUserId(), objectDefinitionId1, objectDefinitionId2, 0,
+				ObjectRelationshipConstants.DELETION_TYPE_PREVENT,
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				name, type);
+
+		ObjectRelationshipLocalServiceUtil.
+			addObjectRelationshipMappingTableValues(
+				_user.getUserId(), objectRelationship.getObjectRelationshipId(),
+				primaryKey1, primaryKey2,
+				ServiceContextTestUtil.getServiceContext());
+
+		_objectRelationships.add(objectRelationship);
+
+		return objectRelationship;
+	}
+
 	private JSONObject _invoke(String endpoint, Http.Method httpMethod)
 		throws Exception {
 
@@ -213,9 +537,7 @@ public class RelatedObjectEntryResourceTest {
 			"Basic " + Base64.encode("test@liferay.com:test".getBytes()));
 		options.setLocation("http://localhost:8080/o/" + endpoint);
 
-		if (httpMethod == Http.Method.PUT) {
-			options.setPut(true);
-		}
+		options.setMethod(httpMethod);
 
 		return JSONFactoryUtil.createJSONObject(HttpUtil.URLtoString(options));
 	}
@@ -251,13 +573,15 @@ public class RelatedObjectEntryResourceTest {
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;
 
 	private ObjectEntry _objectEntry;
-	private ObjectRelationship _objectRelationship;
+	private final List<ObjectRelationship> _objectRelationships =
+		new ArrayList<>();
 
 	@Inject
 	private SystemObjectDefinitionMetadataTracker
 		_systemObjectDefinitionMetadataTracker;
 
 	private User _user;
+	private ObjectDefinition _userSystemObjectDefinition;
 	private SystemObjectDefinitionMetadata _userSystemObjectDefinitionMetadata;
 
 }


### PR DESCRIPTION
**What is new?**
- Create new `DELETE` endpoint in all System Objects APIs `deleteObjectRelationshipMappingTableValues`.
- Create `deleteObjectRelationshipMappingTableValues` method in `ObjectRelationshipServiceImpl` to check permissions.
- Update `deleteObjectRelationshipMappingTableValues` method in `ObjectRelationshipServiceImpl` to update the DB table once an Object Entry is not linked in the Relationship.

**NOTE**
If we want to unlink an `objectEntryId` (System Object) and a `relatedObjectEntryId` (Custom Object) and if one of them doesn't exist, it will throw a 404 status code.

**Addtional changes**
- In `DELETE` and `GET` endpoints we have used the `PersistedModelLocalService` just to check if the `objectEntryId` is from a System Object given its `className` and `classPK`.
- Add more tests cases in `PUT` and `GET` if an `objectEntryId` (from System Object) doesn't exist and if `relatedObjectEntryId` (from Custom Object) doesn't exist.

![image](https://user-images.githubusercontent.com/44723449/196194140-83bdd60c-0cd4-4fe4-bc87-8c2918d3bd2e.png)

This is the first PR to create the endpoints to relate 2 objects. Let's see an example. Imagine a `University` with their `Subjects` and their `Students` in this way:

1. `University` is a Custom Object. Has a one-to-many relationship with `Student` and a many-to-many relationship with Subject
2. A user of Liferay represents a `Student`, so, it is a System Object. It also has a many-to-many relationship with `Subject`
Subject is a custom object.
3. According to these requisites, there should be an endpoint to link the student and the subjects, and this endpoint should be in the existing REST API `headless-admin-user`
How to test it

Deploy the following modules:

1. `object-rest-impl`.
2. `object-api` and `object-service`.

Set the following feature flag to true:

`feature.flag.LPS-153324`

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-162963

