### PR TITLE
LPS-165484 Dot "." in friendly URL should be replaced like the Spaces

### DIFF
--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/util/FriendlyURLNormalizerImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/util/FriendlyURLNormalizerImpl.java
@@ -44,7 +44,7 @@ public class FriendlyURLNormalizerImpl implements FriendlyURLNormalizer {
 
 	@Override
 	public String normalize(String friendlyURL) {
-		return normalize(friendlyURL, false, false);
+		return _normalize(friendlyURL, false, false);
 	}
 
 	@Override
@@ -167,15 +167,15 @@ public class FriendlyURLNormalizerImpl implements FriendlyURLNormalizer {
 
 	@Override
 	public String normalizeWithPeriods(String friendlyURL) {
-		return normalize(friendlyURL, true, false);
+		return _normalize(friendlyURL, true, false);
 	}
 
 	@Override
 	public String normalizeWithPeriodsAndSlashes(String friendlyURL) {
-		return normalize(friendlyURL, true, true);
+		return _normalize(friendlyURL, true, true);
 	}
 
-	protected String normalize(
+	private String _normalize(
 		String friendlyURL, boolean periods, boolean slashes) {
 
 		if (Validator.isNull(friendlyURL)) {

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/util/FriendlyURLNormalizerImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/util/FriendlyURLNormalizerImpl.java
@@ -166,6 +166,11 @@ public class FriendlyURLNormalizerImpl implements FriendlyURLNormalizer {
 	}
 
 	@Override
+	public String normalizeWithPeriods(String friendlyURL) {
+		return normalize(friendlyURL, true, false);
+	}
+
+	@Override
 	public String normalizeWithPeriodsAndSlashes(String friendlyURL) {
 		return normalize(friendlyURL, true, true);
 	}

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/util/FriendlyURLNormalizerImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/util/FriendlyURLNormalizerImpl.java
@@ -44,7 +44,7 @@ public class FriendlyURLNormalizerImpl implements FriendlyURLNormalizer {
 
 	@Override
 	public String normalize(String friendlyURL) {
-		return normalize(friendlyURL, false);
+		return normalize(friendlyURL, false, false);
 	}
 
 	@Override
@@ -167,10 +167,12 @@ public class FriendlyURLNormalizerImpl implements FriendlyURLNormalizer {
 
 	@Override
 	public String normalizeWithPeriodsAndSlashes(String friendlyURL) {
-		return normalize(friendlyURL, true);
+		return normalize(friendlyURL, true, true);
 	}
 
-	protected String normalize(String friendlyURL, boolean periodsAndSlashes) {
+	protected String normalize(
+		String friendlyURL, boolean periods, boolean slashes) {
+
 		if (Validator.isNull(friendlyURL)) {
 			return friendlyURL;
 		}
@@ -193,8 +195,8 @@ public class FriendlyURLNormalizerImpl implements FriendlyURLNormalizer {
 					  (c <= CharPool.LOWER_CASE_Z)) ||
 					 ((CharPool.NUMBER_0 <= c) && (c <= CharPool.NUMBER_9)) ||
 					 (c == CharPool.UNDERLINE) ||
-					 (!periodsAndSlashes &&
-					  ((c == CharPool.SLASH) || (c == CharPool.PERIOD)))) {
+					 (!periods && (c == CharPool.PERIOD)) ||
+					 (!slashes && (c == CharPool.SLASH))) {
 
 				sb.append(c);
 			}

--- a/modules/apps/friendly-url/friendly-url-service/src/test/java/com/liferay/friendly/url/internal/util/FriendlyURLNormalizerImplTest.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/test/java/com/liferay/friendly/url/internal/util/FriendlyURLNormalizerImplTest.java
@@ -197,42 +197,46 @@ public class FriendlyURLNormalizerImplTest {
 
 	@Test
 	public void testNormalizeWithPeriods() {
-		String s1 = RandomTestUtil.randomString();
-		String s2 = RandomTestUtil.randomString();
+		String friendlyURLPrefix = RandomTestUtil.randomString();
+		String friendlyURLSuffix = RandomTestUtil.randomString();
 
 		Assert.assertEquals(
-			_friendlyURLNormalizerImpl.normalize(s1 + s2),
-			_friendlyURLNormalizerImpl.normalizeWithPeriods(s1 + s2));
-
-		Assert.assertEquals(
-			_friendlyURLNormalizerImpl.normalize(s1 + StringPool.DASH + s2),
+			_friendlyURLNormalizerImpl.normalize(
+				friendlyURLPrefix + friendlyURLSuffix),
 			_friendlyURLNormalizerImpl.normalizeWithPeriods(
-				s1 + StringPool.PERIOD + s2));
-
+				friendlyURLPrefix + friendlyURLSuffix));
 		Assert.assertEquals(
-			_friendlyURLNormalizerImpl.normalize(s1 + StringPool.SLASH + s2),
+			_friendlyURLNormalizerImpl.normalize(
+				friendlyURLPrefix + StringPool.DASH + friendlyURLSuffix),
 			_friendlyURLNormalizerImpl.normalizeWithPeriods(
-				s1 + StringPool.SLASH + s2));
+				friendlyURLPrefix + StringPool.PERIOD + friendlyURLSuffix));
+		Assert.assertEquals(
+			_friendlyURLNormalizerImpl.normalize(
+				friendlyURLPrefix + StringPool.SLASH + friendlyURLSuffix),
+			_friendlyURLNormalizerImpl.normalizeWithPeriods(
+				friendlyURLPrefix + StringPool.SLASH + friendlyURLSuffix));
 	}
 
 	@Test
 	public void testNormalizeWithPeriodsAndSlashes() {
-		String s1 = RandomTestUtil.randomString();
-		String s2 = RandomTestUtil.randomString();
+		String friendlyURLPrefix = RandomTestUtil.randomString();
+		String friendlyURLSuffix = RandomTestUtil.randomString();
 
 		Assert.assertEquals(
-			_friendlyURLNormalizerImpl.normalize(s1 + s2),
-			_friendlyURLNormalizerImpl.normalizeWithPeriodsAndSlashes(s1 + s2));
-
-		Assert.assertEquals(
-			_friendlyURLNormalizerImpl.normalize(s1 + StringPool.DASH + s2),
+			_friendlyURLNormalizerImpl.normalize(
+				friendlyURLPrefix + friendlyURLSuffix),
 			_friendlyURLNormalizerImpl.normalizeWithPeriodsAndSlashes(
-				s1 + StringPool.PERIOD + s2));
-
+				friendlyURLPrefix + friendlyURLSuffix));
 		Assert.assertEquals(
-			_friendlyURLNormalizerImpl.normalize(s1 + StringPool.DASH + s2),
+			_friendlyURLNormalizerImpl.normalize(
+				friendlyURLPrefix + StringPool.DASH + friendlyURLSuffix),
 			_friendlyURLNormalizerImpl.normalizeWithPeriodsAndSlashes(
-				s1 + StringPool.SLASH + s2));
+				friendlyURLPrefix + StringPool.PERIOD + friendlyURLSuffix));
+		Assert.assertEquals(
+			_friendlyURLNormalizerImpl.normalize(
+				friendlyURLPrefix + StringPool.DASH + friendlyURLSuffix),
+			_friendlyURLNormalizerImpl.normalizeWithPeriodsAndSlashes(
+				friendlyURLPrefix + StringPool.SLASH + friendlyURLSuffix));
 	}
 
 	@Test

--- a/modules/apps/friendly-url/friendly-url-service/src/test/java/com/liferay/friendly/url/internal/util/FriendlyURLNormalizerImplTest.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/test/java/com/liferay/friendly/url/internal/util/FriendlyURLNormalizerImplTest.java
@@ -18,6 +18,7 @@ import com.liferay.normalizer.internal.NormalizerImpl;
 import com.liferay.petra.nio.CharsetEncoderUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import java.net.URLEncoder;
@@ -192,6 +193,46 @@ public class FriendlyURLNormalizerImplTest {
 			encodedReplacement + StringPool.DASH + encodedValue,
 			_friendlyURLNormalizerImpl.normalizeWithEncoding(
 				"\uDBFF-" + value));
+	}
+
+	@Test
+	public void testNormalizeWithPeriods() {
+		String s1 = RandomTestUtil.randomString();
+		String s2 = RandomTestUtil.randomString();
+
+		Assert.assertEquals(
+			_friendlyURLNormalizerImpl.normalize(s1 + s2),
+			_friendlyURLNormalizerImpl.normalizeWithPeriods(s1 + s2));
+
+		Assert.assertEquals(
+			_friendlyURLNormalizerImpl.normalize(s1 + StringPool.DASH + s2),
+			_friendlyURLNormalizerImpl.normalizeWithPeriods(
+				s1 + StringPool.PERIOD + s2));
+
+		Assert.assertEquals(
+			_friendlyURLNormalizerImpl.normalize(s1 + StringPool.SLASH + s2),
+			_friendlyURLNormalizerImpl.normalizeWithPeriods(
+				s1 + StringPool.SLASH + s2));
+	}
+
+	@Test
+	public void testNormalizeWithPeriodsAndSlashes() {
+		String s1 = RandomTestUtil.randomString();
+		String s2 = RandomTestUtil.randomString();
+
+		Assert.assertEquals(
+			_friendlyURLNormalizerImpl.normalize(s1 + s2),
+			_friendlyURLNormalizerImpl.normalizeWithPeriodsAndSlashes(s1 + s2));
+
+		Assert.assertEquals(
+			_friendlyURLNormalizerImpl.normalize(s1 + StringPool.DASH + s2),
+			_friendlyURLNormalizerImpl.normalizeWithPeriodsAndSlashes(
+				s1 + StringPool.PERIOD + s2));
+
+		Assert.assertEquals(
+			_friendlyURLNormalizerImpl.normalize(s1 + StringPool.DASH + s2),
+			_friendlyURLNormalizerImpl.normalizeWithPeriodsAndSlashes(
+				s1 + StringPool.SLASH + s2));
 	}
 
 	@Test

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -6213,7 +6213,8 @@ public class JournalArticleLocalServiceImpl
 			String urlTitle = friendlyURLEntryLocalService.getUniqueUrlTitle(
 				groupId,
 				_classNameLocalService.getClassNameId(JournalArticle.class),
-				article.getResourcePrimKey(), title,
+				article.getResourcePrimKey(),
+				_friendlyURLNormalizer.normalizeWithPeriods(title),
 				_language.getLanguageId(entry.getKey()));
 
 			friendlyURLMap.put(entry.getKey(), urlTitle);
