### PR TITLE
LPS-165921 portal-search-web Limit drag area to drag button so not to interfere with copy/paste

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/FieldList.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/FieldList.js
@@ -64,7 +64,7 @@ function DropZone({index, move}) {
 }
 
 function Field({children, index, onDelete, showDeleteButton, showDragButton}) {
-	const [{isDragging}, drag] = useDrag({
+	const [{isDragging}, drag, dragPreview] = useDrag({
 		collect: (monitor) => ({
 			isDragging: !!monitor.isDragging(),
 		}),
@@ -72,47 +72,46 @@ function Field({children, index, onDelete, showDeleteButton, showDragButton}) {
 	});
 
 	return (
-		<div
-			ref={drag}
-			style={{
-				cursor: 'move',
-				opacity: isDragging ? 0.5 : 1,
-			}}
-		>
-			<ClayForm.Group className="field-item">
-				<ClayInput.Group>
-					<ClayInput.GroupItem shrink>
-						{showDragButton && (
-							<ClayButton
-								borderless
-								className="drag-handle"
-								displayType="secondary"
-								monospaced
-								small
-							>
-								<ClayIcon symbol="drag" />
-							</ClayButton>
-						)}
-					</ClayInput.GroupItem>
-
-					{children}
-
-					{showDeleteButton && (
-						<ClayInput.GroupItem shrink>
-							<ClayButton
-								borderless
-								displayType="secondary"
-								monospaced
-								onClick={onDelete}
-								small
-							>
-								<ClayIcon symbol="trash" />
-							</ClayButton>
-						</ClayInput.GroupItem>
+		<ClayForm.Group className="field-item" ref={dragPreview}>
+			<ClayInput.Group>
+				<ClayInput.GroupItem
+					ref={drag}
+					shrink
+					style={{
+						cursor: 'move',
+						opacity: isDragging ? 0.5 : 1,
+					}}
+				>
+					{showDragButton && (
+						<ClayButton
+							borderless
+							className="drag-handle"
+							displayType="secondary"
+							monospaced
+							small
+						>
+							<ClayIcon symbol="drag" />
+						</ClayButton>
 					)}
-				</ClayInput.Group>
-			</ClayForm.Group>
-		</div>
+				</ClayInput.GroupItem>
+
+				{children}
+
+				{showDeleteButton && (
+					<ClayInput.GroupItem shrink>
+						<ClayButton
+							borderless
+							displayType="secondary"
+							monospaced
+							onClick={onDelete}
+							small
+						>
+							<ClayIcon symbol="trash" />
+						</ClayButton>
+					</ClayInput.GroupItem>
+				)}
+			</ClayInput.Group>
+		</ClayForm.Group>
 	);
 }
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-165921 - Unable to select and copy-paste from the input fields of the Search Bar Suggestions configurations

Not sure about how to fix the slow UX (I haven't been able to reproduce), but this fix addresses the drag functionality. Starting the drag is now scoped to the drag handle, instead of the whole box, to allow actions like copy/paste.

A quick demo:

https://user-images.githubusercontent.com/14063502/200433627-d45e3712-a134-422b-8f90-94b984f3d7fc.mp4

Tested here: https://github.com/liferay-search/liferay-portal/pull/649
Failures are unrelated.

cc @thektan @oliv-yu
