### PR TITLE
LPS-167677 Apply generic type in Autocomplete component and use specific type everywhere it is used

### DIFF
--- a/modules/apps/notification/notification-web/src/main/resources/META-INF/resources/js/components/Attachments.tsx
+++ b/modules/apps/notification/notification-web/src/main/resources/META-INF/resources/js/components/Attachments.tsx
@@ -126,7 +126,7 @@ export function Attachments({setValues, values}: IProps) {
 			<ClayPanel.Body>
 				<div className="lfr__notification-template-attachments">
 					<div className="lfr__notification-template-attachments-fields">
-						<AutoComplete
+						<AutoComplete<ObjectDefinition>
 							emptyStateMessage={Liferay.Language.get(
 								'no-data-sources-were-found'
 							)}
@@ -134,7 +134,18 @@ export function Attachments({setValues, values}: IProps) {
 							items={filteredObjectDefinitions ?? []}
 							label={Liferay.Language.get('data-source')}
 							onChangeQuery={setQuery}
-							onSelectItem={(item: ObjectDefinition) => {
+							onSelectEmptyStateItem={(emptyStateItem) => {
+								setAttachmentsFields([]);
+								setSelectedEntity(null);
+
+								setValues({
+									...values,
+									objectDefinitionId: Number(
+										emptyStateItem.id
+									),
+								});
+							}}
+							onSelectItem={(item) => {
 								if (item.id) {
 									getAttachmentFields(item.id);
 									setSelectedEntity(item);

--- a/modules/apps/notification/notification-web/src/main/resources/META-INF/resources/js/components/DefinitionOfTerms.tsx
+++ b/modules/apps/notification/notification-web/src/main/resources/META-INF/resources/js/components/DefinitionOfTerms.tsx
@@ -81,14 +81,14 @@ export function DefinitionOfTerms({baseResourceURL}: IProps) {
 			showCollapseIcon={true}
 		>
 			<ClayPanel.Body>
-				<AutoComplete
+				<AutoComplete<ObjectDefinition>
 					emptyStateMessage={Liferay.Language.get(
 						'no-entities-were-found'
 					)}
 					items={filteredObjectDefinitions ?? []}
 					label={Liferay.Language.get('entity')}
 					onChangeQuery={setQuery}
-					onSelectItem={(item: ObjectDefinition) => {
+					onSelectItem={(item) => {
 						getEntityFields(item);
 						setSelectedEntity(item);
 					}}

--- a/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/AutoComplete/index.tsx
+++ b/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/AutoComplete/index.tsx
@@ -20,25 +20,31 @@ import {FieldBase} from '../FieldBase';
 import './index.scss';
 import {CustomSelect} from './CustomSelect';
 
-interface IAutoCompleteProps extends React.HTMLAttributes<HTMLElement> {
-	children: (item: any) => React.ReactNode;
+interface AutoCompleteProps<T> extends React.HTMLAttributes<HTMLElement> {
+	children: (item: T) => React.ReactNode;
 	contentRight?: React.ReactNode;
 	disabled?: boolean;
 	emptyStateMessage: string;
 	error?: string;
 	feedbackMessage?: string;
 	hasEmptyItem?: boolean;
-	items: any[];
+	items: T[];
 	label: string;
 	onChangeQuery: (value: string) => void;
-	onSelectItem: (item: any) => void;
+	onSelectEmptyStateItem?: (emptyStateItem: EmptyStateItem) => void;
+	onSelectItem: (item: T) => void;
 	placeholder?: string;
 	query: string;
 	required?: boolean;
 	value?: string;
 }
 
-export default function AutoComplete({
+type EmptyStateItem = {
+	id: string;
+	label: string;
+};
+
+export default function AutoComplete<T>({
 	children,
 	className,
 	contentRight,
@@ -48,26 +54,22 @@ export default function AutoComplete({
 	feedbackMessage,
 	hasEmptyItem,
 	id,
-	items: initialItems,
+	items,
 	label,
 	onChangeQuery,
+	onSelectEmptyStateItem,
 	onSelectItem,
 	placeholder,
 	query,
 	required = false,
 	value,
-}: IAutoCompleteProps) {
+}: AutoCompleteProps<T>) {
 	const [active, setActive] = useState<boolean>(false);
 
-	const items = hasEmptyItem
-		? [
-				{
-					id: '',
-					label: Liferay.Language.get('choose-an-option'),
-				},
-				...initialItems,
-		  ]
-		: initialItems;
+	const emptyStateItem = {
+		id: '',
+		label: Liferay.Language.get('choose-an-option'),
+	};
 
 	return (
 		<FieldBase
@@ -102,7 +104,7 @@ export default function AutoComplete({
 					value={query}
 				/>
 
-				{(items.length === 1 && items[0].id === '') || !items.length ? (
+				{!items.length ? (
 					<ClayDropDown.ItemList>
 						<ClayDropDown.Item>
 							{emptyStateMessage}
@@ -110,6 +112,22 @@ export default function AutoComplete({
 					</ClayDropDown.ItemList>
 				) : (
 					<ClayDropDown.ItemList>
+						{hasEmptyItem && (
+							<ClayDropDown.Item
+								onClick={() => {
+									setActive(false);
+
+									if (onSelectEmptyStateItem) {
+										onSelectEmptyStateItem(emptyStateItem);
+									}
+								}}
+							>
+								<div className="d-flex justify-content-between">
+									<div>{emptyStateItem.label}</div>
+								</div>
+							</ClayDropDown.Item>
+						)}
+
 						{items.map((item, index) => {
 							return (
 								<ClayDropDown.Item

--- a/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/utils/api.ts
+++ b/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/utils/api.ts
@@ -63,7 +63,7 @@ interface ObjectRelationship {
 	readonly objectDefinitionName2: string;
 	objectRelationshipId: number;
 	parameterObjectFieldId?: number;
-	reverse?: boolean;
+	reverse: boolean;
 	type: ObjectRelationshipType;
 }
 interface PickListItem {

--- a/modules/apps/object/object-js-components-web/types/src/main/resources/META-INF/resources/components/AutoComplete/index.d.ts
+++ b/modules/apps/object/object-js-components-web/types/src/main/resources/META-INF/resources/components/AutoComplete/index.d.ts
@@ -14,24 +14,29 @@
 
 import React from 'react';
 import './index.scss';
-interface IAutoCompleteProps extends React.HTMLAttributes<HTMLElement> {
-	children: (item: any) => React.ReactNode;
+interface AutoCompleteProps<T> extends React.HTMLAttributes<HTMLElement> {
+	children: (item: T) => React.ReactNode;
 	contentRight?: React.ReactNode;
 	disabled?: boolean;
 	emptyStateMessage: string;
 	error?: string;
 	feedbackMessage?: string;
 	hasEmptyItem?: boolean;
-	items: any[];
+	items: T[];
 	label: string;
 	onChangeQuery: (value: string) => void;
-	onSelectItem: (item: any) => void;
+	onSelectEmptyStateItem?: (emptyStateItem: EmptyStateItem) => void;
+	onSelectItem: (item: T) => void;
 	placeholder?: string;
 	query: string;
 	required?: boolean;
 	value?: string;
 }
-export default function AutoComplete({
+declare type EmptyStateItem = {
+	id: string;
+	label: string;
+};
+export default function AutoComplete<T>({
 	children,
 	className,
 	contentRight,
@@ -41,13 +46,14 @@ export default function AutoComplete({
 	feedbackMessage,
 	hasEmptyItem,
 	id,
-	items: initialItems,
+	items,
 	label,
 	onChangeQuery,
+	onSelectEmptyStateItem,
 	onSelectItem,
 	placeholder,
 	query,
 	required,
 	value,
-}: IAutoCompleteProps): JSX.Element;
+}: AutoCompleteProps<T>): JSX.Element;
 export {};

--- a/modules/apps/object/object-js-components-web/types/src/main/resources/META-INF/resources/utils/api.d.ts
+++ b/modules/apps/object/object-js-components-web/types/src/main/resources/META-INF/resources/utils/api.d.ts
@@ -49,7 +49,7 @@ interface ObjectRelationship {
 	readonly objectDefinitionName2: string;
 	objectRelationshipId: number;
 	parameterObjectFieldId?: number;
-	reverse?: boolean;
+	reverse: boolean;
 	type: ObjectRelationshipType;
 }
 interface PickListItem {

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/Layout/LayoutScreen/ModalAddObjectLayoutField.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/Layout/LayoutScreen/ModalAddObjectLayoutField.tsx
@@ -157,7 +157,7 @@ export default function ModalAddObjectLayoutField({
 				</ClayModal.Header>
 
 				<ClayModal.Body>
-					<AutoComplete
+					<AutoComplete<TObjectField>
 						contentRight={
 							<>
 								<ClayLabel
@@ -224,7 +224,7 @@ export default function ModalAddObjectLayoutField({
 											: Liferay.Language.get('optional')}
 									</ClayLabel>
 
-									{objectFieldSettings.find(
+									{objectFieldSettings?.find(
 										(fieldSetting: ObjectFieldSetting) =>
 											fieldSetting.value === 'true' ||
 											fieldSetting.value === 'conditional'

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/Layout/LayoutScreen/ModalAddObjectLayoutTab.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/Layout/LayoutScreen/ModalAddObjectLayoutTab.tsx
@@ -28,7 +28,6 @@ import {
 import classNames from 'classnames';
 import React, {useMemo, useState} from 'react';
 
-import {separateCamelCase} from '../../../utils/string';
 import {TYPES as EVENT_TYPES, useLayoutContext} from '../objectLayoutContext';
 import {TObjectLayoutTab, TObjectRelationship} from '../types';
 
@@ -253,7 +252,7 @@ export function ModalAddObjectLayoutTab({
 					</ClayForm.Group>
 
 					{selectedType === TYPES.RELATIONSHIPS && (
-						<AutoComplete
+						<AutoComplete<TObjectRelationship>
 							contentRight={
 								<ClayLabel
 									className="label-inside-custom-select"
@@ -272,15 +271,9 @@ export function ModalAddObjectLayoutTab({
 							label={Liferay.Language.get('relationship')}
 							onChangeQuery={setQuery}
 							onSelectItem={(item) => {
-								const {type} = item;
-								const selectedItem = {
-									...item,
-									type: separateCamelCase(type),
-								};
-
-								setSelectedRelationship(selectedItem);
+								setSelectedRelationship(item);
 								setValues({
-									objectRelationshipId: selectedItem.id,
+									objectRelationshipId: item.id,
 								});
 							}}
 							query={query}

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModalAddFilter.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModalAddFilter.tsx
@@ -399,7 +399,7 @@ export function ModalAddFilter({
 
 			<ClayModal.Body>
 				{!editingFilter && (
-					<AutoComplete
+					<AutoComplete<ObjectField>
 						emptyStateMessage={Liferay.Language.get(
 							'there-are-no-columns-available'
 						)}

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/AggregationFormBase.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/AggregationFormBase.tsx
@@ -323,7 +323,7 @@ export function AggregationFormBase({
 
 	return (
 		<>
-			<AutoComplete
+			<AutoComplete<TObjectRelationship>
 				emptyStateMessage={Liferay.Language.get(
 					'no-relationships-were-found'
 				)}
@@ -331,7 +331,7 @@ export function AggregationFormBase({
 				items={filteredObjectRelationships ?? []}
 				label={Liferay.Language.get('relationship')}
 				onChangeQuery={setRelationshipsQuery}
-				onSelectItem={(item: TObjectRelationship) => {
+				onSelectItem={(item) => {
 					handleChangeRelatedObjectRelationship(item);
 				}}
 				query={relationshipsQuery}
@@ -358,7 +358,7 @@ export function AggregationFormBase({
 			/>
 
 			{selectedAggregationFunction?.value !== 'COUNT' && (
-				<AutoComplete
+				<AutoComplete<ObjectField>
 					emptyStateMessage={Liferay.Language.get(
 						'no-fields-were-found'
 					)}
@@ -366,7 +366,7 @@ export function AggregationFormBase({
 					items={filteredObjectRelationshipFields ?? []}
 					label={Liferay.Language.get('field')}
 					onChangeQuery={setRelationshipFieldsQuery}
-					onSelectItem={(item: ObjectField) => {
+					onSelectItem={(item) => {
 						handleSummarizeFieldChange(item);
 					}}
 					query={relationshipFieldsQuery}

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/ObjectFieldFormBase.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/ObjectFieldFormBase.tsx
@@ -343,7 +343,7 @@ export default function ObjectFieldFormBase({
 
 			{(values.businessType === 'Picklist' ||
 				values.businessType === 'MultiselectPicklist') && (
-				<AutoComplete
+				<AutoComplete<Partial<PickList>>
 					disabled={disabled}
 					emptyStateMessage={Liferay.Language.get('option-not-found')}
 					error={errors.listTypeDefinitionId}
@@ -413,7 +413,7 @@ export default function ObjectFieldFormBase({
 			</ClayForm.Group>
 
 			{values.state && (
-				<AutoComplete
+				<AutoComplete<PickListItem>
 					emptyStateMessage={Liferay.Language.get('option-not-found')}
 					error={errors.defaultValue}
 					items={filteredPicklistItems}

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/ObjectRelationshipFormBase.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/ObjectRelationshipFormBase.tsx
@@ -187,7 +187,7 @@ export function ObjectRelationshipFormBase({
 				value={selectedType}
 			/>
 
-			<AutoComplete
+			<AutoComplete<ObjectDefinition>
 				disabled={readonly}
 				emptyStateMessage={Liferay.Language.get(
 					'no-objects-were-found'
@@ -196,7 +196,7 @@ export function ObjectRelationshipFormBase({
 				items={filteredRelationships}
 				label={Liferay.Language.get('object')}
 				onChangeQuery={setQuery}
-				onSelectItem={(item: ObjectDefinition) => {
+				onSelectItem={(item) => {
 					setValues({
 						objectDefinitionId2: item.id,
 						objectDefinitionName2: item.name,

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectView/ModalAddDefaultSortColumn/ModalAddDefaultSortColumn.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectView/ModalAddDefaultSortColumn/ModalAddDefaultSortColumn.tsx
@@ -131,7 +131,7 @@ export function ModalAddDefaultSortColumn({
 
 				<ClayModal.Body>
 					{!isEditingSort && (
-						<AutoComplete
+						<AutoComplete<TObjectViewColumn>
 							emptyStateMessage={Liferay.Language.get(
 								'there-are-no-columns-added-in-this-view-yet'
 							)}

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/index.d.ts
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/index.d.ts
@@ -249,7 +249,7 @@ interface ObjectRelationship {
 	readonly objectDefinitionName2: string;
 	objectRelationshipId: number;
 	parameterObjectFieldId?: number;
-	reverse?: boolean;
+	reverse: boolean;
 	type: ObjectRelationshipType;
 }
 


### PR DESCRIPTION
Related Issue: https://issues.liferay.com/browse/LPS-167677

Hello Review, the intention of this PR is to make our Typescript code stronger and more efficient. By adding a generic type to the AutoComplete component and passing this exact type to items, children and onSelectItem we can make this type apply when we are selecting an item and extracting the data to create the children, preventing some bugs from happening and making the component more easy to implement

[Screencast from 2022-11-04 14-09-59.webm](https://user-images.githubusercontent.com/46692326/200048437-5c328e5e-88b7-4e01-b2cc-6eec7be316eb.webm)