### PR TITLE
LPS-164371 Fix lockout issue

### DIFF
--- a/portal-impl/src/com/liferay/portal/security/auth/session/AuthenticatedSessionManagerImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/auth/session/AuthenticatedSessionManagerImpl.java
@@ -463,21 +463,11 @@ public class AuthenticatedSessionManagerImpl
 				headerMap, parameterMap, resultsMap);
 		}
 
-		User user = (User)resultsMap.get("user");
-
 		if (authResult != Authenticator.SUCCESS) {
-			if (user != null) {
-				user = UserLocalServiceUtil.fetchUser(user.getUserId());
-			}
-
-			if (user != null) {
-				UserLocalServiceUtil.checkLockout(user);
-			}
-
 			throw new AuthException();
 		}
 
-		return user;
+		return (User)resultsMap.get("user");
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(


### PR DESCRIPTION
[LPS-164371](https://issues.liferay.com/browse/LPS-164371)

Original pr https://github.com/liferay-appsec/liferay-portal/pull/871

### Description
User enumeration attack with password lockout.

### Changes
In the [AuthenticatedSessionManagerImpl.java](https://github.com/liferay-appsec/liferay-portal/pull/871/files#diff-e70c6501b99fdf61cee42739ce5b9d5ae6d047f78624af63ab6e20840996a393) class the changes are made so, in case the user does not log in correctly, the generic error message is shown in the login instead of showing the user is in lockout. This way an attacker does not know if the user exists on the platform or not.

