### PR TITLE
LPS-166854 We should not scope the related entries by groupId when the parent object definition is scoped by company

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/instance/lifecycle/SystemObjectDefinitionMetadataPortalInstanceLifecycleListener.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/instance/lifecycle/SystemObjectDefinitionMetadataPortalInstanceLifecycleListener.java
@@ -239,8 +239,9 @@ public class SystemObjectDefinitionMetadataPortalInstanceLifecycleListener
 			_bundleContext.registerService(
 				ObjectRelatedModelsProvider.class,
 				new SystemObject1toMObjectRelatedModelsProviderImpl(
-					objectDefinition, _objectEntryLocalService,
-					_objectFieldLocalService, _objectRelationshipLocalService,
+					objectDefinition, _objectDefinitionLocalService,
+					_objectEntryLocalService, _objectFieldLocalService,
+					_objectRelationshipLocalService,
 					_persistedModelLocalServiceRegistry,
 					systemObjectDefinitionMetadata,
 					_systemObjectDefinitionMetadataRegistry),

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/SystemObject1toMObjectRelatedModelsProviderImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/SystemObject1toMObjectRelatedModelsProviderImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.object.internal.related.models;
 
+import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectRelationshipConstants;
 import com.liferay.object.exception.RequiredObjectRelationshipException;
 import com.liferay.object.internal.petra.sql.dsl.DynamicObjectDefinitionTable;
@@ -21,6 +22,7 @@ import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.related.models.ObjectRelatedModelsProvider;
+import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
@@ -56,6 +58,7 @@ public class SystemObject1toMObjectRelatedModelsProviderImpl
 
 	public SystemObject1toMObjectRelatedModelsProviderImpl(
 		ObjectDefinition objectDefinition,
+		ObjectDefinitionLocalService objectDefinitionLocalService,
 		ObjectEntryLocalService objectEntryLocalService,
 		ObjectFieldLocalService objectFieldLocalService,
 		ObjectRelationshipLocalService objectRelationshipLocalService,
@@ -65,6 +68,7 @@ public class SystemObject1toMObjectRelatedModelsProviderImpl
 			systemObjectDefinitionMetadataRegistry) {
 
 		_objectDefinition = objectDefinition;
+		_objectDefinitionLocalService = objectDefinitionLocalService;
 		_objectEntryLocalService = objectEntryLocalService;
 		_objectFieldLocalService = objectFieldLocalService;
 		_objectRelationshipLocalService = objectRelationshipLocalService;
@@ -219,9 +223,14 @@ public class SystemObject1toMObjectRelatedModelsProviderImpl
 
 		Column<?, Long> companyIdColumn = (Column<?, Long>)_table.getColumn(
 			"companyId");
+
 		ObjectRelationship objectRelationship =
 			_objectRelationshipLocalService.getObjectRelationship(
 				objectRelationshipId);
+
+		ObjectDefinition objectDefinition1 =
+			_objectDefinitionLocalService.getObjectDefinition(
+				objectRelationship.getObjectDefinitionId1());
 
 		PersistedModelLocalService persistedModelLocalService =
 			_persistedModelLocalServiceRegistry.getPersistedModelLocalService(
@@ -240,7 +249,11 @@ public class SystemObject1toMObjectRelatedModelsProviderImpl
 						Column<?, Long> groupIdColumn = _table.getColumn(
 							"groupId");
 
-						if (groupIdColumn == null) {
+						if ((groupIdColumn == null) ||
+							Objects.equals(
+								ObjectDefinitionConstants.SCOPE_COMPANY,
+								objectDefinition1.getScope())) {
+
 							return null;
 						}
 
@@ -304,6 +317,10 @@ public class SystemObject1toMObjectRelatedModelsProviderImpl
 			_objectRelationshipLocalService.getObjectRelationship(
 				objectRelationshipId);
 
+		ObjectDefinition objectDefinition1 =
+			_objectDefinitionLocalService.getObjectDefinition(
+				objectRelationship.getObjectDefinitionId1());
+
 		ObjectField objectField = _objectFieldLocalService.getObjectField(
 			objectRelationship.getObjectFieldId2());
 
@@ -333,7 +350,11 @@ public class SystemObject1toMObjectRelatedModelsProviderImpl
 				() -> {
 					Column<?, Long> groupIdColumn = _table.getColumn("groupId");
 
-					if (groupIdColumn == null) {
+					if ((groupIdColumn == null) ||
+						Objects.equals(
+							ObjectDefinitionConstants.SCOPE_COMPANY,
+							objectDefinition1.getScope())) {
+
 						return null;
 					}
 
@@ -355,6 +376,7 @@ public class SystemObject1toMObjectRelatedModelsProviderImpl
 	}
 
 	private final ObjectDefinition _objectDefinition;
+	private final ObjectDefinitionLocalService _objectDefinitionLocalService;
 	private final ObjectEntryLocalService _objectEntryLocalService;
 	private final ObjectFieldLocalService _objectFieldLocalService;
 	private final ObjectRelationshipLocalService

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/SystemObjectMtoMObjectRelatedModelsProviderImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/SystemObjectMtoMObjectRelatedModelsProviderImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.object.internal.related.models;
 
+import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectRelationshipConstants;
 import com.liferay.object.exception.RequiredObjectRelationshipException;
 import com.liferay.object.internal.petra.sql.dsl.DynamicObjectDefinitionTable;
@@ -219,7 +220,11 @@ public class SystemObjectMtoMObjectRelatedModelsProviderImpl
 						Column<?, Long> groupIdColumn = _table.getColumn(
 							"groupId");
 
-						if (groupIdColumn == null) {
+						if ((groupIdColumn == null) ||
+							Objects.equals(
+								ObjectDefinitionConstants.SCOPE_COMPANY,
+								objectDefinition1.getScope())) {
+
 							return null;
 						}
 
@@ -309,7 +314,11 @@ public class SystemObjectMtoMObjectRelatedModelsProviderImpl
 				() -> {
 					Column<?, Long> groupIdColumn = _table.getColumn("groupId");
 
-					if (groupIdColumn == null) {
+					if ((groupIdColumn == null) ||
+						Objects.equals(
+							ObjectDefinitionConstants.SCOPE_COMPANY,
+							objectDefinition1.getScope())) {
+
 						return null;
 					}
 


### PR DESCRIPTION
Related issue: https://issues.liferay.com/browse/LPS-166854

Unrelated Failed Tests: https://testray.liferay.com/home/-/testray/case_results?tab=runs&testrayBuildId=2053875489