### PR TITLE
LPS-167684,LPS-167687,LPS-167690,LPS-167692 Remove redundant usages of the method getSearchActionURL from Commerce

### DIFF
--- a/modules/apps/commerce/commerce-address-web/src/main/java/com/liferay/commerce/address/web/internal/display/context/CommerceCountriesManagementToolbarDisplayContext.java
+++ b/modules/apps/commerce/commerce-address-web/src/main/java/com/liferay/commerce/address/web/internal/display/context/CommerceCountriesManagementToolbarDisplayContext.java
@@ -34,8 +34,6 @@ import com.liferay.portal.kernel.util.WebKeys;
 import java.util.List;
 import java.util.Objects;
 
-import javax.portlet.PortletURL;
-
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -120,13 +118,6 @@ public class CommerceCountriesManagementToolbarDisplayContext
 					LanguageUtil.get(httpServletRequest, getNavigation()));
 			}
 		).build();
-	}
-
-	@Override
-	public String getSearchActionURL() {
-		PortletURL searchActionURL = getPortletURL();
-
-		return searchActionURL.toString();
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-address-web/src/main/java/com/liferay/commerce/address/web/internal/display/context/CommerceRegionsManagementToolbarDisplayContext.java
+++ b/modules/apps/commerce/commerce-address-web/src/main/java/com/liferay/commerce/address/web/internal/display/context/CommerceRegionsManagementToolbarDisplayContext.java
@@ -34,8 +34,6 @@ import com.liferay.portal.kernel.util.WebKeys;
 import java.util.List;
 import java.util.Objects;
 
-import javax.portlet.PortletURL;
-
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -124,13 +122,6 @@ public class CommerceRegionsManagementToolbarDisplayContext
 					LanguageUtil.get(httpServletRequest, getNavigation()));
 			}
 		).build();
-	}
-
-	@Override
-	public String getSearchActionURL() {
-		PortletURL searchActionURL = getPortletURL();
-
-		return searchActionURL.toString();
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-item-selector-web/src/main/java/com/liferay/commerce/item/selector/web/internal/display/context/CommercePriceListItemSelectorViewManagementToolbarDisplayContext.java
+++ b/modules/apps/commerce/commerce-item-selector-web/src/main/java/com/liferay/commerce/item/selector/web/internal/display/context/CommercePriceListItemSelectorViewManagementToolbarDisplayContext.java
@@ -21,8 +21,6 @@ import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 
-import javax.portlet.PortletURL;
-
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -49,13 +47,6 @@ public class CommercePriceListItemSelectorViewManagementToolbarDisplayContext
 		).setKeywords(
 			StringPool.BLANK
 		).buildString();
-	}
-
-	@Override
-	public String getSearchActionURL() {
-		PortletURL searchActionURL = getPortletURL();
-
-		return searchActionURL.toString();
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-item-selector-web/src/main/java/com/liferay/commerce/item/selector/web/internal/display/context/CommercePricingClassItemSelectorViewManagementToolbarDisplayContext.java
+++ b/modules/apps/commerce/commerce-item-selector-web/src/main/java/com/liferay/commerce/item/selector/web/internal/display/context/CommercePricingClassItemSelectorViewManagementToolbarDisplayContext.java
@@ -21,8 +21,6 @@ import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 
-import javax.portlet.PortletURL;
-
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -49,13 +47,6 @@ public class CommercePricingClassItemSelectorViewManagementToolbarDisplayContext
 		).setKeywords(
 			StringPool.BLANK
 		).buildString();
-	}
-
-	@Override
-	public String getSearchActionURL() {
-		PortletURL searchActionURL = getPortletURL();
-
-		return searchActionURL.toString();
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-item-selector-web/src/main/java/com/liferay/commerce/item/selector/web/internal/display/context/CommerceProductInstanceItemSelectorViewManagementToolbarDisplayContext.java
+++ b/modules/apps/commerce/commerce-item-selector-web/src/main/java/com/liferay/commerce/item/selector/web/internal/display/context/CommerceProductInstanceItemSelectorViewManagementToolbarDisplayContext.java
@@ -21,8 +21,6 @@ import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 
-import javax.portlet.PortletURL;
-
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -50,13 +48,6 @@ public class
 		).setKeywords(
 			StringPool.BLANK
 		).buildString();
-	}
-
-	@Override
-	public String getSearchActionURL() {
-		PortletURL searchActionURL = getPortletURL();
-
-		return searchActionURL.toString();
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-product-item-selector-web/src/main/java/com/liferay/commerce/product/item/selector/web/internal/display/context/CPDefinitionItemSelectorViewManagementToolbarDisplayContext.java
+++ b/modules/apps/commerce/commerce-product-item-selector-web/src/main/java/com/liferay/commerce/product/item/selector/web/internal/display/context/CPDefinitionItemSelectorViewManagementToolbarDisplayContext.java
@@ -21,8 +21,6 @@ import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 
-import javax.portlet.PortletURL;
-
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -54,13 +52,6 @@ public class CPDefinitionItemSelectorViewManagementToolbarDisplayContext
 		).setKeywords(
 			StringPool.BLANK
 		).buildString();
