### PR TITLE
LPS-167192 Add tabindex="0" only when it has no url

### DIFF
--- a/portal-web/docroot/html/taglib/ui/icon/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/icon/page.jsp
@@ -65,7 +65,7 @@ if (useDialog || (urlIsNotNull && url.startsWith("javascript:"))) {
 		<span
 			class="<%= cssClass %>"
 
-			<c:if test="<%= toolTip %>">
+			<c:if test="<%= toolTip && !urlIsNotNull %>">
 				tabindex="0"
 			</c:if>
 


### PR DESCRIPTION
Forwarding this manually as failing tests are not related (https://github.com/liferay-frontend/liferay-portal/pull/2832)

cc @tim-cao