### PR TITLE
LPS-166626 Use showTitle param instead of windowState for rendering web content title

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/preview_article_content.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/preview_article_content.jsp
@@ -20,7 +20,7 @@
 JournalArticleDisplay articleDisplay = journalDisplayContext.getArticleDisplay();
 %>
 
-<c:if test="<%= renderRequest.getWindowState() != LiferayWindowState.POP_UP %>">
+<c:if test='<%= Boolean.parseBoolean(renderRequest.getParameter("showTitle")) %>'>
 	<clay:container-fluid
 		cssClass="mt-3"
 	>


### PR DESCRIPTION
This is only for master.

https://issues.liferay.com/browse/LPS-166626

@beltranrengifo @ealonso