-	}
-
-	@Override
-	public String getSearchActionURL() {
-		PortletURL searchActionURL = getPortletURL();
-
-		return searchActionURL.toString();
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-product-item-selector-web/src/main/java/com/liferay/commerce/product/item/selector/web/internal/display/context/CPInstanceItemSelectorViewManagementToolbarDisplayContext.java
+++ b/modules/apps/commerce/commerce-product-item-selector-web/src/main/java/com/liferay/commerce/product/item/selector/web/internal/display/context/CPInstanceItemSelectorViewManagementToolbarDisplayContext.java
@@ -21,8 +21,6 @@ import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 
-import javax.portlet.PortletURL;
-
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -49,13 +47,6 @@ public class CPInstanceItemSelectorViewManagementToolbarDisplayContext
 		).setKeywords(
 			StringPool.BLANK
 		).buildString();
-	}
-
-	@Override
-	public String getSearchActionURL() {
-		PortletURL searchActionURL = getPortletURL();
-
-		return searchActionURL.toString();
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-product-item-selector-web/src/main/java/com/liferay/commerce/product/item/selector/web/internal/display/context/CPOptionItemSelectorViewManagementToolbarDisplayContext.java
+++ b/modules/apps/commerce/commerce-product-item-selector-web/src/main/java/com/liferay/commerce/product/item/selector/web/internal/display/context/CPOptionItemSelectorViewManagementToolbarDisplayContext.java
@@ -21,8 +21,6 @@ import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 
-import javax.portlet.PortletURL;
-
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -49,13 +47,6 @@ public class CPOptionItemSelectorViewManagementToolbarDisplayContext
 		).setKeywords(
 			StringPool.BLANK
 		).buildString();
-	}
-
-	@Override
-	public String getSearchActionURL() {
-		PortletURL searchActionURL = getPortletURL();
-
-		return searchActionURL.toString();
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-product-item-selector-web/src/main/java/com/liferay/commerce/product/item/selector/web/internal/display/context/CPSpecificationOptionItemSelectorViewManagementToolbarDisplayContext.java
+++ b/modules/apps/commerce/commerce-product-item-selector-web/src/main/java/com/liferay/commerce/product/item/selector/web/internal/display/context/CPSpecificationOptionItemSelectorViewManagementToolbarDisplayContext.java
@@ -21,8 +21,6 @@ import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 
-import javax.portlet.PortletURL;
-
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -50,13 +48,6 @@ public class
 		).setKeywords(
 			StringPool.BLANK
 		).buildString();
-	}
-
-	@Override
-	public String getSearchActionURL() {
-		PortletURL searchActionURL = getPortletURL();
-
-		return searchActionURL.toString();
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-product-item-selector-web/src/main/java/com/liferay/commerce/product/item/selector/web/internal/display/context/CommerceChannelsItemSelectorViewManagementToolbarDisplayContext.java
+++ b/modules/apps/commerce/commerce-product-item-selector-web/src/main/java/com/liferay/commerce/product/item/selector/web/internal/display/context/CommerceChannelsItemSelectorViewManagementToolbarDisplayContext.java
@@ -21,8 +21,6 @@ import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 
-import javax.portlet.PortletURL;
-
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -49,13 +47,6 @@ public class CommerceChannelsItemSelectorViewManagementToolbarDisplayContext
 		).setKeywords(
 			StringPool.BLANK
 		).buildString();
-	}
-
-	@Override
-	public String getSearchActionURL() {
-		PortletURL searchActionURL = getPortletURL();
-
-		return searchActionURL.toString();
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-product-options-web/src/main/java/com/liferay/commerce/product/options/web/internal/display/context/CPSpecificationOptionManagementToolbarDisplayContext.java
+++ b/modules/apps/commerce/commerce-product-options-web/src/main/java/com/liferay/commerce/product/options/web/internal/display/context/CPSpecificationOptionManagementToolbarDisplayContext.java
@@ -35,8 +35,6 @@ import com.liferay.portal.kernel.util.Validator;
 import java.util.List;
 import java.util.Objects;
 
-import javax.portlet.PortletURL;
-
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -131,13 +129,6 @@ public class CPSpecificationOptionManagementToolbarDisplayContext
 		}
 
 		return null;
-	}
-
-	@Override
-	public String getSearchActionURL() {
-		PortletURL searchActionURL = getPortletURL();
-
-		return searchActionURL.toString();
 	}
 
 	@Override


### PR DESCRIPTION
Manual forward from https://github.com/liferay-usm/liferay-portal/pull/852

> This is an update for subtasks:
> [LPS-167684](https://issues.liferay.com/browse/LPS-167684)
> [LPS-167687](https://issues.liferay.com/browse/LPS-167687)
> [LPS-167690](https://issues.liferay.com/browse/LPS-167690)
> [LPS-167692](https://issues.liferay.com/browse/LPS-167692)
> 
> cc @gislayne-vitorino @drewbrokke