### PR TITLE
LPS-167021 Remove redundant usages of the method getSearchActionURL from asset-categories-admin-web

### DIFF
--- a/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/display/context/AssetCategoriesManagementToolbarDisplayContext.java
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/display/context/AssetCategoriesManagementToolbarDisplayContext.java
@@ -42,8 +42,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import javax.portlet.PortletURL;
-
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -261,13 +259,6 @@ public class AssetCategoriesManagementToolbarDisplayContext
 					LanguageUtil.get(httpServletRequest, "category"));
 			}
 		).build();
-	}
-
-	@Override
-	public String getSearchActionURL() {
-		PortletURL searchActionURL = getPortletURL();
-
-		return searchActionURL.toString();
 	}
 
 	@Override

--- a/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/display/context/AssetVocabulariesManagementToolbarDisplayContext.java
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/display/context/AssetVocabulariesManagementToolbarDisplayContext.java
@@ -21,8 +21,6 @@ import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 
-import javax.portlet.PortletURL;
-
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -52,13 +50,6 @@ public class AssetVocabulariesManagementToolbarDisplayContext
 		).setKeywords(
 			StringPool.BLANK
 		).buildString();
-	}
-
-	@Override
-	public String getSearchActionURL() {
-		PortletURL searchActionURL = getPortletURL();
-
-		return searchActionURL.toString();
 	}
 
 	@Override


### PR DESCRIPTION
Manual forward from https://github.com/liferay-usm/liferay-portal/pull/818
> This is an update for [subtask: LPS-167021](https://issues.liferay.com/browse/LPS-167021), [LPS-161233](https://issues.liferay.com/browse/LPS-161233)