### PR TITLE
LPS-147259 Refuse to serve invalid content from ComboServlet

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/RequestDispatcherUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/RequestDispatcherUtil.java
@@ -31,7 +31,7 @@ import javax.servlet.http.HttpServletResponse;
  */
 public class RequestDispatcherUtil {
 
-	public static ObjectValuePair<String, Long> getContentAndLastModifiedTime(
+	public static BufferCacheServletResponse getBufferCacheServletResponse(
 			RequestDispatcher requestDispatcher,
 			HttpServletRequest httpServletRequest,
 			HttpServletResponse httpServletResponse)
@@ -89,6 +89,19 @@ public class RequestDispatcherUtil {
 
 			},
 			bufferCacheServletResponse);
+
+		return bufferCacheServletResponse;
+	}
+
+	public static ObjectValuePair<String, Long> getContentAndLastModifiedTime(
+			RequestDispatcher requestDispatcher,
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse)
+		throws Exception {
+
+		BufferCacheServletResponse bufferCacheServletResponse =
+			getBufferCacheServletResponse(
+				requestDispatcher, httpServletRequest, httpServletResponse);
 
 		return new ObjectValuePair<>(
 			bufferCacheServletResponse.getString(),

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/packageinfo
@@ -1,1 +1,1 @@
-version 11.1.0
+version 11.2.0


### PR DESCRIPTION
Forwarded manually as per https://github.com/liferay-frontend/liferay-portal/pull/2856#issuecomment-1312244507

----

Invalid content is defined as a resource:

  - Not returning HTTP 200 status
  - A resource not returning "Content-Type": "application/javascript", "text/javascript" or "text/css"
  - A resource returning "Cache-Control": "no-cache" or "no-store"

According to comment:

https://issues.liferay.com/browse/LPS-147259?focusedCommentId=2794620&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-2794620