@@ -9252,7 +9253,9 @@ public class JournalArticleLocalServiceImpl
 			String urlTitle = friendlyURLEntryLocalService.getUniqueUrlTitle(
 				groupId,
 				_classNameLocalService.getClassNameId(JournalArticle.class),
-				resourcePrimKey, friendlyURL, languageId);
+				resourcePrimKey,
+				_friendlyURLNormalizer.normalizeWithPeriods(friendlyURL),
+				languageId);
 
 			urlTitleMap.put(languageId, urlTitle);
 		}
@@ -9269,7 +9272,9 @@ public class JournalArticleLocalServiceImpl
 						groupId,
 						_classNameLocalService.getClassNameId(
 							JournalArticle.class),
-						resourcePrimKey, value, languageId);
+						resourcePrimKey,
+						_friendlyURLNormalizer.normalizeWithPeriods(value),
+						languageId);
 
 				urlTitleMap.put(languageId, urlTitle);
 			}

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleLocalServiceTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleLocalServiceTest.java
@@ -160,8 +160,15 @@ public class JournalArticleLocalServiceTest {
 
 		Locale locale = _portal.getSiteDefaultLocale(_group.getGroupId());
 
-		String friendlyURL = _friendlyURLNormalizer.normalize(
-			RandomTestUtil.randomString());
+		String friendlyURL = _friendlyURLNormalizer.normalizeWithPeriods(
+			StringBundler.concat(
+				RandomTestUtil.randomString(5), StringPool.PERIOD,
+				RandomTestUtil.randomString(5), StringPool.SLASH,
+				RandomTestUtil.randomString(5)));
+
+		Assert.assertTrue(friendlyURL.contains(StringPool.DASH));
+		Assert.assertFalse(friendlyURL.contains(StringPool.PERIOD));
+		Assert.assertTrue(friendlyURL.contains(StringPool.SLASH));
 
 		Map<Locale, String> friendlyURLMap = journalArticle.getFriendlyURLMap();
 

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleLocalServiceTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleLocalServiceTest.java
@@ -81,7 +81,7 @@ import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.CalendarFactoryUtil;
 import com.liferay.portal.kernel.util.Constants;
-import com.liferay.portal.kernel.util.FriendlyURLNormalizerUtil;
+import com.liferay.portal.kernel.util.FriendlyURLNormalizer;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -160,7 +160,7 @@ public class JournalArticleLocalServiceTest {
 
 		Locale locale = _portal.getSiteDefaultLocale(_group.getGroupId());
 
-		String friendlyURL = FriendlyURLNormalizerUtil.normalize(
+		String friendlyURL = _friendlyURLNormalizer.normalize(
 			RandomTestUtil.randomString());
 
 		Map<Locale, String> friendlyURLMap = journalArticle.getFriendlyURLMap();
@@ -836,6 +836,9 @@ public class JournalArticleLocalServiceTest {
 
 	@Inject
 	private DDMTemplateLinkLocalService _ddmTemplateLinkLocalService;
+
+	@Inject
+	private FriendlyURLNormalizer _friendlyURLNormalizer;
 
 	@DeleteAfterTestRun
 	private Group _group;

--- a/portal-kernel/bnd.bnd
+++ b/portal-kernel/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 85.0.1
+Bundle-Version: 85.1.0
 Export-Package:\
 	!com.liferay.portal.kernel.internal.*,\
 	!com.liferay.portal.kernel.module.util,\

--- a/portal-kernel/src/com/liferay/portal/kernel/util/FriendlyURLNormalizer.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/FriendlyURLNormalizer.java
@@ -26,6 +26,8 @@ public interface FriendlyURLNormalizer {
 
 	public String normalizeWithEncoding(String friendlyURL);
 
+	public String normalizeWithPeriods(String friendlyURL);
+
 	public String normalizeWithPeriodsAndSlashes(String friendlyURL);
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 47.0.0
+version 47.1.0


### PR DESCRIPTION
Original PR comment:

> https://issues.liferay.com/browse/LPS-165484
> 
> Hi Team ❤️ 
> In order to preserve allowing the slashes in the web content URLs while replacing the dots, I have added a new method in the FriendlyURLNormalizer interface. 
> Could you please review this PR?
> I didn't add it in FriendlyURLNormalizerUtil too because I didn't use it. So I think that it should be added when it will be needed not before but I am not sure if I am doing it right 😅 
> Please, let me know if I should make this or any other changes.
> Thanks!
> Regards
> 
> cc: @ealonso

@brianchandotcom resending this pull directly to you since after a few retries we confirmed this pull is not related to any of the failing tests in https://github.com/liferay-lima/liferay-portal/pull/3674.