### PR TITLE
LPS-167664, LPS-167665 Remove redundant usages of the method getSearchActionURL

### DIFF
--- a/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/display/context/AssetListManagementToolbarDisplayContext.java
+++ b/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/display/context/AssetListManagementToolbarDisplayContext.java
@@ -40,8 +40,6 @@ import com.liferay.staging.StagingGroupHelperUtil;
 
 import java.util.List;
 
-import javax.portlet.PortletURL;
-
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -160,13 +158,6 @@ public class AssetListManagementToolbarDisplayContext
 					LanguageUtil.get(httpServletRequest, "dynamic-collection"));
 			}
 		).build();
-	}
-
-	@Override
-	public String getSearchActionURL() {
-		PortletURL searchActionURL = getPortletURL();
-
-		return searchActionURL.toString();
 	}
 
 	@Override

--- a/modules/apps/asset/asset-tags-selector-web/src/main/java/com/liferay/asset/tags/selector/web/internal/display/context/AssetTagsSelectorManagementToolbarDisplayContext.java
+++ b/modules/apps/asset/asset-tags-selector-web/src/main/java/com/liferay/asset/tags/selector/web/internal/display/context/AssetTagsSelectorManagementToolbarDisplayContext.java
@@ -20,8 +20,6 @@ import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 
-import javax.portlet.PortletURL;
-
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -53,13 +51,6 @@ public class AssetTagsSelectorManagementToolbarDisplayContext
 	@Override
 	public String getComponentId() {
 		return "assetTagsSelectorManagementToolbar";
-	}
-
-	@Override
-	public String getSearchActionURL() {
-		PortletURL searchActionURL = getPortletURL();
-
-		return searchActionURL.toString();
 	}
 
 	@Override


### PR DESCRIPTION
Manual forward from https://github.com/liferay-usm/liferay-portal/pull/831 and https://github.com/liferay-usm/liferay-portal/pull/832

This is an update for [subtasks: LPS-167665](https://issues.liferay.com/browse/LPS-167665) and [LPS-167664](https://issues.liferay.com/browse/LPS-167664), [LPS-161233](https://issues.liferay.com/browse/LPS-161233)

cc @gislayne-vitorino @drewbrokke