### PR TITLE
LPS-168582 Copying fragments to the deploy folder does not propagate the changes correctly and causes errors 

### DIFF
--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLinkLocalService.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLinkLocalService.java
@@ -15,6 +15,7 @@
 package com.liferay.fragment.service;
 
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
+import com.liferay.fragment.model.FragmentEntry;
 import com.liferay.fragment.model.FragmentEntryLink;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.sql.dsl.query.DSLQuery;
@@ -480,6 +481,10 @@ public interface FragmentEntryLinkLocalService
 	public FragmentEntryLink updateFragmentEntryLink(
 			long fragmentEntryLinkId, String editableValues,
 			boolean updateClassedModel)
+		throws PortalException;
+
+	public void updateLatestChanges(
+			FragmentEntry fragmentEntry, FragmentEntryLink fragmentEntryLink)
 		throws PortalException;
 
 	public void updateLatestChanges(long fragmentEntryLinkId)

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLinkLocalServiceUtil.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLinkLocalServiceUtil.java
@@ -635,6 +635,14 @@ public class FragmentEntryLinkLocalServiceUtil {
 			fragmentEntryLinkId, editableValues, updateClassedModel);
 	}
 
+	public static void updateLatestChanges(
+			com.liferay.fragment.model.FragmentEntry fragmentEntry,
+			FragmentEntryLink fragmentEntryLink)
+		throws PortalException {
+
+		getService().updateLatestChanges(fragmentEntry, fragmentEntryLink);
+	}
+
 	public static void updateLatestChanges(long fragmentEntryLinkId)
 		throws PortalException {
 

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLinkLocalServiceWrapper.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLinkLocalServiceWrapper.java
@@ -725,6 +725,16 @@ public class FragmentEntryLinkLocalServiceWrapper
 	}
 
 	@Override
