### PR TITLE
LPS-169184 Fix grammar error in default email message for creating a new account

### DIFF
--- a/portal-impl/src/com/liferay/portlet/admin/dependencies/email_user_added_reset_password_body.tmpl
+++ b/portal-impl/src/com/liferay/portlet/admin/dependencies/email_user_added_reset_password_body.tmpl
@@ -2,7 +2,7 @@ Dear new user,<br /><br />
 
 Welcome! You recently created an account at [$PORTAL_URL$].
 
-You can setup your password here: [$PASSWORD_SETUP_URL$]<br /><br /> Enjoy!<br /><br />
+You can set up your password here: [$PASSWORD_SETUP_URL$]<br /><br /> Enjoy!<br /><br />
 
 Sincerely,<br />
 [$FROM_NAME$]<br />


### PR DESCRIPTION
Manually forwarded from https://github.com/mbowerman/liferay-portal/pull/137 since the `ci:forward` command was failing.

[LPS-169184](https://issues.liferay.com/browse/LPS-169184)