### PR TITLE
LPS-166657 LPS-166190 search-experiences-rest-impl: Fix mismatch in 'enabled' property

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/SentenceTransformerValidationResultResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/SentenceTransformerValidationResultResourceImpl.java
@@ -67,8 +67,6 @@ public class SentenceTransformerValidationResultResourceImpl
 			"embeddingVectorDimensions",
 			jsonObject.getInt("embeddingVectorDimensions")
 		).put(
-			"enabled", jsonObject.getBoolean("enabled")
-		).put(
 			"enableGPU", jsonObject.getBoolean("enableGPU")
 		).put(
 			"huggingFaceAccessToken",
@@ -82,6 +80,9 @@ public class SentenceTransformerValidationResultResourceImpl
 			"model", jsonObject.getString("model")
 		).put(
 			"modelTimeout", jsonObject.getInt("modelTimeout")
+		).put(
+			"sentenceTransformerEnabled",
+			jsonObject.getBoolean("sentenceTransformerEnabled")
 		).put(
 			"sentenceTransformProvider",
 			jsonObject.getString("sentenceTransformProvider")


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-166657
https://issues.liferay.com/browse/LPS-166190

Tested here: https://github.com/liferay-search/liferay-portal/pull/636
Failures are unrelated.