+	public void updateLatestChanges(
+			com.liferay.fragment.model.FragmentEntry fragmentEntry,
+			FragmentEntryLink fragmentEntryLink)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		_fragmentEntryLinkLocalService.updateLatestChanges(
+			fragmentEntry, fragmentEntryLink);
+	}
+
+	@Override
 	public void updateLatestChanges(long fragmentEntryLinkId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 

--- a/modules/apps/fragment/fragment-api/src/main/resources/com/liferay/fragment/service/packageinfo
+++ b/modules/apps/fragment/fragment-api/src/main/resources/com/liferay/fragment/service/packageinfo
@@ -1,1 +1,1 @@
-version 7.2.0
+version 7.3.0

--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/contributor/FragmentCollectionContributorRegistryImpl.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/contributor/FragmentCollectionContributorRegistryImpl.java
@@ -38,7 +38,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.osgi.framework.BundleContext;
@@ -172,51 +171,12 @@ public class FragmentCollectionContributorRegistryImpl
 				fragmentEntry.getFragmentEntryKey());
 
 		for (FragmentEntryLink fragmentEntryLink : fragmentEntryLinks) {
-			boolean modified = false;
-
-			if (!Objects.equals(
-					fragmentEntryLink.getCss(), fragmentEntry.getCss())) {
-
-				fragmentEntryLink.setCss(fragmentEntry.getCss());
-
-				modified = true;
+			try {
+				_fragmentEntryLinkLocalService.updateLatestChanges(
+					fragmentEntry, fragmentEntryLink);
 			}
-
-			if (!Objects.equals(
-					fragmentEntryLink.getHtml(), fragmentEntry.getHtml())) {
-
-				fragmentEntryLink.setHtml(fragmentEntry.getHtml());
-
-				modified = true;
-			}
-
-			if (!Objects.equals(
-					fragmentEntryLink.getJs(), fragmentEntry.getJs())) {
-
-				fragmentEntryLink.setJs(fragmentEntry.getJs());
-
-				modified = true;
-			}
-
-			if (!Objects.equals(
-					fragmentEntryLink.getConfiguration(),
-					fragmentEntry.getConfiguration())) {
-
-				fragmentEntryLink.setConfiguration(
-					fragmentEntry.getConfiguration());
-
-				modified = true;
-			}
-
-			if (fragmentEntryLink.getType() != fragmentEntry.getType()) {
-				fragmentEntryLink.setType(fragmentEntry.getType());
-
-				modified = true;
-			}
-
-			if (modified) {
-				_fragmentEntryLinkLocalService.updateFragmentEntryLink(
-					fragmentEntryLink);
+			catch (PortalException portalException) {
+				_log.error(portalException);
 			}
 		}
 	}

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/contributor/test/FragmentCollectionContributorTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/contributor/test/FragmentCollectionContributorTest.java
@@ -19,14 +19,30 @@ import com.liferay.fragment.constants.FragmentConstants;
 import com.liferay.fragment.contributor.FragmentCollectionContributor;
 import com.liferay.fragment.contributor.FragmentCollectionContributorRegistry;
 import com.liferay.fragment.model.FragmentEntry;
+import com.liferay.fragment.model.FragmentEntryLink;
+import com.liferay.fragment.service.FragmentEntryLinkLocalService;
 import com.liferay.fragment.service.FragmentEntryLocalServiceUtil;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.segments.service.SegmentsExperienceLocalService;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -35,6 +51,7 @@ import java.util.Locale;
 import java.util.Map;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -54,7 +71,102 @@ public class FragmentCollectionContributorTest {
 	@ClassRule
 	@Rule
 	public static final AggregateTestRule aggregateTestRule =
-		new LiferayIntegrationTestRule();
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_serviceContext = ServiceContextTestUtil.getServiceContext(
+			_group.getGroupId());
+	}
+
+	@Test
+	public void testPropagateContributedFragmentEntry() throws Exception {
+		String fragmentCollectionContributorKey = RandomTestUtil.randomString();
+
+		String fragmentEntryKey = StringBundler.concat(
+			fragmentCollectionContributorKey, StringPool.DASH,
+			RandomTestUtil.randomString());
+
+		Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		long segmentsExperienceId =
+			_segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
+				layout.getPlid());
+
+		FragmentEntryLink fragmentEntryLink =
+			_fragmentEntryLinkLocalService.addFragmentEntryLink(
+				TestPropsValues.getUserId(), _group.getGroupId(), 0, 0,
+				segmentsExperienceId, layout.getPlid(), StringPool.BLANK,
+				"<div data-lfr-editable-id=\"editable-1\" " +
+					"data-lfr-editable-type=\"rich-text\">EDITABLE 1</div>",
+				StringPool.BLANK, StringPool.BLANK, null, StringPool.BLANK, 0,
+				fragmentEntryKey, FragmentConstants.TYPE_COMPONENT,
+				_serviceContext);
+
+		String modifiedHtml = StringBundler.concat(
+			"<div data-lfr-editable-id=\"editable-1\" ",
+			"data-lfr-editable-type=\"rich-text\">EDITABLE 1</div>",
+			"<div data-lfr-editable-id=\"editable-2\" ",
+			"data-lfr-editable-type=\"rich-text\">EDITABLE 2</div>");
+
+		ServiceRegistration<?> serviceRegistration = _getServiceRegistration(
+			new TestFragmentCollectionContributor(
+				fragmentCollectionContributorKey,
+				HashMapBuilder.put(
+					FragmentConstants.TYPE_COMPONENT,
+					_getFragmentEntry(
+						fragmentEntryKey, modifiedHtml,
+						FragmentConstants.TYPE_COMPONENT)
+				).build()));
+
+		try {
+			FragmentEntryLink persistedFragmentEntryLink =
+				_fragmentEntryLinkLocalService.getFragmentEntryLink(
+					fragmentEntryLink.getFragmentEntryLinkId());
+
+			Assert.assertEquals(
+				modifiedHtml, persistedFragmentEntryLink.getHtml());
+
+			JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
+				persistedFragmentEntryLink.getEditableValues());
+
+			JSONObject editableFragmentEntryProcessorJSONObject =
+				jsonObject.getJSONObject(
+					"com.liferay.fragment.entry.processor.editable." +
+						"EditableFragmentEntryProcessor");
+
+			Assert.assertEquals(
+				editableFragmentEntryProcessorJSONObject.toString(), 2,
+				editableFragmentEntryProcessorJSONObject.length());
+
+			Assert.assertTrue(
+				editableFragmentEntryProcessorJSONObject.has("editable-1"));
+
+			JSONObject editable1JSONObject =
+				editableFragmentEntryProcessorJSONObject.getJSONObject(
+					"editable-1");
+
+			Assert.assertEquals(
+				"EDITABLE 1", editable1JSONObject.get("defaultValue"));
+
+			Assert.assertTrue(
+				editableFragmentEntryProcessorJSONObject.has("editable-2"));
+
+			JSONObject editable2JSONObject =
+				editableFragmentEntryProcessorJSONObject.getJSONObject(
+					"editable-2");
+
+			Assert.assertEquals(
+				"EDITABLE 2", editable2JSONObject.get("defaultValue"));
+		}
+		finally {
+			serviceRegistration.unregister();
+		}
+	}
 
 	@Test
 	public void testRegisterContributedFragmentEntries() {
@@ -162,6 +274,17 @@ public class FragmentCollectionContributorTest {
 	@Inject
 	private FragmentCollectionContributorRegistry
 		_fragmentCollectionContributorRegistry;
+
+	@Inject
+	private FragmentEntryLinkLocalService _fragmentEntryLinkLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private SegmentsExperienceLocalService _segmentsExperienceLocalService;
+
+	private ServiceContext _serviceContext;
 
 	private static class TestFragmentCollectionContributor
 		implements FragmentCollectionContributor {


### PR DESCRIPTION
This is ony for master.

@ealonso @jkappler 

Original comment:

## Motivation

[Link to ticket](https://issues.liferay.com/browse/LPS-168582)

This issue fixes a bug where there is a dissociation between propagating fragments from the UI and propagating changes from a collection contributor. This is because the changes are updated in a different way in each case.


## Proposed solution

Standardize how we propagate the changes from fragments to where they are used by creating a new method that receives the fragmentEntryLink and fragmentEntry and update the usages accordingly


## Change summary:

* Improve performance by updating the changes only if there are changes 
* Adds integration tests for propagation from fragment collection contributor


## Test Scenario

Sadly, it's not that easy to test, the best way to do so would be to follow the steps in the LPS by deploying bot jars to the portal. Another way would be to change any existing contributed fragment and follow the steps in the ticket.