### PR TITLE
LPS-167117 Skip Base*ResourceImpl.java for avoiding import com.liferay.petra.function.transform.TransformUtil

### DIFF
--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -148,6 +148,7 @@ public class DefaultObjectEntryManagerImplTest {
 		_simpleDTOConverterContext = new DefaultDTOConverterContext(
 			false, Collections.emptyMap(), _dtoConverterRegistry, null,
 			LocaleUtil.getDefault(), null, _user);
+
 		_user = TestPropsValues.getUser();
 
 		PermissionThreadLocal.setPermissionChecker(

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaModuleIllegalImportsCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaModuleIllegalImportsCheck.java
@@ -14,6 +14,7 @@
 
 package com.liferay.source.formatter.check;
 
+import com.liferay.petra.string.StringPool;
 import com.liferay.source.formatter.check.util.JavaSourceUtil;
 
 import java.util.regex.Matcher;
@@ -78,8 +79,13 @@ public class JavaModuleIllegalImportsCheck extends BaseFileCheck {
 					"LPS-64335");
 		}
 
+		int pos = fileName.lastIndexOf(StringPool.SLASH);
+
+		String shortFileName = fileName.substring(pos + 1);
+
 		if (absolutePath.matches(".+/internal/resource/v\\d*(_\\d+)+/.+") &&
 			fileName.endsWith("ResourceImpl.java") &&
+			!shortFileName.startsWith("Base") &&
 			content.contains(
 				"import com.liferay.petra.function.transform.TransformUtil")) {
 


### PR DESCRIPTION
Hi Brian,

`Base*ResourceImpl.java` might not be generated by REST Builder
Tested [here](https://github.com/ling-alan-huang/liferay-portal/pull/1480), unrelated failures.

/cc @ccorreagg