### PR TITLE
LPS-165783 - Update npm-scripts to latest to use new cache mechanism

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -94,6 +94,7 @@
         -e '!.gradle' \
         -e '!.gradle/**/*' \
         -e '!.idea' \
+        -e '!/modules/.npmscripts' \
         -e '!/modules/node_modules' \
         -e '!/modules/node_modules_cache' \
         -e '!/modules/private/node_modules_cache' \

--- a/modules/.gitignore
+++ b/modules/.gitignore
@@ -4,6 +4,7 @@
 .gh.json
 .gradle/
 .idea/
+.npmscripts/
 .project
 .sass-cache/
 .settings/

--- a/modules/apps/batch-planner/batch-planner-web/package.json
+++ b/modules/apps/batch-planner/batch-planner-web/package.json
@@ -1,7 +1,6 @@
 {
 	"dependencies": {
 		"@liferay/frontend-js-react-web": "*",
-		"fetch-mock": "^5.13.1",
 		"frontend-js-web": "*",
 		"react": "16.12.0"
 	},

--- a/modules/apps/commerce/commerce-frontend-js/.npmbundlerrc
+++ b/modules/apps/commerce/commerce-frontend-js/.npmbundlerrc
@@ -1,9 +1,0 @@
-{
-	"config": {
-		"imports": {
-			"frontend-taglib-clay": {
-				"/": ">=7.0.0"
-			}
-		}
-	}
-}

--- a/modules/apps/commerce/commerce-frontend-js/package.json
+++ b/modules/apps/commerce/commerce-frontend-js/package.json
@@ -5,9 +5,7 @@
 		"@liferay/frontend-js-react-web": "*",
 		"@liferay/frontend-js-state-web": "*",
 		"frontend-js-web": "*",
-		"html-webpack-plugin": "5.5.0",
-		"react": "16.12.0",
-		"webpack": "5.70.0"
+		"react": "16.12.0"
 	},
 	"devDependencies": {
 		"clay-css": "^2.16.2",

--- a/modules/apps/commerce/commerce-theme-minium/commerce-theme-minium-impl/package.json
+++ b/modules/apps/commerce/commerce-theme-minium/commerce-theme-minium-impl/package.json
@@ -1,6 +1,5 @@
 {
 	"dependencies": {
-		"@liferay/eslint-plugin": "*",
 		"metal-component": "2.16.8",
 		"metal-soy": "2.16.9"
 	},

--- a/modules/apps/commerce/commerce-theme-minium/commerce-theme-minium/package.json
+++ b/modules/apps/commerce/commerce-theme-minium/commerce-theme-minium/package.json
@@ -1,8 +1,4 @@
 {
-	"dependencies": {
-		"gulp": "*",
-		"liferay-theme-tasks": "*"
-	},
 	"keywords": [
 		"liferay-theme"
 	],

--- a/modules/apps/commerce/commerce-theme-speedwell/commerce-theme-speedwell/package.json
+++ b/modules/apps/commerce/commerce-theme-speedwell/commerce-theme-speedwell/package.json
@@ -1,8 +1,4 @@
 {
-	"dependencies": {
-		"gulp": "*",
-		"liferay-theme-tasks": "*"
-	},
 	"keywords": [
 		"liferay-theme"
 	],

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/package.json
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/package.json
@@ -1,7 +1,4 @@
 {
-	"dependencies": {
-		"@liferay/eslint-plugin": "*"
-	},
 	"jest": {
 		"collectCoverageFrom": [
 			"src/main/resources/META-INF/resources/js/**/*.es.js"

--- a/modules/apps/frontend-js/frontend-js-a11y-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-a11y-web/package.json
@@ -1,8 +1,7 @@
 {
 	"dependencies": {
 		"@liferay/frontend-js-react-web": "*",
-		"axe-core": "4.2.0",
-		"crypto": "1.0.1"
+		"axe-core": "4.2.0"
 	},
 	"main": "index.js",
 	"name": "@liferay/frontend-js-a11y-web",

--- a/modules/apps/frontend-js/frontend-js-svg4everybody-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-svg4everybody-web/package.json
@@ -1,7 +1,4 @@
 {
-	"dependencies": {
-		"webpack": "5.70.0"
-	},
 	"main": "index.js",
 	"name": "frontend-js-svg4everybody-web",
 	"private": true,

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
@@ -76,6 +76,7 @@
 		"date-fns": "^1.30.1",
 		"react": "16.12.0"
 	},
+	"main": "index.js",
 	"name": "frontend-taglib-clay",
 	"private": true,
 	"scripts": {

--- a/modules/apps/frontend-theme/frontend-theme-admin/package.json
+++ b/modules/apps/frontend-theme/frontend-theme-admin/package.json
@@ -3,10 +3,6 @@
 	"bugs": {
 		"url": "https://issues.liferay.com/"
 	},
-	"dependencies": {
-		"gulp": "*",
-		"liferay-theme-tasks": "*"
-	},
 	"keywords": [
 		"liferay-theme"
 	],

--- a/modules/apps/frontend-theme/frontend-theme-classic/package.json
+++ b/modules/apps/frontend-theme/frontend-theme-classic/package.json
@@ -3,10 +3,6 @@
 	"bugs": {
 		"url": "https://issues.liferay.com/"
 	},
-	"dependencies": {
-		"gulp": "*",
-		"liferay-theme-tasks": "*"
-	},
 	"keywords": [
 		"liferay-theme"
 	],

--- a/modules/apps/frontend-theme/frontend-theme-dialect/package.json
+++ b/modules/apps/frontend-theme/frontend-theme-dialect/package.json
@@ -3,10 +3,6 @@
 	"bugs": {
 		"url": "https://issues.liferay.com/"
 	},
-	"dependencies": {
-		"gulp": "*",
-		"liferay-theme-tasks": "*"
-	},
 	"keywords": [
 		"liferay-theme"
 	],

--- a/modules/apps/object/object-web/package.json
+++ b/modules/apps/object/object-web/package.json
@@ -11,6 +11,7 @@
 		"frontend-js-web": "*",
 		"text-mask-core": "^5.1.2"
 	},
+	"main": "index.js",
 	"name": "@liferay/object-web",
 	"private": true,
 	"scripts": {

--- a/modules/apps/site-initializer/site-initializer-liferay-learn/src/main/resources/site-initializer/fragments/group/public-sites-navigation/fragments/navigation-menu-item/index.js
+++ b/modules/apps/site-initializer/site-initializer-liferay-learn/src/main/resources/site-initializer/fragments/group/public-sites-navigation/fragments/navigation-menu-item/index.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */

--- a/modules/apps/site-initializer/site-initializer-liferay-learn/src/main/resources/site-initializer/fragments/group/public-sites-navigation/fragments/navigation-menu-item/index.scss
+++ b/modules/apps/site-initializer/site-initializer-liferay-learn/src/main/resources/site-initializer/fragments/group/public-sites-navigation/fragments/navigation-menu-item/index.scss
@@ -10,7 +10,9 @@
 		border-radius: 4px;
 		width: 100%;
 
-		&:hover, &:active, &:focus {
+		&:hover,
+		&:active,
+		&:focus {
 			background: var(--color-action-primary-hover-lighten);
 			color: var(--color-action-primary-default);
 

--- a/modules/apps/site-initializer/site-initializer-liferay-learn/src/main/resources/site-initializer/fragments/group/public-sites-navigation/fragments/public-sites-navigation/index.js
+++ b/modules/apps/site-initializer/site-initializer-liferay-learn/src/main/resources/site-initializer/fragments/group/public-sites-navigation/fragments/public-sites-navigation/index.js
@@ -38,9 +38,8 @@ closeBtn.addEventListener('click', () => {
 	tabletMobileNavSection.classList.toggle('menu-open');
 });
 
-
 accountMenus.forEach((accountMenu) => {
-	accountMenu.addEventListener('click', () =>  {
+	accountMenu.addEventListener('click', () => {
 		accountMenu.classList.toggle('menu-open');
 	});
 });

--- a/modules/dxp/apps/commerce/commerce-organization-web/package.json
+++ b/modules/dxp/apps/commerce/commerce-organization-web/package.json
@@ -4,9 +4,7 @@
 		"commerce-frontend-js": "*",
 		"d3": "5.9.3",
 		"frontend-js-web": "*",
-		"html-webpack-plugin": "5.5.0",
-		"react": "16.12.0",
-		"webpack": "5.70.0"
+		"react": "16.12.0"
 	},
 	"jest": {
 		"testPathIgnorePatterns": [

--- a/modules/dxp/apps/commerce/commerce-shop-by-diagram-web/package.json
+++ b/modules/dxp/apps/commerce/commerce-shop-by-diagram-web/package.json
@@ -6,10 +6,8 @@
 		"d3": "5.9.3",
 		"fetch-mock": "^5.13.1",
 		"frontend-js-web": "*",
-		"html-webpack-plugin": "5.5.0",
 		"item-selector-taglib": "*",
-		"react": "16.12.0",
-		"webpack": "5.70.0"
+		"react": "16.12.0"
 	},
 	"jest": {
 		"moduleNameMapper": {

--- a/modules/dxp/apps/commerce/commerce-shop-by-diagram-web/package.json
+++ b/modules/dxp/apps/commerce/commerce-shop-by-diagram-web/package.json
@@ -4,7 +4,6 @@
 		"@liferay/frontend-js-state-web": "*",
 		"commerce-frontend-js": "*",
 		"d3": "5.9.3",
-		"fetch-mock": "^5.13.1",
 		"frontend-js-web": "*",
 		"item-selector-taglib": "*",
 		"react": "16.12.0"

--- a/modules/etl/mulesoft/.gitignore
+++ b/modules/etl/mulesoft/.gitignore
@@ -4,6 +4,7 @@
 .gh.json
 .gradle/
 .idea/
+.npmscripts/
 .project
 .sass-cache/
 .settings/

--- a/modules/package.json
+++ b/modules/package.json
@@ -6,6 +6,7 @@
 		"alloy-ui": "^3.1.0-deprecated.40",
 		"babel-plugin-incremental-dom": "3.4.0",
 		"compass-mixins": "0.12.10",
+		"fetch-mock": "^5.13.1",
 		"jsdoc": "3.6.3",
 		"liferay-frontend-common-css": "1.0.4",
 		"metal-jest-serializer": "2.0.0"

--- a/modules/package.json
+++ b/modules/package.json
@@ -1,7 +1,7 @@
 {
 	"devDependencies": {
 		"@liferay/eslint-plugin": "1.4.0",
-		"@liferay/npm-scripts": "47.8.3",
+		"@liferay/npm-scripts": "47.9.0",
 		"acorn": "7.1.0",
 		"alloy-ui": "^3.1.0-deprecated.40",
 		"babel-plugin-incremental-dom": "3.4.0",

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -1793,7 +1793,7 @@
   resolved "https://registry.yarnpkg.com/@liferay/amd-loader/-/amd-loader-5.2.0.tgz#760905b2cad058048c96063329f8a178b5ce0dc7"
   integrity sha512-6Fd036qsogJaH71KUNrPA2tk3o1c1EYBsMBPMnqsTsn4iwRxqDEs1+/bxuUg4PkyXo9hFme/wXgRLFy0x5pifw==
 
-"@liferay/eslint-plugin@*", "@liferay/eslint-plugin@1.4.0":
+"@liferay/eslint-plugin@1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@liferay/eslint-plugin/-/eslint-plugin-1.4.0.tgz#fabc93c0c4d2997714713ce490f278e700205206"
   integrity sha512-UKqa4Dp2vQgSnndBYKY/eF+o02NS419H18D5CWp+bbZ5o81Oka0+K2ybLrQgLGnES15jMZUG4cNHWI63tOXsVw==
@@ -5284,11 +5284,6 @@ crypto-js@^4.1.1:
   resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.1.1.tgz#9e485bcf03521041bd85844786b83fb7619736cf"
   integrity sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw==
 
-crypto@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/crypto/-/crypto-1.0.1.tgz#2af1b7cad8175d24c8a1b0778255794a21803037"
-  integrity sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==
-
 cson-parser@^1.1.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/cson-parser/-/cson-parser-1.3.5.tgz#7ec675e039145533bf2a6a856073f1599d9c2d24"
@@ -8211,7 +8206,7 @@ gulp-zip@^3.2.0:
     through2 "^2.0.1"
     yazl "^2.1.0"
 
-gulp@*, gulp@^4.0.2:
+gulp@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/gulp/-/gulp-4.0.2.tgz#543651070fd0f6ab0a0650c6a3e6ff5a7cb09caa"
   integrity sha512-dvEs27SCZt2ibF29xYgmnwwCYZxdxhQ/+LFWlbAW8y7jt68L/65402Lz3+CKy0Ov4rOs+NERmDq7YlZaDqUIfA==
@@ -10351,7 +10346,7 @@ liferay-npm-bundler@2.29.0:
     xml-js "^1.6.8"
     yargs "^14.0.0"
 
-liferay-theme-tasks@*, liferay-theme-tasks@11.4.0:
+liferay-theme-tasks@11.4.0:
   version "11.4.0"
   resolved "https://registry.yarnpkg.com/liferay-theme-tasks/-/liferay-theme-tasks-11.4.0.tgz#1191d4c54d94ae96ec4901e4fa9d9c2d9b0ecad4"
   integrity sha512-h4LMEPXYmqCcZ0CcrK0iJoytgEIEjNqakvowj8y/yszmoot7IyoUXOCb81EItVmFafa7HJnqv7GBc1SZCEnKnQ==

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -1864,10 +1864,10 @@
     xml-js "^1.6.8"
     yargs "^14.0.0"
 
-"@liferay/npm-scripts@47.8.3":
-  version "47.8.3"
-  resolved "https://registry.yarnpkg.com/@liferay/npm-scripts/-/npm-scripts-47.8.3.tgz#fa23f358fb6f02f325b8c4ad88548c8b7a5b58bf"
-  integrity sha512-EXn1YQZojjcXEDm9pHMjlc2DetUYbLYo9Qe2H55wdneQRGukE6R5r6jeQpmJkr/661dVJUw/1Ck8DKBfL7JnkQ==
+"@liferay/npm-scripts@47.9.0":
+  version "47.9.0"
+  resolved "https://registry.yarnpkg.com/@liferay/npm-scripts/-/npm-scripts-47.9.0.tgz#140cb677ac67ea904af15cee3f714aa39c0ed179"
+  integrity sha512-98VQcjHCkSjQL1o1h6KMFxqnOmGof6ZKfgLMCO6wvehk2R/9lvteDP5yQsUldfHt10EHIwMpHaQILZCymfJ+Vg==
   dependencies:
     "@babel/cli" "^7.2.3"
     "@babel/core" "^7.8.3"

--- a/portal-kernel/test/unit/com/liferay/portal/modules/dependencies/git_repo_gitignore.tmpl
+++ b/portal-kernel/test/unit/com/liferay/portal/modules/dependencies/git_repo_gitignore.tmpl
@@ -4,6 +4,7 @@
 .gh.json
 .gradle/
 .idea/
+.npmscripts/
 .project
 .sass-cache/
 .settings/


### PR DESCRIPTION
Manual forward and QA approval from: https://github.com/liferay-frontend/liferay-portal/pull/2825

This PR should help address build times after the first initial `ant all`, both for individual modules and subsequent `ant all`.

Below are numbers from my machine

| Type | `ant all` | Single Module(commerce-product-service) |
| ---- | ---- | ---- |
| Current (master) | 21m | 3m 30s, 17s, 18s |
| npm-scripts cache | 14m | 1m 24s, 17s  |

--------------------------------

This adds the new version of npm-scripts which includes a caching mechanism between builds.

https://issues.liferay.com/browse/LPS-165783

Here is how it works

First build:
- Stores built files at `./modules/.npmscripts/build/artifacts/${MODULE_NAME}/build/**`
- Hashes src and built files at `./modules/.npmscripts/build/artifacts/${MODULE_NAME}/buildinfo.json`

- Before running babel, bundler, webpack, etc. we check if any previous build exists
    - Checks `./modules/.npmscripts/build/artifacts/${MODULE_NAME}/buildinfo.json`
    - Checks `./modules/.npmscripts/build/artifacts/${MODULE_NAME}/build/**` ()

Subsequent builds:
Check...
- previous build info doesn't exist -> REBUILD
- can't read previous build info -> REBUILD
- number of source files change -> REBUILD
- src files content changes -> REBUILD
- src files content doesn't change
    - build file doesn't exist -> copy previous build from cache
    - previous build files exist
         - file is same as last build -> DO NOTHING
         - file has changed -> REBUILD

Use can also force a build with `yarn build --force` or by deleting the `./modules/.npmscripts` directory.

The only change needed in DXP is adding `./modules/.npmscripts` to .gitignore and also excluding it from `ant clean`.