### PR TITLE
LPS-165642 Fix tooltip visibility on focus

### DIFF
--- a/portal-web/docroot/html/taglib/ui/icon/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/icon/page.jsp
@@ -67,6 +67,7 @@ if (useDialog || (urlIsNotNull && url.startsWith("javascript:"))) {
 			<c:if test="<%= !label && Validator.isNotNull(message) %>">
 				title="<%= HtmlUtil.escapeAttribute(LanguageUtil.get(resourceBundle, HtmlUtil.stripHtml(message))) %>"
 			</c:if>
+
 			<c:if test="<%= toolTip %>">
 				tabindex="0"
 			</c:if>

--- a/portal-web/docroot/html/taglib/ui/icon/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/icon/page.jsp
@@ -67,6 +67,9 @@ if (useDialog || (urlIsNotNull && url.startsWith("javascript:"))) {
 			<c:if test="<%= !label && Validator.isNotNull(message) %>">
 				title="<%= HtmlUtil.escapeAttribute(LanguageUtil.get(resourceBundle, HtmlUtil.stripHtml(message))) %>"
 			</c:if>
+			<c:if test="<%= toolTip %>">
+				tabindex="0"
+			</c:if>
 		>
 			<c:choose>
 				<c:when test="<%= urlIsNotNull %>">


### PR DESCRIPTION
(manual forward from https://github.com/liferay-frontend/liferay-portal/pull/2822)

[**Part of BofA accessibility initiative**]

In this PR we're making tabbable the icons produced by the `<liferay-ui:icon-help>` tag. Any help icon produced by the tag has now a chance to get the focus in tab navigation. Once a [new clay release](https://github.com/liferay-frontend/liferay-portal/pull/2816) is merged, this fix will make most of the elements with `lfr-portal-tooltip` class to show the tooltip upon keyboard navigation.

There are some leftovers which still make use of `lfr-portal-tooltip` class in JSP and some react components, that may not be tabbable yet. Turning these into tabbable elements require an additional effort to analyze the cases and propose a new pattern for at least 2 scenarios:

- manual markup generated in JSP via <span class="lfr-portal-tooltip" ...> ([example](https://github.com/liferay/liferay-portal/blob/9afa7a895ae9e777af6eeca17a52a74f13036512/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/view_publications.jsp#L46-L50))
- React components in charge of this, where a variety of situations exist. To illustrate, [this](https://github.com/liferay/liferay-portal/blob/faea9e8da22cef2782f89acd81ff98960e5564cf/modules/apps/digital-signature/digital-signature-web/src/main/resources/META-INF/resources/js/components/form/FormBase.js#L28-L35) custom component, replicated [here](https://github.com/liferay/liferay-portal/blob/faea9e8da22cef2782f89acd81ff98960e5564cf/modules/apps/adaptive-media/adaptive-media-web/src/main/resources/META-INF/resources/adaptive_media/js/form/Components.js#L34-L43), or [this](https://github.com/liferay/liferay-portal/blob/c02c5b669456075c5a8284f15ce903759f180e89/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/fragment-editor/FragmentEditor.js#L260-L276) and [this other](https://github.com/liferay/liferay-portal/blob/a22a9f6d44469c57ee3ef85233f034cf9050678d/modules/apps/sharing/sharing-taglib/src/main/resources/META-INF/resources/collaborators/js/components/Collaborators.es.js#L79-L85) usage.

So, we'll likely need a sequel to unify usages and patterns, or else adopt a general approach where every `lfr-portal-tooltip` element is made tabbable automatically. Due to the effort this requires, we'll leave that for a different ticket

Other usages of IconTag (such as the `IconListTag`) have puposedly been left out because of the minimal usages we have in DXP, none of which treat the icons as tooltip

cc @pablo-agulla, @edalgrin @marcoscv-work 