### PR TITLE
LPS-163008: Service Builder automate and validate for duplicate ERC

### DIFF
--- a/modules/apps/account/account-api/bnd.bnd
+++ b/modules/apps/account/account-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Account API
 Bundle-SymbolicName: com.liferay.account.api
-Bundle-Version: 12.7.0
+Bundle-Version: 13.0.0
 Export-Package:\
 	com.liferay.account.configuration,\
 	com.liferay.account.constants,\

--- a/modules/apps/account/account-api/src/main/java/com/liferay/account/exception/DuplicateAccountEntryExternalReferenceCodeException.java
+++ b/modules/apps/account/account-api/src/main/java/com/liferay/account/exception/DuplicateAccountEntryExternalReferenceCodeException.java
@@ -14,13 +14,13 @@
 
 package com.liferay.account.exception;
 
-import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.SystemException;
 
 /**
  * @author Brian Wing Shun Chan
  */
 public class DuplicateAccountEntryExternalReferenceCodeException
-	extends PortalException {
+	extends SystemException {
 
 	public DuplicateAccountEntryExternalReferenceCodeException() {
 	}

--- a/modules/apps/account/account-api/src/main/java/com/liferay/account/service/AccountEntryLocalService.java
+++ b/modules/apps/account/account-api/src/main/java/com/liferay/account/service/AccountEntryLocalService.java
@@ -248,24 +248,9 @@ public interface AccountEntryLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public AccountEntry fetchAccountEntry(long accountEntryId);
 
-	/**
-	 * Returns the account entry with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the account entry's external reference code
-	 * @return the matching account entry, or <code>null</code> if a matching account entry could not be found
-	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public AccountEntry fetchAccountEntryByExternalReferenceCode(
-		long companyId, String externalReferenceCode);
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchAccountEntryByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public AccountEntry fetchAccountEntryByReferenceCode(
-		long companyId, String externalReferenceCode);
+		String externalReferenceCode, long companyId);
 
 	/**
 	 * Returns the account entry with the matching UUID and company.
@@ -325,17 +310,9 @@ public interface AccountEntryLocalService
 	public AccountEntry getAccountEntry(long accountEntryId)
 		throws PortalException;
 
-	/**
-	 * Returns the account entry with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the account entry's external reference code
-	 * @return the matching account entry
-	 * @throws PortalException if a matching account entry could not be found
-	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public AccountEntry getAccountEntryByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
+			String externalReferenceCode, long companyId)
 		throws PortalException;
 
 	/**

--- a/modules/apps/account/account-api/src/main/java/com/liferay/account/service/AccountEntryLocalServiceUtil.java
+++ b/modules/apps/account/account-api/src/main/java/com/liferay/account/service/AccountEntryLocalServiceUtil.java
@@ -284,29 +284,11 @@ public class AccountEntryLocalServiceUtil {
 		return getService().fetchAccountEntry(accountEntryId);
 	}
 
-	/**
-	 * Returns the account entry with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the account entry's external reference code
-	 * @return the matching account entry, or <code>null</code> if a matching account entry could not be found
-	 */
 	public static AccountEntry fetchAccountEntryByExternalReferenceCode(
-		long companyId, String externalReferenceCode) {
+		String externalReferenceCode, long companyId) {
 
 		return getService().fetchAccountEntryByExternalReferenceCode(
-			companyId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchAccountEntryByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	public static AccountEntry fetchAccountEntryByReferenceCode(
-		long companyId, String externalReferenceCode) {
-
-		return getService().fetchAccountEntryByReferenceCode(
-			companyId, externalReferenceCode);
+			externalReferenceCode, companyId);
 	}
 
 	/**
@@ -382,20 +364,12 @@ public class AccountEntryLocalServiceUtil {
 		return getService().getAccountEntry(accountEntryId);
 	}
 
-	/**
-	 * Returns the account entry with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the account entry's external reference code
-	 * @return the matching account entry
-	 * @throws PortalException if a matching account entry could not be found
-	 */
 	public static AccountEntry getAccountEntryByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
+			String externalReferenceCode, long companyId)
 		throws PortalException {
 
 		return getService().getAccountEntryByExternalReferenceCode(
-			companyId, externalReferenceCode);
+			externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/account/account-api/src/main/java/com/liferay/account/service/AccountEntryLocalServiceWrapper.java
+++ b/modules/apps/account/account-api/src/main/java/com/liferay/account/service/AccountEntryLocalServiceWrapper.java
@@ -322,34 +322,14 @@ public class AccountEntryLocalServiceWrapper
 		return _accountEntryLocalService.fetchAccountEntry(accountEntryId);
 	}
 
-	/**
-	 * Returns the account entry with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the account entry's external reference code
-	 * @return the matching account entry, or <code>null</code> if a matching account entry could not be found
-	 */
 	@Override
 	public com.liferay.account.model.AccountEntry
 		fetchAccountEntryByExternalReferenceCode(
-			long companyId, String externalReferenceCode) {
+			String externalReferenceCode, long companyId) {
 
 		return _accountEntryLocalService.
 			fetchAccountEntryByExternalReferenceCode(
-				companyId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchAccountEntryByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public com.liferay.account.model.AccountEntry
-		fetchAccountEntryByReferenceCode(
-			long companyId, String externalReferenceCode) {
-
-		return _accountEntryLocalService.fetchAccountEntryByReferenceCode(
-			companyId, externalReferenceCode);
+				externalReferenceCode, companyId);
 	}
 
 	/**
@@ -442,22 +422,14 @@ public class AccountEntryLocalServiceWrapper
 		return _accountEntryLocalService.getAccountEntry(accountEntryId);
 	}
 
-	/**
-	 * Returns the account entry with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the account entry's external reference code
-	 * @return the matching account entry
-	 * @throws PortalException if a matching account entry could not be found
-	 */
 	@Override
 	public com.liferay.account.model.AccountEntry
 			getAccountEntryByExternalReferenceCode(
-				long companyId, String externalReferenceCode)
+				String externalReferenceCode, long companyId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _accountEntryLocalService.getAccountEntryByExternalReferenceCode(
-			companyId, externalReferenceCode);
+			externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/account/account-api/src/main/java/com/liferay/account/service/AccountGroupLocalService.java
+++ b/modules/apps/account/account-api/src/main/java/com/liferay/account/service/AccountGroupLocalService.java
@@ -217,24 +217,9 @@ public interface AccountGroupLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public AccountGroup fetchAccountGroup(long accountGroupId);
 
-	/**
-	 * Returns the account group with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the account group's external reference code
-	 * @return the matching account group, or <code>null</code> if a matching account group could not be found
-	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public AccountGroup fetchAccountGroupByExternalReferenceCode(
-		long companyId, String externalReferenceCode);
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchAccountGroupByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public AccountGroup fetchAccountGroupByReferenceCode(
-		long companyId, String externalReferenceCode);
+		String externalReferenceCode, long companyId);
 
 	/**
 	 * Returns the account group with the matching UUID and company.
@@ -258,17 +243,9 @@ public interface AccountGroupLocalService
 	public AccountGroup getAccountGroup(long accountGroupId)
 		throws PortalException;
 
-	/**
-	 * Returns the account group with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the account group's external reference code
-	 * @return the matching account group
-	 * @throws PortalException if a matching account group could not be found
-	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public AccountGroup getAccountGroupByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
+			String externalReferenceCode, long companyId)
 		throws PortalException;
 
 	/**

--- a/modules/apps/account/account-api/src/main/java/com/liferay/account/service/AccountGroupLocalServiceUtil.java
+++ b/modules/apps/account/account-api/src/main/java/com/liferay/account/service/AccountGroupLocalServiceUtil.java
@@ -225,29 +225,11 @@ public class AccountGroupLocalServiceUtil {
 		return getService().fetchAccountGroup(accountGroupId);
 	}
 
-	/**
-	 * Returns the account group with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the account group's external reference code
-	 * @return the matching account group, or <code>null</code> if a matching account group could not be found
-	 */
 	public static AccountGroup fetchAccountGroupByExternalReferenceCode(
-		long companyId, String externalReferenceCode) {
+		String externalReferenceCode, long companyId) {
 
 		return getService().fetchAccountGroupByExternalReferenceCode(
-			companyId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchAccountGroupByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	public static AccountGroup fetchAccountGroupByReferenceCode(
-		long companyId, String externalReferenceCode) {
-
-		return getService().fetchAccountGroupByReferenceCode(
-			companyId, externalReferenceCode);
+			externalReferenceCode, companyId);
 	}
 
 	/**
@@ -277,20 +259,12 @@ public class AccountGroupLocalServiceUtil {
 		return getService().getAccountGroup(accountGroupId);
 	}
 
-	/**
-	 * Returns the account group with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the account group's external reference code
-	 * @return the matching account group
-	 * @throws PortalException if a matching account group could not be found
-	 */
 	public static AccountGroup getAccountGroupByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
+			String externalReferenceCode, long companyId)
 		throws PortalException {
 
 		return getService().getAccountGroupByExternalReferenceCode(
-			companyId, externalReferenceCode);
+			externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/account/account-api/src/main/java/com/liferay/account/service/AccountGroupLocalServiceWrapper.java
+++ b/modules/apps/account/account-api/src/main/java/com/liferay/account/service/AccountGroupLocalServiceWrapper.java
@@ -253,34 +253,14 @@ public class AccountGroupLocalServiceWrapper
 		return _accountGroupLocalService.fetchAccountGroup(accountGroupId);
 	}
 
-	/**
-	 * Returns the account group with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the account group's external reference code
-	 * @return the matching account group, or <code>null</code> if a matching account group could not be found
-	 */
 	@Override
 	public com.liferay.account.model.AccountGroup
 		fetchAccountGroupByExternalReferenceCode(
-			long companyId, String externalReferenceCode) {
+			String externalReferenceCode, long companyId) {
 
 		return _accountGroupLocalService.
 			fetchAccountGroupByExternalReferenceCode(
-				companyId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchAccountGroupByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public com.liferay.account.model.AccountGroup
-		fetchAccountGroupByReferenceCode(
-			long companyId, String externalReferenceCode) {
-
-		return _accountGroupLocalService.fetchAccountGroupByReferenceCode(
-			companyId, externalReferenceCode);
+				externalReferenceCode, companyId);
 	}
 
 	/**
@@ -313,22 +293,14 @@ public class AccountGroupLocalServiceWrapper
 		return _accountGroupLocalService.getAccountGroup(accountGroupId);
 	}
 
-	/**
-	 * Returns the account group with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the account group's external reference code
-	 * @return the matching account group
-	 * @throws PortalException if a matching account group could not be found
-	 */
 	@Override
 	public com.liferay.account.model.AccountGroup
 			getAccountGroupByExternalReferenceCode(
-				long companyId, String externalReferenceCode)
+				String externalReferenceCode, long companyId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _accountGroupLocalService.getAccountGroupByExternalReferenceCode(
-			companyId, externalReferenceCode);
+			externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/account/account-api/src/main/java/com/liferay/account/service/persistence/AccountEntryPersistence.java
+++ b/modules/apps/account/account-api/src/main/java/com/liferay/account/service/persistence/AccountEntryPersistence.java
@@ -1128,57 +1128,57 @@ public interface AccountEntryPersistence extends BasePersistence<AccountEntry> {
 	public int filterCountByU_T(long userId, String type);
 
 	/**
-	 * Returns the account entry where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchEntryException</code> if it could not be found.
+	 * Returns the account entry where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchEntryException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching account entry
 	 * @throws NoSuchEntryException if a matching account entry could not be found
 	 */
-	public AccountEntry findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public AccountEntry findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchEntryException;
 
 	/**
-	 * Returns the account entry where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the account entry where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching account entry, or <code>null</code> if a matching account entry could not be found
 	 */
-	public AccountEntry fetchByC_ERC(
-		long companyId, String externalReferenceCode);
+	public AccountEntry fetchByERC_C(
+		String externalReferenceCode, long companyId);
 
 	/**
-	 * Returns the account entry where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the account entry where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching account entry, or <code>null</code> if a matching account entry could not be found
 	 */
-	public AccountEntry fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache);
+	public AccountEntry fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache);
 
 	/**
-	 * Removes the account entry where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the account entry where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the account entry that was removed
 	 */
-	public AccountEntry removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public AccountEntry removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchEntryException;
 
 	/**
-	 * Returns the number of account entries where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of account entries where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching account entries
 	 */
-	public int countByC_ERC(long companyId, String externalReferenceCode);
+	public int countByERC_C(String externalReferenceCode, long companyId);
 
 	/**
 	 * Caches the account entry in the entity cache if it is enabled.

--- a/modules/apps/account/account-api/src/main/java/com/liferay/account/service/persistence/AccountEntryUtil.java
+++ b/modules/apps/account/account-api/src/main/java/com/liferay/account/service/persistence/AccountEntryUtil.java
@@ -1408,73 +1408,73 @@ public class AccountEntryUtil {
 	}
 
 	/**
-	 * Returns the account entry where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchEntryException</code> if it could not be found.
+	 * Returns the account entry where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchEntryException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching account entry
 	 * @throws NoSuchEntryException if a matching account entry could not be found
 	 */
-	public static AccountEntry findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public static AccountEntry findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws com.liferay.account.exception.NoSuchEntryException {
 
-		return getPersistence().findByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().findByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the account entry where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the account entry where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching account entry, or <code>null</code> if a matching account entry could not be found
 	 */
-	public static AccountEntry fetchByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public static AccountEntry fetchByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return getPersistence().fetchByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().fetchByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the account entry where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the account entry where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching account entry, or <code>null</code> if a matching account entry could not be found
 	 */
-	public static AccountEntry fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache) {
+	public static AccountEntry fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache) {
 
-		return getPersistence().fetchByC_ERC(
-			companyId, externalReferenceCode, useFinderCache);
+		return getPersistence().fetchByERC_C(
+			externalReferenceCode, companyId, useFinderCache);
 	}
 
 	/**
-	 * Removes the account entry where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the account entry where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the account entry that was removed
 	 */
-	public static AccountEntry removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public static AccountEntry removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws com.liferay.account.exception.NoSuchEntryException {
 
-		return getPersistence().removeByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().removeByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the number of account entries where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of account entries where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching account entries
 	 */
-	public static int countByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public static int countByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return getPersistence().countByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().countByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/account/account-api/src/main/java/com/liferay/account/service/persistence/AccountGroupPersistence.java
+++ b/modules/apps/account/account-api/src/main/java/com/liferay/account/service/persistence/AccountGroupPersistence.java
@@ -1432,57 +1432,57 @@ public interface AccountGroupPersistence extends BasePersistence<AccountGroup> {
 	public int filterCountByC_T(long companyId, String type);
 
 	/**
-	 * Returns the account group where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchGroupException</code> if it could not be found.
+	 * Returns the account group where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchGroupException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching account group
 	 * @throws NoSuchGroupException if a matching account group could not be found
 	 */
-	public AccountGroup findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public AccountGroup findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchGroupException;
 
 	/**
-	 * Returns the account group where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the account group where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching account group, or <code>null</code> if a matching account group could not be found
 	 */
-	public AccountGroup fetchByC_ERC(
-		long companyId, String externalReferenceCode);
+	public AccountGroup fetchByERC_C(
+		String externalReferenceCode, long companyId);
 
 	/**
-	 * Returns the account group where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the account group where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching account group, or <code>null</code> if a matching account group could not be found
 	 */
-	public AccountGroup fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache);
+	public AccountGroup fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache);
 
 	/**
-	 * Removes the account group where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the account group where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the account group that was removed
 	 */
-	public AccountGroup removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public AccountGroup removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchGroupException;
 
 	/**
-	 * Returns the number of account groups where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of account groups where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching account groups
 	 */
-	public int countByC_ERC(long companyId, String externalReferenceCode);
+	public int countByERC_C(String externalReferenceCode, long companyId);
 
 	/**
 	 * Caches the account group in the entity cache if it is enabled.

--- a/modules/apps/account/account-api/src/main/java/com/liferay/account/service/persistence/AccountGroupUtil.java
+++ b/modules/apps/account/account-api/src/main/java/com/liferay/account/service/persistence/AccountGroupUtil.java
@@ -1790,73 +1790,73 @@ public class AccountGroupUtil {
 	}
 
 	/**
-	 * Returns the account group where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchGroupException</code> if it could not be found.
+	 * Returns the account group where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchGroupException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching account group
 	 * @throws NoSuchGroupException if a matching account group could not be found
 	 */
-	public static AccountGroup findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public static AccountGroup findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws com.liferay.account.exception.NoSuchGroupException {
 
-		return getPersistence().findByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().findByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the account group where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the account group where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching account group, or <code>null</code> if a matching account group could not be found
 	 */
-	public static AccountGroup fetchByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public static AccountGroup fetchByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return getPersistence().fetchByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().fetchByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the account group where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the account group where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching account group, or <code>null</code> if a matching account group could not be found
 	 */
-	public static AccountGroup fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache) {
+	public static AccountGroup fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache) {
 
-		return getPersistence().fetchByC_ERC(
-			companyId, externalReferenceCode, useFinderCache);
+		return getPersistence().fetchByERC_C(
+			externalReferenceCode, companyId, useFinderCache);
 	}
 
 	/**
-	 * Removes the account group where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the account group where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the account group that was removed
 	 */
-	public static AccountGroup removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public static AccountGroup removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws com.liferay.account.exception.NoSuchGroupException {
 
-		return getPersistence().removeByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().removeByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the number of account groups where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of account groups where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching account groups
 	 */
-	public static int countByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public static int countByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return getPersistence().countByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().countByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/account/account-api/src/main/resources/com/liferay/account/exception/packageinfo
+++ b/modules/apps/account/account-api/src/main/resources/com/liferay/account/exception/packageinfo
@@ -1,1 +1,1 @@
-version 2.3.0
+version 3.0.0

--- a/modules/apps/account/account-api/src/main/resources/com/liferay/account/service/packageinfo
+++ b/modules/apps/account/account-api/src/main/resources/com/liferay/account/service/packageinfo
@@ -1,1 +1,1 @@
-version 7.8.0
+version 8.0.0

--- a/modules/apps/account/account-api/src/main/resources/com/liferay/account/service/persistence/packageinfo
+++ b/modules/apps/account/account-api/src/main/resources/com/liferay/account/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 3.5.0
+version 4.0.0

--- a/modules/apps/account/account-service/service.xml
+++ b/modules/apps/account/account-service/service.xml
@@ -229,11 +229,9 @@
 		<exception>AccountEntryUserRelEmailAddress</exception>
 		<exception>AccountGroupName</exception>
 		<exception>DefaultAccountGroup</exception>
-		<exception>DuplicateAccountEntryExternalReferenceCode</exception>
 		<exception>DuplicateAccountEntryId</exception>
 		<exception>DuplicateAccountEntryOrganizationRel</exception>
 		<exception>DuplicateAccountEntryUserRel</exception>
-		<exception>DuplicateAccountGroupExternalReferenceCode</exception>
 		<exception>DuplicateAccountGroupRel</exception>
 	</exceptions>
 </service-builder>

--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/object/system/AccountEntrySystemObjectDefinitionMetadata.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/object/system/AccountEntrySystemObjectDefinitionMetadata.java
@@ -56,7 +56,7 @@ public class AccountEntrySystemObjectDefinitionMetadata
 		throws PortalException {
 
 		return _accountEntryLocalService.getAccountEntryByExternalReferenceCode(
-			companyId, externalReferenceCode);
+			externalReferenceCode, companyId);
 	}
 
 	@Override

--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/service/base/AccountEntryLocalServiceBaseImpl.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/service/base/AccountEntryLocalServiceBaseImpl.java
@@ -278,48 +278,21 @@ public abstract class AccountEntryLocalServiceBaseImpl
 			uuid, companyId, null);
 	}
 
-	/**
-	 * Returns the account entry with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the account entry's external reference code
-	 * @return the matching account entry, or <code>null</code> if a matching account entry could not be found
-	 */
 	@Override
 	public AccountEntry fetchAccountEntryByExternalReferenceCode(
-		long companyId, String externalReferenceCode) {
+		String externalReferenceCode, long companyId) {
 
-		return accountEntryPersistence.fetchByC_ERC(
-			companyId, externalReferenceCode);
+		return accountEntryPersistence.fetchByERC_C(
+			externalReferenceCode, companyId);
 	}
 
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchAccountEntryByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public AccountEntry fetchAccountEntryByReferenceCode(
-		long companyId, String externalReferenceCode) {
-
-		return fetchAccountEntryByExternalReferenceCode(
-			companyId, externalReferenceCode);
-	}
-
-	/**
-	 * Returns the account entry with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the account entry's external reference code
-	 * @return the matching account entry
-	 * @throws PortalException if a matching account entry could not be found
-	 */
 	@Override
 	public AccountEntry getAccountEntryByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
+			String externalReferenceCode, long companyId)
 		throws PortalException {
 
-		return accountEntryPersistence.findByC_ERC(
-			companyId, externalReferenceCode);
+		return accountEntryPersistence.findByERC_C(
+			externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/service/base/AccountGroupLocalServiceBaseImpl.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/service/base/AccountGroupLocalServiceBaseImpl.java
@@ -270,48 +270,21 @@ public abstract class AccountGroupLocalServiceBaseImpl
 			uuid, companyId, null);
 	}
 
-	/**
-	 * Returns the account group with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the account group's external reference code
-	 * @return the matching account group, or <code>null</code> if a matching account group could not be found
-	 */
 	@Override
 	public AccountGroup fetchAccountGroupByExternalReferenceCode(
-		long companyId, String externalReferenceCode) {
+		String externalReferenceCode, long companyId) {
 
-		return accountGroupPersistence.fetchByC_ERC(
-			companyId, externalReferenceCode);
+		return accountGroupPersistence.fetchByERC_C(
+			externalReferenceCode, companyId);
 	}
 
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchAccountGroupByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public AccountGroup fetchAccountGroupByReferenceCode(
-		long companyId, String externalReferenceCode) {
-
-		return fetchAccountGroupByExternalReferenceCode(
-			companyId, externalReferenceCode);
-	}
-
-	/**
-	 * Returns the account group with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the account group's external reference code
-	 * @return the matching account group
-	 * @throws PortalException if a matching account group could not be found
-	 */
 	@Override
 	public AccountGroup getAccountGroupByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
+			String externalReferenceCode, long companyId)
 		throws PortalException {
 
-		return accountGroupPersistence.findByC_ERC(
-			companyId, externalReferenceCode);
+		return accountGroupPersistence.findByERC_C(
+			externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountEntryLocalServiceImpl.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountEntryLocalServiceImpl.java
@@ -19,7 +19,6 @@ import com.liferay.account.exception.AccountEntryDomainsException;
 import com.liferay.account.exception.AccountEntryEmailAddressException;
 import com.liferay.account.exception.AccountEntryNameException;
 import com.liferay.account.exception.AccountEntryTypeException;
-import com.liferay.account.exception.DuplicateAccountEntryExternalReferenceCodeException;
 import com.liferay.account.model.AccountEntry;
 import com.liferay.account.model.AccountEntryOrganizationRelTable;
 import com.liferay.account.model.AccountEntryTable;
@@ -266,7 +265,7 @@ public class AccountEntryLocalServiceImpl
 		User user = _userLocalService.getUser(userId);
 
 		AccountEntry accountEntry = fetchAccountEntryByExternalReferenceCode(
-			user.getCompanyId(), externalReferenceCode);
+			externalReferenceCode, user.getCompanyId());
 
 		if (accountEntry != null) {
 			return updateAccountEntry(
@@ -738,9 +737,6 @@ public class AccountEntryLocalServiceImpl
 
 			return accountEntry;
 		}
-
-		_validateExternalReferenceCode(
-			accountEntry.getAccountEntryId(), externalReferenceCode);
 
 		accountEntry.setExternalReferenceCode(externalReferenceCode);
 
@@ -1232,28 +1228,6 @@ public class AccountEntryLocalServiceImpl
 				emailAddress)) {
 
 			throw new AccountEntryEmailAddressException();
-		}
-	}
-
-	private void _validateExternalReferenceCode(
-			long accountEntryId, String externalReferenceCode)
-		throws PortalException {
-
-		if (Validator.isNull(externalReferenceCode)) {
-			return;
-		}
-
-		AccountEntry accountEntry = getAccountEntry(accountEntryId);
-
-		accountEntry = fetchAccountEntryByExternalReferenceCode(
-			accountEntry.getCompanyId(), externalReferenceCode);
-
-		if (accountEntry == null) {
-			return;
-		}
-
-		if (accountEntry.getAccountEntryId() != accountEntryId) {
-			throw new DuplicateAccountEntryExternalReferenceCodeException();
 		}
 	}
 

--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountEntryServiceImpl.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountEntryServiceImpl.java
@@ -103,7 +103,7 @@ public class AccountEntryServiceImpl extends AccountEntryServiceBaseImpl {
 
 		AccountEntry accountEntry =
 			accountEntryLocalService.fetchAccountEntryByExternalReferenceCode(
-				permissionChecker.getCompanyId(), externalReferenceCode);
+				externalReferenceCode, permissionChecker.getCompanyId());
 
 		long accountEntryId = 0;
 

--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountEntryServiceImpl.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountEntryServiceImpl.java
@@ -183,7 +183,7 @@ public class AccountEntryServiceImpl extends AccountEntryServiceBaseImpl {
 
 		AccountEntry accountEntry =
 			accountEntryLocalService.fetchAccountEntryByExternalReferenceCode(
-				companyId, externalReferenceCode);
+				externalReferenceCode, companyId);
 
 		if (accountEntry != null) {
 			_accountEntryModelResourcePermission.check(

--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountGroupLocalServiceImpl.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountGroupLocalServiceImpl.java
@@ -16,7 +16,6 @@ package com.liferay.account.service.impl;
 
 import com.liferay.account.constants.AccountConstants;
 import com.liferay.account.exception.AccountGroupNameException;
-import com.liferay.account.exception.DuplicateAccountGroupExternalReferenceCodeException;
 import com.liferay.account.model.AccountGroup;
 import com.liferay.account.model.AccountGroupRel;
 import com.liferay.account.service.base.AccountGroupLocalServiceBaseImpl;
@@ -273,9 +272,6 @@ public class AccountGroupLocalServiceImpl
 			return accountGroup;
 		}
 
-		_validateExternalReferenceCode(
-			accountGroup.getAccountGroupId(), externalReferenceCode);
-
 		accountGroup.setExternalReferenceCode(externalReferenceCode);
 
 		return updateAccountGroup(accountGroup);
@@ -359,28 +355,6 @@ public class AccountGroupLocalServiceImpl
 
 		throw new SearchException(
 			"Unable to fix the search index after 10 attempts");
-	}
-
-	private void _validateExternalReferenceCode(
-			long accountGroupId, String externalReferenceCode)
-		throws PortalException {
-
-		if (Validator.isNull(externalReferenceCode)) {
-			return;
-		}
-
-		AccountGroup accountGroup = getAccountGroup(accountGroupId);
-
-		accountGroup = fetchAccountGroupByExternalReferenceCode(
-			accountGroup.getCompanyId(), externalReferenceCode);
-
-		if (accountGroup == null) {
-			return;
-		}
-
-		if (accountGroup.getAccountGroupId() != accountGroupId) {
-			throw new DuplicateAccountGroupExternalReferenceCodeException();
-		}
 	}
 
 	private void _validateName(String name) throws PortalException {

--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/service/persistence/impl/AccountEntryPersistenceImpl.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/service/persistence/impl/AccountEntryPersistenceImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.account.service.persistence.impl;
 
+import com.liferay.account.exception.DuplicateAccountEntryExternalReferenceCodeException;
 import com.liferay.account.exception.NoSuchEntryException;
 import com.liferay.account.model.AccountEntry;
 import com.liferay.account.model.AccountEntryTable;
@@ -4899,35 +4900,35 @@ public class AccountEntryPersistenceImpl
 	private static final String _FINDER_COLUMN_U_T_TYPE_3_SQL =
 		"(accountEntry.type_ IS NULL OR accountEntry.type_ = '')";
 
-	private FinderPath _finderPathFetchByC_ERC;
-	private FinderPath _finderPathCountByC_ERC;
+	private FinderPath _finderPathFetchByERC_C;
+	private FinderPath _finderPathCountByERC_C;
 
 	/**
-	 * Returns the account entry where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchEntryException</code> if it could not be found.
+	 * Returns the account entry where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchEntryException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching account entry
 	 * @throws NoSuchEntryException if a matching account entry could not be found
 	 */
 	@Override
-	public AccountEntry findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public AccountEntry findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchEntryException {
 
-		AccountEntry accountEntry = fetchByC_ERC(
-			companyId, externalReferenceCode);
+		AccountEntry accountEntry = fetchByERC_C(
+			externalReferenceCode, companyId);
 
 		if (accountEntry == null) {
 			StringBundler sb = new StringBundler(6);
 
 			sb.append(_NO_SUCH_ENTITY_WITH_KEY);
 
-			sb.append("companyId=");
-			sb.append(companyId);
-
-			sb.append(", externalReferenceCode=");
+			sb.append("externalReferenceCode=");
 			sb.append(externalReferenceCode);
+
+			sb.append(", companyId=");
+			sb.append(companyId);
 
 			sb.append("}");
 
@@ -4942,53 +4943,53 @@ public class AccountEntryPersistenceImpl
 	}
 
 	/**
-	 * Returns the account entry where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the account entry where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching account entry, or <code>null</code> if a matching account entry could not be found
 	 */
 	@Override
-	public AccountEntry fetchByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public AccountEntry fetchByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return fetchByC_ERC(companyId, externalReferenceCode, true);
+		return fetchByERC_C(externalReferenceCode, companyId, true);
 	}
 
 	/**
-	 * Returns the account entry where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the account entry where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching account entry, or <code>null</code> if a matching account entry could not be found
 	 */
 	@Override
-	public AccountEntry fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache) {
+	public AccountEntry fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache) {
 
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
 		Object[] finderArgs = null;
 
 		if (useFinderCache) {
-			finderArgs = new Object[] {companyId, externalReferenceCode};
+			finderArgs = new Object[] {externalReferenceCode, companyId};
 		}
 
 		Object result = null;
 
 		if (useFinderCache) {
 			result = finderCache.getResult(
-				_finderPathFetchByC_ERC, finderArgs, this);
+				_finderPathFetchByERC_C, finderArgs, this);
 		}
 
 		if (result instanceof AccountEntry) {
 			AccountEntry accountEntry = (AccountEntry)result;
 
-			if ((companyId != accountEntry.getCompanyId()) ||
-				!Objects.equals(
+			if (!Objects.equals(
 					externalReferenceCode,
-					accountEntry.getExternalReferenceCode())) {
+					accountEntry.getExternalReferenceCode()) ||
+				(companyId != accountEntry.getCompanyId())) {
 
 				result = null;
 			}
@@ -4999,18 +5000,18 @@ public class AccountEntryPersistenceImpl
 
 			sb.append(_SQL_SELECT_ACCOUNTENTRY_WHERE);
 
-			sb.append(_FINDER_COLUMN_C_ERC_COMPANYID_2);
-
 			boolean bindExternalReferenceCode = false;
 
 			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3);
 			}
 			else {
 				bindExternalReferenceCode = true;
 
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2);
 			}
+
+			sb.append(_FINDER_COLUMN_ERC_C_COMPANYID_2);
 
 			String sql = sb.toString();
 
@@ -5023,18 +5024,18 @@ public class AccountEntryPersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
-				queryPos.add(companyId);
-
 				if (bindExternalReferenceCode) {
 					queryPos.add(externalReferenceCode);
 				}
+
+				queryPos.add(companyId);
 
 				List<AccountEntry> list = query.list();
 
 				if (list.isEmpty()) {
 					if (useFinderCache) {
 						finderCache.putResult(
-							_finderPathFetchByC_ERC, finderArgs, list);
+							_finderPathFetchByERC_C, finderArgs, list);
 					}
 				}
 				else {
@@ -5062,37 +5063,37 @@ public class AccountEntryPersistenceImpl
 	}
 
 	/**
-	 * Removes the account entry where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the account entry where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the account entry that was removed
 	 */
 	@Override
-	public AccountEntry removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public AccountEntry removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchEntryException {
 
-		AccountEntry accountEntry = findByC_ERC(
-			companyId, externalReferenceCode);
+		AccountEntry accountEntry = findByERC_C(
+			externalReferenceCode, companyId);
 
 		return remove(accountEntry);
 	}
 
 	/**
-	 * Returns the number of account entries where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of account entries where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching account entries
 	 */
 	@Override
-	public int countByC_ERC(long companyId, String externalReferenceCode) {
+	public int countByERC_C(String externalReferenceCode, long companyId) {
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
-		FinderPath finderPath = _finderPathCountByC_ERC;
+		FinderPath finderPath = _finderPathCountByERC_C;
 
-		Object[] finderArgs = new Object[] {companyId, externalReferenceCode};
+		Object[] finderArgs = new Object[] {externalReferenceCode, companyId};
 
 		Long count = (Long)finderCache.getResult(finderPath, finderArgs, this);
 
@@ -5101,18 +5102,18 @@ public class AccountEntryPersistenceImpl
 
 			sb.append(_SQL_COUNT_ACCOUNTENTRY_WHERE);
 
-			sb.append(_FINDER_COLUMN_C_ERC_COMPANYID_2);
-
 			boolean bindExternalReferenceCode = false;
 
 			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3);
 			}
 			else {
 				bindExternalReferenceCode = true;
 
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2);
 			}
+
+			sb.append(_FINDER_COLUMN_ERC_C_COMPANYID_2);
 
 			String sql = sb.toString();
 
@@ -5125,11 +5126,11 @@ public class AccountEntryPersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
-				queryPos.add(companyId);
-
 				if (bindExternalReferenceCode) {
 					queryPos.add(externalReferenceCode);
 				}
+
+				queryPos.add(companyId);
 
 				count = (Long)query.uniqueResult();
 
@@ -5146,14 +5147,14 @@ public class AccountEntryPersistenceImpl
 		return count.intValue();
 	}
 
-	private static final String _FINDER_COLUMN_C_ERC_COMPANYID_2 =
-		"accountEntry.companyId = ? AND ";
+	private static final String _FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2 =
+		"accountEntry.externalReferenceCode = ? AND ";
 
-	private static final String _FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2 =
-		"accountEntry.externalReferenceCode = ?";
+	private static final String _FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3 =
+		"(accountEntry.externalReferenceCode IS NULL OR accountEntry.externalReferenceCode = '') AND ";
 
-	private static final String _FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3 =
-		"(accountEntry.externalReferenceCode IS NULL OR accountEntry.externalReferenceCode = '')";
+	private static final String _FINDER_COLUMN_ERC_C_COMPANYID_2 =
+		"accountEntry.companyId = ?";
 
 	public AccountEntryPersistenceImpl() {
 		Map<String, String> dbColumnNames = new HashMap<String, String>();
@@ -5182,10 +5183,10 @@ public class AccountEntryPersistenceImpl
 			AccountEntryImpl.class, accountEntry.getPrimaryKey(), accountEntry);
 
 		finderCache.putResult(
-			_finderPathFetchByC_ERC,
+			_finderPathFetchByERC_C,
 			new Object[] {
-				accountEntry.getCompanyId(),
-				accountEntry.getExternalReferenceCode()
+				accountEntry.getExternalReferenceCode(),
+				accountEntry.getCompanyId()
 			},
 			accountEntry);
 	}
@@ -5262,13 +5263,13 @@ public class AccountEntryPersistenceImpl
 		AccountEntryModelImpl accountEntryModelImpl) {
 
 		Object[] args = new Object[] {
-			accountEntryModelImpl.getCompanyId(),
-			accountEntryModelImpl.getExternalReferenceCode()
+			accountEntryModelImpl.getExternalReferenceCode(),
+			accountEntryModelImpl.getCompanyId()
 		};
 
-		finderCache.putResult(_finderPathCountByC_ERC, args, Long.valueOf(1));
+		finderCache.putResult(_finderPathCountByERC_C, args, Long.valueOf(1));
 		finderCache.putResult(
-			_finderPathFetchByC_ERC, args, accountEntryModelImpl);
+			_finderPathFetchByERC_C, args, accountEntryModelImpl);
 	}
 
 	/**
@@ -5410,6 +5411,25 @@ public class AccountEntryPersistenceImpl
 
 		if (Validator.isNull(accountEntry.getExternalReferenceCode())) {
 			accountEntry.setExternalReferenceCode(accountEntry.getUuid());
+		}
+		else {
+			AccountEntry ercAccountEntry = fetchByERC_C(
+				accountEntry.getExternalReferenceCode(),
+				accountEntry.getCompanyId());
+
+			if (isNew) {
+				if (ercAccountEntry != null) {
+					throw new DuplicateAccountEntryExternalReferenceCodeException();
+				}
+			}
+			else {
+				if ((ercAccountEntry != null) &&
+					(accountEntry.getAccountEntryId() !=
+						ercAccountEntry.getAccountEntryId())) {
+
+					throw new DuplicateAccountEntryExternalReferenceCodeException();
+				}
+			}
 		}
 
 		ServiceContext serviceContext =
@@ -5836,15 +5856,15 @@ public class AccountEntryPersistenceImpl
 			new String[] {Long.class.getName(), String.class.getName()},
 			new String[] {"userId", "type_"}, false);
 
-		_finderPathFetchByC_ERC = new FinderPath(
-			FINDER_CLASS_NAME_ENTITY, "fetchByC_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"companyId", "externalReferenceCode"}, true);
+		_finderPathFetchByERC_C = new FinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, true);
 
-		_finderPathCountByC_ERC = new FinderPath(
-			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"companyId", "externalReferenceCode"}, false);
+		_finderPathCountByERC_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, false);
 
 		_setAccountEntryUtilPersistence(this);
 	}

--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/service/persistence/impl/AccountEntryPersistenceImpl.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/service/persistence/impl/AccountEntryPersistenceImpl.java
@@ -5419,7 +5419,9 @@ public class AccountEntryPersistenceImpl
 
 			if (isNew) {
 				if (ercAccountEntry != null) {
-					throw new DuplicateAccountEntryExternalReferenceCodeException();
+					throw new DuplicateAccountEntryExternalReferenceCodeException(
+						"Duplicate AccountEntry with external reference code " +
+							accountEntry.getExternalReferenceCode());
 				}
 			}
 			else {
@@ -5427,7 +5429,9 @@ public class AccountEntryPersistenceImpl
 					(accountEntry.getAccountEntryId() !=
 						ercAccountEntry.getAccountEntryId())) {
 
-					throw new DuplicateAccountEntryExternalReferenceCodeException();
+					throw new DuplicateAccountEntryExternalReferenceCodeException(
+						"Duplicate AccountEntry with external reference code " +
+							accountEntry.getExternalReferenceCode());
 				}
 			}
 		}

--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/service/persistence/impl/AccountGroupPersistenceImpl.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/service/persistence/impl/AccountGroupPersistenceImpl.java
@@ -6434,7 +6434,9 @@ public class AccountGroupPersistenceImpl
 
 			if (isNew) {
 				if (ercAccountGroup != null) {
-					throw new DuplicateAccountGroupExternalReferenceCodeException();
+					throw new DuplicateAccountGroupExternalReferenceCodeException(
+						"Duplicate AccountGroup with external reference code " +
+							accountGroup.getExternalReferenceCode());
 				}
 			}
 			else {
@@ -6442,7 +6444,9 @@ public class AccountGroupPersistenceImpl
 					(accountGroup.getAccountGroupId() !=
 						ercAccountGroup.getAccountGroupId())) {
 
-					throw new DuplicateAccountGroupExternalReferenceCodeException();
+					throw new DuplicateAccountGroupExternalReferenceCodeException(
+						"Duplicate AccountGroup with external reference code " +
+							accountGroup.getExternalReferenceCode());
 				}
 			}
 		}

--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/service/persistence/impl/AccountGroupPersistenceImpl.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/service/persistence/impl/AccountGroupPersistenceImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.account.service.persistence.impl;
 
+import com.liferay.account.exception.DuplicateAccountGroupExternalReferenceCodeException;
 import com.liferay.account.exception.NoSuchGroupException;
 import com.liferay.account.model.AccountGroup;
 import com.liferay.account.model.AccountGroupTable;
@@ -5914,35 +5915,35 @@ public class AccountGroupPersistenceImpl
 	private static final String _FINDER_COLUMN_C_T_TYPE_3_SQL =
 		"(accountGroup.type_ IS NULL OR accountGroup.type_ = '')";
 
-	private FinderPath _finderPathFetchByC_ERC;
-	private FinderPath _finderPathCountByC_ERC;
+	private FinderPath _finderPathFetchByERC_C;
+	private FinderPath _finderPathCountByERC_C;
 
 	/**
-	 * Returns the account group where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchGroupException</code> if it could not be found.
+	 * Returns the account group where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchGroupException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching account group
 	 * @throws NoSuchGroupException if a matching account group could not be found
 	 */
 	@Override
-	public AccountGroup findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public AccountGroup findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchGroupException {
 
-		AccountGroup accountGroup = fetchByC_ERC(
-			companyId, externalReferenceCode);
+		AccountGroup accountGroup = fetchByERC_C(
+			externalReferenceCode, companyId);
 
 		if (accountGroup == null) {
 			StringBundler sb = new StringBundler(6);
 
 			sb.append(_NO_SUCH_ENTITY_WITH_KEY);
 
-			sb.append("companyId=");
-			sb.append(companyId);
-
-			sb.append(", externalReferenceCode=");
+			sb.append("externalReferenceCode=");
 			sb.append(externalReferenceCode);
+
+			sb.append(", companyId=");
+			sb.append(companyId);
 
 			sb.append("}");
 
@@ -5957,53 +5958,53 @@ public class AccountGroupPersistenceImpl
 	}
 
 	/**
-	 * Returns the account group where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the account group where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching account group, or <code>null</code> if a matching account group could not be found
 	 */
 	@Override
-	public AccountGroup fetchByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public AccountGroup fetchByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return fetchByC_ERC(companyId, externalReferenceCode, true);
+		return fetchByERC_C(externalReferenceCode, companyId, true);
 	}
 
 	/**
-	 * Returns the account group where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the account group where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching account group, or <code>null</code> if a matching account group could not be found
 	 */
 	@Override
-	public AccountGroup fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache) {
+	public AccountGroup fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache) {
 
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
 		Object[] finderArgs = null;
 
 		if (useFinderCache) {
-			finderArgs = new Object[] {companyId, externalReferenceCode};
+			finderArgs = new Object[] {externalReferenceCode, companyId};
 		}
 
 		Object result = null;
 
 		if (useFinderCache) {
 			result = finderCache.getResult(
-				_finderPathFetchByC_ERC, finderArgs, this);
+				_finderPathFetchByERC_C, finderArgs, this);
 		}
 
 		if (result instanceof AccountGroup) {
 			AccountGroup accountGroup = (AccountGroup)result;
 
-			if ((companyId != accountGroup.getCompanyId()) ||
-				!Objects.equals(
+			if (!Objects.equals(
 					externalReferenceCode,
-					accountGroup.getExternalReferenceCode())) {
+					accountGroup.getExternalReferenceCode()) ||
+				(companyId != accountGroup.getCompanyId())) {
 
 				result = null;
 			}
@@ -6014,18 +6015,18 @@ public class AccountGroupPersistenceImpl
 
 			sb.append(_SQL_SELECT_ACCOUNTGROUP_WHERE);
 
-			sb.append(_FINDER_COLUMN_C_ERC_COMPANYID_2);
-
 			boolean bindExternalReferenceCode = false;
 
 			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3);
 			}
 			else {
 				bindExternalReferenceCode = true;
 
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2);
 			}
+
+			sb.append(_FINDER_COLUMN_ERC_C_COMPANYID_2);
 
 			String sql = sb.toString();
 
@@ -6038,18 +6039,18 @@ public class AccountGroupPersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
-				queryPos.add(companyId);
-
 				if (bindExternalReferenceCode) {
 					queryPos.add(externalReferenceCode);
 				}
+
+				queryPos.add(companyId);
 
 				List<AccountGroup> list = query.list();
 
 				if (list.isEmpty()) {
 					if (useFinderCache) {
 						finderCache.putResult(
-							_finderPathFetchByC_ERC, finderArgs, list);
+							_finderPathFetchByERC_C, finderArgs, list);
 					}
 				}
 				else {
@@ -6077,37 +6078,37 @@ public class AccountGroupPersistenceImpl
 	}
 
 	/**
-	 * Removes the account group where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the account group where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the account group that was removed
 	 */
 	@Override
-	public AccountGroup removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public AccountGroup removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchGroupException {
 
-		AccountGroup accountGroup = findByC_ERC(
-			companyId, externalReferenceCode);
+		AccountGroup accountGroup = findByERC_C(
+			externalReferenceCode, companyId);
 
 		return remove(accountGroup);
 	}
 
 	/**
-	 * Returns the number of account groups where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of account groups where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching account groups
 	 */
 	@Override
-	public int countByC_ERC(long companyId, String externalReferenceCode) {
+	public int countByERC_C(String externalReferenceCode, long companyId) {
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
-		FinderPath finderPath = _finderPathCountByC_ERC;
+		FinderPath finderPath = _finderPathCountByERC_C;
 
-		Object[] finderArgs = new Object[] {companyId, externalReferenceCode};
+		Object[] finderArgs = new Object[] {externalReferenceCode, companyId};
 
 		Long count = (Long)finderCache.getResult(finderPath, finderArgs, this);
 
@@ -6116,18 +6117,18 @@ public class AccountGroupPersistenceImpl
 
 			sb.append(_SQL_COUNT_ACCOUNTGROUP_WHERE);
 
-			sb.append(_FINDER_COLUMN_C_ERC_COMPANYID_2);
-
 			boolean bindExternalReferenceCode = false;
 
 			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3);
 			}
 			else {
 				bindExternalReferenceCode = true;
 
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2);
 			}
+
+			sb.append(_FINDER_COLUMN_ERC_C_COMPANYID_2);
 
 			String sql = sb.toString();
 
@@ -6140,11 +6141,11 @@ public class AccountGroupPersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
-				queryPos.add(companyId);
-
 				if (bindExternalReferenceCode) {
 					queryPos.add(externalReferenceCode);
 				}
+
+				queryPos.add(companyId);
 
 				count = (Long)query.uniqueResult();
 
@@ -6161,14 +6162,14 @@ public class AccountGroupPersistenceImpl
 		return count.intValue();
 	}
 
-	private static final String _FINDER_COLUMN_C_ERC_COMPANYID_2 =
-		"accountGroup.companyId = ? AND ";
+	private static final String _FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2 =
+		"accountGroup.externalReferenceCode = ? AND ";
 
-	private static final String _FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2 =
-		"accountGroup.externalReferenceCode = ?";
+	private static final String _FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3 =
+		"(accountGroup.externalReferenceCode IS NULL OR accountGroup.externalReferenceCode = '') AND ";
 
-	private static final String _FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3 =
-		"(accountGroup.externalReferenceCode IS NULL OR accountGroup.externalReferenceCode = '')";
+	private static final String _FINDER_COLUMN_ERC_C_COMPANYID_2 =
+		"accountGroup.companyId = ?";
 
 	public AccountGroupPersistenceImpl() {
 		Map<String, String> dbColumnNames = new HashMap<String, String>();
@@ -6197,10 +6198,10 @@ public class AccountGroupPersistenceImpl
 			AccountGroupImpl.class, accountGroup.getPrimaryKey(), accountGroup);
 
 		finderCache.putResult(
-			_finderPathFetchByC_ERC,
+			_finderPathFetchByERC_C,
 			new Object[] {
-				accountGroup.getCompanyId(),
-				accountGroup.getExternalReferenceCode()
+				accountGroup.getExternalReferenceCode(),
+				accountGroup.getCompanyId()
 			},
 			accountGroup);
 	}
@@ -6277,13 +6278,13 @@ public class AccountGroupPersistenceImpl
 		AccountGroupModelImpl accountGroupModelImpl) {
 
 		Object[] args = new Object[] {
-			accountGroupModelImpl.getCompanyId(),
-			accountGroupModelImpl.getExternalReferenceCode()
+			accountGroupModelImpl.getExternalReferenceCode(),
+			accountGroupModelImpl.getCompanyId()
 		};
 
-		finderCache.putResult(_finderPathCountByC_ERC, args, Long.valueOf(1));
+		finderCache.putResult(_finderPathCountByERC_C, args, Long.valueOf(1));
 		finderCache.putResult(
-			_finderPathFetchByC_ERC, args, accountGroupModelImpl);
+			_finderPathFetchByERC_C, args, accountGroupModelImpl);
 	}
 
 	/**
@@ -6425,6 +6426,25 @@ public class AccountGroupPersistenceImpl
 
 		if (Validator.isNull(accountGroup.getExternalReferenceCode())) {
 			accountGroup.setExternalReferenceCode(accountGroup.getUuid());
+		}
+		else {
+			AccountGroup ercAccountGroup = fetchByERC_C(
+				accountGroup.getExternalReferenceCode(),
+				accountGroup.getCompanyId());
+
+			if (isNew) {
+				if (ercAccountGroup != null) {
+					throw new DuplicateAccountGroupExternalReferenceCodeException();
+				}
+			}
+			else {
+				if ((ercAccountGroup != null) &&
+					(accountGroup.getAccountGroupId() !=
+						ercAccountGroup.getAccountGroupId())) {
+
+					throw new DuplicateAccountGroupExternalReferenceCodeException();
+				}
+			}
 		}
 
 		ServiceContext serviceContext =
@@ -6874,15 +6894,15 @@ public class AccountGroupPersistenceImpl
 			new String[] {Long.class.getName(), String.class.getName()},
 			new String[] {"companyId", "type_"}, false);
 
-		_finderPathFetchByC_ERC = new FinderPath(
-			FINDER_CLASS_NAME_ENTITY, "fetchByC_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"companyId", "externalReferenceCode"}, true);
+		_finderPathFetchByERC_C = new FinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, true);
 
-		_finderPathCountByC_ERC = new FinderPath(
-			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"companyId", "externalReferenceCode"}, false);
+		_finderPathCountByERC_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, false);
 
 		_setAccountGroupUtilPersistence(this);
 	}

--- a/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/persistence/test/AccountEntryPersistenceTest.java
+++ b/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/persistence/test/AccountEntryPersistenceTest.java
@@ -14,6 +14,7 @@
 
 package com.liferay.account.service.persistence.test;
 
+import com.liferay.account.exception.DuplicateAccountEntryExternalReferenceCodeException;
 import com.liferay.account.exception.NoSuchEntryException;
 import com.liferay.account.model.AccountEntry;
 import com.liferay.account.service.AccountEntryLocalServiceUtil;
@@ -252,6 +253,26 @@ public class AccountEntryPersistenceTest {
 			Time.getShortTimestamp(newAccountEntry.getStatusDate()));
 	}
 
+	@Test(expected = DuplicateAccountEntryExternalReferenceCodeException.class)
+	public void testUpdateWithExistingExternalReferenceCode() throws Exception {
+		AccountEntry accountEntry = addAccountEntry();
+
+		AccountEntry newAccountEntry = addAccountEntry();
+
+		newAccountEntry.setCompanyId(accountEntry.getCompanyId());
+
+		newAccountEntry = _persistence.update(newAccountEntry);
+
+		Session session = _persistence.getCurrentSession();
+
+		session.evict(newAccountEntry);
+
+		newAccountEntry.setExternalReferenceCode(
+			accountEntry.getExternalReferenceCode());
+
+		_persistence.update(newAccountEntry);
+	}
+
 	@Test
 	public void testCountByUuid() throws Exception {
 		_persistence.countByUuid("");
@@ -295,12 +316,12 @@ public class AccountEntryPersistenceTest {
 	}
 
 	@Test
-	public void testCountByC_ERC() throws Exception {
-		_persistence.countByC_ERC(RandomTestUtil.nextLong(), "");
+	public void testCountByERC_C() throws Exception {
+		_persistence.countByERC_C("", RandomTestUtil.nextLong());
 
-		_persistence.countByC_ERC(0L, "null");
+		_persistence.countByERC_C("null", 0L);
 
-		_persistence.countByC_ERC(0L, (String)null);
+		_persistence.countByERC_C((String)null, 0L);
 	}
 
 	@Test
@@ -605,15 +626,15 @@ public class AccountEntryPersistenceTest {
 
 	private void _assertOriginalValues(AccountEntry accountEntry) {
 		Assert.assertEquals(
-			Long.valueOf(accountEntry.getCompanyId()),
-			ReflectionTestUtil.<Long>invoke(
-				accountEntry, "getColumnOriginalValue",
-				new Class<?>[] {String.class}, "companyId"));
-		Assert.assertEquals(
 			accountEntry.getExternalReferenceCode(),
 			ReflectionTestUtil.invoke(
 				accountEntry, "getColumnOriginalValue",
 				new Class<?>[] {String.class}, "externalReferenceCode"));
+		Assert.assertEquals(
+			Long.valueOf(accountEntry.getCompanyId()),
+			ReflectionTestUtil.<Long>invoke(
+				accountEntry, "getColumnOriginalValue",
+				new Class<?>[] {String.class}, "companyId"));
 	}
 
 	protected AccountEntry addAccountEntry() throws Exception {

--- a/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/persistence/test/AccountGroupPersistenceTest.java
+++ b/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/persistence/test/AccountGroupPersistenceTest.java
@@ -14,6 +14,7 @@
 
 package com.liferay.account.service.persistence.test;
 
+import com.liferay.account.exception.DuplicateAccountGroupExternalReferenceCodeException;
 import com.liferay.account.exception.NoSuchGroupException;
 import com.liferay.account.model.AccountGroup;
 import com.liferay.account.service.AccountGroupLocalServiceUtil;
@@ -189,6 +190,26 @@ public class AccountGroupPersistenceTest {
 			existingAccountGroup.getType(), newAccountGroup.getType());
 	}
 
+	@Test(expected = DuplicateAccountGroupExternalReferenceCodeException.class)
+	public void testUpdateWithExistingExternalReferenceCode() throws Exception {
+		AccountGroup accountGroup = addAccountGroup();
+
+		AccountGroup newAccountGroup = addAccountGroup();
+
+		newAccountGroup.setCompanyId(accountGroup.getCompanyId());
+
+		newAccountGroup = _persistence.update(newAccountGroup);
+
+		Session session = _persistence.getCurrentSession();
+
+		session.evict(newAccountGroup);
+
+		newAccountGroup.setExternalReferenceCode(
+			accountGroup.getExternalReferenceCode());
+
+		_persistence.update(newAccountGroup);
+	}
+
 	@Test
 	public void testCountByUuid() throws Exception {
 		_persistence.countByUuid("");
@@ -245,12 +266,12 @@ public class AccountGroupPersistenceTest {
 	}
 
 	@Test
-	public void testCountByC_ERC() throws Exception {
-		_persistence.countByC_ERC(RandomTestUtil.nextLong(), "");
+	public void testCountByERC_C() throws Exception {
+		_persistence.countByERC_C("", RandomTestUtil.nextLong());
 
-		_persistence.countByC_ERC(0L, "null");
+		_persistence.countByERC_C("null", 0L);
 
-		_persistence.countByC_ERC(0L, (String)null);
+		_persistence.countByERC_C((String)null, 0L);
 	}
 
 	@Test
@@ -550,15 +571,15 @@ public class AccountGroupPersistenceTest {
 
 	private void _assertOriginalValues(AccountGroup accountGroup) {
 		Assert.assertEquals(
-			Long.valueOf(accountGroup.getCompanyId()),
-			ReflectionTestUtil.<Long>invoke(
-				accountGroup, "getColumnOriginalValue",
-				new Class<?>[] {String.class}, "companyId"));
-		Assert.assertEquals(
 			accountGroup.getExternalReferenceCode(),
 			ReflectionTestUtil.invoke(
 				accountGroup, "getColumnOriginalValue",
 				new Class<?>[] {String.class}, "externalReferenceCode"));
+		Assert.assertEquals(
+			Long.valueOf(accountGroup.getCompanyId()),
+			ReflectionTestUtil.<Long>invoke(
+				accountGroup, "getColumnOriginalValue",
+				new Class<?>[] {String.class}, "companyId"));
 	}
 
 	protected AccountGroup addAccountGroup() throws Exception {

--- a/modules/apps/batch-engine/batch-engine-api/bnd.bnd
+++ b/modules/apps/batch-engine/batch-engine-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Batch Engine API
 Bundle-SymbolicName: com.liferay.batch.engine.api
-Bundle-Version: 17.1.1
+Bundle-Version: 18.0.0
 Export-Package:\
 	com.liferay.batch.engine,\
 	com.liferay.batch.engine.configuration,\

--- a/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/exception/DuplicateBatchEngineExportTaskExternalReferenceCodeException.java
+++ b/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/exception/DuplicateBatchEngineExportTaskExternalReferenceCodeException.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.batch.engine.exception;
+
+import com.liferay.portal.kernel.exception.SystemException;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class DuplicateBatchEngineExportTaskExternalReferenceCodeException
+	extends SystemException {
+
+	public DuplicateBatchEngineExportTaskExternalReferenceCodeException() {
+	}
+
+	public DuplicateBatchEngineExportTaskExternalReferenceCodeException(
+		String msg) {
+
+		super(msg);
+	}
+
+	public DuplicateBatchEngineExportTaskExternalReferenceCodeException(
+		String msg, Throwable throwable) {
+
+		super(msg, throwable);
+	}
+
+	public DuplicateBatchEngineExportTaskExternalReferenceCodeException(
+		Throwable throwable) {
+
+		super(throwable);
+	}
+
+}

--- a/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/exception/DuplicateBatchEngineImportTaskExternalReferenceCodeException.java
+++ b/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/exception/DuplicateBatchEngineImportTaskExternalReferenceCodeException.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.batch.engine.exception;
+
+import com.liferay.portal.kernel.exception.SystemException;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class DuplicateBatchEngineImportTaskExternalReferenceCodeException
+	extends SystemException {
+
+	public DuplicateBatchEngineImportTaskExternalReferenceCodeException() {
+	}
+
+	public DuplicateBatchEngineImportTaskExternalReferenceCodeException(
+		String msg) {
+
+		super(msg);
+	}
+
+	public DuplicateBatchEngineImportTaskExternalReferenceCodeException(
+		String msg, Throwable throwable) {
+
+		super(msg, throwable);
+	}
+
+	public DuplicateBatchEngineImportTaskExternalReferenceCodeException(
+		Throwable throwable) {
+
+		super(throwable);
+	}
+
+}

--- a/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/service/BatchEngineExportTaskLocalService.java
+++ b/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/service/BatchEngineExportTaskLocalService.java
@@ -217,25 +217,10 @@ public interface BatchEngineExportTaskLocalService
 	public BatchEngineExportTask fetchBatchEngineExportTask(
 		long batchEngineExportTaskId);
 
-	/**
-	 * Returns the batch engine export task with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the batch engine export task's external reference code
-	 * @return the matching batch engine export task, or <code>null</code> if a matching batch engine export task could not be found
-	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public BatchEngineExportTask
 		fetchBatchEngineExportTaskByExternalReferenceCode(
-			long companyId, String externalReferenceCode);
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchBatchEngineExportTaskByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public BatchEngineExportTask fetchBatchEngineExportTaskByReferenceCode(
-		long companyId, String externalReferenceCode);
+			String externalReferenceCode, long companyId);
 
 	/**
 	 * Returns the batch engine export task with the matching UUID and company.
@@ -263,18 +248,10 @@ public interface BatchEngineExportTaskLocalService
 			long batchEngineExportTaskId)
 		throws PortalException;
 
-	/**
-	 * Returns the batch engine export task with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the batch engine export task's external reference code
-	 * @return the matching batch engine export task
-	 * @throws PortalException if a matching batch engine export task could not be found
-	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public BatchEngineExportTask
 			getBatchEngineExportTaskByExternalReferenceCode(
-				long companyId, String externalReferenceCode)
+				String externalReferenceCode, long companyId)
 		throws PortalException;
 
 	/**

--- a/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/service/BatchEngineExportTaskLocalServiceUtil.java
+++ b/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/service/BatchEngineExportTaskLocalServiceUtil.java
@@ -234,31 +234,12 @@ public class BatchEngineExportTaskLocalServiceUtil {
 		return getService().fetchBatchEngineExportTask(batchEngineExportTaskId);
 	}
 
-	/**
-	 * Returns the batch engine export task with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the batch engine export task's external reference code
-	 * @return the matching batch engine export task, or <code>null</code> if a matching batch engine export task could not be found
-	 */
 	public static BatchEngineExportTask
 		fetchBatchEngineExportTaskByExternalReferenceCode(
-			long companyId, String externalReferenceCode) {
+			String externalReferenceCode, long companyId) {
 
 		return getService().fetchBatchEngineExportTaskByExternalReferenceCode(
-			companyId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchBatchEngineExportTaskByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	public static BatchEngineExportTask
-		fetchBatchEngineExportTaskByReferenceCode(
-			long companyId, String externalReferenceCode) {
-
-		return getService().fetchBatchEngineExportTaskByReferenceCode(
-			companyId, externalReferenceCode);
+			externalReferenceCode, companyId);
 	}
 
 	/**
@@ -296,21 +277,13 @@ public class BatchEngineExportTaskLocalServiceUtil {
 		return getService().getBatchEngineExportTask(batchEngineExportTaskId);
 	}
 
-	/**
-	 * Returns the batch engine export task with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the batch engine export task's external reference code
-	 * @return the matching batch engine export task
-	 * @throws PortalException if a matching batch engine export task could not be found
-	 */
 	public static BatchEngineExportTask
 			getBatchEngineExportTaskByExternalReferenceCode(
-				long companyId, String externalReferenceCode)
+				String externalReferenceCode, long companyId)
 		throws PortalException {
 
 		return getService().getBatchEngineExportTaskByExternalReferenceCode(
-			companyId, externalReferenceCode);
+			externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/service/BatchEngineExportTaskLocalServiceWrapper.java
+++ b/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/service/BatchEngineExportTaskLocalServiceWrapper.java
@@ -262,35 +262,14 @@ public class BatchEngineExportTaskLocalServiceWrapper
 			batchEngineExportTaskId);
 	}
 
-	/**
-	 * Returns the batch engine export task with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the batch engine export task's external reference code
-	 * @return the matching batch engine export task, or <code>null</code> if a matching batch engine export task could not be found
-	 */
 	@Override
 	public com.liferay.batch.engine.model.BatchEngineExportTask
 		fetchBatchEngineExportTaskByExternalReferenceCode(
-			long companyId, String externalReferenceCode) {
+			String externalReferenceCode, long companyId) {
 
 		return _batchEngineExportTaskLocalService.
 			fetchBatchEngineExportTaskByExternalReferenceCode(
-				companyId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchBatchEngineExportTaskByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public com.liferay.batch.engine.model.BatchEngineExportTask
-		fetchBatchEngineExportTaskByReferenceCode(
-			long companyId, String externalReferenceCode) {
-
-		return _batchEngineExportTaskLocalService.
-			fetchBatchEngineExportTaskByReferenceCode(
-				companyId, externalReferenceCode);
+				externalReferenceCode, companyId);
 	}
 
 	/**
@@ -332,23 +311,15 @@ public class BatchEngineExportTaskLocalServiceWrapper
 			batchEngineExportTaskId);
 	}
 
-	/**
-	 * Returns the batch engine export task with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the batch engine export task's external reference code
-	 * @return the matching batch engine export task
-	 * @throws PortalException if a matching batch engine export task could not be found
-	 */
 	@Override
 	public com.liferay.batch.engine.model.BatchEngineExportTask
 			getBatchEngineExportTaskByExternalReferenceCode(
-				long companyId, String externalReferenceCode)
+				String externalReferenceCode, long companyId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _batchEngineExportTaskLocalService.
 			getBatchEngineExportTaskByExternalReferenceCode(
-				companyId, externalReferenceCode);
+				externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/service/BatchEngineImportTaskLocalService.java
+++ b/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/service/BatchEngineImportTaskLocalService.java
@@ -220,25 +220,10 @@ public interface BatchEngineImportTaskLocalService
 	public BatchEngineImportTask fetchBatchEngineImportTask(
 		long batchEngineImportTaskId);
 
-	/**
-	 * Returns the batch engine import task with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the batch engine import task's external reference code
-	 * @return the matching batch engine import task, or <code>null</code> if a matching batch engine import task could not be found
-	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public BatchEngineImportTask
 		fetchBatchEngineImportTaskByExternalReferenceCode(
-			long companyId, String externalReferenceCode);
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchBatchEngineImportTaskByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public BatchEngineImportTask fetchBatchEngineImportTaskByReferenceCode(
-		long companyId, String externalReferenceCode);
+			String externalReferenceCode, long companyId);
 
 	/**
 	 * Returns the batch engine import task with the matching UUID and company.
@@ -266,18 +251,10 @@ public interface BatchEngineImportTaskLocalService
 			long batchEngineImportTaskId)
 		throws PortalException;
 
-	/**
-	 * Returns the batch engine import task with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the batch engine import task's external reference code
-	 * @return the matching batch engine import task
-	 * @throws PortalException if a matching batch engine import task could not be found
-	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public BatchEngineImportTask
 			getBatchEngineImportTaskByExternalReferenceCode(
-				long companyId, String externalReferenceCode)
+				String externalReferenceCode, long companyId)
 		throws PortalException;
 
 	/**

--- a/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/service/BatchEngineImportTaskLocalServiceUtil.java
+++ b/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/service/BatchEngineImportTaskLocalServiceUtil.java
@@ -237,31 +237,12 @@ public class BatchEngineImportTaskLocalServiceUtil {
 		return getService().fetchBatchEngineImportTask(batchEngineImportTaskId);
 	}
 
-	/**
-	 * Returns the batch engine import task with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the batch engine import task's external reference code
-	 * @return the matching batch engine import task, or <code>null</code> if a matching batch engine import task could not be found
-	 */
 	public static BatchEngineImportTask
 		fetchBatchEngineImportTaskByExternalReferenceCode(
-			long companyId, String externalReferenceCode) {
+			String externalReferenceCode, long companyId) {
 
 		return getService().fetchBatchEngineImportTaskByExternalReferenceCode(
-			companyId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchBatchEngineImportTaskByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	public static BatchEngineImportTask
-		fetchBatchEngineImportTaskByReferenceCode(
-			long companyId, String externalReferenceCode) {
-
-		return getService().fetchBatchEngineImportTaskByReferenceCode(
-			companyId, externalReferenceCode);
+			externalReferenceCode, companyId);
 	}
 
 	/**
@@ -299,21 +280,13 @@ public class BatchEngineImportTaskLocalServiceUtil {
 		return getService().getBatchEngineImportTask(batchEngineImportTaskId);
 	}
 
-	/**
-	 * Returns the batch engine import task with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the batch engine import task's external reference code
-	 * @return the matching batch engine import task
-	 * @throws PortalException if a matching batch engine import task could not be found
-	 */
 	public static BatchEngineImportTask
 			getBatchEngineImportTaskByExternalReferenceCode(
-				long companyId, String externalReferenceCode)
+				String externalReferenceCode, long companyId)
 		throws PortalException {
 
 		return getService().getBatchEngineImportTaskByExternalReferenceCode(
-			companyId, externalReferenceCode);
+			externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/service/BatchEngineImportTaskLocalServiceWrapper.java
+++ b/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/service/BatchEngineImportTaskLocalServiceWrapper.java
@@ -265,35 +265,14 @@ public class BatchEngineImportTaskLocalServiceWrapper
 			batchEngineImportTaskId);
 	}
 
-	/**
-	 * Returns the batch engine import task with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the batch engine import task's external reference code
-	 * @return the matching batch engine import task, or <code>null</code> if a matching batch engine import task could not be found
-	 */
 	@Override
 	public com.liferay.batch.engine.model.BatchEngineImportTask
 		fetchBatchEngineImportTaskByExternalReferenceCode(
-			long companyId, String externalReferenceCode) {
+			String externalReferenceCode, long companyId) {
 
 		return _batchEngineImportTaskLocalService.
 			fetchBatchEngineImportTaskByExternalReferenceCode(
-				companyId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchBatchEngineImportTaskByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public com.liferay.batch.engine.model.BatchEngineImportTask
-		fetchBatchEngineImportTaskByReferenceCode(
-			long companyId, String externalReferenceCode) {
-
-		return _batchEngineImportTaskLocalService.
-			fetchBatchEngineImportTaskByReferenceCode(
-				companyId, externalReferenceCode);
+				externalReferenceCode, companyId);
 	}
 
 	/**
@@ -335,23 +314,15 @@ public class BatchEngineImportTaskLocalServiceWrapper
 			batchEngineImportTaskId);
 	}
 
-	/**
-	 * Returns the batch engine import task with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the batch engine import task's external reference code
-	 * @return the matching batch engine import task
-	 * @throws PortalException if a matching batch engine import task could not be found
-	 */
 	@Override
 	public com.liferay.batch.engine.model.BatchEngineImportTask
 			getBatchEngineImportTaskByExternalReferenceCode(
-				long companyId, String externalReferenceCode)
+				String externalReferenceCode, long companyId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _batchEngineImportTaskLocalService.
 			getBatchEngineImportTaskByExternalReferenceCode(
-				companyId, externalReferenceCode);
+				externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/service/persistence/BatchEngineExportTaskPersistence.java
+++ b/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/service/persistence/BatchEngineExportTaskPersistence.java
@@ -628,57 +628,57 @@ public interface BatchEngineExportTaskPersistence
 	public int countByExecuteStatus(String executeStatus);
 
 	/**
-	 * Returns the batch engine export task where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchExportTaskException</code> if it could not be found.
+	 * Returns the batch engine export task where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchExportTaskException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching batch engine export task
 	 * @throws NoSuchExportTaskException if a matching batch engine export task could not be found
 	 */
-	public BatchEngineExportTask findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public BatchEngineExportTask findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchExportTaskException;
 
 	/**
-	 * Returns the batch engine export task where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the batch engine export task where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching batch engine export task, or <code>null</code> if a matching batch engine export task could not be found
 	 */
-	public BatchEngineExportTask fetchByC_ERC(
-		long companyId, String externalReferenceCode);
+	public BatchEngineExportTask fetchByERC_C(
+		String externalReferenceCode, long companyId);
 
 	/**
-	 * Returns the batch engine export task where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the batch engine export task where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching batch engine export task, or <code>null</code> if a matching batch engine export task could not be found
 	 */
-	public BatchEngineExportTask fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache);
+	public BatchEngineExportTask fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache);
 
 	/**
-	 * Removes the batch engine export task where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the batch engine export task where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the batch engine export task that was removed
 	 */
-	public BatchEngineExportTask removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public BatchEngineExportTask removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchExportTaskException;
 
 	/**
-	 * Returns the number of batch engine export tasks where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of batch engine export tasks where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching batch engine export tasks
 	 */
-	public int countByC_ERC(long companyId, String externalReferenceCode);
+	public int countByERC_C(String externalReferenceCode, long companyId);
 
 	/**
 	 * Caches the batch engine export task in the entity cache if it is enabled.

--- a/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/service/persistence/BatchEngineExportTaskUtil.java
+++ b/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/service/persistence/BatchEngineExportTaskUtil.java
@@ -825,73 +825,73 @@ public class BatchEngineExportTaskUtil {
 	}
 
 	/**
-	 * Returns the batch engine export task where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchExportTaskException</code> if it could not be found.
+	 * Returns the batch engine export task where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchExportTaskException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching batch engine export task
 	 * @throws NoSuchExportTaskException if a matching batch engine export task could not be found
 	 */
-	public static BatchEngineExportTask findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public static BatchEngineExportTask findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws com.liferay.batch.engine.exception.NoSuchExportTaskException {
 
-		return getPersistence().findByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().findByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the batch engine export task where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the batch engine export task where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching batch engine export task, or <code>null</code> if a matching batch engine export task could not be found
 	 */
-	public static BatchEngineExportTask fetchByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public static BatchEngineExportTask fetchByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return getPersistence().fetchByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().fetchByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the batch engine export task where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the batch engine export task where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching batch engine export task, or <code>null</code> if a matching batch engine export task could not be found
 	 */
-	public static BatchEngineExportTask fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache) {
+	public static BatchEngineExportTask fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache) {
 
-		return getPersistence().fetchByC_ERC(
-			companyId, externalReferenceCode, useFinderCache);
+		return getPersistence().fetchByERC_C(
+			externalReferenceCode, companyId, useFinderCache);
 	}
 
 	/**
-	 * Removes the batch engine export task where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the batch engine export task where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the batch engine export task that was removed
 	 */
-	public static BatchEngineExportTask removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public static BatchEngineExportTask removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws com.liferay.batch.engine.exception.NoSuchExportTaskException {
 
-		return getPersistence().removeByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().removeByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the number of batch engine export tasks where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of batch engine export tasks where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching batch engine export tasks
 	 */
-	public static int countByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public static int countByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return getPersistence().countByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().countByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/service/persistence/BatchEngineImportTaskPersistence.java
+++ b/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/service/persistence/BatchEngineImportTaskPersistence.java
@@ -628,57 +628,57 @@ public interface BatchEngineImportTaskPersistence
 	public int countByExecuteStatus(String executeStatus);
 
 	/**
-	 * Returns the batch engine import task where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchImportTaskException</code> if it could not be found.
+	 * Returns the batch engine import task where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchImportTaskException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching batch engine import task
 	 * @throws NoSuchImportTaskException if a matching batch engine import task could not be found
 	 */
-	public BatchEngineImportTask findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public BatchEngineImportTask findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchImportTaskException;
 
 	/**
-	 * Returns the batch engine import task where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the batch engine import task where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching batch engine import task, or <code>null</code> if a matching batch engine import task could not be found
 	 */
-	public BatchEngineImportTask fetchByC_ERC(
-		long companyId, String externalReferenceCode);
+	public BatchEngineImportTask fetchByERC_C(
+		String externalReferenceCode, long companyId);
 
 	/**
-	 * Returns the batch engine import task where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the batch engine import task where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching batch engine import task, or <code>null</code> if a matching batch engine import task could not be found
 	 */
-	public BatchEngineImportTask fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache);
+	public BatchEngineImportTask fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache);
 
 	/**
-	 * Removes the batch engine import task where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the batch engine import task where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the batch engine import task that was removed
 	 */
-	public BatchEngineImportTask removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public BatchEngineImportTask removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchImportTaskException;
 
 	/**
-	 * Returns the number of batch engine import tasks where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of batch engine import tasks where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching batch engine import tasks
 	 */
-	public int countByC_ERC(long companyId, String externalReferenceCode);
+	public int countByERC_C(String externalReferenceCode, long companyId);
 
 	/**
 	 * Caches the batch engine import task in the entity cache if it is enabled.

--- a/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/service/persistence/BatchEngineImportTaskUtil.java
+++ b/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/service/persistence/BatchEngineImportTaskUtil.java
@@ -825,73 +825,73 @@ public class BatchEngineImportTaskUtil {
 	}
 
 	/**
-	 * Returns the batch engine import task where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchImportTaskException</code> if it could not be found.
+	 * Returns the batch engine import task where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchImportTaskException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching batch engine import task
 	 * @throws NoSuchImportTaskException if a matching batch engine import task could not be found
 	 */
-	public static BatchEngineImportTask findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public static BatchEngineImportTask findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws com.liferay.batch.engine.exception.NoSuchImportTaskException {
 
-		return getPersistence().findByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().findByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the batch engine import task where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the batch engine import task where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching batch engine import task, or <code>null</code> if a matching batch engine import task could not be found
 	 */
-	public static BatchEngineImportTask fetchByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public static BatchEngineImportTask fetchByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return getPersistence().fetchByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().fetchByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the batch engine import task where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the batch engine import task where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching batch engine import task, or <code>null</code> if a matching batch engine import task could not be found
 	 */
-	public static BatchEngineImportTask fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache) {
+	public static BatchEngineImportTask fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache) {
 
-		return getPersistence().fetchByC_ERC(
-			companyId, externalReferenceCode, useFinderCache);
+		return getPersistence().fetchByERC_C(
+			externalReferenceCode, companyId, useFinderCache);
 	}
 
 	/**
-	 * Removes the batch engine import task where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the batch engine import task where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the batch engine import task that was removed
 	 */
-	public static BatchEngineImportTask removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public static BatchEngineImportTask removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws com.liferay.batch.engine.exception.NoSuchImportTaskException {
 
-		return getPersistence().removeByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().removeByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the number of batch engine import tasks where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of batch engine import tasks where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching batch engine import tasks
 	 */
-	public static int countByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public static int countByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return getPersistence().countByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().countByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/batch-engine/batch-engine-api/src/main/resources/com/liferay/batch/engine/exception/packageinfo
+++ b/modules/apps/batch-engine/batch-engine-api/src/main/resources/com/liferay/batch/engine/exception/packageinfo
@@ -1,1 +1,1 @@
-version 1.2.0
+version 1.3.0

--- a/modules/apps/batch-engine/batch-engine-api/src/main/resources/com/liferay/batch/engine/service/packageinfo
+++ b/modules/apps/batch-engine/batch-engine-api/src/main/resources/com/liferay/batch/engine/service/packageinfo
@@ -1,1 +1,1 @@
-version 4.0.0
+version 5.0.0

--- a/modules/apps/batch-engine/batch-engine-api/src/main/resources/com/liferay/batch/engine/service/persistence/packageinfo
+++ b/modules/apps/batch-engine/batch-engine-api/src/main/resources/com/liferay/batch/engine/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 3.3.0
+version 4.0.0

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/service/base/BatchEngineExportTaskLocalServiceBaseImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/service/base/BatchEngineExportTaskLocalServiceBaseImpl.java
@@ -290,50 +290,23 @@ public abstract class BatchEngineExportTaskLocalServiceBaseImpl
 			uuid, companyId, null);
 	}
 
-	/**
-	 * Returns the batch engine export task with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the batch engine export task's external reference code
-	 * @return the matching batch engine export task, or <code>null</code> if a matching batch engine export task could not be found
-	 */
 	@Override
 	public BatchEngineExportTask
 		fetchBatchEngineExportTaskByExternalReferenceCode(
-			long companyId, String externalReferenceCode) {
+			String externalReferenceCode, long companyId) {
 
-		return batchEngineExportTaskPersistence.fetchByC_ERC(
-			companyId, externalReferenceCode);
+		return batchEngineExportTaskPersistence.fetchByERC_C(
+			externalReferenceCode, companyId);
 	}
 
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchBatchEngineExportTaskByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public BatchEngineExportTask fetchBatchEngineExportTaskByReferenceCode(
-		long companyId, String externalReferenceCode) {
-
-		return fetchBatchEngineExportTaskByExternalReferenceCode(
-			companyId, externalReferenceCode);
-	}
-
-	/**
-	 * Returns the batch engine export task with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the batch engine export task's external reference code
-	 * @return the matching batch engine export task
-	 * @throws PortalException if a matching batch engine export task could not be found
-	 */
 	@Override
 	public BatchEngineExportTask
 			getBatchEngineExportTaskByExternalReferenceCode(
-				long companyId, String externalReferenceCode)
+				String externalReferenceCode, long companyId)
 		throws PortalException {
 
-		return batchEngineExportTaskPersistence.findByC_ERC(
-			companyId, externalReferenceCode);
+		return batchEngineExportTaskPersistence.findByERC_C(
+			externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/service/base/BatchEngineImportTaskLocalServiceBaseImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/service/base/BatchEngineImportTaskLocalServiceBaseImpl.java
@@ -290,50 +290,23 @@ public abstract class BatchEngineImportTaskLocalServiceBaseImpl
 			uuid, companyId, null);
 	}
 
-	/**
-	 * Returns the batch engine import task with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the batch engine import task's external reference code
-	 * @return the matching batch engine import task, or <code>null</code> if a matching batch engine import task could not be found
-	 */
 	@Override
 	public BatchEngineImportTask
 		fetchBatchEngineImportTaskByExternalReferenceCode(
-			long companyId, String externalReferenceCode) {
+			String externalReferenceCode, long companyId) {
 
-		return batchEngineImportTaskPersistence.fetchByC_ERC(
-			companyId, externalReferenceCode);
+		return batchEngineImportTaskPersistence.fetchByERC_C(
+			externalReferenceCode, companyId);
 	}
 
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchBatchEngineImportTaskByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public BatchEngineImportTask fetchBatchEngineImportTaskByReferenceCode(
-		long companyId, String externalReferenceCode) {
-
-		return fetchBatchEngineImportTaskByExternalReferenceCode(
-			companyId, externalReferenceCode);
-	}
-
-	/**
-	 * Returns the batch engine import task with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the batch engine import task's external reference code
-	 * @return the matching batch engine import task
-	 * @throws PortalException if a matching batch engine import task could not be found
-	 */
 	@Override
 	public BatchEngineImportTask
 			getBatchEngineImportTaskByExternalReferenceCode(
-				long companyId, String externalReferenceCode)
+				String externalReferenceCode, long companyId)
 		throws PortalException {
 
-		return batchEngineImportTaskPersistence.findByC_ERC(
-			companyId, externalReferenceCode);
+		return batchEngineImportTaskPersistence.findByERC_C(
+			externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/service/persistence/impl/BatchEngineExportTaskPersistenceImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/service/persistence/impl/BatchEngineExportTaskPersistenceImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.batch.engine.service.persistence.impl;
 
+import com.liferay.batch.engine.exception.DuplicateBatchEngineExportTaskExternalReferenceCodeException;
 import com.liferay.batch.engine.exception.NoSuchExportTaskException;
 import com.liferay.batch.engine.model.BatchEngineExportTask;
 import com.liferay.batch.engine.model.BatchEngineExportTaskTable;
@@ -2285,35 +2286,35 @@ public class BatchEngineExportTaskPersistenceImpl
 	private static final String _FINDER_COLUMN_EXECUTESTATUS_EXECUTESTATUS_3 =
 		"(batchEngineExportTask.executeStatus IS NULL OR batchEngineExportTask.executeStatus = '')";
 
-	private FinderPath _finderPathFetchByC_ERC;
-	private FinderPath _finderPathCountByC_ERC;
+	private FinderPath _finderPathFetchByERC_C;
+	private FinderPath _finderPathCountByERC_C;
 
 	/**
-	 * Returns the batch engine export task where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchExportTaskException</code> if it could not be found.
+	 * Returns the batch engine export task where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchExportTaskException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching batch engine export task
 	 * @throws NoSuchExportTaskException if a matching batch engine export task could not be found
 	 */
 	@Override
-	public BatchEngineExportTask findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public BatchEngineExportTask findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchExportTaskException {
 
-		BatchEngineExportTask batchEngineExportTask = fetchByC_ERC(
-			companyId, externalReferenceCode);
+		BatchEngineExportTask batchEngineExportTask = fetchByERC_C(
+			externalReferenceCode, companyId);
 
 		if (batchEngineExportTask == null) {
 			StringBundler sb = new StringBundler(6);
 
 			sb.append(_NO_SUCH_ENTITY_WITH_KEY);
 
-			sb.append("companyId=");
-			sb.append(companyId);
-
-			sb.append(", externalReferenceCode=");
+			sb.append("externalReferenceCode=");
 			sb.append(externalReferenceCode);
+
+			sb.append(", companyId=");
+			sb.append(companyId);
 
 			sb.append("}");
 
@@ -2328,54 +2329,54 @@ public class BatchEngineExportTaskPersistenceImpl
 	}
 
 	/**
-	 * Returns the batch engine export task where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the batch engine export task where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching batch engine export task, or <code>null</code> if a matching batch engine export task could not be found
 	 */
 	@Override
-	public BatchEngineExportTask fetchByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public BatchEngineExportTask fetchByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return fetchByC_ERC(companyId, externalReferenceCode, true);
+		return fetchByERC_C(externalReferenceCode, companyId, true);
 	}
 
 	/**
-	 * Returns the batch engine export task where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the batch engine export task where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching batch engine export task, or <code>null</code> if a matching batch engine export task could not be found
 	 */
 	@Override
-	public BatchEngineExportTask fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache) {
+	public BatchEngineExportTask fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache) {
 
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
 		Object[] finderArgs = null;
 
 		if (useFinderCache) {
-			finderArgs = new Object[] {companyId, externalReferenceCode};
+			finderArgs = new Object[] {externalReferenceCode, companyId};
 		}
 
 		Object result = null;
 
 		if (useFinderCache) {
 			result = finderCache.getResult(
-				_finderPathFetchByC_ERC, finderArgs, this);
+				_finderPathFetchByERC_C, finderArgs, this);
 		}
 
 		if (result instanceof BatchEngineExportTask) {
 			BatchEngineExportTask batchEngineExportTask =
 				(BatchEngineExportTask)result;
 
-			if ((companyId != batchEngineExportTask.getCompanyId()) ||
-				!Objects.equals(
+			if (!Objects.equals(
 					externalReferenceCode,
-					batchEngineExportTask.getExternalReferenceCode())) {
+					batchEngineExportTask.getExternalReferenceCode()) ||
+				(companyId != batchEngineExportTask.getCompanyId())) {
 
 				result = null;
 			}
@@ -2386,18 +2387,18 @@ public class BatchEngineExportTaskPersistenceImpl
 
 			sb.append(_SQL_SELECT_BATCHENGINEEXPORTTASK_WHERE);
 
-			sb.append(_FINDER_COLUMN_C_ERC_COMPANYID_2);
-
 			boolean bindExternalReferenceCode = false;
 
 			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3);
 			}
 			else {
 				bindExternalReferenceCode = true;
 
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2);
 			}
+
+			sb.append(_FINDER_COLUMN_ERC_C_COMPANYID_2);
 
 			String sql = sb.toString();
 
@@ -2410,18 +2411,18 @@ public class BatchEngineExportTaskPersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
-				queryPos.add(companyId);
-
 				if (bindExternalReferenceCode) {
 					queryPos.add(externalReferenceCode);
 				}
+
+				queryPos.add(companyId);
 
 				List<BatchEngineExportTask> list = query.list();
 
 				if (list.isEmpty()) {
 					if (useFinderCache) {
 						finderCache.putResult(
-							_finderPathFetchByC_ERC, finderArgs, list);
+							_finderPathFetchByERC_C, finderArgs, list);
 					}
 				}
 				else {
@@ -2449,37 +2450,37 @@ public class BatchEngineExportTaskPersistenceImpl
 	}
 
 	/**
-	 * Removes the batch engine export task where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the batch engine export task where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the batch engine export task that was removed
 	 */
 	@Override
-	public BatchEngineExportTask removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public BatchEngineExportTask removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchExportTaskException {
 
-		BatchEngineExportTask batchEngineExportTask = findByC_ERC(
-			companyId, externalReferenceCode);
+		BatchEngineExportTask batchEngineExportTask = findByERC_C(
+			externalReferenceCode, companyId);
 
 		return remove(batchEngineExportTask);
 	}
 
 	/**
-	 * Returns the number of batch engine export tasks where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of batch engine export tasks where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching batch engine export tasks
 	 */
 	@Override
-	public int countByC_ERC(long companyId, String externalReferenceCode) {
+	public int countByERC_C(String externalReferenceCode, long companyId) {
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
-		FinderPath finderPath = _finderPathCountByC_ERC;
+		FinderPath finderPath = _finderPathCountByERC_C;
 
-		Object[] finderArgs = new Object[] {companyId, externalReferenceCode};
+		Object[] finderArgs = new Object[] {externalReferenceCode, companyId};
 
 		Long count = (Long)finderCache.getResult(finderPath, finderArgs, this);
 
@@ -2488,18 +2489,18 @@ public class BatchEngineExportTaskPersistenceImpl
 
 			sb.append(_SQL_COUNT_BATCHENGINEEXPORTTASK_WHERE);
 
-			sb.append(_FINDER_COLUMN_C_ERC_COMPANYID_2);
-
 			boolean bindExternalReferenceCode = false;
 
 			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3);
 			}
 			else {
 				bindExternalReferenceCode = true;
 
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2);
 			}
+
+			sb.append(_FINDER_COLUMN_ERC_C_COMPANYID_2);
 
 			String sql = sb.toString();
 
@@ -2512,11 +2513,11 @@ public class BatchEngineExportTaskPersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
-				queryPos.add(companyId);
-
 				if (bindExternalReferenceCode) {
 					queryPos.add(externalReferenceCode);
 				}
+
+				queryPos.add(companyId);
 
 				count = (Long)query.uniqueResult();
 
@@ -2533,14 +2534,14 @@ public class BatchEngineExportTaskPersistenceImpl
 		return count.intValue();
 	}
 
-	private static final String _FINDER_COLUMN_C_ERC_COMPANYID_2 =
-		"batchEngineExportTask.companyId = ? AND ";
+	private static final String _FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2 =
+		"batchEngineExportTask.externalReferenceCode = ? AND ";
 
-	private static final String _FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2 =
-		"batchEngineExportTask.externalReferenceCode = ?";
+	private static final String _FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3 =
+		"(batchEngineExportTask.externalReferenceCode IS NULL OR batchEngineExportTask.externalReferenceCode = '') AND ";
 
-	private static final String _FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3 =
-		"(batchEngineExportTask.externalReferenceCode IS NULL OR batchEngineExportTask.externalReferenceCode = '')";
+	private static final String _FINDER_COLUMN_ERC_C_COMPANYID_2 =
+		"batchEngineExportTask.companyId = ?";
 
 	public BatchEngineExportTaskPersistenceImpl() {
 		Map<String, String> dbColumnNames = new HashMap<String, String>();
@@ -2569,10 +2570,10 @@ public class BatchEngineExportTaskPersistenceImpl
 			batchEngineExportTask.getPrimaryKey(), batchEngineExportTask);
 
 		finderCache.putResult(
-			_finderPathFetchByC_ERC,
+			_finderPathFetchByERC_C,
 			new Object[] {
-				batchEngineExportTask.getCompanyId(),
-				batchEngineExportTask.getExternalReferenceCode()
+				batchEngineExportTask.getExternalReferenceCode(),
+				batchEngineExportTask.getCompanyId()
 			},
 			batchEngineExportTask);
 	}
@@ -2659,13 +2660,13 @@ public class BatchEngineExportTaskPersistenceImpl
 		BatchEngineExportTaskModelImpl batchEngineExportTaskModelImpl) {
 
 		Object[] args = new Object[] {
-			batchEngineExportTaskModelImpl.getCompanyId(),
-			batchEngineExportTaskModelImpl.getExternalReferenceCode()
+			batchEngineExportTaskModelImpl.getExternalReferenceCode(),
+			batchEngineExportTaskModelImpl.getCompanyId()
 		};
 
-		finderCache.putResult(_finderPathCountByC_ERC, args, Long.valueOf(1));
+		finderCache.putResult(_finderPathCountByERC_C, args, Long.valueOf(1));
 		finderCache.putResult(
-			_finderPathFetchByC_ERC, args, batchEngineExportTaskModelImpl);
+			_finderPathFetchByERC_C, args, batchEngineExportTaskModelImpl);
 	}
 
 	/**
@@ -2819,6 +2820,30 @@ public class BatchEngineExportTaskPersistenceImpl
 
 			batchEngineExportTask.setExternalReferenceCode(
 				batchEngineExportTask.getUuid());
+		}
+		else {
+			BatchEngineExportTask ercBatchEngineExportTask = fetchByERC_C(
+				batchEngineExportTask.getExternalReferenceCode(),
+				batchEngineExportTask.getCompanyId());
+
+			if (isNew) {
+				if (ercBatchEngineExportTask != null) {
+					throw new DuplicateBatchEngineExportTaskExternalReferenceCodeException(
+						"Duplicate BatchEngineExportTask with external reference code " +
+							batchEngineExportTask.getExternalReferenceCode());
+				}
+			}
+			else {
+				if ((ercBatchEngineExportTask != null) &&
+					(batchEngineExportTask.getBatchEngineExportTaskId() !=
+						ercBatchEngineExportTask.
+							getBatchEngineExportTaskId())) {
+
+					throw new DuplicateBatchEngineExportTaskExternalReferenceCodeException(
+						"Duplicate BatchEngineExportTask with external reference code " +
+							batchEngineExportTask.getExternalReferenceCode());
+				}
+			}
 		}
 
 		ServiceContext serviceContext =
@@ -3240,15 +3265,15 @@ public class BatchEngineExportTaskPersistenceImpl
 			new String[] {String.class.getName()},
 			new String[] {"executeStatus"}, false);
 
-		_finderPathFetchByC_ERC = new FinderPath(
-			FINDER_CLASS_NAME_ENTITY, "fetchByC_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"companyId", "externalReferenceCode"}, true);
+		_finderPathFetchByERC_C = new FinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, true);
 
-		_finderPathCountByC_ERC = new FinderPath(
-			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"companyId", "externalReferenceCode"}, false);
+		_finderPathCountByERC_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, false);
 
 		_setBatchEngineExportTaskUtilPersistence(this);
 	}

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/service/persistence/impl/BatchEngineImportTaskPersistenceImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/service/persistence/impl/BatchEngineImportTaskPersistenceImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.batch.engine.service.persistence.impl;
 
+import com.liferay.batch.engine.exception.DuplicateBatchEngineImportTaskExternalReferenceCodeException;
 import com.liferay.batch.engine.exception.NoSuchImportTaskException;
 import com.liferay.batch.engine.model.BatchEngineImportTask;
 import com.liferay.batch.engine.model.BatchEngineImportTaskTable;
@@ -2285,35 +2286,35 @@ public class BatchEngineImportTaskPersistenceImpl
 	private static final String _FINDER_COLUMN_EXECUTESTATUS_EXECUTESTATUS_3 =
 		"(batchEngineImportTask.executeStatus IS NULL OR batchEngineImportTask.executeStatus = '')";
 
-	private FinderPath _finderPathFetchByC_ERC;
-	private FinderPath _finderPathCountByC_ERC;
+	private FinderPath _finderPathFetchByERC_C;
+	private FinderPath _finderPathCountByERC_C;
 
 	/**
-	 * Returns the batch engine import task where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchImportTaskException</code> if it could not be found.
+	 * Returns the batch engine import task where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchImportTaskException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching batch engine import task
 	 * @throws NoSuchImportTaskException if a matching batch engine import task could not be found
 	 */
 	@Override
-	public BatchEngineImportTask findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public BatchEngineImportTask findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchImportTaskException {
 
-		BatchEngineImportTask batchEngineImportTask = fetchByC_ERC(
-			companyId, externalReferenceCode);
+		BatchEngineImportTask batchEngineImportTask = fetchByERC_C(
+			externalReferenceCode, companyId);
 
 		if (batchEngineImportTask == null) {
 			StringBundler sb = new StringBundler(6);
 
 			sb.append(_NO_SUCH_ENTITY_WITH_KEY);
 
-			sb.append("companyId=");
-			sb.append(companyId);
-
-			sb.append(", externalReferenceCode=");
+			sb.append("externalReferenceCode=");
 			sb.append(externalReferenceCode);
+
+			sb.append(", companyId=");
+			sb.append(companyId);
 
 			sb.append("}");
 
@@ -2328,54 +2329,54 @@ public class BatchEngineImportTaskPersistenceImpl
 	}
 
 	/**
-	 * Returns the batch engine import task where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the batch engine import task where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching batch engine import task, or <code>null</code> if a matching batch engine import task could not be found
 	 */
 	@Override
-	public BatchEngineImportTask fetchByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public BatchEngineImportTask fetchByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return fetchByC_ERC(companyId, externalReferenceCode, true);
+		return fetchByERC_C(externalReferenceCode, companyId, true);
 	}
 
 	/**
-	 * Returns the batch engine import task where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the batch engine import task where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching batch engine import task, or <code>null</code> if a matching batch engine import task could not be found
 	 */
 	@Override
-	public BatchEngineImportTask fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache) {
+	public BatchEngineImportTask fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache) {
 
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
 		Object[] finderArgs = null;
 
 		if (useFinderCache) {
-			finderArgs = new Object[] {companyId, externalReferenceCode};
+			finderArgs = new Object[] {externalReferenceCode, companyId};
 		}
 
 		Object result = null;
 
 		if (useFinderCache) {
 			result = finderCache.getResult(
-				_finderPathFetchByC_ERC, finderArgs, this);
+				_finderPathFetchByERC_C, finderArgs, this);
 		}
 
 		if (result instanceof BatchEngineImportTask) {
 			BatchEngineImportTask batchEngineImportTask =
 				(BatchEngineImportTask)result;
 
-			if ((companyId != batchEngineImportTask.getCompanyId()) ||
-				!Objects.equals(
+			if (!Objects.equals(
 					externalReferenceCode,
-					batchEngineImportTask.getExternalReferenceCode())) {
+					batchEngineImportTask.getExternalReferenceCode()) ||
+				(companyId != batchEngineImportTask.getCompanyId())) {
 
 				result = null;
 			}
@@ -2386,18 +2387,18 @@ public class BatchEngineImportTaskPersistenceImpl
 
 			sb.append(_SQL_SELECT_BATCHENGINEIMPORTTASK_WHERE);
 
-			sb.append(_FINDER_COLUMN_C_ERC_COMPANYID_2);
-
 			boolean bindExternalReferenceCode = false;
 
 			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3);
 			}
 			else {
 				bindExternalReferenceCode = true;
 
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2);
 			}
+
+			sb.append(_FINDER_COLUMN_ERC_C_COMPANYID_2);
 
 			String sql = sb.toString();
 
@@ -2410,18 +2411,18 @@ public class BatchEngineImportTaskPersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
-				queryPos.add(companyId);
-
 				if (bindExternalReferenceCode) {
 					queryPos.add(externalReferenceCode);
 				}
+
+				queryPos.add(companyId);
 
 				List<BatchEngineImportTask> list = query.list();
 
 				if (list.isEmpty()) {
 					if (useFinderCache) {
 						finderCache.putResult(
-							_finderPathFetchByC_ERC, finderArgs, list);
+							_finderPathFetchByERC_C, finderArgs, list);
 					}
 				}
 				else {
@@ -2449,37 +2450,37 @@ public class BatchEngineImportTaskPersistenceImpl
 	}
 
 	/**
-	 * Removes the batch engine import task where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the batch engine import task where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the batch engine import task that was removed
 	 */
 	@Override
-	public BatchEngineImportTask removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public BatchEngineImportTask removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchImportTaskException {
 
-		BatchEngineImportTask batchEngineImportTask = findByC_ERC(
-			companyId, externalReferenceCode);
+		BatchEngineImportTask batchEngineImportTask = findByERC_C(
+			externalReferenceCode, companyId);
 
 		return remove(batchEngineImportTask);
 	}
 
 	/**
-	 * Returns the number of batch engine import tasks where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of batch engine import tasks where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching batch engine import tasks
 	 */
 	@Override
-	public int countByC_ERC(long companyId, String externalReferenceCode) {
+	public int countByERC_C(String externalReferenceCode, long companyId) {
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
-		FinderPath finderPath = _finderPathCountByC_ERC;
+		FinderPath finderPath = _finderPathCountByERC_C;
 
-		Object[] finderArgs = new Object[] {companyId, externalReferenceCode};
+		Object[] finderArgs = new Object[] {externalReferenceCode, companyId};
 
 		Long count = (Long)finderCache.getResult(finderPath, finderArgs, this);
 
@@ -2488,18 +2489,18 @@ public class BatchEngineImportTaskPersistenceImpl
 
 			sb.append(_SQL_COUNT_BATCHENGINEIMPORTTASK_WHERE);
 
-			sb.append(_FINDER_COLUMN_C_ERC_COMPANYID_2);
-
 			boolean bindExternalReferenceCode = false;
 
 			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3);
 			}
 			else {
 				bindExternalReferenceCode = true;
 
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2);
 			}
+
+			sb.append(_FINDER_COLUMN_ERC_C_COMPANYID_2);
 
 			String sql = sb.toString();
 
@@ -2512,11 +2513,11 @@ public class BatchEngineImportTaskPersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
-				queryPos.add(companyId);
-
 				if (bindExternalReferenceCode) {
 					queryPos.add(externalReferenceCode);
 				}
+
+				queryPos.add(companyId);
 
 				count = (Long)query.uniqueResult();
 
@@ -2533,14 +2534,14 @@ public class BatchEngineImportTaskPersistenceImpl
 		return count.intValue();
 	}
 
-	private static final String _FINDER_COLUMN_C_ERC_COMPANYID_2 =
-		"batchEngineImportTask.companyId = ? AND ";
+	private static final String _FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2 =
+		"batchEngineImportTask.externalReferenceCode = ? AND ";
 
-	private static final String _FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2 =
-		"batchEngineImportTask.externalReferenceCode = ?";
+	private static final String _FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3 =
+		"(batchEngineImportTask.externalReferenceCode IS NULL OR batchEngineImportTask.externalReferenceCode = '') AND ";
 
-	private static final String _FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3 =
-		"(batchEngineImportTask.externalReferenceCode IS NULL OR batchEngineImportTask.externalReferenceCode = '')";
+	private static final String _FINDER_COLUMN_ERC_C_COMPANYID_2 =
+		"batchEngineImportTask.companyId = ?";
 
 	public BatchEngineImportTaskPersistenceImpl() {
 		Map<String, String> dbColumnNames = new HashMap<String, String>();
@@ -2569,10 +2570,10 @@ public class BatchEngineImportTaskPersistenceImpl
 			batchEngineImportTask.getPrimaryKey(), batchEngineImportTask);
 
 		finderCache.putResult(
-			_finderPathFetchByC_ERC,
+			_finderPathFetchByERC_C,
 			new Object[] {
-				batchEngineImportTask.getCompanyId(),
-				batchEngineImportTask.getExternalReferenceCode()
+				batchEngineImportTask.getExternalReferenceCode(),
+				batchEngineImportTask.getCompanyId()
 			},
 			batchEngineImportTask);
 	}
@@ -2659,13 +2660,13 @@ public class BatchEngineImportTaskPersistenceImpl
 		BatchEngineImportTaskModelImpl batchEngineImportTaskModelImpl) {
 
 		Object[] args = new Object[] {
-			batchEngineImportTaskModelImpl.getCompanyId(),
-			batchEngineImportTaskModelImpl.getExternalReferenceCode()
+			batchEngineImportTaskModelImpl.getExternalReferenceCode(),
+			batchEngineImportTaskModelImpl.getCompanyId()
 		};
 
-		finderCache.putResult(_finderPathCountByC_ERC, args, Long.valueOf(1));
+		finderCache.putResult(_finderPathCountByERC_C, args, Long.valueOf(1));
 		finderCache.putResult(
-			_finderPathFetchByC_ERC, args, batchEngineImportTaskModelImpl);
+			_finderPathFetchByERC_C, args, batchEngineImportTaskModelImpl);
 	}
 
 	/**
@@ -2819,6 +2820,30 @@ public class BatchEngineImportTaskPersistenceImpl
 
 			batchEngineImportTask.setExternalReferenceCode(
 				batchEngineImportTask.getUuid());
+		}
+		else {
+			BatchEngineImportTask ercBatchEngineImportTask = fetchByERC_C(
+				batchEngineImportTask.getExternalReferenceCode(),
+				batchEngineImportTask.getCompanyId());
+
+			if (isNew) {
+				if (ercBatchEngineImportTask != null) {
+					throw new DuplicateBatchEngineImportTaskExternalReferenceCodeException(
+						"Duplicate BatchEngineImportTask with external reference code " +
+							batchEngineImportTask.getExternalReferenceCode());
+				}
+			}
+			else {
+				if ((ercBatchEngineImportTask != null) &&
+					(batchEngineImportTask.getBatchEngineImportTaskId() !=
+						ercBatchEngineImportTask.
+							getBatchEngineImportTaskId())) {
+
+					throw new DuplicateBatchEngineImportTaskExternalReferenceCodeException(
+						"Duplicate BatchEngineImportTask with external reference code " +
+							batchEngineImportTask.getExternalReferenceCode());
+				}
+			}
 		}
 
 		ServiceContext serviceContext =
@@ -3240,15 +3265,15 @@ public class BatchEngineImportTaskPersistenceImpl
 			new String[] {String.class.getName()},
 			new String[] {"executeStatus"}, false);
 
-		_finderPathFetchByC_ERC = new FinderPath(
-			FINDER_CLASS_NAME_ENTITY, "fetchByC_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"companyId", "externalReferenceCode"}, true);
+		_finderPathFetchByERC_C = new FinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, true);
 
-		_finderPathCountByC_ERC = new FinderPath(
-			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"companyId", "externalReferenceCode"}, false);
+		_finderPathCountByERC_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, false);
 
 		_setBatchEngineImportTaskUtilPersistence(this);
 	}

--- a/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/display/context/BatchPlannerPlanDisplayContext.java
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/display/context/BatchPlannerPlanDisplayContext.java
@@ -213,9 +213,9 @@ public class BatchPlannerPlanDisplayContext extends BaseDisplayContext {
 			BatchEngineExportTask batchEngineExportTask =
 				BatchEngineExportTaskLocalServiceUtil.
 					getBatchEngineExportTaskByExternalReferenceCode(
-						batchPlannerPlan.getCompanyId(),
 						String.valueOf(
-							batchPlannerPlan.getBatchPlannerPlanId()));
+							batchPlannerPlan.getBatchPlannerPlanId()),
+						batchPlannerPlan.getCompanyId());
 
 			builder.processedItemsCount(
 				batchEngineExportTask.getProcessedItemsCount()
@@ -227,9 +227,9 @@ public class BatchPlannerPlanDisplayContext extends BaseDisplayContext {
 			BatchEngineImportTask batchEngineImportTask =
 				BatchEngineImportTaskLocalServiceUtil.
 					getBatchEngineImportTaskByExternalReferenceCode(
-						batchPlannerPlan.getCompanyId(),
 						String.valueOf(
-							batchPlannerPlan.getBatchPlannerPlanId()));
+							batchPlannerPlan.getBatchPlannerPlanId()),
+						batchPlannerPlan.getCompanyId());
 
 			int batchEngineImportTaskErrorsCount =
 				batchEngineImportTask.getBatchEngineImportTaskErrorsCount();

--- a/modules/apps/blogs/blogs-api/bnd.bnd
+++ b/modules/apps/blogs/blogs-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Blogs API
 Bundle-SymbolicName: com.liferay.blogs.api
-Bundle-Version: 12.0.1
+Bundle-Version: 13.0.0
 Export-Package:\
 	com.liferay.blogs.configuration,\
 	com.liferay.blogs.configuration.definition,\

--- a/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/exception/DuplicateBlogsEntryExternalReferenceCodeException.java
+++ b/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/exception/DuplicateBlogsEntryExternalReferenceCodeException.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.blogs.exception;
+
+import com.liferay.portal.kernel.exception.SystemException;
+
+/**
+ * @author Brian Wing Shun Chan
+ */
+public class DuplicateBlogsEntryExternalReferenceCodeException
+	extends SystemException {
+
+	public DuplicateBlogsEntryExternalReferenceCodeException() {
+	}
+
+	public DuplicateBlogsEntryExternalReferenceCodeException(String msg) {
+		super(msg);
+	}
+
+	public DuplicateBlogsEntryExternalReferenceCodeException(
+		String msg, Throwable throwable) {
+
+		super(msg, throwable);
+	}
+
+	public DuplicateBlogsEntryExternalReferenceCodeException(
+		Throwable throwable) {
+
+		super(throwable);
+	}
+
+}

--- a/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/exception/DuplicateEntryExternalReferenceCodeException.java
+++ b/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/exception/DuplicateEntryExternalReferenceCodeException.java
@@ -14,13 +14,13 @@
 
 package com.liferay.blogs.exception;
 
-import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.SystemException;
 
 /**
  * @author Brian Wing Shun Chan
  */
 public class DuplicateEntryExternalReferenceCodeException
-	extends PortalException {
+	extends SystemException {
 
 	public DuplicateEntryExternalReferenceCodeException() {
 	}

--- a/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryLocalService.java
+++ b/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryLocalService.java
@@ -321,24 +321,9 @@ public interface BlogsEntryLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public BlogsEntry fetchBlogsEntry(long entryId);
 
-	/**
-	 * Returns the blogs entry with the matching external reference code and group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the blogs entry's external reference code
-	 * @return the matching blogs entry, or <code>null</code> if a matching blogs entry could not be found
-	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public BlogsEntry fetchBlogsEntryByExternalReferenceCode(
-		long groupId, String externalReferenceCode);
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchBlogsEntryByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public BlogsEntry fetchBlogsEntryByReferenceCode(
-		long groupId, String externalReferenceCode);
+		String externalReferenceCode, long groupId);
 
 	/**
 	 * Returns the blogs entry matching the UUID and group.
@@ -415,17 +400,9 @@ public interface BlogsEntryLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public BlogsEntry getBlogsEntry(long entryId) throws PortalException;
 
-	/**
-	 * Returns the blogs entry with the matching external reference code and group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the blogs entry's external reference code
-	 * @return the matching blogs entry
-	 * @throws PortalException if a matching blogs entry could not be found
-	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public BlogsEntry getBlogsEntryByExternalReferenceCode(
-			long groupId, String externalReferenceCode)
+			String externalReferenceCode, long groupId)
 		throws PortalException;
 
 	/**

--- a/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryLocalServiceUtil.java
+++ b/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryLocalServiceUtil.java
@@ -413,29 +413,11 @@ public class BlogsEntryLocalServiceUtil {
 		return getService().fetchBlogsEntry(entryId);
 	}
 
-	/**
-	 * Returns the blogs entry with the matching external reference code and group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the blogs entry's external reference code
-	 * @return the matching blogs entry, or <code>null</code> if a matching blogs entry could not be found
-	 */
 	public static BlogsEntry fetchBlogsEntryByExternalReferenceCode(
-		long groupId, String externalReferenceCode) {
+		String externalReferenceCode, long groupId) {
 
 		return getService().fetchBlogsEntryByExternalReferenceCode(
-			groupId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchBlogsEntryByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	public static BlogsEntry fetchBlogsEntryByReferenceCode(
-		long groupId, String externalReferenceCode) {
-
-		return getService().fetchBlogsEntryByReferenceCode(
-			groupId, externalReferenceCode);
+			externalReferenceCode, groupId);
 	}
 
 	/**
@@ -529,20 +511,12 @@ public class BlogsEntryLocalServiceUtil {
 		return getService().getBlogsEntry(entryId);
 	}
 
-	/**
-	 * Returns the blogs entry with the matching external reference code and group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the blogs entry's external reference code
-	 * @return the matching blogs entry
-	 * @throws PortalException if a matching blogs entry could not be found
-	 */
 	public static BlogsEntry getBlogsEntryByExternalReferenceCode(
-			long groupId, String externalReferenceCode)
+			String externalReferenceCode, long groupId)
 		throws PortalException {
 
 		return getService().getBlogsEntryByExternalReferenceCode(
-			groupId, externalReferenceCode);
+			externalReferenceCode, groupId);
 	}
 
 	/**

--- a/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryLocalServiceWrapper.java
+++ b/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryLocalServiceWrapper.java
@@ -457,31 +457,12 @@ public class BlogsEntryLocalServiceWrapper
 		return _blogsEntryLocalService.fetchBlogsEntry(entryId);
 	}
 
-	/**
-	 * Returns the blogs entry with the matching external reference code and group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the blogs entry's external reference code
-	 * @return the matching blogs entry, or <code>null</code> if a matching blogs entry could not be found
-	 */
 	@Override
 	public BlogsEntry fetchBlogsEntryByExternalReferenceCode(
-		long groupId, String externalReferenceCode) {
+		String externalReferenceCode, long groupId) {
 
 		return _blogsEntryLocalService.fetchBlogsEntryByExternalReferenceCode(
-			groupId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchBlogsEntryByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public BlogsEntry fetchBlogsEntryByReferenceCode(
-		long groupId, String externalReferenceCode) {
-
-		return _blogsEntryLocalService.fetchBlogsEntryByReferenceCode(
-			groupId, externalReferenceCode);
+			externalReferenceCode, groupId);
 	}
 
 	/**
@@ -586,21 +567,13 @@ public class BlogsEntryLocalServiceWrapper
 		return _blogsEntryLocalService.getBlogsEntry(entryId);
 	}
 
-	/**
-	 * Returns the blogs entry with the matching external reference code and group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the blogs entry's external reference code
-	 * @return the matching blogs entry
-	 * @throws PortalException if a matching blogs entry could not be found
-	 */
 	@Override
 	public BlogsEntry getBlogsEntryByExternalReferenceCode(
-			long groupId, String externalReferenceCode)
+			String externalReferenceCode, long groupId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _blogsEntryLocalService.getBlogsEntryByExternalReferenceCode(
-			groupId, externalReferenceCode);
+			externalReferenceCode, groupId);
 	}
 
 	/**

--- a/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/persistence/BlogsEntryPersistence.java
+++ b/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/persistence/BlogsEntryPersistence.java
@@ -5265,54 +5265,54 @@ public interface BlogsEntryPersistence
 		long groupId, long userId, Date displayDate, int status);
 
 	/**
-	 * Returns the blogs entry where groupId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchEntryException</code> if it could not be found.
+	 * Returns the blogs entry where externalReferenceCode = &#63; and groupId = &#63; or throws a <code>NoSuchEntryException</code> if it could not be found.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the matching blogs entry
 	 * @throws NoSuchEntryException if a matching blogs entry could not be found
 	 */
-	public BlogsEntry findByG_ERC(long groupId, String externalReferenceCode)
+	public BlogsEntry findByERC_G(String externalReferenceCode, long groupId)
 		throws NoSuchEntryException;
 
 	/**
-	 * Returns the blogs entry where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the blogs entry where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the matching blogs entry, or <code>null</code> if a matching blogs entry could not be found
 	 */
-	public BlogsEntry fetchByG_ERC(long groupId, String externalReferenceCode);
+	public BlogsEntry fetchByERC_G(String externalReferenceCode, long groupId);
 
 	/**
-	 * Returns the blogs entry where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the blogs entry where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching blogs entry, or <code>null</code> if a matching blogs entry could not be found
 	 */
-	public BlogsEntry fetchByG_ERC(
-		long groupId, String externalReferenceCode, boolean useFinderCache);
+	public BlogsEntry fetchByERC_G(
+		String externalReferenceCode, long groupId, boolean useFinderCache);
 
 	/**
-	 * Removes the blogs entry where groupId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the blogs entry where externalReferenceCode = &#63; and groupId = &#63; from the database.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the blogs entry that was removed
 	 */
-	public BlogsEntry removeByG_ERC(long groupId, String externalReferenceCode)
+	public BlogsEntry removeByERC_G(String externalReferenceCode, long groupId)
 		throws NoSuchEntryException;
 
 	/**
-	 * Returns the number of blogs entries where groupId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of blogs entries where externalReferenceCode = &#63; and groupId = &#63;.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the number of matching blogs entries
 	 */
-	public int countByG_ERC(long groupId, String externalReferenceCode);
+	public int countByERC_G(String externalReferenceCode, long groupId);
 
 	/**
 	 * Caches the blogs entry in the entity cache if it is enabled.

--- a/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/persistence/BlogsEntryUtil.java
+++ b/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/persistence/BlogsEntryUtil.java
@@ -6416,71 +6416,71 @@ public class BlogsEntryUtil {
 	}
 
 	/**
-	 * Returns the blogs entry where groupId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchEntryException</code> if it could not be found.
+	 * Returns the blogs entry where externalReferenceCode = &#63; and groupId = &#63; or throws a <code>NoSuchEntryException</code> if it could not be found.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the matching blogs entry
 	 * @throws NoSuchEntryException if a matching blogs entry could not be found
 	 */
-	public static BlogsEntry findByG_ERC(
-			long groupId, String externalReferenceCode)
+	public static BlogsEntry findByERC_G(
+			String externalReferenceCode, long groupId)
 		throws com.liferay.blogs.exception.NoSuchEntryException {
 
-		return getPersistence().findByG_ERC(groupId, externalReferenceCode);
+		return getPersistence().findByERC_G(externalReferenceCode, groupId);
 	}
 
 	/**
-	 * Returns the blogs entry where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the blogs entry where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the matching blogs entry, or <code>null</code> if a matching blogs entry could not be found
 	 */
-	public static BlogsEntry fetchByG_ERC(
-		long groupId, String externalReferenceCode) {
+	public static BlogsEntry fetchByERC_G(
+		String externalReferenceCode, long groupId) {
 
-		return getPersistence().fetchByG_ERC(groupId, externalReferenceCode);
+		return getPersistence().fetchByERC_G(externalReferenceCode, groupId);
 	}
 
 	/**
-	 * Returns the blogs entry where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the blogs entry where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching blogs entry, or <code>null</code> if a matching blogs entry could not be found
 	 */
-	public static BlogsEntry fetchByG_ERC(
-		long groupId, String externalReferenceCode, boolean useFinderCache) {
+	public static BlogsEntry fetchByERC_G(
+		String externalReferenceCode, long groupId, boolean useFinderCache) {
 
-		return getPersistence().fetchByG_ERC(
-			groupId, externalReferenceCode, useFinderCache);
+		return getPersistence().fetchByERC_G(
+			externalReferenceCode, groupId, useFinderCache);
 	}
 
 	/**
-	 * Removes the blogs entry where groupId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the blogs entry where externalReferenceCode = &#63; and groupId = &#63; from the database.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the blogs entry that was removed
 	 */
-	public static BlogsEntry removeByG_ERC(
-			long groupId, String externalReferenceCode)
+	public static BlogsEntry removeByERC_G(
+			String externalReferenceCode, long groupId)
 		throws com.liferay.blogs.exception.NoSuchEntryException {
 
-		return getPersistence().removeByG_ERC(groupId, externalReferenceCode);
+		return getPersistence().removeByERC_G(externalReferenceCode, groupId);
 	}
 
 	/**
-	 * Returns the number of blogs entries where groupId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of blogs entries where externalReferenceCode = &#63; and groupId = &#63;.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the number of matching blogs entries
 	 */
-	public static int countByG_ERC(long groupId, String externalReferenceCode) {
-		return getPersistence().countByG_ERC(groupId, externalReferenceCode);
+	public static int countByERC_G(String externalReferenceCode, long groupId) {
+		return getPersistence().countByERC_G(externalReferenceCode, groupId);
 	}
 
 	/**

--- a/modules/apps/blogs/blogs-api/src/main/resources/com/liferay/blogs/exception/packageinfo
+++ b/modules/apps/blogs/blogs-api/src/main/resources/com/liferay/blogs/exception/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 2.0.0

--- a/modules/apps/blogs/blogs-api/src/main/resources/com/liferay/blogs/service/packageinfo
+++ b/modules/apps/blogs/blogs-api/src/main/resources/com/liferay/blogs/service/packageinfo
@@ -1,1 +1,1 @@
-version 4.4.0
+version 5.0.0

--- a/modules/apps/blogs/blogs-api/src/main/resources/com/liferay/blogs/service/persistence/packageinfo
+++ b/modules/apps/blogs/blogs-api/src/main/resources/com/liferay/blogs/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 4.1.0
+version 5.0.0

--- a/modules/apps/blogs/blogs-service/service.xml
+++ b/modules/apps/blogs/blogs-service/service.xml
@@ -167,7 +167,6 @@
 	<entity local-service="true" name="BlogsStatsUser" remote-service="false">
 	</entity>
 	<exceptions>
-		<exception>DuplicateEntryExternalReferenceCode</exception>
 		<exception>EntryContent</exception>
 		<exception>EntryCoverImageCrop</exception>
 		<exception>EntryDescription</exception>

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/base/BlogsEntryLocalServiceBaseImpl.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/base/BlogsEntryLocalServiceBaseImpl.java
@@ -277,48 +277,21 @@ public abstract class BlogsEntryLocalServiceBaseImpl
 		return blogsEntryPersistence.fetchByUUID_G(uuid, groupId);
 	}
 
-	/**
-	 * Returns the blogs entry with the matching external reference code and group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the blogs entry's external reference code
-	 * @return the matching blogs entry, or <code>null</code> if a matching blogs entry could not be found
-	 */
 	@Override
 	public BlogsEntry fetchBlogsEntryByExternalReferenceCode(
-		long groupId, String externalReferenceCode) {
+		String externalReferenceCode, long groupId) {
 
-		return blogsEntryPersistence.fetchByG_ERC(
-			groupId, externalReferenceCode);
+		return blogsEntryPersistence.fetchByERC_G(
+			externalReferenceCode, groupId);
 	}
 
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchBlogsEntryByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public BlogsEntry fetchBlogsEntryByReferenceCode(
-		long groupId, String externalReferenceCode) {
-
-		return fetchBlogsEntryByExternalReferenceCode(
-			groupId, externalReferenceCode);
-	}
-
-	/**
-	 * Returns the blogs entry with the matching external reference code and group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the blogs entry's external reference code
-	 * @return the matching blogs entry
-	 * @throws PortalException if a matching blogs entry could not be found
-	 */
 	@Override
 	public BlogsEntry getBlogsEntryByExternalReferenceCode(
-			long groupId, String externalReferenceCode)
+			String externalReferenceCode, long groupId)
 		throws PortalException {
 
-		return blogsEntryPersistence.findByG_ERC(
-			groupId, externalReferenceCode);
+		return blogsEntryPersistence.findByERC_G(
+			externalReferenceCode, groupId);
 	}
 
 	/**

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsEntryLocalServiceImpl.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsEntryLocalServiceImpl.java
@@ -21,7 +21,6 @@ import com.liferay.asset.kernel.service.AssetLinkLocalService;
 import com.liferay.blogs.configuration.BlogsFileUploadsConfiguration;
 import com.liferay.blogs.configuration.BlogsGroupServiceConfiguration;
 import com.liferay.blogs.constants.BlogsConstants;
-import com.liferay.blogs.exception.DuplicateEntryExternalReferenceCodeException;
 import com.liferay.blogs.exception.EntryContentException;
 import com.liferay.blogs.exception.EntryCoverImageCropException;
 import com.liferay.blogs.exception.EntryDisplayDateException;
@@ -300,8 +299,6 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 		_validate(title, urlTitle, content, status);
 
 		long entryId = counterLocalService.increment();
-
-		_validateExternalReferenceCode(externalReferenceCode, groupId);
 
 		if (Validator.isNotNull(urlTitle)) {
 			urlTitle = _validateURLTitle(groupId, urlTitle, serviceContext);
@@ -2350,25 +2347,6 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 		if (content.length() > contentMaxLength) {
 			throw new EntryContentException(
 				"Content has more than " + contentMaxLength + " characters");
-		}
-	}
-
-	private void _validateExternalReferenceCode(
-			String externalReferenceCode, long groupId)
-		throws PortalException {
-
-		if (Validator.isNull(externalReferenceCode)) {
-			return;
-		}
-
-		BlogsEntry entry = blogsEntryPersistence.fetchByG_ERC(
-			groupId, externalReferenceCode);
-
-		if (entry != null) {
-			throw new DuplicateEntryExternalReferenceCodeException(
-				StringBundler.concat(
-					"Duplicate blogs entry external reference code ",
-					externalReferenceCode, " in group ", groupId));
 		}
 	}
 

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsEntryServiceImpl.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsEntryServiceImpl.java
@@ -147,8 +147,8 @@ public class BlogsEntryServiceImpl extends BlogsEntryServiceBaseImpl {
 			long groupId, String externalReferenceCode)
 		throws PortalException {
 
-		BlogsEntry blogsEntry = blogsEntryPersistence.fetchByG_ERC(
-			groupId, externalReferenceCode);
+		BlogsEntry blogsEntry = blogsEntryPersistence.fetchByERC_G(
+			externalReferenceCode, groupId);
 
 		if (blogsEntry != null) {
 			_blogsEntryModelResourcePermission.check(
@@ -165,7 +165,7 @@ public class BlogsEntryServiceImpl extends BlogsEntryServiceBaseImpl {
 
 		BlogsEntry entry =
 			blogsEntryLocalService.getBlogsEntryByExternalReferenceCode(
-				groupId, externalReferenceCode);
+				externalReferenceCode, groupId);
 
 		_blogsEntryModelResourcePermission.check(
 			getPermissionChecker(), entry, ActionKeys.VIEW);

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/persistence/impl/BlogsEntryPersistenceImpl.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/persistence/impl/BlogsEntryPersistenceImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.blogs.service.persistence.impl;
 
+import com.liferay.blogs.exception.DuplicateBlogsEntryExternalReferenceCodeException;
 import com.liferay.blogs.exception.NoSuchEntryException;
 import com.liferay.blogs.model.BlogsEntry;
 import com.liferay.blogs.model.BlogsEntryTable;
@@ -21380,33 +21381,33 @@ public class BlogsEntryPersistenceImpl
 	private static final String _FINDER_COLUMN_G_U_LTD_NOTS_STATUS_2 =
 		"blogsEntry.status != ?";
 
-	private FinderPath _finderPathFetchByG_ERC;
-	private FinderPath _finderPathCountByG_ERC;
+	private FinderPath _finderPathFetchByERC_G;
+	private FinderPath _finderPathCountByERC_G;
 
 	/**
-	 * Returns the blogs entry where groupId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchEntryException</code> if it could not be found.
+	 * Returns the blogs entry where externalReferenceCode = &#63; and groupId = &#63; or throws a <code>NoSuchEntryException</code> if it could not be found.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the matching blogs entry
 	 * @throws NoSuchEntryException if a matching blogs entry could not be found
 	 */
 	@Override
-	public BlogsEntry findByG_ERC(long groupId, String externalReferenceCode)
+	public BlogsEntry findByERC_G(String externalReferenceCode, long groupId)
 		throws NoSuchEntryException {
 
-		BlogsEntry blogsEntry = fetchByG_ERC(groupId, externalReferenceCode);
+		BlogsEntry blogsEntry = fetchByERC_G(externalReferenceCode, groupId);
 
 		if (blogsEntry == null) {
 			StringBundler sb = new StringBundler(6);
 
 			sb.append(_NO_SUCH_ENTITY_WITH_KEY);
 
-			sb.append("groupId=");
-			sb.append(groupId);
-
-			sb.append(", externalReferenceCode=");
+			sb.append("externalReferenceCode=");
 			sb.append(externalReferenceCode);
+
+			sb.append(", groupId=");
+			sb.append(groupId);
 
 			sb.append("}");
 
@@ -21421,28 +21422,28 @@ public class BlogsEntryPersistenceImpl
 	}
 
 	/**
-	 * Returns the blogs entry where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the blogs entry where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the matching blogs entry, or <code>null</code> if a matching blogs entry could not be found
 	 */
 	@Override
-	public BlogsEntry fetchByG_ERC(long groupId, String externalReferenceCode) {
-		return fetchByG_ERC(groupId, externalReferenceCode, true);
+	public BlogsEntry fetchByERC_G(String externalReferenceCode, long groupId) {
+		return fetchByERC_G(externalReferenceCode, groupId, true);
 	}
 
 	/**
-	 * Returns the blogs entry where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the blogs entry where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching blogs entry, or <code>null</code> if a matching blogs entry could not be found
 	 */
 	@Override
-	public BlogsEntry fetchByG_ERC(
-		long groupId, String externalReferenceCode, boolean useFinderCache) {
+	public BlogsEntry fetchByERC_G(
+		String externalReferenceCode, long groupId, boolean useFinderCache) {
 
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
@@ -21452,23 +21453,23 @@ public class BlogsEntryPersistenceImpl
 		Object[] finderArgs = null;
 
 		if (useFinderCache && productionMode) {
-			finderArgs = new Object[] {groupId, externalReferenceCode};
+			finderArgs = new Object[] {externalReferenceCode, groupId};
 		}
 
 		Object result = null;
 
 		if (useFinderCache && productionMode) {
 			result = finderCache.getResult(
-				_finderPathFetchByG_ERC, finderArgs, this);
+				_finderPathFetchByERC_G, finderArgs, this);
 		}
 
 		if (result instanceof BlogsEntry) {
 			BlogsEntry blogsEntry = (BlogsEntry)result;
 
-			if ((groupId != blogsEntry.getGroupId()) ||
-				!Objects.equals(
+			if (!Objects.equals(
 					externalReferenceCode,
-					blogsEntry.getExternalReferenceCode())) {
+					blogsEntry.getExternalReferenceCode()) ||
+				(groupId != blogsEntry.getGroupId())) {
 
 				result = null;
 			}
@@ -21479,18 +21480,18 @@ public class BlogsEntryPersistenceImpl
 
 			sb.append(_SQL_SELECT_BLOGSENTRY_WHERE);
 
-			sb.append(_FINDER_COLUMN_G_ERC_GROUPID_2);
-
 			boolean bindExternalReferenceCode = false;
 
 			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_3);
+				sb.append(_FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_3);
 			}
 			else {
 				bindExternalReferenceCode = true;
 
-				sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_2);
+				sb.append(_FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_2);
 			}
+
+			sb.append(_FINDER_COLUMN_ERC_G_GROUPID_2);
 
 			String sql = sb.toString();
 
@@ -21503,18 +21504,18 @@ public class BlogsEntryPersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
-				queryPos.add(groupId);
-
 				if (bindExternalReferenceCode) {
 					queryPos.add(externalReferenceCode);
 				}
+
+				queryPos.add(groupId);
 
 				List<BlogsEntry> list = query.list();
 
 				if (list.isEmpty()) {
 					if (useFinderCache && productionMode) {
 						finderCache.putResult(
-							_finderPathFetchByG_ERC, finderArgs, list);
+							_finderPathFetchByERC_G, finderArgs, list);
 					}
 				}
 				else {
@@ -21542,30 +21543,30 @@ public class BlogsEntryPersistenceImpl
 	}
 
 	/**
-	 * Removes the blogs entry where groupId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the blogs entry where externalReferenceCode = &#63; and groupId = &#63; from the database.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the blogs entry that was removed
 	 */
 	@Override
-	public BlogsEntry removeByG_ERC(long groupId, String externalReferenceCode)
+	public BlogsEntry removeByERC_G(String externalReferenceCode, long groupId)
 		throws NoSuchEntryException {
 
-		BlogsEntry blogsEntry = findByG_ERC(groupId, externalReferenceCode);
+		BlogsEntry blogsEntry = findByERC_G(externalReferenceCode, groupId);
 
 		return remove(blogsEntry);
 	}
 
 	/**
-	 * Returns the number of blogs entries where groupId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of blogs entries where externalReferenceCode = &#63; and groupId = &#63;.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the number of matching blogs entries
 	 */
 	@Override
-	public int countByG_ERC(long groupId, String externalReferenceCode) {
+	public int countByERC_G(String externalReferenceCode, long groupId) {
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
 		boolean productionMode = ctPersistenceHelper.isProductionMode(
@@ -21577,9 +21578,9 @@ public class BlogsEntryPersistenceImpl
 		Long count = null;
 
 		if (productionMode) {
-			finderPath = _finderPathCountByG_ERC;
+			finderPath = _finderPathCountByERC_G;
 
-			finderArgs = new Object[] {groupId, externalReferenceCode};
+			finderArgs = new Object[] {externalReferenceCode, groupId};
 
 			count = (Long)finderCache.getResult(finderPath, finderArgs, this);
 		}
@@ -21589,18 +21590,18 @@ public class BlogsEntryPersistenceImpl
 
 			sb.append(_SQL_COUNT_BLOGSENTRY_WHERE);
 
-			sb.append(_FINDER_COLUMN_G_ERC_GROUPID_2);
-
 			boolean bindExternalReferenceCode = false;
 
 			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_3);
+				sb.append(_FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_3);
 			}
 			else {
 				bindExternalReferenceCode = true;
 
-				sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_2);
+				sb.append(_FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_2);
 			}
+
+			sb.append(_FINDER_COLUMN_ERC_G_GROUPID_2);
 
 			String sql = sb.toString();
 
@@ -21613,11 +21614,11 @@ public class BlogsEntryPersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
-				queryPos.add(groupId);
-
 				if (bindExternalReferenceCode) {
 					queryPos.add(externalReferenceCode);
 				}
+
+				queryPos.add(groupId);
 
 				count = (Long)query.uniqueResult();
 
@@ -21636,14 +21637,14 @@ public class BlogsEntryPersistenceImpl
 		return count.intValue();
 	}
 
-	private static final String _FINDER_COLUMN_G_ERC_GROUPID_2 =
-		"blogsEntry.groupId = ? AND ";
+	private static final String _FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_2 =
+		"blogsEntry.externalReferenceCode = ? AND ";
 
-	private static final String _FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_2 =
-		"blogsEntry.externalReferenceCode = ?";
+	private static final String _FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_3 =
+		"(blogsEntry.externalReferenceCode IS NULL OR blogsEntry.externalReferenceCode = '') AND ";
 
-	private static final String _FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_3 =
-		"(blogsEntry.externalReferenceCode IS NULL OR blogsEntry.externalReferenceCode = '')";
+	private static final String _FINDER_COLUMN_ERC_G_GROUPID_2 =
+		"blogsEntry.groupId = ?";
 
 	public BlogsEntryPersistenceImpl() {
 		Map<String, String> dbColumnNames = new HashMap<String, String>();
@@ -21685,9 +21686,9 @@ public class BlogsEntryPersistenceImpl
 			blogsEntry);
 
 		finderCache.putResult(
-			_finderPathFetchByG_ERC,
+			_finderPathFetchByERC_G,
 			new Object[] {
-				blogsEntry.getGroupId(), blogsEntry.getExternalReferenceCode()
+				blogsEntry.getExternalReferenceCode(), blogsEntry.getGroupId()
 			},
 			blogsEntry);
 	}
@@ -21783,13 +21784,13 @@ public class BlogsEntryPersistenceImpl
 			_finderPathFetchByG_UT, args, blogsEntryModelImpl);
 
 		args = new Object[] {
-			blogsEntryModelImpl.getGroupId(),
-			blogsEntryModelImpl.getExternalReferenceCode()
+			blogsEntryModelImpl.getExternalReferenceCode(),
+			blogsEntryModelImpl.getGroupId()
 		};
 
-		finderCache.putResult(_finderPathCountByG_ERC, args, Long.valueOf(1));
+		finderCache.putResult(_finderPathCountByERC_G, args, Long.valueOf(1));
 		finderCache.putResult(
-			_finderPathFetchByG_ERC, args, blogsEntryModelImpl);
+			_finderPathFetchByERC_G, args, blogsEntryModelImpl);
 	}
 
 	/**
@@ -21930,6 +21931,27 @@ public class BlogsEntryPersistenceImpl
 
 		if (Validator.isNull(blogsEntry.getExternalReferenceCode())) {
 			blogsEntry.setExternalReferenceCode(blogsEntry.getUuid());
+		}
+		else {
+			BlogsEntry ercBlogsEntry = fetchByERC_G(
+				blogsEntry.getExternalReferenceCode(), blogsEntry.getGroupId());
+
+			if (isNew) {
+				if (ercBlogsEntry != null) {
+					throw new DuplicateBlogsEntryExternalReferenceCodeException(
+						"Duplicate BlogsEntry with external reference code " +
+							blogsEntry.getExternalReferenceCode());
+				}
+			}
+			else {
+				if ((ercBlogsEntry != null) &&
+					(blogsEntry.getEntryId() != ercBlogsEntry.getEntryId())) {
+
+					throw new DuplicateBlogsEntryExternalReferenceCodeException(
+						"Duplicate BlogsEntry with external reference code " +
+							blogsEntry.getExternalReferenceCode());
+				}
+			}
 		}
 
 		ServiceContext serviceContext =
@@ -22520,7 +22542,7 @@ public class BlogsEntryPersistenceImpl
 		_uniqueIndexColumnNames.add(new String[] {"groupId", "urlTitle"});
 
 		_uniqueIndexColumnNames.add(
-			new String[] {"groupId", "externalReferenceCode"});
+			new String[] {"externalReferenceCode", "groupId"});
 	}
 
 	/**
@@ -23017,15 +23039,15 @@ public class BlogsEntryPersistenceImpl
 			},
 			new String[] {"groupId", "userId", "displayDate", "status"}, false);
 
-		_finderPathFetchByG_ERC = new FinderPath(
-			FINDER_CLASS_NAME_ENTITY, "fetchByG_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"groupId", "externalReferenceCode"}, true);
+		_finderPathFetchByERC_G = new FinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByERC_G",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "groupId"}, true);
 
-		_finderPathCountByG_ERC = new FinderPath(
-			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"groupId", "externalReferenceCode"}, false);
+		_finderPathCountByERC_G = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByERC_G",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "groupId"}, false);
 
 		_setBlogsEntryUtilPersistence(this);
 	}

--- a/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/service/persistence/test/BlogsEntryPersistenceTest.java
+++ b/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/service/persistence/test/BlogsEntryPersistenceTest.java
@@ -15,6 +15,7 @@
 package com.liferay.blogs.service.persistence.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.blogs.exception.DuplicateBlogsEntryExternalReferenceCodeException;
 import com.liferay.blogs.exception.NoSuchEntryException;
 import com.liferay.blogs.model.BlogsEntry;
 import com.liferay.blogs.service.BlogsEntryLocalServiceUtil;
@@ -276,6 +277,26 @@ public class BlogsEntryPersistenceTest {
 			Time.getShortTimestamp(newBlogsEntry.getStatusDate()));
 	}
 
+	@Test(expected = DuplicateBlogsEntryExternalReferenceCodeException.class)
+	public void testUpdateWithExistingExternalReferenceCode() throws Exception {
+		BlogsEntry blogsEntry = addBlogsEntry();
+
+		BlogsEntry newBlogsEntry = addBlogsEntry();
+
+		newBlogsEntry.setGroupId(blogsEntry.getGroupId());
+
+		newBlogsEntry = _persistence.update(newBlogsEntry);
+
+		Session session = _persistence.getCurrentSession();
+
+		session.evict(newBlogsEntry);
+
+		newBlogsEntry.setExternalReferenceCode(
+			blogsEntry.getExternalReferenceCode());
+
+		_persistence.update(newBlogsEntry);
+	}
+
 	@Test
 	public void testCountByUuid() throws Exception {
 		_persistence.countByUuid("");
@@ -515,12 +536,12 @@ public class BlogsEntryPersistenceTest {
 	}
 
 	@Test
-	public void testCountByG_ERC() throws Exception {
-		_persistence.countByG_ERC(RandomTestUtil.nextLong(), "");
+	public void testCountByERC_G() throws Exception {
+		_persistence.countByERC_G("", RandomTestUtil.nextLong());
 
-		_persistence.countByG_ERC(0L, "null");
+		_persistence.countByERC_G("null", 0L);
 
-		_persistence.countByG_ERC(0L, (String)null);
+		_persistence.countByERC_G((String)null, 0L);
 	}
 
 	@Test
@@ -844,15 +865,15 @@ public class BlogsEntryPersistenceTest {
 				new Class<?>[] {String.class}, "urlTitle"));
 
 		Assert.assertEquals(
-			Long.valueOf(blogsEntry.getGroupId()),
-			ReflectionTestUtil.<Long>invoke(
-				blogsEntry, "getColumnOriginalValue",
-				new Class<?>[] {String.class}, "groupId"));
-		Assert.assertEquals(
 			blogsEntry.getExternalReferenceCode(),
 			ReflectionTestUtil.invoke(
 				blogsEntry, "getColumnOriginalValue",
 				new Class<?>[] {String.class}, "externalReferenceCode"));
+		Assert.assertEquals(
+			Long.valueOf(blogsEntry.getGroupId()),
+			ReflectionTestUtil.<Long>invoke(
+				blogsEntry, "getColumnOriginalValue",
+				new Class<?>[] {String.class}, "groupId"));
 	}
 
 	protected BlogsEntry addBlogsEntry() throws Exception {

--- a/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/service/test/BlogsEntryLocalServiceTest.java
+++ b/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/service/test/BlogsEntryLocalServiceTest.java
@@ -198,7 +198,7 @@ public class BlogsEntryLocalServiceTest {
 
 		BlogsEntry blogsEntry2 =
 			BlogsEntryLocalServiceUtil.getBlogsEntryByExternalReferenceCode(
-				TestPropsValues.getGroupId(), externalReferenceCode);
+				externalReferenceCode, TestPropsValues.getGroupId());
 
 		Assert.assertEquals(blogsEntry1, blogsEntry2);
 	}

--- a/modules/apps/client-extension/client-extension-api/bnd.bnd
+++ b/modules/apps/client-extension/client-extension-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Client Extension API
 Bundle-SymbolicName: com.liferay.client.extension.api
-Bundle-Version: 6.1.1
+Bundle-Version: 7.0.0
 Export-Package:\
 	com.liferay.client.extension.constants,\
 	com.liferay.client.extension.exception,\

--- a/modules/apps/client-extension/client-extension-api/src/main/java/com/liferay/client/extension/exception/DuplicateClientExtensionEntryExternalReferenceCodeException.java
+++ b/modules/apps/client-extension/client-extension-api/src/main/java/com/liferay/client/extension/exception/DuplicateClientExtensionEntryExternalReferenceCodeException.java
@@ -14,13 +14,13 @@
 
 package com.liferay.client.extension.exception;
 
-import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.SystemException;
 
 /**
  * @author Brian Wing Shun Chan
  */
 public class DuplicateClientExtensionEntryExternalReferenceCodeException
-	extends PortalException {
+	extends SystemException {
 
 	public DuplicateClientExtensionEntryExternalReferenceCodeException() {
 	}

--- a/modules/apps/client-extension/client-extension-api/src/main/java/com/liferay/client/extension/exception/DuplicateClientExtensionEntryRelExternalReferenceCodeException.java
+++ b/modules/apps/client-extension/client-extension-api/src/main/java/com/liferay/client/extension/exception/DuplicateClientExtensionEntryRelExternalReferenceCodeException.java
@@ -12,30 +12,32 @@
  * details.
  */
 
-package com.liferay.account.exception;
+package com.liferay.client.extension.exception;
 
 import com.liferay.portal.kernel.exception.SystemException;
 
 /**
  * @author Brian Wing Shun Chan
  */
-public class DuplicateAccountGroupExternalReferenceCodeException
+public class DuplicateClientExtensionEntryRelExternalReferenceCodeException
 	extends SystemException {
 
-	public DuplicateAccountGroupExternalReferenceCodeException() {
+	public DuplicateClientExtensionEntryRelExternalReferenceCodeException() {
 	}
 
-	public DuplicateAccountGroupExternalReferenceCodeException(String msg) {
+	public DuplicateClientExtensionEntryRelExternalReferenceCodeException(
+		String msg) {
+
 		super(msg);
 	}
 
-	public DuplicateAccountGroupExternalReferenceCodeException(
+	public DuplicateClientExtensionEntryRelExternalReferenceCodeException(
 		String msg, Throwable throwable) {
 
 		super(msg, throwable);
 	}
 
-	public DuplicateAccountGroupExternalReferenceCodeException(
+	public DuplicateClientExtensionEntryRelExternalReferenceCodeException(
 		Throwable throwable) {
 
 		super(throwable);

--- a/modules/apps/client-extension/client-extension-api/src/main/java/com/liferay/client/extension/service/ClientExtensionEntryLocalService.java
+++ b/modules/apps/client-extension/client-extension-api/src/main/java/com/liferay/client/extension/service/ClientExtensionEntryLocalService.java
@@ -241,25 +241,10 @@ public interface ClientExtensionEntryLocalService
 	public ClientExtensionEntry fetchClientExtensionEntry(
 		long clientExtensionEntryId);
 
-	/**
-	 * Returns the client extension entry with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the client extension entry's external reference code
-	 * @return the matching client extension entry, or <code>null</code> if a matching client extension entry could not be found
-	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public ClientExtensionEntry
 		fetchClientExtensionEntryByExternalReferenceCode(
-			long companyId, String externalReferenceCode);
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchClientExtensionEntryByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public ClientExtensionEntry fetchClientExtensionEntryByReferenceCode(
-		long companyId, String externalReferenceCode);
+			String externalReferenceCode, long companyId);
 
 	/**
 	 * Returns the client extension entry with the matching UUID and company.
@@ -324,17 +309,9 @@ public interface ClientExtensionEntryLocalService
 			long clientExtensionEntryId)
 		throws PortalException;
 
-	/**
-	 * Returns the client extension entry with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the client extension entry's external reference code
-	 * @return the matching client extension entry
-	 * @throws PortalException if a matching client extension entry could not be found
-	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public ClientExtensionEntry getClientExtensionEntryByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
+			String externalReferenceCode, long companyId)
 		throws PortalException;
 
 	/**

--- a/modules/apps/client-extension/client-extension-api/src/main/java/com/liferay/client/extension/service/ClientExtensionEntryLocalServiceUtil.java
+++ b/modules/apps/client-extension/client-extension-api/src/main/java/com/liferay/client/extension/service/ClientExtensionEntryLocalServiceUtil.java
@@ -250,30 +250,12 @@ public class ClientExtensionEntryLocalServiceUtil {
 		return getService().fetchClientExtensionEntry(clientExtensionEntryId);
 	}
 
-	/**
-	 * Returns the client extension entry with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the client extension entry's external reference code
-	 * @return the matching client extension entry, or <code>null</code> if a matching client extension entry could not be found
-	 */
 	public static ClientExtensionEntry
 		fetchClientExtensionEntryByExternalReferenceCode(
-			long companyId, String externalReferenceCode) {
+			String externalReferenceCode, long companyId) {
 
 		return getService().fetchClientExtensionEntryByExternalReferenceCode(
-			companyId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchClientExtensionEntryByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	public static ClientExtensionEntry fetchClientExtensionEntryByReferenceCode(
-		long companyId, String externalReferenceCode) {
-
-		return getService().fetchClientExtensionEntryByReferenceCode(
-			companyId, externalReferenceCode);
+			externalReferenceCode, companyId);
 	}
 
 	/**
@@ -360,21 +342,13 @@ public class ClientExtensionEntryLocalServiceUtil {
 		return getService().getClientExtensionEntry(clientExtensionEntryId);
 	}
 
-	/**
-	 * Returns the client extension entry with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the client extension entry's external reference code
-	 * @return the matching client extension entry
-	 * @throws PortalException if a matching client extension entry could not be found
-	 */
 	public static ClientExtensionEntry
 			getClientExtensionEntryByExternalReferenceCode(
-				long companyId, String externalReferenceCode)
+				String externalReferenceCode, long companyId)
 		throws PortalException {
 
 		return getService().getClientExtensionEntryByExternalReferenceCode(
-			companyId, externalReferenceCode);
+			externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/client-extension/client-extension-api/src/main/java/com/liferay/client/extension/service/ClientExtensionEntryLocalServiceWrapper.java
+++ b/modules/apps/client-extension/client-extension-api/src/main/java/com/liferay/client/extension/service/ClientExtensionEntryLocalServiceWrapper.java
@@ -282,34 +282,14 @@ public class ClientExtensionEntryLocalServiceWrapper
 			clientExtensionEntryId);
 	}
 
-	/**
-	 * Returns the client extension entry with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the client extension entry's external reference code
-	 * @return the matching client extension entry, or <code>null</code> if a matching client extension entry could not be found
-	 */
 	@Override
 	public ClientExtensionEntry
 		fetchClientExtensionEntryByExternalReferenceCode(
-			long companyId, String externalReferenceCode) {
+			String externalReferenceCode, long companyId) {
 
 		return _clientExtensionEntryLocalService.
 			fetchClientExtensionEntryByExternalReferenceCode(
-				companyId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchClientExtensionEntryByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public ClientExtensionEntry fetchClientExtensionEntryByReferenceCode(
-		long companyId, String externalReferenceCode) {
-
-		return _clientExtensionEntryLocalService.
-			fetchClientExtensionEntryByReferenceCode(
-				companyId, externalReferenceCode);
+				externalReferenceCode, companyId);
 	}
 
 	/**
@@ -408,22 +388,14 @@ public class ClientExtensionEntryLocalServiceWrapper
 			clientExtensionEntryId);
 	}
 
-	/**
-	 * Returns the client extension entry with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the client extension entry's external reference code
-	 * @return the matching client extension entry
-	 * @throws PortalException if a matching client extension entry could not be found
-	 */
 	@Override
 	public ClientExtensionEntry getClientExtensionEntryByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
+			String externalReferenceCode, long companyId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _clientExtensionEntryLocalService.
 			getClientExtensionEntryByExternalReferenceCode(
-				companyId, externalReferenceCode);
+				externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/client-extension/client-extension-api/src/main/java/com/liferay/client/extension/service/ClientExtensionEntryRelLocalService.java
+++ b/modules/apps/client-extension/client-extension-api/src/main/java/com/liferay/client/extension/service/ClientExtensionEntryRelLocalService.java
@@ -230,25 +230,10 @@ public interface ClientExtensionEntryRelLocalService
 	public ClientExtensionEntryRel fetchClientExtensionEntryRel(
 		long classNameId, long classPK, String type);
 
-	/**
-	 * Returns the client extension entry rel with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the client extension entry rel's external reference code
-	 * @return the matching client extension entry rel, or <code>null</code> if a matching client extension entry rel could not be found
-	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public ClientExtensionEntryRel
 		fetchClientExtensionEntryRelByExternalReferenceCode(
-			long companyId, String externalReferenceCode);
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchClientExtensionEntryRelByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public ClientExtensionEntryRel fetchClientExtensionEntryRelByReferenceCode(
-		long companyId, String externalReferenceCode);
+			String externalReferenceCode, long companyId);
 
 	/**
 	 * Returns the client extension entry rel matching the UUID and group.
@@ -276,18 +261,10 @@ public interface ClientExtensionEntryRelLocalService
 			long clientExtensionEntryRelId)
 		throws PortalException;
 
-	/**
-	 * Returns the client extension entry rel with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the client extension entry rel's external reference code
-	 * @return the matching client extension entry rel
-	 * @throws PortalException if a matching client extension entry rel could not be found
-	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public ClientExtensionEntryRel
 			getClientExtensionEntryRelByExternalReferenceCode(
-				long companyId, String externalReferenceCode)
+				String externalReferenceCode, long companyId)
 		throws PortalException;
 
 	/**

--- a/modules/apps/client-extension/client-extension-api/src/main/java/com/liferay/client/extension/service/ClientExtensionEntryRelLocalServiceUtil.java
+++ b/modules/apps/client-extension/client-extension-api/src/main/java/com/liferay/client/extension/service/ClientExtensionEntryRelLocalServiceUtil.java
@@ -258,31 +258,12 @@ public class ClientExtensionEntryRelLocalServiceUtil {
 			classNameId, classPK, type);
 	}
 
-	/**
-	 * Returns the client extension entry rel with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the client extension entry rel's external reference code
-	 * @return the matching client extension entry rel, or <code>null</code> if a matching client extension entry rel could not be found
-	 */
 	public static ClientExtensionEntryRel
 		fetchClientExtensionEntryRelByExternalReferenceCode(
-			long companyId, String externalReferenceCode) {
+			String externalReferenceCode, long companyId) {
 
 		return getService().fetchClientExtensionEntryRelByExternalReferenceCode(
-			companyId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchClientExtensionEntryRelByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	public static ClientExtensionEntryRel
-		fetchClientExtensionEntryRelByReferenceCode(
-			long companyId, String externalReferenceCode) {
-
-		return getService().fetchClientExtensionEntryRelByReferenceCode(
-			companyId, externalReferenceCode);
+			externalReferenceCode, companyId);
 	}
 
 	/**
@@ -321,21 +302,13 @@ public class ClientExtensionEntryRelLocalServiceUtil {
 			clientExtensionEntryRelId);
 	}
 
-	/**
-	 * Returns the client extension entry rel with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the client extension entry rel's external reference code
-	 * @return the matching client extension entry rel
-	 * @throws PortalException if a matching client extension entry rel could not be found
-	 */
 	public static ClientExtensionEntryRel
 			getClientExtensionEntryRelByExternalReferenceCode(
-				long companyId, String externalReferenceCode)
+				String externalReferenceCode, long companyId)
 		throws PortalException {
 
 		return getService().getClientExtensionEntryRelByExternalReferenceCode(
-			companyId, externalReferenceCode);
+			externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/client-extension/client-extension-api/src/main/java/com/liferay/client/extension/service/ClientExtensionEntryRelLocalServiceWrapper.java
+++ b/modules/apps/client-extension/client-extension-api/src/main/java/com/liferay/client/extension/service/ClientExtensionEntryRelLocalServiceWrapper.java
@@ -289,34 +289,14 @@ public class ClientExtensionEntryRelLocalServiceWrapper
 			fetchClientExtensionEntryRel(classNameId, classPK, type);
 	}
 
-	/**
-	 * Returns the client extension entry rel with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the client extension entry rel's external reference code
-	 * @return the matching client extension entry rel, or <code>null</code> if a matching client extension entry rel could not be found
-	 */
 	@Override
 	public ClientExtensionEntryRel
 		fetchClientExtensionEntryRelByExternalReferenceCode(
-			long companyId, String externalReferenceCode) {
+			String externalReferenceCode, long companyId) {
 
 		return _clientExtensionEntryRelLocalService.
 			fetchClientExtensionEntryRelByExternalReferenceCode(
-				companyId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchClientExtensionEntryRelByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public ClientExtensionEntryRel fetchClientExtensionEntryRelByReferenceCode(
-		long companyId, String externalReferenceCode) {
-
-		return _clientExtensionEntryRelLocalService.
-			fetchClientExtensionEntryRelByReferenceCode(
-				companyId, externalReferenceCode);
+				externalReferenceCode, companyId);
 	}
 
 	/**
@@ -357,23 +337,15 @@ public class ClientExtensionEntryRelLocalServiceWrapper
 			clientExtensionEntryRelId);
 	}
 
-	/**
-	 * Returns the client extension entry rel with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the client extension entry rel's external reference code
-	 * @return the matching client extension entry rel
-	 * @throws PortalException if a matching client extension entry rel could not be found
-	 */
 	@Override
 	public ClientExtensionEntryRel
 			getClientExtensionEntryRelByExternalReferenceCode(
-				long companyId, String externalReferenceCode)
+				String externalReferenceCode, long companyId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _clientExtensionEntryRelLocalService.
 			getClientExtensionEntryRelByExternalReferenceCode(
-				companyId, externalReferenceCode);
+				externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/client-extension/client-extension-api/src/main/java/com/liferay/client/extension/service/persistence/ClientExtensionEntryPersistence.java
+++ b/modules/apps/client-extension/client-extension-api/src/main/java/com/liferay/client/extension/service/persistence/ClientExtensionEntryPersistence.java
@@ -909,57 +909,57 @@ public interface ClientExtensionEntryPersistence
 	public int filterCountByC_T(long companyId, String type);
 
 	/**
-	 * Returns the client extension entry where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchClientExtensionEntryException</code> if it could not be found.
+	 * Returns the client extension entry where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchClientExtensionEntryException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching client extension entry
 	 * @throws NoSuchClientExtensionEntryException if a matching client extension entry could not be found
 	 */
-	public ClientExtensionEntry findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public ClientExtensionEntry findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchClientExtensionEntryException;
 
 	/**
-	 * Returns the client extension entry where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the client extension entry where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching client extension entry, or <code>null</code> if a matching client extension entry could not be found
 	 */
-	public ClientExtensionEntry fetchByC_ERC(
-		long companyId, String externalReferenceCode);
+	public ClientExtensionEntry fetchByERC_C(
+		String externalReferenceCode, long companyId);
 
 	/**
-	 * Returns the client extension entry where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the client extension entry where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching client extension entry, or <code>null</code> if a matching client extension entry could not be found
 	 */
-	public ClientExtensionEntry fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache);
+	public ClientExtensionEntry fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache);
 
 	/**
-	 * Removes the client extension entry where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the client extension entry where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the client extension entry that was removed
 	 */
-	public ClientExtensionEntry removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public ClientExtensionEntry removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchClientExtensionEntryException;
 
 	/**
-	 * Returns the number of client extension entries where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of client extension entries where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching client extension entries
 	 */
-	public int countByC_ERC(long companyId, String externalReferenceCode);
+	public int countByERC_C(String externalReferenceCode, long companyId);
 
 	/**
 	 * Caches the client extension entry in the entity cache if it is enabled.

--- a/modules/apps/client-extension/client-extension-api/src/main/java/com/liferay/client/extension/service/persistence/ClientExtensionEntryRelPersistence.java
+++ b/modules/apps/client-extension/client-extension-api/src/main/java/com/liferay/client/extension/service/persistence/ClientExtensionEntryRelPersistence.java
@@ -871,57 +871,57 @@ public interface ClientExtensionEntryRelPersistence
 	public int countByC_C_T(long classNameId, long classPK, String type);
 
 	/**
-	 * Returns the client extension entry rel where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchClientExtensionEntryRelException</code> if it could not be found.
+	 * Returns the client extension entry rel where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchClientExtensionEntryRelException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching client extension entry rel
 	 * @throws NoSuchClientExtensionEntryRelException if a matching client extension entry rel could not be found
 	 */
-	public ClientExtensionEntryRel findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public ClientExtensionEntryRel findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchClientExtensionEntryRelException;
 
 	/**
-	 * Returns the client extension entry rel where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the client extension entry rel where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching client extension entry rel, or <code>null</code> if a matching client extension entry rel could not be found
 	 */
-	public ClientExtensionEntryRel fetchByC_ERC(
-		long companyId, String externalReferenceCode);
+	public ClientExtensionEntryRel fetchByERC_C(
+		String externalReferenceCode, long companyId);
 
 	/**
-	 * Returns the client extension entry rel where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the client extension entry rel where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching client extension entry rel, or <code>null</code> if a matching client extension entry rel could not be found
 	 */
-	public ClientExtensionEntryRel fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache);
+	public ClientExtensionEntryRel fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache);
 
 	/**
-	 * Removes the client extension entry rel where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the client extension entry rel where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the client extension entry rel that was removed
 	 */
-	public ClientExtensionEntryRel removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public ClientExtensionEntryRel removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchClientExtensionEntryRelException;
 
 	/**
-	 * Returns the number of client extension entry rels where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of client extension entry rels where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching client extension entry rels
 	 */
-	public int countByC_ERC(long companyId, String externalReferenceCode);
+	public int countByERC_C(String externalReferenceCode, long companyId);
 
 	/**
 	 * Caches the client extension entry rel in the entity cache if it is enabled.

--- a/modules/apps/client-extension/client-extension-api/src/main/java/com/liferay/client/extension/service/persistence/ClientExtensionEntryRelUtil.java
+++ b/modules/apps/client-extension/client-extension-api/src/main/java/com/liferay/client/extension/service/persistence/ClientExtensionEntryRelUtil.java
@@ -1151,75 +1151,75 @@ public class ClientExtensionEntryRelUtil {
 	}
 
 	/**
-	 * Returns the client extension entry rel where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchClientExtensionEntryRelException</code> if it could not be found.
+	 * Returns the client extension entry rel where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchClientExtensionEntryRelException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching client extension entry rel
 	 * @throws NoSuchClientExtensionEntryRelException if a matching client extension entry rel could not be found
 	 */
-	public static ClientExtensionEntryRel findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public static ClientExtensionEntryRel findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws com.liferay.client.extension.exception.
 			NoSuchClientExtensionEntryRelException {
 
-		return getPersistence().findByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().findByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the client extension entry rel where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the client extension entry rel where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching client extension entry rel, or <code>null</code> if a matching client extension entry rel could not be found
 	 */
-	public static ClientExtensionEntryRel fetchByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public static ClientExtensionEntryRel fetchByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return getPersistence().fetchByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().fetchByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the client extension entry rel where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the client extension entry rel where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching client extension entry rel, or <code>null</code> if a matching client extension entry rel could not be found
 	 */
-	public static ClientExtensionEntryRel fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache) {
+	public static ClientExtensionEntryRel fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache) {
 
-		return getPersistence().fetchByC_ERC(
-			companyId, externalReferenceCode, useFinderCache);
+		return getPersistence().fetchByERC_C(
+			externalReferenceCode, companyId, useFinderCache);
 	}
 
 	/**
-	 * Removes the client extension entry rel where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the client extension entry rel where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the client extension entry rel that was removed
 	 */
-	public static ClientExtensionEntryRel removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public static ClientExtensionEntryRel removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws com.liferay.client.extension.exception.
 			NoSuchClientExtensionEntryRelException {
 
-		return getPersistence().removeByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().removeByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the number of client extension entry rels where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of client extension entry rels where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching client extension entry rels
 	 */
-	public static int countByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public static int countByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return getPersistence().countByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().countByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/client-extension/client-extension-api/src/main/java/com/liferay/client/extension/service/persistence/ClientExtensionEntryUtil.java
+++ b/modules/apps/client-extension/client-extension-api/src/main/java/com/liferay/client/extension/service/persistence/ClientExtensionEntryUtil.java
@@ -1176,75 +1176,75 @@ public class ClientExtensionEntryUtil {
 	}
 
 	/**
-	 * Returns the client extension entry where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchClientExtensionEntryException</code> if it could not be found.
+	 * Returns the client extension entry where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchClientExtensionEntryException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching client extension entry
 	 * @throws NoSuchClientExtensionEntryException if a matching client extension entry could not be found
 	 */
-	public static ClientExtensionEntry findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public static ClientExtensionEntry findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws com.liferay.client.extension.exception.
 			NoSuchClientExtensionEntryException {
 
-		return getPersistence().findByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().findByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the client extension entry where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the client extension entry where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching client extension entry, or <code>null</code> if a matching client extension entry could not be found
 	 */
-	public static ClientExtensionEntry fetchByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public static ClientExtensionEntry fetchByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return getPersistence().fetchByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().fetchByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the client extension entry where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the client extension entry where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching client extension entry, or <code>null</code> if a matching client extension entry could not be found
 	 */
-	public static ClientExtensionEntry fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache) {
+	public static ClientExtensionEntry fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache) {
 
-		return getPersistence().fetchByC_ERC(
-			companyId, externalReferenceCode, useFinderCache);
+		return getPersistence().fetchByERC_C(
+			externalReferenceCode, companyId, useFinderCache);
 	}
 
 	/**
-	 * Removes the client extension entry where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the client extension entry where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the client extension entry that was removed
 	 */
-	public static ClientExtensionEntry removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public static ClientExtensionEntry removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws com.liferay.client.extension.exception.
 			NoSuchClientExtensionEntryException {
 
-		return getPersistence().removeByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().removeByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the number of client extension entries where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of client extension entries where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching client extension entries
 	 */
-	public static int countByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public static int countByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return getPersistence().countByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().countByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/client-extension/client-extension-api/src/main/resources/com/liferay/client/extension/exception/packageinfo
+++ b/modules/apps/client-extension/client-extension-api/src/main/resources/com/liferay/client/extension/exception/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 3.0.0

--- a/modules/apps/client-extension/client-extension-api/src/main/resources/com/liferay/client/extension/service/packageinfo
+++ b/modules/apps/client-extension/client-extension-api/src/main/resources/com/liferay/client/extension/service/packageinfo
@@ -1,1 +1,1 @@
-version 4.0.0
+version 5.0.0

--- a/modules/apps/client-extension/client-extension-api/src/main/resources/com/liferay/client/extension/service/persistence/packageinfo
+++ b/modules/apps/client-extension/client-extension-api/src/main/resources/com/liferay/client/extension/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 1.4.0
+version 2.0.0

--- a/modules/apps/client-extension/client-extension-service/service.xml
+++ b/modules/apps/client-extension/client-extension-service/service.xml
@@ -86,6 +86,5 @@
 	<exceptions>
 		<exception>ClientExtensionEntryType</exception>
 		<exception>ClientExtensionEntryTypeSettings</exception>
-		<exception>DuplicateClientExtensionEntryExternalReferenceCode</exception>
 	</exceptions>
 </service-builder>

--- a/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/service/base/ClientExtensionEntryLocalServiceBaseImpl.java
+++ b/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/service/base/ClientExtensionEntryLocalServiceBaseImpl.java
@@ -293,49 +293,22 @@ public abstract class ClientExtensionEntryLocalServiceBaseImpl
 			uuid, companyId, null);
 	}
 
-	/**
-	 * Returns the client extension entry with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the client extension entry's external reference code
-	 * @return the matching client extension entry, or <code>null</code> if a matching client extension entry could not be found
-	 */
 	@Override
 	public ClientExtensionEntry
 		fetchClientExtensionEntryByExternalReferenceCode(
-			long companyId, String externalReferenceCode) {
+			String externalReferenceCode, long companyId) {
 
-		return clientExtensionEntryPersistence.fetchByC_ERC(
-			companyId, externalReferenceCode);
+		return clientExtensionEntryPersistence.fetchByERC_C(
+			externalReferenceCode, companyId);
 	}
 
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchClientExtensionEntryByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public ClientExtensionEntry fetchClientExtensionEntryByReferenceCode(
-		long companyId, String externalReferenceCode) {
-
-		return fetchClientExtensionEntryByExternalReferenceCode(
-			companyId, externalReferenceCode);
-	}
-
-	/**
-	 * Returns the client extension entry with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the client extension entry's external reference code
-	 * @return the matching client extension entry
-	 * @throws PortalException if a matching client extension entry could not be found
-	 */
 	@Override
 	public ClientExtensionEntry getClientExtensionEntryByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
+			String externalReferenceCode, long companyId)
 		throws PortalException {
 
-		return clientExtensionEntryPersistence.findByC_ERC(
-			companyId, externalReferenceCode);
+		return clientExtensionEntryPersistence.findByERC_C(
+			externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/service/base/ClientExtensionEntryRelLocalServiceBaseImpl.java
+++ b/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/service/base/ClientExtensionEntryRelLocalServiceBaseImpl.java
@@ -288,50 +288,23 @@ public abstract class ClientExtensionEntryRelLocalServiceBaseImpl
 		return clientExtensionEntryRelPersistence.fetchByUUID_G(uuid, groupId);
 	}
 
-	/**
-	 * Returns the client extension entry rel with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the client extension entry rel's external reference code
-	 * @return the matching client extension entry rel, or <code>null</code> if a matching client extension entry rel could not be found
-	 */
 	@Override
 	public ClientExtensionEntryRel
 		fetchClientExtensionEntryRelByExternalReferenceCode(
-			long companyId, String externalReferenceCode) {
+			String externalReferenceCode, long companyId) {
 
-		return clientExtensionEntryRelPersistence.fetchByC_ERC(
-			companyId, externalReferenceCode);
+		return clientExtensionEntryRelPersistence.fetchByERC_C(
+			externalReferenceCode, companyId);
 	}
 
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchClientExtensionEntryRelByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public ClientExtensionEntryRel fetchClientExtensionEntryRelByReferenceCode(
-		long companyId, String externalReferenceCode) {
-
-		return fetchClientExtensionEntryRelByExternalReferenceCode(
-			companyId, externalReferenceCode);
-	}
-
-	/**
-	 * Returns the client extension entry rel with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the client extension entry rel's external reference code
-	 * @return the matching client extension entry rel
-	 * @throws PortalException if a matching client extension entry rel could not be found
-	 */
 	@Override
 	public ClientExtensionEntryRel
 			getClientExtensionEntryRelByExternalReferenceCode(
-				long companyId, String externalReferenceCode)
+				String externalReferenceCode, long companyId)
 		throws PortalException {
 
-		return clientExtensionEntryRelPersistence.findByC_ERC(
-			companyId, externalReferenceCode);
+		return clientExtensionEntryRelPersistence.findByERC_C(
+			externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/service/impl/ClientExtensionEntryLocalServiceImpl.java
+++ b/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/service/impl/ClientExtensionEntryLocalServiceImpl.java
@@ -14,7 +14,6 @@
 
 package com.liferay.client.extension.service.impl;
 
-import com.liferay.client.extension.exception.DuplicateClientExtensionEntryExternalReferenceCodeException;
 import com.liferay.client.extension.model.ClientExtensionEntry;
 import com.liferay.client.extension.service.ClientExtensionEntryRelLocalService;
 import com.liferay.client.extension.service.base.ClientExtensionEntryLocalServiceBaseImpl;
@@ -95,9 +94,6 @@ public class ClientExtensionEntryLocalServiceImpl
 
 		User user = _userLocalService.getUser(userId);
 
-		_validateExternalReferenceCode(
-			user.getCompanyId(), externalReferenceCode);
-
 		_validateTypeSettings(typeSettings, null, type);
 
 		clientExtensionEntry.setExternalReferenceCode(externalReferenceCode);
@@ -135,7 +131,7 @@ public class ClientExtensionEntryLocalServiceImpl
 		ClientExtensionEntry clientExtensionEntry =
 			clientExtensionEntryLocalService.
 				fetchClientExtensionEntryByExternalReferenceCode(
-					user.getCompanyId(), externalReferenceCode);
+					externalReferenceCode, user.getCompanyId());
 
 		if (clientExtensionEntry != null) {
 			return clientExtensionEntryLocalService.updateClientExtensionEntry(
@@ -464,24 +460,6 @@ public class ClientExtensionEntryLocalServiceImpl
 			ClientExtensionEntry.class.getName(),
 			clientExtensionEntry.getClientExtensionEntryId(),
 			clientExtensionEntry, serviceContext, new HashMap<>());
-	}
-
-	private void _validateExternalReferenceCode(
-			long companyId, String externalReferenceCode)
-		throws DuplicateClientExtensionEntryExternalReferenceCodeException {
-
-		if (Validator.isNull(externalReferenceCode)) {
-			return;
-		}
-
-		ClientExtensionEntry clientExtensionEntry =
-			clientExtensionEntryLocalService.
-				fetchClientExtensionEntryByExternalReferenceCode(
-					companyId, externalReferenceCode);
-
-		if (clientExtensionEntry != null) {
-			throw new DuplicateClientExtensionEntryExternalReferenceCodeException();
-		}
 	}
 
 	private void _validateTypeSettings(

--- a/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/service/impl/ClientExtensionEntryServiceImpl.java
+++ b/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/service/impl/ClientExtensionEntryServiceImpl.java
@@ -76,8 +76,8 @@ public class ClientExtensionEntryServiceImpl
 		throws PortalException {
 
 		ClientExtensionEntry clientExtensionEntry =
-			clientExtensionEntryPersistence.findByC_ERC(
-				companyId, externalReferenceCode);
+			clientExtensionEntryPersistence.findByERC_C(
+				externalReferenceCode, companyId);
 
 		return deleteClientExtensionEntry(
 			clientExtensionEntry.getClientExtensionEntryId());
@@ -90,8 +90,8 @@ public class ClientExtensionEntryServiceImpl
 		throws PortalException {
 
 		ClientExtensionEntry clientExtensionEntry =
-			clientExtensionEntryPersistence.fetchByC_ERC(
-				companyId, externalReferenceCode);
+			clientExtensionEntryPersistence.fetchByERC_C(
+				externalReferenceCode, companyId);
 
 		if (clientExtensionEntry != null) {
 			_clientExtensionEntryModelResourcePermission.check(

--- a/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/service/persistence/impl/ClientExtensionEntryPersistenceImpl.java
+++ b/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/service/persistence/impl/ClientExtensionEntryPersistenceImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.client.extension.service.persistence.impl;
 
+import com.liferay.client.extension.exception.DuplicateClientExtensionEntryExternalReferenceCodeException;
 import com.liferay.client.extension.exception.NoSuchClientExtensionEntryException;
 import com.liferay.client.extension.model.ClientExtensionEntry;
 import com.liferay.client.extension.model.ClientExtensionEntryTable;
@@ -4103,35 +4104,35 @@ public class ClientExtensionEntryPersistenceImpl
 	private static final String _FINDER_COLUMN_C_T_TYPE_3_SQL =
 		"(clientExtensionEntry.type_ IS NULL OR clientExtensionEntry.type_ = '')";
 
-	private FinderPath _finderPathFetchByC_ERC;
-	private FinderPath _finderPathCountByC_ERC;
+	private FinderPath _finderPathFetchByERC_C;
+	private FinderPath _finderPathCountByERC_C;
 
 	/**
-	 * Returns the client extension entry where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchClientExtensionEntryException</code> if it could not be found.
+	 * Returns the client extension entry where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchClientExtensionEntryException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching client extension entry
 	 * @throws NoSuchClientExtensionEntryException if a matching client extension entry could not be found
 	 */
 	@Override
-	public ClientExtensionEntry findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public ClientExtensionEntry findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchClientExtensionEntryException {
 
-		ClientExtensionEntry clientExtensionEntry = fetchByC_ERC(
-			companyId, externalReferenceCode);
+		ClientExtensionEntry clientExtensionEntry = fetchByERC_C(
+			externalReferenceCode, companyId);
 
 		if (clientExtensionEntry == null) {
 			StringBundler sb = new StringBundler(6);
 
 			sb.append(_NO_SUCH_ENTITY_WITH_KEY);
 
-			sb.append("companyId=");
-			sb.append(companyId);
-
-			sb.append(", externalReferenceCode=");
+			sb.append("externalReferenceCode=");
 			sb.append(externalReferenceCode);
+
+			sb.append(", companyId=");
+			sb.append(companyId);
 
 			sb.append("}");
 
@@ -4146,30 +4147,30 @@ public class ClientExtensionEntryPersistenceImpl
 	}
 
 	/**
-	 * Returns the client extension entry where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the client extension entry where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching client extension entry, or <code>null</code> if a matching client extension entry could not be found
 	 */
 	@Override
-	public ClientExtensionEntry fetchByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public ClientExtensionEntry fetchByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return fetchByC_ERC(companyId, externalReferenceCode, true);
+		return fetchByERC_C(externalReferenceCode, companyId, true);
 	}
 
 	/**
-	 * Returns the client extension entry where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the client extension entry where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching client extension entry, or <code>null</code> if a matching client extension entry could not be found
 	 */
 	@Override
-	public ClientExtensionEntry fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache) {
+	public ClientExtensionEntry fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache) {
 
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
@@ -4179,24 +4180,24 @@ public class ClientExtensionEntryPersistenceImpl
 		Object[] finderArgs = null;
 
 		if (useFinderCache && productionMode) {
-			finderArgs = new Object[] {companyId, externalReferenceCode};
+			finderArgs = new Object[] {externalReferenceCode, companyId};
 		}
 
 		Object result = null;
 
 		if (useFinderCache && productionMode) {
 			result = finderCache.getResult(
-				_finderPathFetchByC_ERC, finderArgs, this);
+				_finderPathFetchByERC_C, finderArgs, this);
 		}
 
 		if (result instanceof ClientExtensionEntry) {
 			ClientExtensionEntry clientExtensionEntry =
 				(ClientExtensionEntry)result;
 
-			if ((companyId != clientExtensionEntry.getCompanyId()) ||
-				!Objects.equals(
+			if (!Objects.equals(
 					externalReferenceCode,
-					clientExtensionEntry.getExternalReferenceCode())) {
+					clientExtensionEntry.getExternalReferenceCode()) ||
+				(companyId != clientExtensionEntry.getCompanyId())) {
 
 				result = null;
 			}
@@ -4207,18 +4208,18 @@ public class ClientExtensionEntryPersistenceImpl
 
 			sb.append(_SQL_SELECT_CLIENTEXTENSIONENTRY_WHERE);
 
-			sb.append(_FINDER_COLUMN_C_ERC_COMPANYID_2);
-
 			boolean bindExternalReferenceCode = false;
 
 			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3);
 			}
 			else {
 				bindExternalReferenceCode = true;
 
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2);
 			}
+
+			sb.append(_FINDER_COLUMN_ERC_C_COMPANYID_2);
 
 			String sql = sb.toString();
 
@@ -4231,18 +4232,18 @@ public class ClientExtensionEntryPersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
-				queryPos.add(companyId);
-
 				if (bindExternalReferenceCode) {
 					queryPos.add(externalReferenceCode);
 				}
+
+				queryPos.add(companyId);
 
 				List<ClientExtensionEntry> list = query.list();
 
 				if (list.isEmpty()) {
 					if (useFinderCache && productionMode) {
 						finderCache.putResult(
-							_finderPathFetchByC_ERC, finderArgs, list);
+							_finderPathFetchByERC_C, finderArgs, list);
 					}
 				}
 				else {
@@ -4270,32 +4271,32 @@ public class ClientExtensionEntryPersistenceImpl
 	}
 
 	/**
-	 * Removes the client extension entry where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the client extension entry where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the client extension entry that was removed
 	 */
 	@Override
-	public ClientExtensionEntry removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public ClientExtensionEntry removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchClientExtensionEntryException {
 
-		ClientExtensionEntry clientExtensionEntry = findByC_ERC(
-			companyId, externalReferenceCode);
+		ClientExtensionEntry clientExtensionEntry = findByERC_C(
+			externalReferenceCode, companyId);
 
 		return remove(clientExtensionEntry);
 	}
 
 	/**
-	 * Returns the number of client extension entries where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of client extension entries where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching client extension entries
 	 */
 	@Override
-	public int countByC_ERC(long companyId, String externalReferenceCode) {
+	public int countByERC_C(String externalReferenceCode, long companyId) {
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
 		boolean productionMode = ctPersistenceHelper.isProductionMode(
@@ -4307,9 +4308,9 @@ public class ClientExtensionEntryPersistenceImpl
 		Long count = null;
 
 		if (productionMode) {
-			finderPath = _finderPathCountByC_ERC;
+			finderPath = _finderPathCountByERC_C;
 
-			finderArgs = new Object[] {companyId, externalReferenceCode};
+			finderArgs = new Object[] {externalReferenceCode, companyId};
 
 			count = (Long)finderCache.getResult(finderPath, finderArgs, this);
 		}
@@ -4319,18 +4320,18 @@ public class ClientExtensionEntryPersistenceImpl
 
 			sb.append(_SQL_COUNT_CLIENTEXTENSIONENTRY_WHERE);
 
-			sb.append(_FINDER_COLUMN_C_ERC_COMPANYID_2);
-
 			boolean bindExternalReferenceCode = false;
 
 			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3);
 			}
 			else {
 				bindExternalReferenceCode = true;
 
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2);
 			}
+
+			sb.append(_FINDER_COLUMN_ERC_C_COMPANYID_2);
 
 			String sql = sb.toString();
 
@@ -4343,11 +4344,11 @@ public class ClientExtensionEntryPersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
-				queryPos.add(companyId);
-
 				if (bindExternalReferenceCode) {
 					queryPos.add(externalReferenceCode);
 				}
+
+				queryPos.add(companyId);
 
 				count = (Long)query.uniqueResult();
 
@@ -4366,14 +4367,14 @@ public class ClientExtensionEntryPersistenceImpl
 		return count.intValue();
 	}
 
-	private static final String _FINDER_COLUMN_C_ERC_COMPANYID_2 =
-		"clientExtensionEntry.companyId = ? AND ";
+	private static final String _FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2 =
+		"clientExtensionEntry.externalReferenceCode = ? AND ";
 
-	private static final String _FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2 =
-		"clientExtensionEntry.externalReferenceCode = ?";
+	private static final String _FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3 =
+		"(clientExtensionEntry.externalReferenceCode IS NULL OR clientExtensionEntry.externalReferenceCode = '') AND ";
 
-	private static final String _FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3 =
-		"(clientExtensionEntry.externalReferenceCode IS NULL OR clientExtensionEntry.externalReferenceCode = '')";
+	private static final String _FINDER_COLUMN_ERC_C_COMPANYID_2 =
+		"clientExtensionEntry.companyId = ?";
 
 	public ClientExtensionEntryPersistenceImpl() {
 		Map<String, String> dbColumnNames = new HashMap<String, String>();
@@ -4407,10 +4408,10 @@ public class ClientExtensionEntryPersistenceImpl
 			clientExtensionEntry.getPrimaryKey(), clientExtensionEntry);
 
 		finderCache.putResult(
-			_finderPathFetchByC_ERC,
+			_finderPathFetchByERC_C,
 			new Object[] {
-				clientExtensionEntry.getCompanyId(),
-				clientExtensionEntry.getExternalReferenceCode()
+				clientExtensionEntry.getExternalReferenceCode(),
+				clientExtensionEntry.getCompanyId()
 			},
 			clientExtensionEntry);
 	}
@@ -4499,13 +4500,13 @@ public class ClientExtensionEntryPersistenceImpl
 		ClientExtensionEntryModelImpl clientExtensionEntryModelImpl) {
 
 		Object[] args = new Object[] {
-			clientExtensionEntryModelImpl.getCompanyId(),
-			clientExtensionEntryModelImpl.getExternalReferenceCode()
+			clientExtensionEntryModelImpl.getExternalReferenceCode(),
+			clientExtensionEntryModelImpl.getCompanyId()
 		};
 
-		finderCache.putResult(_finderPathCountByC_ERC, args, Long.valueOf(1));
+		finderCache.putResult(_finderPathCountByERC_C, args, Long.valueOf(1));
 		finderCache.putResult(
-			_finderPathFetchByC_ERC, args, clientExtensionEntryModelImpl);
+			_finderPathFetchByERC_C, args, clientExtensionEntryModelImpl);
 	}
 
 	/**
@@ -4657,6 +4658,25 @@ public class ClientExtensionEntryPersistenceImpl
 		if (Validator.isNull(clientExtensionEntry.getExternalReferenceCode())) {
 			clientExtensionEntry.setExternalReferenceCode(
 				clientExtensionEntry.getUuid());
+		}
+		else {
+			ClientExtensionEntry ercClientExtensionEntry = fetchByERC_C(
+				clientExtensionEntry.getExternalReferenceCode(),
+				clientExtensionEntry.getCompanyId());
+
+			if (isNew) {
+				if (ercClientExtensionEntry != null) {
+					throw new DuplicateClientExtensionEntryExternalReferenceCodeException();
+				}
+			}
+			else {
+				if ((ercClientExtensionEntry != null) &&
+					(clientExtensionEntry.getClientExtensionEntryId() !=
+						ercClientExtensionEntry.getClientExtensionEntryId())) {
+
+					throw new DuplicateClientExtensionEntryExternalReferenceCodeException();
+				}
+			}
 		}
 
 		ServiceContext serviceContext =
@@ -5233,7 +5253,7 @@ public class ClientExtensionEntryPersistenceImpl
 			CTColumnResolutionType.STRICT, ctStrictColumnNames);
 
 		_uniqueIndexColumnNames.add(
-			new String[] {"companyId", "externalReferenceCode"});
+			new String[] {"externalReferenceCode", "companyId"});
 	}
 
 	/**
@@ -5330,15 +5350,15 @@ public class ClientExtensionEntryPersistenceImpl
 			new String[] {Long.class.getName(), String.class.getName()},
 			new String[] {"companyId", "type_"}, false);
 
-		_finderPathFetchByC_ERC = new FinderPath(
-			FINDER_CLASS_NAME_ENTITY, "fetchByC_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"companyId", "externalReferenceCode"}, true);
+		_finderPathFetchByERC_C = new FinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, true);
 
-		_finderPathCountByC_ERC = new FinderPath(
-			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"companyId", "externalReferenceCode"}, false);
+		_finderPathCountByERC_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, false);
 
 		_setClientExtensionEntryUtilPersistence(this);
 	}

--- a/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/service/persistence/impl/ClientExtensionEntryPersistenceImpl.java
+++ b/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/service/persistence/impl/ClientExtensionEntryPersistenceImpl.java
@@ -4666,7 +4666,9 @@ public class ClientExtensionEntryPersistenceImpl
 
 			if (isNew) {
 				if (ercClientExtensionEntry != null) {
-					throw new DuplicateClientExtensionEntryExternalReferenceCodeException();
+					throw new DuplicateClientExtensionEntryExternalReferenceCodeException(
+						"Duplicate ClientExtensionEntry with external reference code " +
+							clientExtensionEntry.getExternalReferenceCode());
 				}
 			}
 			else {
@@ -4674,7 +4676,9 @@ public class ClientExtensionEntryPersistenceImpl
 					(clientExtensionEntry.getClientExtensionEntryId() !=
 						ercClientExtensionEntry.getClientExtensionEntryId())) {
 
-					throw new DuplicateClientExtensionEntryExternalReferenceCodeException();
+					throw new DuplicateClientExtensionEntryExternalReferenceCodeException(
+						"Duplicate ClientExtensionEntry with external reference code " +
+							clientExtensionEntry.getExternalReferenceCode());
 				}
 			}
 		}

--- a/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/service/persistence/impl/ClientExtensionEntryRelPersistenceImpl.java
+++ b/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/service/persistence/impl/ClientExtensionEntryRelPersistenceImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.client.extension.service.persistence.impl;
 
+import com.liferay.client.extension.exception.DuplicateClientExtensionEntryRelExternalReferenceCodeException;
 import com.liferay.client.extension.exception.NoSuchClientExtensionEntryRelException;
 import com.liferay.client.extension.model.ClientExtensionEntryRel;
 import com.liferay.client.extension.model.ClientExtensionEntryRelTable;
@@ -3352,35 +3353,35 @@ public class ClientExtensionEntryRelPersistenceImpl
 	private static final String _FINDER_COLUMN_C_C_T_TYPE_3 =
 		"(clientExtensionEntryRel.type IS NULL OR clientExtensionEntryRel.type = '')";
 
-	private FinderPath _finderPathFetchByC_ERC;
-	private FinderPath _finderPathCountByC_ERC;
+	private FinderPath _finderPathFetchByERC_C;
+	private FinderPath _finderPathCountByERC_C;
 
 	/**
-	 * Returns the client extension entry rel where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchClientExtensionEntryRelException</code> if it could not be found.
+	 * Returns the client extension entry rel where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchClientExtensionEntryRelException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching client extension entry rel
 	 * @throws NoSuchClientExtensionEntryRelException if a matching client extension entry rel could not be found
 	 */
 	@Override
-	public ClientExtensionEntryRel findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public ClientExtensionEntryRel findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchClientExtensionEntryRelException {
 
-		ClientExtensionEntryRel clientExtensionEntryRel = fetchByC_ERC(
-			companyId, externalReferenceCode);
+		ClientExtensionEntryRel clientExtensionEntryRel = fetchByERC_C(
+			externalReferenceCode, companyId);
 
 		if (clientExtensionEntryRel == null) {
 			StringBundler sb = new StringBundler(6);
 
 			sb.append(_NO_SUCH_ENTITY_WITH_KEY);
 
-			sb.append("companyId=");
-			sb.append(companyId);
-
-			sb.append(", externalReferenceCode=");
+			sb.append("externalReferenceCode=");
 			sb.append(externalReferenceCode);
+
+			sb.append(", companyId=");
+			sb.append(companyId);
 
 			sb.append("}");
 
@@ -3395,30 +3396,30 @@ public class ClientExtensionEntryRelPersistenceImpl
 	}
 
 	/**
-	 * Returns the client extension entry rel where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the client extension entry rel where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching client extension entry rel, or <code>null</code> if a matching client extension entry rel could not be found
 	 */
 	@Override
-	public ClientExtensionEntryRel fetchByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public ClientExtensionEntryRel fetchByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return fetchByC_ERC(companyId, externalReferenceCode, true);
+		return fetchByERC_C(externalReferenceCode, companyId, true);
 	}
 
 	/**
-	 * Returns the client extension entry rel where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the client extension entry rel where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching client extension entry rel, or <code>null</code> if a matching client extension entry rel could not be found
 	 */
 	@Override
-	public ClientExtensionEntryRel fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache) {
+	public ClientExtensionEntryRel fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache) {
 
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
@@ -3428,24 +3429,24 @@ public class ClientExtensionEntryRelPersistenceImpl
 		Object[] finderArgs = null;
 
 		if (useFinderCache && productionMode) {
-			finderArgs = new Object[] {companyId, externalReferenceCode};
+			finderArgs = new Object[] {externalReferenceCode, companyId};
 		}
 
 		Object result = null;
 
 		if (useFinderCache && productionMode) {
 			result = finderCache.getResult(
-				_finderPathFetchByC_ERC, finderArgs, this);
+				_finderPathFetchByERC_C, finderArgs, this);
 		}
 
 		if (result instanceof ClientExtensionEntryRel) {
 			ClientExtensionEntryRel clientExtensionEntryRel =
 				(ClientExtensionEntryRel)result;
 
-			if ((companyId != clientExtensionEntryRel.getCompanyId()) ||
-				!Objects.equals(
+			if (!Objects.equals(
 					externalReferenceCode,
-					clientExtensionEntryRel.getExternalReferenceCode())) {
+					clientExtensionEntryRel.getExternalReferenceCode()) ||
+				(companyId != clientExtensionEntryRel.getCompanyId())) {
 
 				result = null;
 			}
@@ -3456,18 +3457,18 @@ public class ClientExtensionEntryRelPersistenceImpl
 
 			sb.append(_SQL_SELECT_CLIENTEXTENSIONENTRYREL_WHERE);
 
-			sb.append(_FINDER_COLUMN_C_ERC_COMPANYID_2);
-
 			boolean bindExternalReferenceCode = false;
 
 			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3);
 			}
 			else {
 				bindExternalReferenceCode = true;
 
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2);
 			}
+
+			sb.append(_FINDER_COLUMN_ERC_C_COMPANYID_2);
 
 			String sql = sb.toString();
 
@@ -3480,18 +3481,18 @@ public class ClientExtensionEntryRelPersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
-				queryPos.add(companyId);
-
 				if (bindExternalReferenceCode) {
 					queryPos.add(externalReferenceCode);
 				}
+
+				queryPos.add(companyId);
 
 				List<ClientExtensionEntryRel> list = query.list();
 
 				if (list.isEmpty()) {
 					if (useFinderCache && productionMode) {
 						finderCache.putResult(
-							_finderPathFetchByC_ERC, finderArgs, list);
+							_finderPathFetchByERC_C, finderArgs, list);
 					}
 				}
 				else {
@@ -3520,32 +3521,32 @@ public class ClientExtensionEntryRelPersistenceImpl
 	}
 
 	/**
-	 * Removes the client extension entry rel where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the client extension entry rel where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the client extension entry rel that was removed
 	 */
 	@Override
-	public ClientExtensionEntryRel removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public ClientExtensionEntryRel removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchClientExtensionEntryRelException {
 
-		ClientExtensionEntryRel clientExtensionEntryRel = findByC_ERC(
-			companyId, externalReferenceCode);
+		ClientExtensionEntryRel clientExtensionEntryRel = findByERC_C(
+			externalReferenceCode, companyId);
 
 		return remove(clientExtensionEntryRel);
 	}
 
 	/**
-	 * Returns the number of client extension entry rels where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of client extension entry rels where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching client extension entry rels
 	 */
 	@Override
-	public int countByC_ERC(long companyId, String externalReferenceCode) {
+	public int countByERC_C(String externalReferenceCode, long companyId) {
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
 		boolean productionMode = ctPersistenceHelper.isProductionMode(
@@ -3557,9 +3558,9 @@ public class ClientExtensionEntryRelPersistenceImpl
 		Long count = null;
 
 		if (productionMode) {
-			finderPath = _finderPathCountByC_ERC;
+			finderPath = _finderPathCountByERC_C;
 
-			finderArgs = new Object[] {companyId, externalReferenceCode};
+			finderArgs = new Object[] {externalReferenceCode, companyId};
 
 			count = (Long)finderCache.getResult(finderPath, finderArgs, this);
 		}
@@ -3569,18 +3570,18 @@ public class ClientExtensionEntryRelPersistenceImpl
 
 			sb.append(_SQL_COUNT_CLIENTEXTENSIONENTRYREL_WHERE);
 
-			sb.append(_FINDER_COLUMN_C_ERC_COMPANYID_2);
-
 			boolean bindExternalReferenceCode = false;
 
 			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3);
 			}
 			else {
 				bindExternalReferenceCode = true;
 
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2);
 			}
+
+			sb.append(_FINDER_COLUMN_ERC_C_COMPANYID_2);
 
 			String sql = sb.toString();
 
@@ -3593,11 +3594,11 @@ public class ClientExtensionEntryRelPersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
-				queryPos.add(companyId);
-
 				if (bindExternalReferenceCode) {
 					queryPos.add(externalReferenceCode);
 				}
+
+				queryPos.add(companyId);
 
 				count = (Long)query.uniqueResult();
 
@@ -3616,14 +3617,14 @@ public class ClientExtensionEntryRelPersistenceImpl
 		return count.intValue();
 	}
 
-	private static final String _FINDER_COLUMN_C_ERC_COMPANYID_2 =
-		"clientExtensionEntryRel.companyId = ? AND ";
+	private static final String _FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2 =
+		"clientExtensionEntryRel.externalReferenceCode = ? AND ";
 
-	private static final String _FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2 =
-		"clientExtensionEntryRel.externalReferenceCode = ?";
+	private static final String _FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3 =
+		"(clientExtensionEntryRel.externalReferenceCode IS NULL OR clientExtensionEntryRel.externalReferenceCode = '') AND ";
 
-	private static final String _FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3 =
-		"(clientExtensionEntryRel.externalReferenceCode IS NULL OR clientExtensionEntryRel.externalReferenceCode = '')";
+	private static final String _FINDER_COLUMN_ERC_C_COMPANYID_2 =
+		"clientExtensionEntryRel.companyId = ?";
 
 	public ClientExtensionEntryRelPersistenceImpl() {
 		Map<String, String> dbColumnNames = new HashMap<String, String>();
@@ -3665,10 +3666,10 @@ public class ClientExtensionEntryRelPersistenceImpl
 			clientExtensionEntryRel);
 
 		finderCache.putResult(
-			_finderPathFetchByC_ERC,
+			_finderPathFetchByERC_C,
 			new Object[] {
-				clientExtensionEntryRel.getCompanyId(),
-				clientExtensionEntryRel.getExternalReferenceCode()
+				clientExtensionEntryRel.getExternalReferenceCode(),
+				clientExtensionEntryRel.getCompanyId()
 			},
 			clientExtensionEntryRel);
 	}
@@ -3770,13 +3771,13 @@ public class ClientExtensionEntryRelPersistenceImpl
 			_finderPathFetchByUUID_G, args, clientExtensionEntryRelModelImpl);
 
 		args = new Object[] {
-			clientExtensionEntryRelModelImpl.getCompanyId(),
-			clientExtensionEntryRelModelImpl.getExternalReferenceCode()
+			clientExtensionEntryRelModelImpl.getExternalReferenceCode(),
+			clientExtensionEntryRelModelImpl.getCompanyId()
 		};
 
-		finderCache.putResult(_finderPathCountByC_ERC, args, Long.valueOf(1));
+		finderCache.putResult(_finderPathCountByERC_C, args, Long.valueOf(1));
 		finderCache.putResult(
-			_finderPathFetchByC_ERC, args, clientExtensionEntryRelModelImpl);
+			_finderPathFetchByERC_C, args, clientExtensionEntryRelModelImpl);
 	}
 
 	/**
@@ -3932,6 +3933,26 @@ public class ClientExtensionEntryRelPersistenceImpl
 
 			clientExtensionEntryRel.setExternalReferenceCode(
 				clientExtensionEntryRel.getUuid());
+		}
+		else {
+			ClientExtensionEntryRel ercClientExtensionEntryRel = fetchByERC_C(
+				clientExtensionEntryRel.getExternalReferenceCode(),
+				clientExtensionEntryRel.getCompanyId());
+
+			if (isNew) {
+				if (ercClientExtensionEntryRel != null) {
+					throw new DuplicateClientExtensionEntryRelExternalReferenceCodeException();
+				}
+			}
+			else {
+				if ((ercClientExtensionEntryRel != null) &&
+					(clientExtensionEntryRel.getClientExtensionEntryRelId() !=
+						ercClientExtensionEntryRel.
+							getClientExtensionEntryRelId())) {
+
+					throw new DuplicateClientExtensionEntryRelExternalReferenceCodeException();
+				}
+			}
 		}
 
 		ServiceContext serviceContext =
@@ -4487,7 +4508,7 @@ public class ClientExtensionEntryRelPersistenceImpl
 		_uniqueIndexColumnNames.add(new String[] {"uuid_", "groupId"});
 
 		_uniqueIndexColumnNames.add(
-			new String[] {"companyId", "externalReferenceCode"});
+			new String[] {"externalReferenceCode", "companyId"});
 	}
 
 	/**
@@ -4620,15 +4641,15 @@ public class ClientExtensionEntryRelPersistenceImpl
 			},
 			new String[] {"classNameId", "classPK", "type_"}, false);
 
-		_finderPathFetchByC_ERC = new FinderPath(
-			FINDER_CLASS_NAME_ENTITY, "fetchByC_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"companyId", "externalReferenceCode"}, true);
+		_finderPathFetchByERC_C = new FinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, true);
 
-		_finderPathCountByC_ERC = new FinderPath(
-			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"companyId", "externalReferenceCode"}, false);
+		_finderPathCountByERC_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, false);
 
 		_setClientExtensionEntryRelUtilPersistence(this);
 	}

--- a/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/service/persistence/impl/ClientExtensionEntryRelPersistenceImpl.java
+++ b/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/service/persistence/impl/ClientExtensionEntryRelPersistenceImpl.java
@@ -3941,7 +3941,9 @@ public class ClientExtensionEntryRelPersistenceImpl
 
 			if (isNew) {
 				if (ercClientExtensionEntryRel != null) {
-					throw new DuplicateClientExtensionEntryRelExternalReferenceCodeException();
+					throw new DuplicateClientExtensionEntryRelExternalReferenceCodeException(
+						"Duplicate ClientExtensionEntryRel with external reference code " +
+							clientExtensionEntryRel.getExternalReferenceCode());
 				}
 			}
 			else {
@@ -3950,7 +3952,9 @@ public class ClientExtensionEntryRelPersistenceImpl
 						ercClientExtensionEntryRel.
 							getClientExtensionEntryRelId())) {
 
-					throw new DuplicateClientExtensionEntryRelExternalReferenceCodeException();
+					throw new DuplicateClientExtensionEntryRelExternalReferenceCodeException(
+						"Duplicate ClientExtensionEntryRel with external reference code " +
+							clientExtensionEntryRel.getExternalReferenceCode());
 				}
 			}
 		}

--- a/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/service/persistence/test/ClientExtensionEntryPersistenceTest.java
+++ b/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/service/persistence/test/ClientExtensionEntryPersistenceTest.java
@@ -15,6 +15,7 @@
 package com.liferay.client.extension.service.persistence.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.client.extension.exception.DuplicateClientExtensionEntryExternalReferenceCodeException;
 import com.liferay.client.extension.exception.NoSuchClientExtensionEntryException;
 import com.liferay.client.extension.model.ClientExtensionEntry;
 import com.liferay.client.extension.service.ClientExtensionEntryLocalServiceUtil;
@@ -239,6 +240,30 @@ public class ClientExtensionEntryPersistenceTest {
 			Time.getShortTimestamp(newClientExtensionEntry.getStatusDate()));
 	}
 
+	@Test(
+		expected = DuplicateClientExtensionEntryExternalReferenceCodeException.class
+	)
+	public void testUpdateWithExistingExternalReferenceCode() throws Exception {
+		ClientExtensionEntry clientExtensionEntry = addClientExtensionEntry();
+
+		ClientExtensionEntry newClientExtensionEntry =
+			addClientExtensionEntry();
+
+		newClientExtensionEntry.setCompanyId(
+			clientExtensionEntry.getCompanyId());
+
+		newClientExtensionEntry = _persistence.update(newClientExtensionEntry);
+
+		Session session = _persistence.getCurrentSession();
+
+		session.evict(newClientExtensionEntry);
+
+		newClientExtensionEntry.setExternalReferenceCode(
+			clientExtensionEntry.getExternalReferenceCode());
+
+		_persistence.update(newClientExtensionEntry);
+	}
+
 	@Test
 	public void testCountByUuid() throws Exception {
 		_persistence.countByUuid("");
@@ -274,12 +299,12 @@ public class ClientExtensionEntryPersistenceTest {
 	}
 
 	@Test
-	public void testCountByC_ERC() throws Exception {
-		_persistence.countByC_ERC(RandomTestUtil.nextLong(), "");
+	public void testCountByERC_C() throws Exception {
+		_persistence.countByERC_C("", RandomTestUtil.nextLong());
 
-		_persistence.countByC_ERC(0L, "null");
+		_persistence.countByERC_C("null", 0L);
 
-		_persistence.countByC_ERC(0L, (String)null);
+		_persistence.countByERC_C((String)null, 0L);
 	}
 
 	@Test
@@ -613,15 +638,15 @@ public class ClientExtensionEntryPersistenceTest {
 		ClientExtensionEntry clientExtensionEntry) {
 
 		Assert.assertEquals(
-			Long.valueOf(clientExtensionEntry.getCompanyId()),
-			ReflectionTestUtil.<Long>invoke(
-				clientExtensionEntry, "getColumnOriginalValue",
-				new Class<?>[] {String.class}, "companyId"));
-		Assert.assertEquals(
 			clientExtensionEntry.getExternalReferenceCode(),
 			ReflectionTestUtil.invoke(
 				clientExtensionEntry, "getColumnOriginalValue",
 				new Class<?>[] {String.class}, "externalReferenceCode"));
+		Assert.assertEquals(
+			Long.valueOf(clientExtensionEntry.getCompanyId()),
+			ReflectionTestUtil.<Long>invoke(
+				clientExtensionEntry, "getColumnOriginalValue",
+				new Class<?>[] {String.class}, "companyId"));
 	}
 
 	protected ClientExtensionEntry addClientExtensionEntry() throws Exception {

--- a/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/service/persistence/test/ClientExtensionEntryRelPersistenceTest.java
+++ b/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/service/persistence/test/ClientExtensionEntryRelPersistenceTest.java
@@ -15,6 +15,7 @@
 package com.liferay.client.extension.service.persistence.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.client.extension.exception.DuplicateClientExtensionEntryRelExternalReferenceCodeException;
 import com.liferay.client.extension.exception.NoSuchClientExtensionEntryRelException;
 import com.liferay.client.extension.model.ClientExtensionEntryRel;
 import com.liferay.client.extension.service.ClientExtensionEntryRelLocalServiceUtil;
@@ -230,6 +231,32 @@ public class ClientExtensionEntryRelPersistenceTest {
 				newClientExtensionEntryRel.getLastPublishDate()));
 	}
 
+	@Test(
+		expected = DuplicateClientExtensionEntryRelExternalReferenceCodeException.class
+	)
+	public void testUpdateWithExistingExternalReferenceCode() throws Exception {
+		ClientExtensionEntryRel clientExtensionEntryRel =
+			addClientExtensionEntryRel();
+
+		ClientExtensionEntryRel newClientExtensionEntryRel =
+			addClientExtensionEntryRel();
+
+		newClientExtensionEntryRel.setCompanyId(
+			clientExtensionEntryRel.getCompanyId());
+
+		newClientExtensionEntryRel = _persistence.update(
+			newClientExtensionEntryRel);
+
+		Session session = _persistence.getCurrentSession();
+
+		session.evict(newClientExtensionEntryRel);
+
+		newClientExtensionEntryRel.setExternalReferenceCode(
+			clientExtensionEntryRel.getExternalReferenceCode());
+
+		_persistence.update(newClientExtensionEntryRel);
+	}
+
 	@Test
 	public void testCountByUuid() throws Exception {
 		_persistence.countByUuid("");
@@ -285,12 +312,12 @@ public class ClientExtensionEntryRelPersistenceTest {
 	}
 
 	@Test
-	public void testCountByC_ERC() throws Exception {
-		_persistence.countByC_ERC(RandomTestUtil.nextLong(), "");
+	public void testCountByERC_C() throws Exception {
+		_persistence.countByERC_C("", RandomTestUtil.nextLong());
 
-		_persistence.countByC_ERC(0L, "null");
+		_persistence.countByERC_C("null", 0L);
 
-		_persistence.countByC_ERC(0L, (String)null);
+		_persistence.countByERC_C((String)null, 0L);
 	}
 
 	@Test
@@ -637,15 +664,15 @@ public class ClientExtensionEntryRelPersistenceTest {
 				new Class<?>[] {String.class}, "groupId"));
 
 		Assert.assertEquals(
-			Long.valueOf(clientExtensionEntryRel.getCompanyId()),
-			ReflectionTestUtil.<Long>invoke(
-				clientExtensionEntryRel, "getColumnOriginalValue",
-				new Class<?>[] {String.class}, "companyId"));
-		Assert.assertEquals(
 			clientExtensionEntryRel.getExternalReferenceCode(),
 			ReflectionTestUtil.invoke(
 				clientExtensionEntryRel, "getColumnOriginalValue",
 				new Class<?>[] {String.class}, "externalReferenceCode"));
+		Assert.assertEquals(
+			Long.valueOf(clientExtensionEntryRel.getCompanyId()),
+			ReflectionTestUtil.<Long>invoke(
+				clientExtensionEntryRel, "getColumnOriginalValue",
+				new Class<?>[] {String.class}, "companyId"));
 	}
 
 	protected ClientExtensionEntryRel addClientExtensionEntryRel()

--- a/modules/apps/client-extension/client-extension-type-impl/src/main/java/com/liferay/client/extension/type/internal/manager/CETManagerImpl.java
+++ b/modules/apps/client-extension/client-extension-type-impl/src/main/java/com/liferay/client/extension/type/internal/manager/CETManagerImpl.java
@@ -82,7 +82,7 @@ public class CETManagerImpl implements CETManager {
 		ClientExtensionEntry clientExtensionEntry =
 			_clientExtensionEntryLocalService.
 				fetchClientExtensionEntryByExternalReferenceCode(
-					companyId, externalReferenceCode);
+					externalReferenceCode, companyId);
 
 		if (clientExtensionEntry != null) {
 			try {

--- a/modules/apps/commerce/commerce-account-api/bnd.bnd
+++ b/modules/apps/commerce/commerce-account-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Commerce Account API
 Bundle-SymbolicName: com.liferay.commerce.account.api
-Bundle-Version: 18.3.1
+Bundle-Version: 18.4.0
 Export-Package:\
 	com.liferay.commerce.account.configuration,\
 	com.liferay.commerce.account.constants,\

--- a/modules/apps/commerce/commerce-account-api/src/main/java/com/liferay/commerce/account/exception/DuplicateCommerceAccountExternalReferenceCodeException.java
+++ b/modules/apps/commerce/commerce-account-api/src/main/java/com/liferay/commerce/account/exception/DuplicateCommerceAccountExternalReferenceCodeException.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.commerce.account.exception;
+
+import com.liferay.portal.kernel.exception.SystemException;
+
+/**
+ * @author Marco Leo
+ */
+public class DuplicateCommerceAccountExternalReferenceCodeException
+	extends SystemException {
+
+	public DuplicateCommerceAccountExternalReferenceCodeException() {
+	}
+
+	public DuplicateCommerceAccountExternalReferenceCodeException(String msg) {
+		super(msg);
+	}
+
+	public DuplicateCommerceAccountExternalReferenceCodeException(
+		String msg, Throwable throwable) {
+
+		super(msg, throwable);
+	}
+
+	public DuplicateCommerceAccountExternalReferenceCodeException(
+		Throwable throwable) {
+
+		super(throwable);
+	}
+
+}

--- a/modules/apps/commerce/commerce-account-api/src/main/java/com/liferay/commerce/account/exception/DuplicateCommerceAccountGroupCommerceAccountRelExternalReferenceCodeException.java
+++ b/modules/apps/commerce/commerce-account-api/src/main/java/com/liferay/commerce/account/exception/DuplicateCommerceAccountGroupCommerceAccountRelExternalReferenceCodeException.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.commerce.account.exception;
+
+import com.liferay.portal.kernel.exception.SystemException;
+
+/**
+ * @author Marco Leo
+ */
+public class
+	DuplicateCommerceAccountGroupCommerceAccountRelExternalReferenceCodeException
+		extends SystemException {
+
+	public DuplicateCommerceAccountGroupCommerceAccountRelExternalReferenceCodeException() {
+	}
+
+	public DuplicateCommerceAccountGroupCommerceAccountRelExternalReferenceCodeException(
+		String msg) {
+
+		super(msg);
+	}
+
+	public DuplicateCommerceAccountGroupCommerceAccountRelExternalReferenceCodeException(
+		String msg, Throwable throwable) {
+
+		super(msg, throwable);
+	}
+
+	public DuplicateCommerceAccountGroupCommerceAccountRelExternalReferenceCodeException(
+		Throwable throwable) {
+
+		super(throwable);
+	}
+
+}

--- a/modules/apps/commerce/commerce-account-api/src/main/java/com/liferay/commerce/account/exception/DuplicateCommerceAccountGroupExternalReferenceCodeException.java
+++ b/modules/apps/commerce/commerce-account-api/src/main/java/com/liferay/commerce/account/exception/DuplicateCommerceAccountGroupExternalReferenceCodeException.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.commerce.account.exception;
+
+import com.liferay.portal.kernel.exception.SystemException;
+
+/**
+ * @author Marco Leo
+ */
+public class DuplicateCommerceAccountGroupExternalReferenceCodeException
+	extends SystemException {
+
+	public DuplicateCommerceAccountGroupExternalReferenceCodeException() {
+	}
+
+	public DuplicateCommerceAccountGroupExternalReferenceCodeException(
+		String msg) {
+
+		super(msg);
+	}
+
+	public DuplicateCommerceAccountGroupExternalReferenceCodeException(
+		String msg, Throwable throwable) {
+
+		super(msg, throwable);
+	}
+
+	public DuplicateCommerceAccountGroupExternalReferenceCodeException(
+		Throwable throwable) {
+
+		super(throwable);
+	}
+
+}

--- a/modules/apps/commerce/commerce-account-api/src/main/resources/com/liferay/commerce/account/exception/packageinfo
+++ b/modules/apps/commerce/commerce-account-api/src/main/resources/com/liferay/commerce/account/exception/packageinfo
@@ -1,1 +1,1 @@
-version 1.5.0
+version 1.6.0

--- a/modules/apps/commerce/commerce-account-service/service.xml
+++ b/modules/apps/commerce/commerce-account-service/service.xml
@@ -230,9 +230,6 @@
 		<exception>CommerceAccountName</exception>
 		<exception>CommerceAccountType</exception>
 		<exception>CommerceAccountUserRelEmailAddress</exception>
-		<exception>DuplicateCommerceAccount</exception>
-		<exception>DuplicateCommerceAccountGroupCommerceAccountRel</exception>
-		<exception>DuplicateCommerceAccountGroupRel</exception>
 		<exception>SystemCommerceAccountGroup</exception>
 	</exceptions>
 </service-builder>

--- a/modules/apps/commerce/commerce-account-service/src/main/java/com/liferay/commerce/account/service/impl/CommerceAccountGroupLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-account-service/src/main/java/com/liferay/commerce/account/service/impl/CommerceAccountGroupLocalServiceImpl.java
@@ -187,7 +187,7 @@ public class CommerceAccountGroupLocalServiceImpl
 
 		return CommerceAccountGroupImpl.fromAccountGroup(
 			_accountGroupLocalService.fetchAccountGroupByExternalReferenceCode(
-				companyId, externalReferenceCode));
+				externalReferenceCode, companyId));
 	}
 
 	@Override
@@ -384,7 +384,7 @@ public class CommerceAccountGroupLocalServiceImpl
 			CommerceAccountGroupImpl.fromAccountGroup(
 				_accountGroupLocalService.
 					fetchAccountGroupByExternalReferenceCode(
-						companyId, externalReferenceCode));
+						externalReferenceCode, companyId));
 
 		if ((commerceAccountGroup != null) &&
 			(commerceAccountGroup.getCommerceAccountGroupId() !=

--- a/modules/apps/commerce/commerce-account-service/src/main/java/com/liferay/commerce/account/service/impl/CommerceAccountLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-account-service/src/main/java/com/liferay/commerce/account/service/impl/CommerceAccountLocalServiceImpl.java
@@ -177,8 +177,8 @@ public class CommerceAccountLocalServiceImpl
 				CommerceAccountImpl.fromAccountEntry(
 					_accountEntryLocalService.
 						fetchAccountEntryByExternalReferenceCode(
-							serviceContext.getCompanyId(),
-							externalReferenceCode));
+							externalReferenceCode,
+							serviceContext.getCompanyId()));
 
 			if (commerceAccount != null) {
 				return commerceAccountLocalService.updateCommerceAccount(
@@ -315,7 +315,7 @@ public class CommerceAccountLocalServiceImpl
 
 		return CommerceAccountImpl.fromAccountEntry(
 			_accountEntryLocalService.fetchAccountEntryByExternalReferenceCode(
-				companyId, externalReferenceCode));
+				externalReferenceCode, companyId));
 	}
 
 	@Override
@@ -330,7 +330,7 @@ public class CommerceAccountLocalServiceImpl
 
 		return CommerceAccountImpl.fromAccountEntry(
 			_accountEntryLocalService.fetchAccountEntryByExternalReferenceCode(
-				companyId, externalReferenceCode));
+				externalReferenceCode, companyId));
 	}
 
 	@Override
@@ -697,7 +697,7 @@ public class CommerceAccountLocalServiceImpl
 
 		CommerceAccount commerceAccount = CommerceAccountImpl.fromAccountEntry(
 			_accountEntryLocalService.fetchAccountEntryByExternalReferenceCode(
-				companyId, externalReferenceCode));
+				externalReferenceCode, companyId));
 
 		if ((commerceAccount != null) &&
 			(commerceAccount.getCommerceAccountId() != commerceAccountId)) {

--- a/modules/apps/commerce/commerce-api/bnd.bnd
+++ b/modules/apps/commerce/commerce-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Commerce API
 Bundle-SymbolicName: com.liferay.commerce.api
-Bundle-Version: 55.1.1
+Bundle-Version: 56.0.0
 Export-Package:\
 	com.liferay.commerce.address,\
 	com.liferay.commerce.checkout.helper,\

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/exception/DuplicateCommerceAddressExternalReferenceCodeException.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/exception/DuplicateCommerceAddressExternalReferenceCodeException.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.commerce.exception;
+
+import com.liferay.portal.kernel.exception.SystemException;
+
+/**
+ * @author Alessio Antonio Rendina
+ */
+public class DuplicateCommerceAddressExternalReferenceCodeException
+	extends SystemException {
+
+	public DuplicateCommerceAddressExternalReferenceCodeException() {
+	}
+
+	public DuplicateCommerceAddressExternalReferenceCodeException(String msg) {
+		super(msg);
+	}
+
+	public DuplicateCommerceAddressExternalReferenceCodeException(
+		String msg, Throwable throwable) {
+
+		super(msg, throwable);
+	}
+
+	public DuplicateCommerceAddressExternalReferenceCodeException(
+		Throwable throwable) {
+
+		super(throwable);
+	}
+
+}

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/exception/DuplicateCommerceOrderExternalReferenceCodeException.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/exception/DuplicateCommerceOrderExternalReferenceCodeException.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.commerce.exception;
+
+import com.liferay.portal.kernel.exception.SystemException;
+
+/**
+ * @author Alessio Antonio Rendina
+ */
+public class DuplicateCommerceOrderExternalReferenceCodeException
+	extends SystemException {
+
+	public DuplicateCommerceOrderExternalReferenceCodeException() {
+	}
+
+	public DuplicateCommerceOrderExternalReferenceCodeException(String msg) {
+		super(msg);
+	}
+
+	public DuplicateCommerceOrderExternalReferenceCodeException(
+		String msg, Throwable throwable) {
+
+		super(msg, throwable);
+	}
+
+	public DuplicateCommerceOrderExternalReferenceCodeException(
+		Throwable throwable) {
+
+		super(throwable);
+	}
+
+}

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/exception/DuplicateCommerceOrderItemExternalReferenceCodeException.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/exception/DuplicateCommerceOrderItemExternalReferenceCodeException.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.commerce.exception;
+
+import com.liferay.portal.kernel.exception.SystemException;
+
+/**
+ * @author Alessio Antonio Rendina
+ */
+public class DuplicateCommerceOrderItemExternalReferenceCodeException
+	extends SystemException {
+
+	public DuplicateCommerceOrderItemExternalReferenceCodeException() {
+	}
+
+	public DuplicateCommerceOrderItemExternalReferenceCodeException(
+		String msg) {
+
+		super(msg);
+	}
+
+	public DuplicateCommerceOrderItemExternalReferenceCodeException(
+		String msg, Throwable throwable) {
+
+		super(msg, throwable);
+	}
+
+	public DuplicateCommerceOrderItemExternalReferenceCodeException(
+		Throwable throwable) {
+
+		super(throwable);
+	}
+
+}

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/exception/DuplicateCommerceOrderNoteExternalReferenceCodeException.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/exception/DuplicateCommerceOrderNoteExternalReferenceCodeException.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.commerce.exception;
+
+import com.liferay.portal.kernel.exception.SystemException;
+
+/**
+ * @author Alessio Antonio Rendina
+ */
+public class DuplicateCommerceOrderNoteExternalReferenceCodeException
+	extends SystemException {
+
+	public DuplicateCommerceOrderNoteExternalReferenceCodeException() {
+	}
+
+	public DuplicateCommerceOrderNoteExternalReferenceCodeException(
+		String msg) {
+
+		super(msg);
+	}
+
+	public DuplicateCommerceOrderNoteExternalReferenceCodeException(
+		String msg, Throwable throwable) {
+
+		super(msg, throwable);
+	}
+
+	public DuplicateCommerceOrderNoteExternalReferenceCodeException(
+		Throwable throwable) {
+
+		super(throwable);
+	}
+
+}

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/exception/DuplicateCommerceOrderTypeExternalReferenceCodeException.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/exception/DuplicateCommerceOrderTypeExternalReferenceCodeException.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.commerce.exception;
+
+import com.liferay.portal.kernel.exception.SystemException;
+
+/**
+ * @author Alessio Antonio Rendina
+ */
+public class DuplicateCommerceOrderTypeExternalReferenceCodeException
+	extends SystemException {
+
+	public DuplicateCommerceOrderTypeExternalReferenceCodeException() {
+	}
+
+	public DuplicateCommerceOrderTypeExternalReferenceCodeException(
+		String msg) {
+
+		super(msg);
+	}
+
+	public DuplicateCommerceOrderTypeExternalReferenceCodeException(
+		String msg, Throwable throwable) {
+
+		super(msg, throwable);
+	}
+
+	public DuplicateCommerceOrderTypeExternalReferenceCodeException(
+		Throwable throwable) {
+
+		super(throwable);
+	}
+
+}

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/exception/DuplicateCommerceOrderTypeRelExternalReferenceCodeException.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/exception/DuplicateCommerceOrderTypeRelExternalReferenceCodeException.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.commerce.exception;
+
+import com.liferay.portal.kernel.exception.SystemException;
+
+/**
+ * @author Alessio Antonio Rendina
+ */
+public class DuplicateCommerceOrderTypeRelExternalReferenceCodeException
+	extends SystemException {
+
+	public DuplicateCommerceOrderTypeRelExternalReferenceCodeException() {
+	}
+
+	public DuplicateCommerceOrderTypeRelExternalReferenceCodeException(
+		String msg) {
+
+		super(msg);
+	}
+
+	public DuplicateCommerceOrderTypeRelExternalReferenceCodeException(
+		String msg, Throwable throwable) {
+
+		super(msg, throwable);
+	}
+
+	public DuplicateCommerceOrderTypeRelExternalReferenceCodeException(
+		Throwable throwable) {
+
+		super(throwable);
+	}
+
+}

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/exception/DuplicateCommerceShipmentExternalReferenceCodeException.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/exception/DuplicateCommerceShipmentExternalReferenceCodeException.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.commerce.exception;
+
+import com.liferay.portal.kernel.exception.SystemException;
+
+/**
+ * @author Alessio Antonio Rendina
+ */
+public class DuplicateCommerceShipmentExternalReferenceCodeException
+	extends SystemException {
+
+	public DuplicateCommerceShipmentExternalReferenceCodeException() {
+	}
+
+	public DuplicateCommerceShipmentExternalReferenceCodeException(String msg) {
+		super(msg);
+	}
+
+	public DuplicateCommerceShipmentExternalReferenceCodeException(
+		String msg, Throwable throwable) {
+
+		super(msg, throwable);
+	}
+
+	public DuplicateCommerceShipmentExternalReferenceCodeException(
+		Throwable throwable) {
+
+		super(throwable);
+	}
+
+}

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/exception/DuplicateCommerceShipmentItemExternalReferenceCodeException.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/exception/DuplicateCommerceShipmentItemExternalReferenceCodeException.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.commerce.exception;
+
+import com.liferay.portal.kernel.exception.SystemException;
+
+/**
+ * @author Alessio Antonio Rendina
+ */
+public class DuplicateCommerceShipmentItemExternalReferenceCodeException
+	extends SystemException {
+
+	public DuplicateCommerceShipmentItemExternalReferenceCodeException() {
+	}
+
+	public DuplicateCommerceShipmentItemExternalReferenceCodeException(
+		String msg) {
+
+		super(msg);
+	}
+
+	public DuplicateCommerceShipmentItemExternalReferenceCodeException(
+		String msg, Throwable throwable) {
+
+		super(msg, throwable);
+	}
+
+	public DuplicateCommerceShipmentItemExternalReferenceCodeException(
+		Throwable throwable) {
+
+		super(throwable);
+	}
+
+}

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderItemLocalService.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderItemLocalService.java
@@ -260,24 +260,9 @@ public interface CommerceOrderItemLocalService
 	public CommerceOrderItem fetchCommerceOrderItemByBookedQuantityId(
 		long bookedQuantityId);
 
-	/**
-	 * Returns the commerce order item with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce order item's external reference code
-	 * @return the matching commerce order item, or <code>null</code> if a matching commerce order item could not be found
-	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public CommerceOrderItem fetchCommerceOrderItemByExternalReferenceCode(
-		long companyId, String externalReferenceCode);
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchCommerceOrderItemByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CommerceOrderItem fetchCommerceOrderItemByReferenceCode(
-		long companyId, String externalReferenceCode);
+		String externalReferenceCode, long companyId);
 
 	/**
 	 * Returns the commerce order item matching the UUID and group.
@@ -317,17 +302,9 @@ public interface CommerceOrderItemLocalService
 	public CommerceOrderItem getCommerceOrderItem(long commerceOrderItemId)
 		throws PortalException;
 
-	/**
-	 * Returns the commerce order item with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce order item's external reference code
-	 * @return the matching commerce order item
-	 * @throws PortalException if a matching commerce order item could not be found
-	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public CommerceOrderItem getCommerceOrderItemByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
+			String externalReferenceCode, long companyId)
 		throws PortalException;
 
 	/**

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderItemLocalServiceUtil.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderItemLocalServiceUtil.java
@@ -307,30 +307,12 @@ public class CommerceOrderItemLocalServiceUtil {
 			bookedQuantityId);
 	}
 
-	/**
-	 * Returns the commerce order item with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce order item's external reference code
-	 * @return the matching commerce order item, or <code>null</code> if a matching commerce order item could not be found
-	 */
 	public static CommerceOrderItem
 		fetchCommerceOrderItemByExternalReferenceCode(
-			long companyId, String externalReferenceCode) {
+			String externalReferenceCode, long companyId) {
 
 		return getService().fetchCommerceOrderItemByExternalReferenceCode(
-			companyId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchCommerceOrderItemByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	public static CommerceOrderItem fetchCommerceOrderItemByReferenceCode(
-		long companyId, String externalReferenceCode) {
-
-		return getService().fetchCommerceOrderItemByReferenceCode(
-			companyId, externalReferenceCode);
+			externalReferenceCode, companyId);
 	}
 
 	/**
@@ -389,20 +371,12 @@ public class CommerceOrderItemLocalServiceUtil {
 		return getService().getCommerceOrderItem(commerceOrderItemId);
 	}
 
-	/**
-	 * Returns the commerce order item with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce order item's external reference code
-	 * @return the matching commerce order item
-	 * @throws PortalException if a matching commerce order item could not be found
-	 */
 	public static CommerceOrderItem getCommerceOrderItemByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
+			String externalReferenceCode, long companyId)
 		throws PortalException {
 
 		return getService().getCommerceOrderItemByExternalReferenceCode(
-			companyId, externalReferenceCode);
+			externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderItemLocalServiceWrapper.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderItemLocalServiceWrapper.java
@@ -344,35 +344,14 @@ public class CommerceOrderItemLocalServiceWrapper
 			fetchCommerceOrderItemByBookedQuantityId(bookedQuantityId);
 	}
 
-	/**
-	 * Returns the commerce order item with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce order item's external reference code
-	 * @return the matching commerce order item, or <code>null</code> if a matching commerce order item could not be found
-	 */
 	@Override
 	public com.liferay.commerce.model.CommerceOrderItem
 		fetchCommerceOrderItemByExternalReferenceCode(
-			long companyId, String externalReferenceCode) {
+			String externalReferenceCode, long companyId) {
 
 		return _commerceOrderItemLocalService.
 			fetchCommerceOrderItemByExternalReferenceCode(
-				companyId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchCommerceOrderItemByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public com.liferay.commerce.model.CommerceOrderItem
-		fetchCommerceOrderItemByReferenceCode(
-			long companyId, String externalReferenceCode) {
-
-		return _commerceOrderItemLocalService.
-			fetchCommerceOrderItemByReferenceCode(
-				companyId, externalReferenceCode);
+				externalReferenceCode, companyId);
 	}
 
 	/**
@@ -439,23 +418,15 @@ public class CommerceOrderItemLocalServiceWrapper
 			commerceOrderItemId);
 	}
 
-	/**
-	 * Returns the commerce order item with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce order item's external reference code
-	 * @return the matching commerce order item
-	 * @throws PortalException if a matching commerce order item could not be found
-	 */
 	@Override
 	public com.liferay.commerce.model.CommerceOrderItem
 			getCommerceOrderItemByExternalReferenceCode(
-				long companyId, String externalReferenceCode)
+				String externalReferenceCode, long companyId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _commerceOrderItemLocalService.
 			getCommerceOrderItemByExternalReferenceCode(
-				companyId, externalReferenceCode);
+				externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderLocalService.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderLocalService.java
@@ -319,24 +319,9 @@ public interface CommerceOrderLocalService
 	public CommerceOrder fetchCommerceOrder(
 		long commerceAccountId, long groupId, long userId, int orderStatus);
 
-	/**
-	 * Returns the commerce order with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce order's external reference code
-	 * @return the matching commerce order, or <code>null</code> if a matching commerce order could not be found
-	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public CommerceOrder fetchCommerceOrderByExternalReferenceCode(
-		long companyId, String externalReferenceCode);
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchCommerceOrderByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CommerceOrder fetchCommerceOrderByReferenceCode(
-		long companyId, String externalReferenceCode);
+		String externalReferenceCode, long companyId);
 
 	/**
 	 * Returns the commerce order matching the UUID and group.
@@ -363,17 +348,9 @@ public interface CommerceOrderLocalService
 	public CommerceOrder getCommerceOrder(long commerceOrderId)
 		throws PortalException;
 
-	/**
-	 * Returns the commerce order with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce order's external reference code
-	 * @return the matching commerce order
-	 * @throws PortalException if a matching commerce order could not be found
-	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public CommerceOrder getCommerceOrderByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
+			String externalReferenceCode, long companyId)
 		throws PortalException;
 
 	/**

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderLocalServiceUtil.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderLocalServiceUtil.java
@@ -394,29 +394,11 @@ public class CommerceOrderLocalServiceUtil {
 			commerceAccountId, groupId, userId, orderStatus);
 	}
 
-	/**
-	 * Returns the commerce order with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce order's external reference code
-	 * @return the matching commerce order, or <code>null</code> if a matching commerce order could not be found
-	 */
 	public static CommerceOrder fetchCommerceOrderByExternalReferenceCode(
-		long companyId, String externalReferenceCode) {
+		String externalReferenceCode, long companyId) {
 
 		return getService().fetchCommerceOrderByExternalReferenceCode(
-			companyId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchCommerceOrderByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	public static CommerceOrder fetchCommerceOrderByReferenceCode(
-		long companyId, String externalReferenceCode) {
-
-		return getService().fetchCommerceOrderByReferenceCode(
-			companyId, externalReferenceCode);
+			externalReferenceCode, companyId);
 	}
 
 	/**
@@ -451,20 +433,12 @@ public class CommerceOrderLocalServiceUtil {
 		return getService().getCommerceOrder(commerceOrderId);
 	}
 
-	/**
-	 * Returns the commerce order with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce order's external reference code
-	 * @return the matching commerce order
-	 * @throws PortalException if a matching commerce order could not be found
-	 */
 	public static CommerceOrder getCommerceOrderByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
+			String externalReferenceCode, long companyId)
 		throws PortalException {
 
 		return getService().getCommerceOrderByExternalReferenceCode(
-			companyId, externalReferenceCode);
+			externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderLocalServiceWrapper.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderLocalServiceWrapper.java
@@ -432,34 +432,14 @@ public class CommerceOrderLocalServiceWrapper
 			commerceAccountId, groupId, userId, orderStatus);
 	}
 
-	/**
-	 * Returns the commerce order with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce order's external reference code
-	 * @return the matching commerce order, or <code>null</code> if a matching commerce order could not be found
-	 */
 	@Override
 	public com.liferay.commerce.model.CommerceOrder
 		fetchCommerceOrderByExternalReferenceCode(
-			long companyId, String externalReferenceCode) {
+			String externalReferenceCode, long companyId) {
 
 		return _commerceOrderLocalService.
 			fetchCommerceOrderByExternalReferenceCode(
-				companyId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchCommerceOrderByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public com.liferay.commerce.model.CommerceOrder
-		fetchCommerceOrderByReferenceCode(
-			long companyId, String externalReferenceCode) {
-
-		return _commerceOrderLocalService.fetchCommerceOrderByReferenceCode(
-			companyId, externalReferenceCode);
+				externalReferenceCode, companyId);
 	}
 
 	/**
@@ -499,23 +479,15 @@ public class CommerceOrderLocalServiceWrapper
 		return _commerceOrderLocalService.getCommerceOrder(commerceOrderId);
 	}
 
-	/**
-	 * Returns the commerce order with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce order's external reference code
-	 * @return the matching commerce order
-	 * @throws PortalException if a matching commerce order could not be found
-	 */
 	@Override
 	public com.liferay.commerce.model.CommerceOrder
 			getCommerceOrderByExternalReferenceCode(
-				long companyId, String externalReferenceCode)
+				String externalReferenceCode, long companyId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _commerceOrderLocalService.
 			getCommerceOrderByExternalReferenceCode(
-				companyId, externalReferenceCode);
+				externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderNoteLocalService.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderNoteLocalService.java
@@ -227,24 +227,9 @@ public interface CommerceOrderNoteLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public CommerceOrderNote fetchCommerceOrderNote(long commerceOrderNoteId);
 
-	/**
-	 * Returns the commerce order note with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce order note's external reference code
-	 * @return the matching commerce order note, or <code>null</code> if a matching commerce order note could not be found
-	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public CommerceOrderNote fetchCommerceOrderNoteByExternalReferenceCode(
-		long companyId, String externalReferenceCode);
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchCommerceOrderNoteByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CommerceOrderNote fetchCommerceOrderNoteByReferenceCode(
-		long companyId, String externalReferenceCode);
+		String externalReferenceCode, long companyId);
 
 	/**
 	 * Returns the commerce order note matching the UUID and group.
@@ -271,17 +256,9 @@ public interface CommerceOrderNoteLocalService
 	public CommerceOrderNote getCommerceOrderNote(long commerceOrderNoteId)
 		throws PortalException;
 
-	/**
-	 * Returns the commerce order note with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce order note's external reference code
-	 * @return the matching commerce order note
-	 * @throws PortalException if a matching commerce order note could not be found
-	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public CommerceOrderNote getCommerceOrderNoteByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
+			String externalReferenceCode, long companyId)
 		throws PortalException;
 
 	/**

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderNoteLocalServiceUtil.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderNoteLocalServiceUtil.java
@@ -260,30 +260,12 @@ public class CommerceOrderNoteLocalServiceUtil {
 		return getService().fetchCommerceOrderNote(commerceOrderNoteId);
 	}
 
-	/**
-	 * Returns the commerce order note with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce order note's external reference code
-	 * @return the matching commerce order note, or <code>null</code> if a matching commerce order note could not be found
-	 */
 	public static CommerceOrderNote
 		fetchCommerceOrderNoteByExternalReferenceCode(
-			long companyId, String externalReferenceCode) {
+			String externalReferenceCode, long companyId) {
 
 		return getService().fetchCommerceOrderNoteByExternalReferenceCode(
-			companyId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchCommerceOrderNoteByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	public static CommerceOrderNote fetchCommerceOrderNoteByReferenceCode(
-		long companyId, String externalReferenceCode) {
-
-		return getService().fetchCommerceOrderNoteByReferenceCode(
-			companyId, externalReferenceCode);
+			externalReferenceCode, companyId);
 	}
 
 	/**
@@ -320,20 +302,12 @@ public class CommerceOrderNoteLocalServiceUtil {
 		return getService().getCommerceOrderNote(commerceOrderNoteId);
 	}
 
-	/**
-	 * Returns the commerce order note with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce order note's external reference code
-	 * @return the matching commerce order note
-	 * @throws PortalException if a matching commerce order note could not be found
-	 */
 	public static CommerceOrderNote getCommerceOrderNoteByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
+			String externalReferenceCode, long companyId)
 		throws PortalException {
 
 		return getService().getCommerceOrderNoteByExternalReferenceCode(
-			companyId, externalReferenceCode);
+			externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderNoteLocalServiceWrapper.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderNoteLocalServiceWrapper.java
@@ -292,35 +292,14 @@ public class CommerceOrderNoteLocalServiceWrapper
 			commerceOrderNoteId);
 	}
 
-	/**
-	 * Returns the commerce order note with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce order note's external reference code
-	 * @return the matching commerce order note, or <code>null</code> if a matching commerce order note could not be found
-	 */
 	@Override
 	public com.liferay.commerce.model.CommerceOrderNote
 		fetchCommerceOrderNoteByExternalReferenceCode(
-			long companyId, String externalReferenceCode) {
+			String externalReferenceCode, long companyId) {
 
 		return _commerceOrderNoteLocalService.
 			fetchCommerceOrderNoteByExternalReferenceCode(
-				companyId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchCommerceOrderNoteByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public com.liferay.commerce.model.CommerceOrderNote
-		fetchCommerceOrderNoteByReferenceCode(
-			long companyId, String externalReferenceCode) {
-
-		return _commerceOrderNoteLocalService.
-			fetchCommerceOrderNoteByReferenceCode(
-				companyId, externalReferenceCode);
+				externalReferenceCode, companyId);
 	}
 
 	/**
@@ -361,23 +340,15 @@ public class CommerceOrderNoteLocalServiceWrapper
 			commerceOrderNoteId);
 	}
 
-	/**
-	 * Returns the commerce order note with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce order note's external reference code
-	 * @return the matching commerce order note
-	 * @throws PortalException if a matching commerce order note could not be found
-	 */
 	@Override
 	public com.liferay.commerce.model.CommerceOrderNote
 			getCommerceOrderNoteByExternalReferenceCode(
-				long companyId, String externalReferenceCode)
+				String externalReferenceCode, long companyId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _commerceOrderNoteLocalService.
 			getCommerceOrderNoteByExternalReferenceCode(
-				companyId, externalReferenceCode);
+				externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderTypeLocalService.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderTypeLocalService.java
@@ -230,24 +230,9 @@ public interface CommerceOrderTypeLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public CommerceOrderType fetchCommerceOrderType(long commerceOrderTypeId);
 
-	/**
-	 * Returns the commerce order type with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce order type's external reference code
-	 * @return the matching commerce order type, or <code>null</code> if a matching commerce order type could not be found
-	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public CommerceOrderType fetchCommerceOrderTypeByExternalReferenceCode(
-		long companyId, String externalReferenceCode);
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchCommerceOrderTypeByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CommerceOrderType fetchCommerceOrderTypeByReferenceCode(
-		long companyId, String externalReferenceCode);
+		String externalReferenceCode, long companyId);
 
 	/**
 	 * Returns the commerce order type with the matching UUID and company.
@@ -274,17 +259,9 @@ public interface CommerceOrderTypeLocalService
 	public CommerceOrderType getCommerceOrderType(long commerceOrderTypeId)
 		throws PortalException;
 
-	/**
-	 * Returns the commerce order type with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce order type's external reference code
-	 * @return the matching commerce order type
-	 * @throws PortalException if a matching commerce order type could not be found
-	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public CommerceOrderType getCommerceOrderTypeByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
+			String externalReferenceCode, long companyId)
 		throws PortalException;
 
 	/**

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderTypeLocalServiceUtil.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderTypeLocalServiceUtil.java
@@ -252,30 +252,12 @@ public class CommerceOrderTypeLocalServiceUtil {
 		return getService().fetchCommerceOrderType(commerceOrderTypeId);
 	}
 
-	/**
-	 * Returns the commerce order type with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce order type's external reference code
-	 * @return the matching commerce order type, or <code>null</code> if a matching commerce order type could not be found
-	 */
 	public static CommerceOrderType
 		fetchCommerceOrderTypeByExternalReferenceCode(
-			long companyId, String externalReferenceCode) {
+			String externalReferenceCode, long companyId) {
 
 		return getService().fetchCommerceOrderTypeByExternalReferenceCode(
-			companyId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchCommerceOrderTypeByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	public static CommerceOrderType fetchCommerceOrderTypeByReferenceCode(
-		long companyId, String externalReferenceCode) {
-
-		return getService().fetchCommerceOrderTypeByReferenceCode(
-			companyId, externalReferenceCode);
+			externalReferenceCode, companyId);
 	}
 
 	/**
@@ -312,20 +294,12 @@ public class CommerceOrderTypeLocalServiceUtil {
 		return getService().getCommerceOrderType(commerceOrderTypeId);
 	}
 
-	/**
-	 * Returns the commerce order type with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce order type's external reference code
-	 * @return the matching commerce order type
-	 * @throws PortalException if a matching commerce order type could not be found
-	 */
 	public static CommerceOrderType getCommerceOrderTypeByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
+			String externalReferenceCode, long companyId)
 		throws PortalException {
 
 		return getService().getCommerceOrderTypeByExternalReferenceCode(
-			companyId, externalReferenceCode);
+			externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderTypeLocalServiceWrapper.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderTypeLocalServiceWrapper.java
@@ -281,35 +281,14 @@ public class CommerceOrderTypeLocalServiceWrapper
 			commerceOrderTypeId);
 	}
 
-	/**
-	 * Returns the commerce order type with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce order type's external reference code
-	 * @return the matching commerce order type, or <code>null</code> if a matching commerce order type could not be found
-	 */
 	@Override
 	public com.liferay.commerce.model.CommerceOrderType
 		fetchCommerceOrderTypeByExternalReferenceCode(
-			long companyId, String externalReferenceCode) {
+			String externalReferenceCode, long companyId) {
 
 		return _commerceOrderTypeLocalService.
 			fetchCommerceOrderTypeByExternalReferenceCode(
-				companyId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchCommerceOrderTypeByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public com.liferay.commerce.model.CommerceOrderType
-		fetchCommerceOrderTypeByReferenceCode(
-			long companyId, String externalReferenceCode) {
-
-		return _commerceOrderTypeLocalService.
-			fetchCommerceOrderTypeByReferenceCode(
-				companyId, externalReferenceCode);
+				externalReferenceCode, companyId);
 	}
 
 	/**
@@ -350,23 +329,15 @@ public class CommerceOrderTypeLocalServiceWrapper
 			commerceOrderTypeId);
 	}
 
-	/**
-	 * Returns the commerce order type with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce order type's external reference code
-	 * @return the matching commerce order type
-	 * @throws PortalException if a matching commerce order type could not be found
-	 */
 	@Override
 	public com.liferay.commerce.model.CommerceOrderType
 			getCommerceOrderTypeByExternalReferenceCode(
-				long companyId, String externalReferenceCode)
+				String externalReferenceCode, long companyId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _commerceOrderTypeLocalService.
 			getCommerceOrderTypeByExternalReferenceCode(
-				companyId, externalReferenceCode);
+				externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderTypeRelLocalService.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderTypeRelLocalService.java
@@ -220,25 +220,10 @@ public interface CommerceOrderTypeRelLocalService
 	public CommerceOrderTypeRel fetchCommerceOrderTypeRel(
 		long commerceOrderTypeRelId);
 
-	/**
-	 * Returns the commerce order type rel with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce order type rel's external reference code
-	 * @return the matching commerce order type rel, or <code>null</code> if a matching commerce order type rel could not be found
-	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public CommerceOrderTypeRel
 		fetchCommerceOrderTypeRelByExternalReferenceCode(
-			long companyId, String externalReferenceCode);
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchCommerceOrderTypeRelByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CommerceOrderTypeRel fetchCommerceOrderTypeRelByReferenceCode(
-		long companyId, String externalReferenceCode);
+			String externalReferenceCode, long companyId);
 
 	/**
 	 * Returns the commerce order type rel with the matching UUID and company.
@@ -276,17 +261,9 @@ public interface CommerceOrderTypeRelLocalService
 			long commerceOrderTypeRelId)
 		throws PortalException;
 
-	/**
-	 * Returns the commerce order type rel with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce order type rel's external reference code
-	 * @return the matching commerce order type rel
-	 * @throws PortalException if a matching commerce order type rel could not be found
-	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public CommerceOrderTypeRel getCommerceOrderTypeRelByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
+			String externalReferenceCode, long companyId)
 		throws PortalException;
 
 	/**

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderTypeRelLocalServiceUtil.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderTypeRelLocalServiceUtil.java
@@ -242,30 +242,12 @@ public class CommerceOrderTypeRelLocalServiceUtil {
 		return getService().fetchCommerceOrderTypeRel(commerceOrderTypeRelId);
 	}
 
-	/**
-	 * Returns the commerce order type rel with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce order type rel's external reference code
-	 * @return the matching commerce order type rel, or <code>null</code> if a matching commerce order type rel could not be found
-	 */
 	public static CommerceOrderTypeRel
 		fetchCommerceOrderTypeRelByExternalReferenceCode(
-			long companyId, String externalReferenceCode) {
+			String externalReferenceCode, long companyId) {
 
 		return getService().fetchCommerceOrderTypeRelByExternalReferenceCode(
-			companyId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchCommerceOrderTypeRelByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	public static CommerceOrderTypeRel fetchCommerceOrderTypeRelByReferenceCode(
-		long companyId, String externalReferenceCode) {
-
-		return getService().fetchCommerceOrderTypeRelByReferenceCode(
-			companyId, externalReferenceCode);
+			externalReferenceCode, companyId);
 	}
 
 	/**
@@ -320,21 +302,13 @@ public class CommerceOrderTypeRelLocalServiceUtil {
 		return getService().getCommerceOrderTypeRel(commerceOrderTypeRelId);
 	}
 
-	/**
-	 * Returns the commerce order type rel with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce order type rel's external reference code
-	 * @return the matching commerce order type rel
-	 * @throws PortalException if a matching commerce order type rel could not be found
-	 */
 	public static CommerceOrderTypeRel
 			getCommerceOrderTypeRelByExternalReferenceCode(
-				long companyId, String externalReferenceCode)
+				String externalReferenceCode, long companyId)
 		throws PortalException {
 
 		return getService().getCommerceOrderTypeRelByExternalReferenceCode(
-			companyId, externalReferenceCode);
+			externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderTypeRelLocalServiceWrapper.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderTypeRelLocalServiceWrapper.java
@@ -276,35 +276,14 @@ public class CommerceOrderTypeRelLocalServiceWrapper
 			commerceOrderTypeRelId);
 	}
 
-	/**
-	 * Returns the commerce order type rel with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce order type rel's external reference code
-	 * @return the matching commerce order type rel, or <code>null</code> if a matching commerce order type rel could not be found
-	 */
 	@Override
 	public com.liferay.commerce.model.CommerceOrderTypeRel
 		fetchCommerceOrderTypeRelByExternalReferenceCode(
-			long companyId, String externalReferenceCode) {
+			String externalReferenceCode, long companyId) {
 
 		return _commerceOrderTypeRelLocalService.
 			fetchCommerceOrderTypeRelByExternalReferenceCode(
-				companyId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchCommerceOrderTypeRelByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public com.liferay.commerce.model.CommerceOrderTypeRel
-		fetchCommerceOrderTypeRelByReferenceCode(
-			long companyId, String externalReferenceCode) {
-
-		return _commerceOrderTypeRelLocalService.
-			fetchCommerceOrderTypeRelByReferenceCode(
-				companyId, externalReferenceCode);
+				externalReferenceCode, companyId);
 	}
 
 	/**
@@ -367,23 +346,15 @@ public class CommerceOrderTypeRelLocalServiceWrapper
 			commerceOrderTypeRelId);
 	}
 
-	/**
-	 * Returns the commerce order type rel with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce order type rel's external reference code
-	 * @return the matching commerce order type rel
-	 * @throws PortalException if a matching commerce order type rel could not be found
-	 */
 	@Override
 	public com.liferay.commerce.model.CommerceOrderTypeRel
 			getCommerceOrderTypeRelByExternalReferenceCode(
-				long companyId, String externalReferenceCode)
+				String externalReferenceCode, long companyId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _commerceOrderTypeRelLocalService.
 			getCommerceOrderTypeRelByExternalReferenceCode(
-				companyId, externalReferenceCode);
+				externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceShipmentItemLocalService.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceShipmentItemLocalService.java
@@ -251,25 +251,10 @@ public interface CommerceShipmentItemLocalService
 		long commerceShipmentId, long commerceOrderItemId,
 		long commerceInventoryWarehouseId);
 
-	/**
-	 * Returns the commerce shipment item with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce shipment item's external reference code
-	 * @return the matching commerce shipment item, or <code>null</code> if a matching commerce shipment item could not be found
-	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public CommerceShipmentItem
 		fetchCommerceShipmentItemByExternalReferenceCode(
-			long companyId, String externalReferenceCode);
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchCommerceShipmentItemByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CommerceShipmentItem fetchCommerceShipmentItemByReferenceCode(
-		long companyId, String externalReferenceCode);
+			String externalReferenceCode, long companyId);
 
 	/**
 	 * Returns the commerce shipment item matching the UUID and group.
@@ -297,17 +282,9 @@ public interface CommerceShipmentItemLocalService
 			long commerceShipmentItemId)
 		throws PortalException;
 
-	/**
-	 * Returns the commerce shipment item with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce shipment item's external reference code
-	 * @return the matching commerce shipment item
-	 * @throws PortalException if a matching commerce shipment item could not be found
-	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public CommerceShipmentItem getCommerceShipmentItemByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
+			String externalReferenceCode, long companyId)
 		throws PortalException;
 
 	/**

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceShipmentItemLocalServiceUtil.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceShipmentItemLocalServiceUtil.java
@@ -288,30 +288,12 @@ public class CommerceShipmentItemLocalServiceUtil {
 			commerceInventoryWarehouseId);
 	}
 
-	/**
-	 * Returns the commerce shipment item with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce shipment item's external reference code
-	 * @return the matching commerce shipment item, or <code>null</code> if a matching commerce shipment item could not be found
-	 */
 	public static CommerceShipmentItem
 		fetchCommerceShipmentItemByExternalReferenceCode(
-			long companyId, String externalReferenceCode) {
+			String externalReferenceCode, long companyId) {
 
 		return getService().fetchCommerceShipmentItemByExternalReferenceCode(
-			companyId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchCommerceShipmentItemByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	public static CommerceShipmentItem fetchCommerceShipmentItemByReferenceCode(
-		long companyId, String externalReferenceCode) {
-
-		return getService().fetchCommerceShipmentItemByReferenceCode(
-			companyId, externalReferenceCode);
+			externalReferenceCode, companyId);
 	}
 
 	/**
@@ -348,21 +330,13 @@ public class CommerceShipmentItemLocalServiceUtil {
 		return getService().getCommerceShipmentItem(commerceShipmentItemId);
 	}
 
-	/**
-	 * Returns the commerce shipment item with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce shipment item's external reference code
-	 * @return the matching commerce shipment item
-	 * @throws PortalException if a matching commerce shipment item could not be found
-	 */
 	public static CommerceShipmentItem
 			getCommerceShipmentItemByExternalReferenceCode(
-				long companyId, String externalReferenceCode)
+				String externalReferenceCode, long companyId)
 		throws PortalException {
 
 		return getService().getCommerceShipmentItemByExternalReferenceCode(
-			companyId, externalReferenceCode);
+			externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceShipmentItemLocalServiceWrapper.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceShipmentItemLocalServiceWrapper.java
@@ -331,35 +331,14 @@ public class CommerceShipmentItemLocalServiceWrapper
 			commerceInventoryWarehouseId);
 	}
 
-	/**
-	 * Returns the commerce shipment item with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce shipment item's external reference code
-	 * @return the matching commerce shipment item, or <code>null</code> if a matching commerce shipment item could not be found
-	 */
 	@Override
 	public com.liferay.commerce.model.CommerceShipmentItem
 		fetchCommerceShipmentItemByExternalReferenceCode(
-			long companyId, String externalReferenceCode) {
+			String externalReferenceCode, long companyId) {
 
 		return _commerceShipmentItemLocalService.
 			fetchCommerceShipmentItemByExternalReferenceCode(
-				companyId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchCommerceShipmentItemByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public com.liferay.commerce.model.CommerceShipmentItem
-		fetchCommerceShipmentItemByReferenceCode(
-			long companyId, String externalReferenceCode) {
-
-		return _commerceShipmentItemLocalService.
-			fetchCommerceShipmentItemByReferenceCode(
-				companyId, externalReferenceCode);
+				externalReferenceCode, companyId);
 	}
 
 	/**
@@ -400,23 +379,15 @@ public class CommerceShipmentItemLocalServiceWrapper
 			commerceShipmentItemId);
 	}
 
-	/**
-	 * Returns the commerce shipment item with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce shipment item's external reference code
-	 * @return the matching commerce shipment item
-	 * @throws PortalException if a matching commerce shipment item could not be found
-	 */
 	@Override
 	public com.liferay.commerce.model.CommerceShipmentItem
 			getCommerceShipmentItemByExternalReferenceCode(
-				long companyId, String externalReferenceCode)
+				String externalReferenceCode, long companyId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _commerceShipmentItemLocalService.
 			getCommerceShipmentItemByExternalReferenceCode(
-				companyId, externalReferenceCode);
+				externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceShipmentLocalService.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceShipmentLocalService.java
@@ -242,24 +242,9 @@ public interface CommerceShipmentLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public CommerceShipment fetchCommerceShipment(long commerceShipmentId);
 
-	/**
-	 * Returns the commerce shipment with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce shipment's external reference code
-	 * @return the matching commerce shipment, or <code>null</code> if a matching commerce shipment could not be found
-	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public CommerceShipment fetchCommerceShipmentByExternalReferenceCode(
-		long companyId, String externalReferenceCode);
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchCommerceShipmentByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CommerceShipment fetchCommerceShipmentByReferenceCode(
-		long companyId, String externalReferenceCode);
+		String externalReferenceCode, long companyId);
 
 	/**
 	 * Returns the commerce shipment matching the UUID and group.
@@ -286,17 +271,9 @@ public interface CommerceShipmentLocalService
 	public CommerceShipment getCommerceShipment(long commerceShipmentId)
 		throws PortalException;
 
-	/**
-	 * Returns the commerce shipment with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce shipment's external reference code
-	 * @return the matching commerce shipment
-	 * @throws PortalException if a matching commerce shipment could not be found
-	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public CommerceShipment getCommerceShipmentByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
+			String externalReferenceCode, long companyId)
 		throws PortalException;
 
 	/**

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceShipmentLocalServiceUtil.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceShipmentLocalServiceUtil.java
@@ -271,29 +271,11 @@ public class CommerceShipmentLocalServiceUtil {
 		return getService().fetchCommerceShipment(commerceShipmentId);
 	}
 
-	/**
-	 * Returns the commerce shipment with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce shipment's external reference code
-	 * @return the matching commerce shipment, or <code>null</code> if a matching commerce shipment could not be found
-	 */
 	public static CommerceShipment fetchCommerceShipmentByExternalReferenceCode(
-		long companyId, String externalReferenceCode) {
+		String externalReferenceCode, long companyId) {
 
 		return getService().fetchCommerceShipmentByExternalReferenceCode(
-			companyId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchCommerceShipmentByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	public static CommerceShipment fetchCommerceShipmentByReferenceCode(
-		long companyId, String externalReferenceCode) {
-
-		return getService().fetchCommerceShipmentByReferenceCode(
-			companyId, externalReferenceCode);
+			externalReferenceCode, companyId);
 	}
 
 	/**
@@ -329,20 +311,12 @@ public class CommerceShipmentLocalServiceUtil {
 		return getService().getCommerceShipment(commerceShipmentId);
 	}
 
-	/**
-	 * Returns the commerce shipment with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce shipment's external reference code
-	 * @return the matching commerce shipment
-	 * @throws PortalException if a matching commerce shipment could not be found
-	 */
 	public static CommerceShipment getCommerceShipmentByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
+			String externalReferenceCode, long companyId)
 		throws PortalException {
 
 		return getService().getCommerceShipmentByExternalReferenceCode(
-			companyId, externalReferenceCode);
+			externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceShipmentLocalServiceWrapper.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceShipmentLocalServiceWrapper.java
@@ -306,35 +306,14 @@ public class CommerceShipmentLocalServiceWrapper
 			commerceShipmentId);
 	}
 
-	/**
-	 * Returns the commerce shipment with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce shipment's external reference code
-	 * @return the matching commerce shipment, or <code>null</code> if a matching commerce shipment could not be found
-	 */
 	@Override
 	public com.liferay.commerce.model.CommerceShipment
 		fetchCommerceShipmentByExternalReferenceCode(
-			long companyId, String externalReferenceCode) {
+			String externalReferenceCode, long companyId) {
 
 		return _commerceShipmentLocalService.
 			fetchCommerceShipmentByExternalReferenceCode(
-				companyId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchCommerceShipmentByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public com.liferay.commerce.model.CommerceShipment
-		fetchCommerceShipmentByReferenceCode(
-			long companyId, String externalReferenceCode) {
-
-		return _commerceShipmentLocalService.
-			fetchCommerceShipmentByReferenceCode(
-				companyId, externalReferenceCode);
+				externalReferenceCode, companyId);
 	}
 
 	/**
@@ -375,23 +354,15 @@ public class CommerceShipmentLocalServiceWrapper
 			commerceShipmentId);
 	}
 
-	/**
-	 * Returns the commerce shipment with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce shipment's external reference code
-	 * @return the matching commerce shipment
-	 * @throws PortalException if a matching commerce shipment could not be found
-	 */
 	@Override
 	public com.liferay.commerce.model.CommerceShipment
 			getCommerceShipmentByExternalReferenceCode(
-				long companyId, String externalReferenceCode)
+				String externalReferenceCode, long companyId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _commerceShipmentLocalService.
 			getCommerceShipmentByExternalReferenceCode(
-				companyId, externalReferenceCode);
+				externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/persistence/CommerceOrderItemPersistence.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/persistence/CommerceOrderItemPersistence.java
@@ -1322,57 +1322,57 @@ public interface CommerceOrderItemPersistence
 	public int countByC_S(long commerceOrderId, boolean subscription);
 
 	/**
-	 * Returns the commerce order item where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchOrderItemException</code> if it could not be found.
+	 * Returns the commerce order item where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchOrderItemException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce order item
 	 * @throws NoSuchOrderItemException if a matching commerce order item could not be found
 	 */
-	public CommerceOrderItem findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public CommerceOrderItem findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchOrderItemException;
 
 	/**
-	 * Returns the commerce order item where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the commerce order item where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce order item, or <code>null</code> if a matching commerce order item could not be found
 	 */
-	public CommerceOrderItem fetchByC_ERC(
-		long companyId, String externalReferenceCode);
+	public CommerceOrderItem fetchByERC_C(
+		String externalReferenceCode, long companyId);
 
 	/**
-	 * Returns the commerce order item where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the commerce order item where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching commerce order item, or <code>null</code> if a matching commerce order item could not be found
 	 */
-	public CommerceOrderItem fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache);
+	public CommerceOrderItem fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache);
 
 	/**
-	 * Removes the commerce order item where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the commerce order item where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the commerce order item that was removed
 	 */
-	public CommerceOrderItem removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public CommerceOrderItem removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchOrderItemException;
 
 	/**
-	 * Returns the number of commerce order items where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of commerce order items where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching commerce order items
 	 */
-	public int countByC_ERC(long companyId, String externalReferenceCode);
+	public int countByERC_C(String externalReferenceCode, long companyId);
 
 	/**
 	 * Caches the commerce order item in the entity cache if it is enabled.

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/persistence/CommerceOrderItemUtil.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/persistence/CommerceOrderItemUtil.java
@@ -1686,73 +1686,73 @@ public class CommerceOrderItemUtil {
 	}
 
 	/**
-	 * Returns the commerce order item where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchOrderItemException</code> if it could not be found.
+	 * Returns the commerce order item where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchOrderItemException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce order item
 	 * @throws NoSuchOrderItemException if a matching commerce order item could not be found
 	 */
-	public static CommerceOrderItem findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public static CommerceOrderItem findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws com.liferay.commerce.exception.NoSuchOrderItemException {
 
-		return getPersistence().findByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().findByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the commerce order item where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the commerce order item where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce order item, or <code>null</code> if a matching commerce order item could not be found
 	 */
-	public static CommerceOrderItem fetchByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public static CommerceOrderItem fetchByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return getPersistence().fetchByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().fetchByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the commerce order item where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the commerce order item where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching commerce order item, or <code>null</code> if a matching commerce order item could not be found
 	 */
-	public static CommerceOrderItem fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache) {
+	public static CommerceOrderItem fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache) {
 
-		return getPersistence().fetchByC_ERC(
-			companyId, externalReferenceCode, useFinderCache);
+		return getPersistence().fetchByERC_C(
+			externalReferenceCode, companyId, useFinderCache);
 	}
 
 	/**
-	 * Removes the commerce order item where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the commerce order item where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the commerce order item that was removed
 	 */
-	public static CommerceOrderItem removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public static CommerceOrderItem removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws com.liferay.commerce.exception.NoSuchOrderItemException {
 
-		return getPersistence().removeByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().removeByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the number of commerce order items where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of commerce order items where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching commerce order items
 	 */
-	public static int countByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public static int countByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return getPersistence().countByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().countByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/persistence/CommerceOrderNotePersistence.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/persistence/CommerceOrderNotePersistence.java
@@ -689,57 +689,57 @@ public interface CommerceOrderNotePersistence
 	public int countByC_R(long commerceOrderId, boolean restricted);
 
 	/**
-	 * Returns the commerce order note where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchOrderNoteException</code> if it could not be found.
+	 * Returns the commerce order note where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchOrderNoteException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce order note
 	 * @throws NoSuchOrderNoteException if a matching commerce order note could not be found
 	 */
-	public CommerceOrderNote findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public CommerceOrderNote findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchOrderNoteException;
 
 	/**
-	 * Returns the commerce order note where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the commerce order note where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce order note, or <code>null</code> if a matching commerce order note could not be found
 	 */
-	public CommerceOrderNote fetchByC_ERC(
-		long companyId, String externalReferenceCode);
+	public CommerceOrderNote fetchByERC_C(
+		String externalReferenceCode, long companyId);
 
 	/**
-	 * Returns the commerce order note where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the commerce order note where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching commerce order note, or <code>null</code> if a matching commerce order note could not be found
 	 */
-	public CommerceOrderNote fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache);
+	public CommerceOrderNote fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache);
 
 	/**
-	 * Removes the commerce order note where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the commerce order note where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the commerce order note that was removed
 	 */
-	public CommerceOrderNote removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public CommerceOrderNote removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchOrderNoteException;
 
 	/**
-	 * Returns the number of commerce order notes where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of commerce order notes where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching commerce order notes
 	 */
-	public int countByC_ERC(long companyId, String externalReferenceCode);
+	public int countByERC_C(String externalReferenceCode, long companyId);
 
 	/**
 	 * Caches the commerce order note in the entity cache if it is enabled.

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/persistence/CommerceOrderNoteUtil.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/persistence/CommerceOrderNoteUtil.java
@@ -900,73 +900,73 @@ public class CommerceOrderNoteUtil {
 	}
 
 	/**
-	 * Returns the commerce order note where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchOrderNoteException</code> if it could not be found.
+	 * Returns the commerce order note where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchOrderNoteException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce order note
 	 * @throws NoSuchOrderNoteException if a matching commerce order note could not be found
 	 */
-	public static CommerceOrderNote findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public static CommerceOrderNote findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws com.liferay.commerce.exception.NoSuchOrderNoteException {
 
-		return getPersistence().findByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().findByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the commerce order note where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the commerce order note where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce order note, or <code>null</code> if a matching commerce order note could not be found
 	 */
-	public static CommerceOrderNote fetchByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public static CommerceOrderNote fetchByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return getPersistence().fetchByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().fetchByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the commerce order note where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the commerce order note where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching commerce order note, or <code>null</code> if a matching commerce order note could not be found
 	 */
-	public static CommerceOrderNote fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache) {
+	public static CommerceOrderNote fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache) {
 
-		return getPersistence().fetchByC_ERC(
-			companyId, externalReferenceCode, useFinderCache);
+		return getPersistence().fetchByERC_C(
+			externalReferenceCode, companyId, useFinderCache);
 	}
 
 	/**
-	 * Removes the commerce order note where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the commerce order note where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the commerce order note that was removed
 	 */
-	public static CommerceOrderNote removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public static CommerceOrderNote removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws com.liferay.commerce.exception.NoSuchOrderNoteException {
 
-		return getPersistence().removeByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().removeByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the number of commerce order notes where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of commerce order notes where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching commerce order notes
 	 */
-	public static int countByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public static int countByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return getPersistence().countByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().countByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/persistence/CommerceOrderPersistence.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/persistence/CommerceOrderPersistence.java
@@ -2096,57 +2096,57 @@ public interface CommerceOrderPersistence
 		Date createDate, long commerceAccountId, int orderStatus);
 
 	/**
-	 * Returns the commerce order where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchOrderException</code> if it could not be found.
+	 * Returns the commerce order where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchOrderException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce order
 	 * @throws NoSuchOrderException if a matching commerce order could not be found
 	 */
-	public CommerceOrder findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public CommerceOrder findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchOrderException;
 
 	/**
-	 * Returns the commerce order where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the commerce order where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce order, or <code>null</code> if a matching commerce order could not be found
 	 */
-	public CommerceOrder fetchByC_ERC(
-		long companyId, String externalReferenceCode);
+	public CommerceOrder fetchByERC_C(
+		String externalReferenceCode, long companyId);
 
 	/**
-	 * Returns the commerce order where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the commerce order where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching commerce order, or <code>null</code> if a matching commerce order could not be found
 	 */
-	public CommerceOrder fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache);
+	public CommerceOrder fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache);
 
 	/**
-	 * Removes the commerce order where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the commerce order where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the commerce order that was removed
 	 */
-	public CommerceOrder removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public CommerceOrder removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchOrderException;
 
 	/**
-	 * Returns the number of commerce orders where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of commerce orders where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching commerce orders
 	 */
-	public int countByC_ERC(long companyId, String externalReferenceCode);
+	public int countByERC_C(String externalReferenceCode, long companyId);
 
 	/**
 	 * Caches the commerce order in the entity cache if it is enabled.

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/persistence/CommerceOrderTypePersistence.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/persistence/CommerceOrderTypePersistence.java
@@ -1359,57 +1359,57 @@ public interface CommerceOrderTypePersistence
 	public int filterCountByLtE_S(Date expirationDate, int status);
 
 	/**
-	 * Returns the commerce order type where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchOrderTypeException</code> if it could not be found.
+	 * Returns the commerce order type where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchOrderTypeException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce order type
 	 * @throws NoSuchOrderTypeException if a matching commerce order type could not be found
 	 */
-	public CommerceOrderType findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public CommerceOrderType findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchOrderTypeException;
 
 	/**
-	 * Returns the commerce order type where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the commerce order type where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce order type, or <code>null</code> if a matching commerce order type could not be found
 	 */
-	public CommerceOrderType fetchByC_ERC(
-		long companyId, String externalReferenceCode);
+	public CommerceOrderType fetchByERC_C(
+		String externalReferenceCode, long companyId);
 
 	/**
-	 * Returns the commerce order type where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the commerce order type where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching commerce order type, or <code>null</code> if a matching commerce order type could not be found
 	 */
-	public CommerceOrderType fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache);
+	public CommerceOrderType fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache);
 
 	/**
-	 * Removes the commerce order type where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the commerce order type where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the commerce order type that was removed
 	 */
-	public CommerceOrderType removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public CommerceOrderType removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchOrderTypeException;
 
 	/**
-	 * Returns the number of commerce order types where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of commerce order types where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching commerce order types
 	 */
-	public int countByC_ERC(long companyId, String externalReferenceCode);
+	public int countByERC_C(String externalReferenceCode, long companyId);
 
 	/**
 	 * Caches the commerce order type in the entity cache if it is enabled.

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/persistence/CommerceOrderTypeRelPersistence.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/persistence/CommerceOrderTypeRelPersistence.java
@@ -700,57 +700,57 @@ public interface CommerceOrderTypeRelPersistence
 		long classNameId, long classPK, long commerceOrderTypeId);
 
 	/**
-	 * Returns the commerce order type rel where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchOrderTypeRelException</code> if it could not be found.
+	 * Returns the commerce order type rel where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchOrderTypeRelException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce order type rel
 	 * @throws NoSuchOrderTypeRelException if a matching commerce order type rel could not be found
 	 */
-	public CommerceOrderTypeRel findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public CommerceOrderTypeRel findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchOrderTypeRelException;
 
 	/**
-	 * Returns the commerce order type rel where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the commerce order type rel where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce order type rel, or <code>null</code> if a matching commerce order type rel could not be found
 	 */
-	public CommerceOrderTypeRel fetchByC_ERC(
-		long companyId, String externalReferenceCode);
+	public CommerceOrderTypeRel fetchByERC_C(
+		String externalReferenceCode, long companyId);
 
 	/**
-	 * Returns the commerce order type rel where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the commerce order type rel where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching commerce order type rel, or <code>null</code> if a matching commerce order type rel could not be found
 	 */
-	public CommerceOrderTypeRel fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache);
+	public CommerceOrderTypeRel fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache);
 
 	/**
-	 * Removes the commerce order type rel where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the commerce order type rel where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the commerce order type rel that was removed
 	 */
-	public CommerceOrderTypeRel removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public CommerceOrderTypeRel removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchOrderTypeRelException;
 
 	/**
-	 * Returns the number of commerce order type rels where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of commerce order type rels where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching commerce order type rels
 	 */
-	public int countByC_ERC(long companyId, String externalReferenceCode);
+	public int countByERC_C(String externalReferenceCode, long companyId);
 
 	/**
 	 * Caches the commerce order type rel in the entity cache if it is enabled.

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/persistence/CommerceOrderTypeRelUtil.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/persistence/CommerceOrderTypeRelUtil.java
@@ -923,73 +923,73 @@ public class CommerceOrderTypeRelUtil {
 	}
 
 	/**
-	 * Returns the commerce order type rel where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchOrderTypeRelException</code> if it could not be found.
+	 * Returns the commerce order type rel where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchOrderTypeRelException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce order type rel
 	 * @throws NoSuchOrderTypeRelException if a matching commerce order type rel could not be found
 	 */
-	public static CommerceOrderTypeRel findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public static CommerceOrderTypeRel findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws com.liferay.commerce.exception.NoSuchOrderTypeRelException {
 
-		return getPersistence().findByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().findByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the commerce order type rel where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the commerce order type rel where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce order type rel, or <code>null</code> if a matching commerce order type rel could not be found
 	 */
-	public static CommerceOrderTypeRel fetchByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public static CommerceOrderTypeRel fetchByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return getPersistence().fetchByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().fetchByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the commerce order type rel where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the commerce order type rel where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching commerce order type rel, or <code>null</code> if a matching commerce order type rel could not be found
 	 */
-	public static CommerceOrderTypeRel fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache) {
+	public static CommerceOrderTypeRel fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache) {
 
-		return getPersistence().fetchByC_ERC(
-			companyId, externalReferenceCode, useFinderCache);
+		return getPersistence().fetchByERC_C(
+			externalReferenceCode, companyId, useFinderCache);
 	}
 
 	/**
-	 * Removes the commerce order type rel where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the commerce order type rel where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the commerce order type rel that was removed
 	 */
-	public static CommerceOrderTypeRel removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public static CommerceOrderTypeRel removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws com.liferay.commerce.exception.NoSuchOrderTypeRelException {
 
-		return getPersistence().removeByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().removeByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the number of commerce order type rels where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of commerce order type rels where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching commerce order type rels
 	 */
-	public static int countByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public static int countByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return getPersistence().countByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().countByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/persistence/CommerceOrderTypeUtil.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/persistence/CommerceOrderTypeUtil.java
@@ -1699,73 +1699,73 @@ public class CommerceOrderTypeUtil {
 	}
 
 	/**
-	 * Returns the commerce order type where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchOrderTypeException</code> if it could not be found.
+	 * Returns the commerce order type where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchOrderTypeException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce order type
 	 * @throws NoSuchOrderTypeException if a matching commerce order type could not be found
 	 */
-	public static CommerceOrderType findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public static CommerceOrderType findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws com.liferay.commerce.exception.NoSuchOrderTypeException {
 
-		return getPersistence().findByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().findByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the commerce order type where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the commerce order type where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce order type, or <code>null</code> if a matching commerce order type could not be found
 	 */
-	public static CommerceOrderType fetchByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public static CommerceOrderType fetchByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return getPersistence().fetchByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().fetchByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the commerce order type where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the commerce order type where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching commerce order type, or <code>null</code> if a matching commerce order type could not be found
 	 */
-	public static CommerceOrderType fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache) {
+	public static CommerceOrderType fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache) {
 
-		return getPersistence().fetchByC_ERC(
-			companyId, externalReferenceCode, useFinderCache);
+		return getPersistence().fetchByERC_C(
+			externalReferenceCode, companyId, useFinderCache);
 	}
 
 	/**
-	 * Removes the commerce order type where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the commerce order type where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the commerce order type that was removed
 	 */
-	public static CommerceOrderType removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public static CommerceOrderType removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws com.liferay.commerce.exception.NoSuchOrderTypeException {
 
-		return getPersistence().removeByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().removeByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the number of commerce order types where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of commerce order types where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching commerce order types
 	 */
-	public static int countByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public static int countByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return getPersistence().countByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().countByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/persistence/CommerceOrderUtil.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/persistence/CommerceOrderUtil.java
@@ -2596,73 +2596,73 @@ public class CommerceOrderUtil {
 	}
 
 	/**
-	 * Returns the commerce order where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchOrderException</code> if it could not be found.
+	 * Returns the commerce order where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchOrderException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce order
 	 * @throws NoSuchOrderException if a matching commerce order could not be found
 	 */
-	public static CommerceOrder findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public static CommerceOrder findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws com.liferay.commerce.exception.NoSuchOrderException {
 
-		return getPersistence().findByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().findByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the commerce order where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the commerce order where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce order, or <code>null</code> if a matching commerce order could not be found
 	 */
-	public static CommerceOrder fetchByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public static CommerceOrder fetchByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return getPersistence().fetchByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().fetchByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the commerce order where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the commerce order where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching commerce order, or <code>null</code> if a matching commerce order could not be found
 	 */
-	public static CommerceOrder fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache) {
+	public static CommerceOrder fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache) {
 
-		return getPersistence().fetchByC_ERC(
-			companyId, externalReferenceCode, useFinderCache);
+		return getPersistence().fetchByERC_C(
+			externalReferenceCode, companyId, useFinderCache);
 	}
 
 	/**
-	 * Removes the commerce order where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the commerce order where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the commerce order that was removed
 	 */
-	public static CommerceOrder removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public static CommerceOrder removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws com.liferay.commerce.exception.NoSuchOrderException {
 
-		return getPersistence().removeByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().removeByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the number of commerce orders where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of commerce orders where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching commerce orders
 	 */
-	public static int countByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public static int countByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return getPersistence().countByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().countByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/persistence/CommerceShipmentItemPersistence.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/persistence/CommerceShipmentItemPersistence.java
@@ -1041,57 +1041,57 @@ public interface CommerceShipmentItemPersistence
 		long commerceInventoryWarehouseId);
 
 	/**
-	 * Returns the commerce shipment item where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchShipmentItemException</code> if it could not be found.
+	 * Returns the commerce shipment item where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchShipmentItemException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce shipment item
 	 * @throws NoSuchShipmentItemException if a matching commerce shipment item could not be found
 	 */
-	public CommerceShipmentItem findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public CommerceShipmentItem findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchShipmentItemException;
 
 	/**
-	 * Returns the commerce shipment item where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the commerce shipment item where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce shipment item, or <code>null</code> if a matching commerce shipment item could not be found
 	 */
-	public CommerceShipmentItem fetchByC_ERC(
-		long companyId, String externalReferenceCode);
+	public CommerceShipmentItem fetchByERC_C(
+		String externalReferenceCode, long companyId);
 
 	/**
-	 * Returns the commerce shipment item where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the commerce shipment item where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching commerce shipment item, or <code>null</code> if a matching commerce shipment item could not be found
 	 */
-	public CommerceShipmentItem fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache);
+	public CommerceShipmentItem fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache);
 
 	/**
-	 * Removes the commerce shipment item where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the commerce shipment item where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the commerce shipment item that was removed
 	 */
-	public CommerceShipmentItem removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public CommerceShipmentItem removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchShipmentItemException;
 
 	/**
-	 * Returns the number of commerce shipment items where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of commerce shipment items where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching commerce shipment items
 	 */
-	public int countByC_ERC(long companyId, String externalReferenceCode);
+	public int countByERC_C(String externalReferenceCode, long companyId);
 
 	/**
 	 * Caches the commerce shipment item in the entity cache if it is enabled.

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/persistence/CommerceShipmentItemUtil.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/persistence/CommerceShipmentItemUtil.java
@@ -1350,73 +1350,73 @@ public class CommerceShipmentItemUtil {
 	}
 
 	/**
-	 * Returns the commerce shipment item where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchShipmentItemException</code> if it could not be found.
+	 * Returns the commerce shipment item where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchShipmentItemException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce shipment item
 	 * @throws NoSuchShipmentItemException if a matching commerce shipment item could not be found
 	 */
-	public static CommerceShipmentItem findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public static CommerceShipmentItem findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws com.liferay.commerce.exception.NoSuchShipmentItemException {
 
-		return getPersistence().findByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().findByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the commerce shipment item where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the commerce shipment item where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce shipment item, or <code>null</code> if a matching commerce shipment item could not be found
 	 */
-	public static CommerceShipmentItem fetchByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public static CommerceShipmentItem fetchByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return getPersistence().fetchByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().fetchByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the commerce shipment item where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the commerce shipment item where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching commerce shipment item, or <code>null</code> if a matching commerce shipment item could not be found
 	 */
-	public static CommerceShipmentItem fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache) {
+	public static CommerceShipmentItem fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache) {
 
-		return getPersistence().fetchByC_ERC(
-			companyId, externalReferenceCode, useFinderCache);
+		return getPersistence().fetchByERC_C(
+			externalReferenceCode, companyId, useFinderCache);
 	}
 
 	/**
-	 * Removes the commerce shipment item where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the commerce shipment item where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the commerce shipment item that was removed
 	 */
-	public static CommerceShipmentItem removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public static CommerceShipmentItem removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws com.liferay.commerce.exception.NoSuchShipmentItemException {
 
-		return getPersistence().removeByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().removeByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the number of commerce shipment items where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of commerce shipment items where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching commerce shipment items
 	 */
-	public static int countByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public static int countByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return getPersistence().countByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().countByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/persistence/CommerceShipmentPersistence.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/persistence/CommerceShipmentPersistence.java
@@ -1073,57 +1073,57 @@ public interface CommerceShipmentPersistence
 	public int countByG_S(long[] groupIds, int status);
 
 	/**
-	 * Returns the commerce shipment where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchShipmentException</code> if it could not be found.
+	 * Returns the commerce shipment where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchShipmentException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce shipment
 	 * @throws NoSuchShipmentException if a matching commerce shipment could not be found
 	 */
-	public CommerceShipment findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public CommerceShipment findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchShipmentException;
 
 	/**
-	 * Returns the commerce shipment where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the commerce shipment where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce shipment, or <code>null</code> if a matching commerce shipment could not be found
 	 */
-	public CommerceShipment fetchByC_ERC(
-		long companyId, String externalReferenceCode);
+	public CommerceShipment fetchByERC_C(
+		String externalReferenceCode, long companyId);
 
 	/**
-	 * Returns the commerce shipment where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the commerce shipment where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching commerce shipment, or <code>null</code> if a matching commerce shipment could not be found
 	 */
-	public CommerceShipment fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache);
+	public CommerceShipment fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache);
 
 	/**
-	 * Removes the commerce shipment where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the commerce shipment where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the commerce shipment that was removed
 	 */
-	public CommerceShipment removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public CommerceShipment removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchShipmentException;
 
 	/**
-	 * Returns the number of commerce shipments where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of commerce shipments where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching commerce shipments
 	 */
-	public int countByC_ERC(long companyId, String externalReferenceCode);
+	public int countByERC_C(String externalReferenceCode, long companyId);
 
 	/**
 	 * Caches the commerce shipment in the entity cache if it is enabled.

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/persistence/CommerceShipmentUtil.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/persistence/CommerceShipmentUtil.java
@@ -1345,73 +1345,73 @@ public class CommerceShipmentUtil {
 	}
 
 	/**
-	 * Returns the commerce shipment where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchShipmentException</code> if it could not be found.
+	 * Returns the commerce shipment where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchShipmentException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce shipment
 	 * @throws NoSuchShipmentException if a matching commerce shipment could not be found
 	 */
-	public static CommerceShipment findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public static CommerceShipment findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws com.liferay.commerce.exception.NoSuchShipmentException {
 
-		return getPersistence().findByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().findByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the commerce shipment where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the commerce shipment where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce shipment, or <code>null</code> if a matching commerce shipment could not be found
 	 */
-	public static CommerceShipment fetchByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public static CommerceShipment fetchByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return getPersistence().fetchByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().fetchByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the commerce shipment where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the commerce shipment where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching commerce shipment, or <code>null</code> if a matching commerce shipment could not be found
 	 */
-	public static CommerceShipment fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache) {
+	public static CommerceShipment fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache) {
 
-		return getPersistence().fetchByC_ERC(
-			companyId, externalReferenceCode, useFinderCache);
+		return getPersistence().fetchByERC_C(
+			externalReferenceCode, companyId, useFinderCache);
 	}
 
 	/**
-	 * Removes the commerce shipment where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the commerce shipment where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the commerce shipment that was removed
 	 */
-	public static CommerceShipment removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public static CommerceShipment removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws com.liferay.commerce.exception.NoSuchShipmentException {
 
-		return getPersistence().removeByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().removeByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the number of commerce shipments where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of commerce shipments where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching commerce shipments
 	 */
-	public static int countByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public static int countByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return getPersistence().countByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().countByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/commerce/commerce-api/src/main/resources/com/liferay/commerce/exception/packageinfo
+++ b/modules/apps/commerce/commerce-api/src/main/resources/com/liferay/commerce/exception/packageinfo
@@ -1,1 +1,1 @@
-version 5.6.0
+version 5.7.0

--- a/modules/apps/commerce/commerce-api/src/main/resources/com/liferay/commerce/service/packageinfo
+++ b/modules/apps/commerce/commerce-api/src/main/resources/com/liferay/commerce/service/packageinfo
@@ -1,1 +1,1 @@
-version 26.0.1
+version 27.0.0

--- a/modules/apps/commerce/commerce-api/src/main/resources/com/liferay/commerce/service/persistence/packageinfo
+++ b/modules/apps/commerce/commerce-api/src/main/resources/com/liferay/commerce/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 10.5.0
+version 11.0.0

--- a/modules/apps/commerce/commerce-discount-api/bnd.bnd
+++ b/modules/apps/commerce/commerce-discount-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Commerce Discount API
 Bundle-SymbolicName: com.liferay.commerce.discount.api
-Bundle-Version: 12.1.1
+Bundle-Version: 13.0.0
 Export-Package:\
 	com.liferay.commerce.discount.application.strategy,\
 	com.liferay.commerce.discount.configuration,\

--- a/modules/apps/commerce/commerce-discount-api/src/main/java/com/liferay/commerce/discount/exception/DuplicateCommerceDiscountExternalReferenceCodeException.java
+++ b/modules/apps/commerce/commerce-discount-api/src/main/java/com/liferay/commerce/discount/exception/DuplicateCommerceDiscountExternalReferenceCodeException.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.commerce.discount.exception;
+
+import com.liferay.portal.kernel.exception.SystemException;
+
+/**
+ * @author Marco Leo
+ */
+public class DuplicateCommerceDiscountExternalReferenceCodeException
+	extends SystemException {
+
+	public DuplicateCommerceDiscountExternalReferenceCodeException() {
+	}
+
+	public DuplicateCommerceDiscountExternalReferenceCodeException(String msg) {
+		super(msg);
+	}
+
+	public DuplicateCommerceDiscountExternalReferenceCodeException(
+		String msg, Throwable throwable) {
+
+		super(msg, throwable);
+	}
+
+	public DuplicateCommerceDiscountExternalReferenceCodeException(
+		Throwable throwable) {
+
+		super(throwable);
+	}
+
+}

--- a/modules/apps/commerce/commerce-discount-api/src/main/java/com/liferay/commerce/discount/service/CommerceDiscountLocalService.java
+++ b/modules/apps/commerce/commerce-discount-api/src/main/java/com/liferay/commerce/discount/service/CommerceDiscountLocalService.java
@@ -391,24 +391,9 @@ public interface CommerceDiscountLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public CommerceDiscount fetchCommerceDiscount(long commerceDiscountId);
 
-	/**
-	 * Returns the commerce discount with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce discount's external reference code
-	 * @return the matching commerce discount, or <code>null</code> if a matching commerce discount could not be found
-	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public CommerceDiscount fetchCommerceDiscountByExternalReferenceCode(
-		long companyId, String externalReferenceCode);
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchCommerceDiscountByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CommerceDiscount fetchCommerceDiscountByReferenceCode(
-		long companyId, String externalReferenceCode);
+		String externalReferenceCode, long companyId);
 
 	/**
 	 * Returns the commerce discount with the matching UUID and company.
@@ -543,17 +528,9 @@ public interface CommerceDiscountLocalService
 	public CommerceDiscount getCommerceDiscount(long commerceDiscountId)
 		throws PortalException;
 
-	/**
-	 * Returns the commerce discount with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce discount's external reference code
-	 * @return the matching commerce discount
-	 * @throws PortalException if a matching commerce discount could not be found
-	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public CommerceDiscount getCommerceDiscountByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
+			String externalReferenceCode, long companyId)
 		throws PortalException;
 
 	/**

--- a/modules/apps/commerce/commerce-discount-api/src/main/java/com/liferay/commerce/discount/service/CommerceDiscountLocalServiceUtil.java
+++ b/modules/apps/commerce/commerce-discount-api/src/main/java/com/liferay/commerce/discount/service/CommerceDiscountLocalServiceUtil.java
@@ -510,29 +510,11 @@ public class CommerceDiscountLocalServiceUtil {
 		return getService().fetchCommerceDiscount(commerceDiscountId);
 	}
 
-	/**
-	 * Returns the commerce discount with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce discount's external reference code
-	 * @return the matching commerce discount, or <code>null</code> if a matching commerce discount could not be found
-	 */
 	public static CommerceDiscount fetchCommerceDiscountByExternalReferenceCode(
-		long companyId, String externalReferenceCode) {
+		String externalReferenceCode, long companyId) {
 
 		return getService().fetchCommerceDiscountByExternalReferenceCode(
-			companyId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchCommerceDiscountByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	public static CommerceDiscount fetchCommerceDiscountByReferenceCode(
-		long companyId, String externalReferenceCode) {
-
-		return getService().fetchCommerceDiscountByReferenceCode(
-			companyId, externalReferenceCode);
+			externalReferenceCode, companyId);
 	}
 
 	/**
@@ -764,20 +746,12 @@ public class CommerceDiscountLocalServiceUtil {
 		return getService().getCommerceDiscount(commerceDiscountId);
 	}
 
-	/**
-	 * Returns the commerce discount with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce discount's external reference code
-	 * @return the matching commerce discount
-	 * @throws PortalException if a matching commerce discount could not be found
-	 */
 	public static CommerceDiscount getCommerceDiscountByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
+			String externalReferenceCode, long companyId)
 		throws PortalException {
 
 		return getService().getCommerceDiscountByExternalReferenceCode(
-			companyId, externalReferenceCode);
+			externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/commerce/commerce-discount-api/src/main/java/com/liferay/commerce/discount/service/CommerceDiscountLocalServiceWrapper.java
+++ b/modules/apps/commerce/commerce-discount-api/src/main/java/com/liferay/commerce/discount/service/CommerceDiscountLocalServiceWrapper.java
@@ -564,35 +564,14 @@ public class CommerceDiscountLocalServiceWrapper
 			commerceDiscountId);
 	}
 
-	/**
-	 * Returns the commerce discount with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce discount's external reference code
-	 * @return the matching commerce discount, or <code>null</code> if a matching commerce discount could not be found
-	 */
 	@Override
 	public com.liferay.commerce.discount.model.CommerceDiscount
 		fetchCommerceDiscountByExternalReferenceCode(
-			long companyId, String externalReferenceCode) {
+			String externalReferenceCode, long companyId) {
 
 		return _commerceDiscountLocalService.
 			fetchCommerceDiscountByExternalReferenceCode(
-				companyId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchCommerceDiscountByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public com.liferay.commerce.discount.model.CommerceDiscount
-		fetchCommerceDiscountByReferenceCode(
-			long companyId, String externalReferenceCode) {
-
-		return _commerceDiscountLocalService.
-			fetchCommerceDiscountByReferenceCode(
-				companyId, externalReferenceCode);
+				externalReferenceCode, companyId);
 	}
 
 	/**
@@ -874,23 +853,15 @@ public class CommerceDiscountLocalServiceWrapper
 			commerceDiscountId);
 	}
 
-	/**
-	 * Returns the commerce discount with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce discount's external reference code
-	 * @return the matching commerce discount
-	 * @throws PortalException if a matching commerce discount could not be found
-	 */
 	@Override
 	public com.liferay.commerce.discount.model.CommerceDiscount
 			getCommerceDiscountByExternalReferenceCode(
-				long companyId, String externalReferenceCode)
+				String externalReferenceCode, long companyId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _commerceDiscountLocalService.
 			getCommerceDiscountByExternalReferenceCode(
-				companyId, externalReferenceCode);
+				externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/commerce/commerce-discount-api/src/main/java/com/liferay/commerce/discount/service/persistence/CommerceDiscountPersistence.java
+++ b/modules/apps/commerce/commerce-discount-api/src/main/java/com/liferay/commerce/discount/service/persistence/CommerceDiscountPersistence.java
@@ -1685,57 +1685,57 @@ public interface CommerceDiscountPersistence
 		long companyId, String level, boolean active, int status);
 
 	/**
-	 * Returns the commerce discount where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchDiscountException</code> if it could not be found.
+	 * Returns the commerce discount where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchDiscountException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce discount
 	 * @throws NoSuchDiscountException if a matching commerce discount could not be found
 	 */
-	public CommerceDiscount findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public CommerceDiscount findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchDiscountException;
 
 	/**
-	 * Returns the commerce discount where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the commerce discount where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce discount, or <code>null</code> if a matching commerce discount could not be found
 	 */
-	public CommerceDiscount fetchByC_ERC(
-		long companyId, String externalReferenceCode);
+	public CommerceDiscount fetchByERC_C(
+		String externalReferenceCode, long companyId);
 
 	/**
-	 * Returns the commerce discount where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the commerce discount where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching commerce discount, or <code>null</code> if a matching commerce discount could not be found
 	 */
-	public CommerceDiscount fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache);
+	public CommerceDiscount fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache);
 
 	/**
-	 * Removes the commerce discount where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the commerce discount where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the commerce discount that was removed
 	 */
-	public CommerceDiscount removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public CommerceDiscount removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchDiscountException;
 
 	/**
-	 * Returns the number of commerce discounts where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of commerce discounts where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching commerce discounts
 	 */
-	public int countByC_ERC(long companyId, String externalReferenceCode);
+	public int countByERC_C(String externalReferenceCode, long companyId);
 
 	/**
 	 * Caches the commerce discount in the entity cache if it is enabled.

--- a/modules/apps/commerce/commerce-discount-api/src/main/java/com/liferay/commerce/discount/service/persistence/CommerceDiscountUtil.java
+++ b/modules/apps/commerce/commerce-discount-api/src/main/java/com/liferay/commerce/discount/service/persistence/CommerceDiscountUtil.java
@@ -2091,73 +2091,73 @@ public class CommerceDiscountUtil {
 	}
 
 	/**
-	 * Returns the commerce discount where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchDiscountException</code> if it could not be found.
+	 * Returns the commerce discount where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchDiscountException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce discount
 	 * @throws NoSuchDiscountException if a matching commerce discount could not be found
 	 */
-	public static CommerceDiscount findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public static CommerceDiscount findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws com.liferay.commerce.discount.exception.NoSuchDiscountException {
 
-		return getPersistence().findByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().findByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the commerce discount where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the commerce discount where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce discount, or <code>null</code> if a matching commerce discount could not be found
 	 */
-	public static CommerceDiscount fetchByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public static CommerceDiscount fetchByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return getPersistence().fetchByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().fetchByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the commerce discount where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the commerce discount where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching commerce discount, or <code>null</code> if a matching commerce discount could not be found
 	 */
-	public static CommerceDiscount fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache) {
+	public static CommerceDiscount fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache) {
 
-		return getPersistence().fetchByC_ERC(
-			companyId, externalReferenceCode, useFinderCache);
+		return getPersistence().fetchByERC_C(
+			externalReferenceCode, companyId, useFinderCache);
 	}
 
 	/**
-	 * Removes the commerce discount where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the commerce discount where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the commerce discount that was removed
 	 */
-	public static CommerceDiscount removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public static CommerceDiscount removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws com.liferay.commerce.discount.exception.NoSuchDiscountException {
 
-		return getPersistence().removeByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().removeByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the number of commerce discounts where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of commerce discounts where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching commerce discounts
 	 */
-	public static int countByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public static int countByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return getPersistence().countByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().countByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/commerce/commerce-discount-api/src/main/resources/com/liferay/commerce/discount/exception/packageinfo
+++ b/modules/apps/commerce/commerce-discount-api/src/main/resources/com/liferay/commerce/discount/exception/packageinfo
@@ -1,1 +1,1 @@
-version 2.6.0
+version 2.7.0

--- a/modules/apps/commerce/commerce-discount-api/src/main/resources/com/liferay/commerce/discount/service/packageinfo
+++ b/modules/apps/commerce/commerce-discount-api/src/main/resources/com/liferay/commerce/discount/service/packageinfo
@@ -1,1 +1,1 @@
-version 7.0.0
+version 8.0.0

--- a/modules/apps/commerce/commerce-discount-api/src/main/resources/com/liferay/commerce/discount/service/persistence/packageinfo
+++ b/modules/apps/commerce/commerce-discount-api/src/main/resources/com/liferay/commerce/discount/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 4.1.0
+version 5.0.0

--- a/modules/apps/commerce/commerce-discount-service/src/main/java/com/liferay/commerce/discount/service/base/CommerceDiscountLocalServiceBaseImpl.java
+++ b/modules/apps/commerce/commerce-discount-service/src/main/java/com/liferay/commerce/discount/service/base/CommerceDiscountLocalServiceBaseImpl.java
@@ -284,48 +284,21 @@ public abstract class CommerceDiscountLocalServiceBaseImpl
 			uuid, companyId, null);
 	}
 
-	/**
-	 * Returns the commerce discount with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce discount's external reference code
-	 * @return the matching commerce discount, or <code>null</code> if a matching commerce discount could not be found
-	 */
 	@Override
 	public CommerceDiscount fetchCommerceDiscountByExternalReferenceCode(
-		long companyId, String externalReferenceCode) {
+		String externalReferenceCode, long companyId) {
 
-		return commerceDiscountPersistence.fetchByC_ERC(
-			companyId, externalReferenceCode);
+		return commerceDiscountPersistence.fetchByERC_C(
+			externalReferenceCode, companyId);
 	}
 
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchCommerceDiscountByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public CommerceDiscount fetchCommerceDiscountByReferenceCode(
-		long companyId, String externalReferenceCode) {
-
-		return fetchCommerceDiscountByExternalReferenceCode(
-			companyId, externalReferenceCode);
-	}
-
-	/**
-	 * Returns the commerce discount with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce discount's external reference code
-	 * @return the matching commerce discount
-	 * @throws PortalException if a matching commerce discount could not be found
-	 */
 	@Override
 	public CommerceDiscount getCommerceDiscountByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
+			String externalReferenceCode, long companyId)
 		throws PortalException {
 
-		return commerceDiscountPersistence.findByC_ERC(
-			companyId, externalReferenceCode);
+		return commerceDiscountPersistence.findByERC_C(
+			externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/commerce/commerce-discount-service/src/main/java/com/liferay/commerce/discount/service/impl/CommerceDiscountLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-discount-service/src/main/java/com/liferay/commerce/discount/service/impl/CommerceDiscountLocalServiceImpl.java
@@ -294,9 +294,6 @@ public class CommerceDiscountLocalServiceImpl
 			externalReferenceCode = null;
 		}
 
-		_validateExternalReferenceCode(
-			externalReferenceCode, serviceContext.getCompanyId());
-
 		// Commerce discount
 
 		User user = _userLocalService.getUser(userId);
@@ -1984,25 +1981,6 @@ public class CommerceDiscountLocalServiceImpl
 			((level4 != null) && (level4.compareTo(maxValue) > 0))) {
 
 			throw new CommerceDiscountMaxPriceValueException();
-		}
-	}
-
-	private void _validateExternalReferenceCode(
-			String externalReferenceCode, long companyId)
-		throws PortalException {
-
-		if (Validator.isNull(externalReferenceCode)) {
-			return;
-		}
-
-		CommerceDiscount commerceDiscount =
-			commerceDiscountPersistence.fetchByERC_C(
-				externalReferenceCode, companyId);
-
-		if (commerceDiscount != null) {
-			throw new DuplicateCommerceDiscountException(
-				"There is another commerce discount with external reference " +
-					"code " + externalReferenceCode);
 		}
 	}
 

--- a/modules/apps/commerce/commerce-discount-service/src/main/java/com/liferay/commerce/discount/service/impl/CommerceDiscountLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-discount-service/src/main/java/com/liferay/commerce/discount/service/impl/CommerceDiscountLocalServiceImpl.java
@@ -463,8 +463,8 @@ public class CommerceDiscountLocalServiceImpl
 
 		if (!Validator.isBlank(externalReferenceCode)) {
 			CommerceDiscount commerceDiscount =
-				commerceDiscountPersistence.fetchByC_ERC(
-					serviceContext.getCompanyId(), externalReferenceCode);
+				commerceDiscountPersistence.fetchByERC_C(
+					externalReferenceCode, serviceContext.getCompanyId());
 
 			if (commerceDiscount != null) {
 				return commerceDiscountLocalService.updateCommerceDiscount(
@@ -537,8 +537,8 @@ public class CommerceDiscountLocalServiceImpl
 
 		if (!Validator.isBlank(externalReferenceCode)) {
 			CommerceDiscount commerceDiscount =
-				commerceDiscountPersistence.fetchByC_ERC(
-					serviceContext.getCompanyId(), externalReferenceCode);
+				commerceDiscountPersistence.fetchByERC_C(
+					externalReferenceCode, serviceContext.getCompanyId());
 
 			if (commerceDiscount != null) {
 				return commerceDiscountLocalService.updateCommerceDiscount(
@@ -656,8 +656,8 @@ public class CommerceDiscountLocalServiceImpl
 			return null;
 		}
 
-		return commerceDiscountPersistence.fetchByC_ERC(
-			companyId, externalReferenceCode);
+		return commerceDiscountPersistence.fetchByERC_C(
+			externalReferenceCode, companyId);
 	}
 
 	@Override
@@ -668,8 +668,8 @@ public class CommerceDiscountLocalServiceImpl
 			return null;
 		}
 
-		return commerceDiscountPersistence.fetchByC_ERC(
-			companyId, externalReferenceCode);
+		return commerceDiscountPersistence.fetchByERC_C(
+			externalReferenceCode, companyId);
 	}
 
 	@Override
@@ -1996,8 +1996,8 @@ public class CommerceDiscountLocalServiceImpl
 		}
 
 		CommerceDiscount commerceDiscount =
-			commerceDiscountPersistence.fetchByC_ERC(
-				companyId, externalReferenceCode);
+			commerceDiscountPersistence.fetchByERC_C(
+				externalReferenceCode, companyId);
 
 		if (commerceDiscount != null) {
 			throw new DuplicateCommerceDiscountException(

--- a/modules/apps/commerce/commerce-discount-service/src/main/java/com/liferay/commerce/discount/service/impl/CommerceDiscountServiceImpl.java
+++ b/modules/apps/commerce/commerce-discount-service/src/main/java/com/liferay/commerce/discount/service/impl/CommerceDiscountServiceImpl.java
@@ -248,8 +248,8 @@ public class CommerceDiscountServiceImpl
 
 		if (!Validator.isBlank(externalReferenceCode)) {
 			CommerceDiscount commerceDiscount =
-				commerceDiscountPersistence.fetchByC_ERC(
-					serviceContext.getCompanyId(), externalReferenceCode);
+				commerceDiscountPersistence.fetchByERC_C(
+					externalReferenceCode, serviceContext.getCompanyId());
 
 			if (commerceDiscount != null) {
 				return updateCommerceDiscount(

--- a/modules/apps/commerce/commerce-discount-service/src/main/java/com/liferay/commerce/discount/service/persistence/impl/CommerceDiscountPersistenceImpl.java
+++ b/modules/apps/commerce/commerce-discount-service/src/main/java/com/liferay/commerce/discount/service/persistence/impl/CommerceDiscountPersistenceImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.commerce.discount.service.persistence.impl;
 
+import com.liferay.commerce.discount.exception.DuplicateCommerceDiscountExternalReferenceCodeException;
 import com.liferay.commerce.discount.exception.NoSuchDiscountException;
 import com.liferay.commerce.discount.model.CommerceDiscount;
 import com.liferay.commerce.discount.model.CommerceDiscountTable;
@@ -7473,35 +7474,35 @@ public class CommerceDiscountPersistenceImpl
 	private static final String _FINDER_COLUMN_C_L_A_S_STATUS_2 =
 		"commerceDiscount.status = ?";
 
-	private FinderPath _finderPathFetchByC_ERC;
-	private FinderPath _finderPathCountByC_ERC;
+	private FinderPath _finderPathFetchByERC_C;
+	private FinderPath _finderPathCountByERC_C;
 
 	/**
-	 * Returns the commerce discount where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchDiscountException</code> if it could not be found.
+	 * Returns the commerce discount where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchDiscountException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce discount
 	 * @throws NoSuchDiscountException if a matching commerce discount could not be found
 	 */
 	@Override
-	public CommerceDiscount findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public CommerceDiscount findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchDiscountException {
 
-		CommerceDiscount commerceDiscount = fetchByC_ERC(
-			companyId, externalReferenceCode);
+		CommerceDiscount commerceDiscount = fetchByERC_C(
+			externalReferenceCode, companyId);
 
 		if (commerceDiscount == null) {
 			StringBundler sb = new StringBundler(6);
 
 			sb.append(_NO_SUCH_ENTITY_WITH_KEY);
 
-			sb.append("companyId=");
-			sb.append(companyId);
-
-			sb.append(", externalReferenceCode=");
+			sb.append("externalReferenceCode=");
 			sb.append(externalReferenceCode);
+
+			sb.append(", companyId=");
+			sb.append(companyId);
 
 			sb.append("}");
 
@@ -7516,53 +7517,53 @@ public class CommerceDiscountPersistenceImpl
 	}
 
 	/**
-	 * Returns the commerce discount where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the commerce discount where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce discount, or <code>null</code> if a matching commerce discount could not be found
 	 */
 	@Override
-	public CommerceDiscount fetchByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public CommerceDiscount fetchByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return fetchByC_ERC(companyId, externalReferenceCode, true);
+		return fetchByERC_C(externalReferenceCode, companyId, true);
 	}
 
 	/**
-	 * Returns the commerce discount where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the commerce discount where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching commerce discount, or <code>null</code> if a matching commerce discount could not be found
 	 */
 	@Override
-	public CommerceDiscount fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache) {
+	public CommerceDiscount fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache) {
 
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
 		Object[] finderArgs = null;
 
 		if (useFinderCache) {
-			finderArgs = new Object[] {companyId, externalReferenceCode};
+			finderArgs = new Object[] {externalReferenceCode, companyId};
 		}
 
 		Object result = null;
 
 		if (useFinderCache) {
 			result = finderCache.getResult(
-				_finderPathFetchByC_ERC, finderArgs, this);
+				_finderPathFetchByERC_C, finderArgs, this);
 		}
 
 		if (result instanceof CommerceDiscount) {
 			CommerceDiscount commerceDiscount = (CommerceDiscount)result;
 
-			if ((companyId != commerceDiscount.getCompanyId()) ||
-				!Objects.equals(
+			if (!Objects.equals(
 					externalReferenceCode,
-					commerceDiscount.getExternalReferenceCode())) {
+					commerceDiscount.getExternalReferenceCode()) ||
+				(companyId != commerceDiscount.getCompanyId())) {
 
 				result = null;
 			}
@@ -7573,18 +7574,18 @@ public class CommerceDiscountPersistenceImpl
 
 			sb.append(_SQL_SELECT_COMMERCEDISCOUNT_WHERE);
 
-			sb.append(_FINDER_COLUMN_C_ERC_COMPANYID_2);
-
 			boolean bindExternalReferenceCode = false;
 
 			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3);
 			}
 			else {
 				bindExternalReferenceCode = true;
 
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2);
 			}
+
+			sb.append(_FINDER_COLUMN_ERC_C_COMPANYID_2);
 
 			String sql = sb.toString();
 
@@ -7597,18 +7598,18 @@ public class CommerceDiscountPersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
-				queryPos.add(companyId);
-
 				if (bindExternalReferenceCode) {
 					queryPos.add(externalReferenceCode);
 				}
+
+				queryPos.add(companyId);
 
 				List<CommerceDiscount> list = query.list();
 
 				if (list.isEmpty()) {
 					if (useFinderCache) {
 						finderCache.putResult(
-							_finderPathFetchByC_ERC, finderArgs, list);
+							_finderPathFetchByERC_C, finderArgs, list);
 					}
 				}
 				else {
@@ -7636,37 +7637,37 @@ public class CommerceDiscountPersistenceImpl
 	}
 
 	/**
-	 * Removes the commerce discount where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the commerce discount where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the commerce discount that was removed
 	 */
 	@Override
-	public CommerceDiscount removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public CommerceDiscount removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchDiscountException {
 
-		CommerceDiscount commerceDiscount = findByC_ERC(
-			companyId, externalReferenceCode);
+		CommerceDiscount commerceDiscount = findByERC_C(
+			externalReferenceCode, companyId);
 
 		return remove(commerceDiscount);
 	}
 
 	/**
-	 * Returns the number of commerce discounts where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of commerce discounts where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching commerce discounts
 	 */
 	@Override
-	public int countByC_ERC(long companyId, String externalReferenceCode) {
+	public int countByERC_C(String externalReferenceCode, long companyId) {
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
-		FinderPath finderPath = _finderPathCountByC_ERC;
+		FinderPath finderPath = _finderPathCountByERC_C;
 
-		Object[] finderArgs = new Object[] {companyId, externalReferenceCode};
+		Object[] finderArgs = new Object[] {externalReferenceCode, companyId};
 
 		Long count = (Long)finderCache.getResult(finderPath, finderArgs, this);
 
@@ -7675,18 +7676,18 @@ public class CommerceDiscountPersistenceImpl
 
 			sb.append(_SQL_COUNT_COMMERCEDISCOUNT_WHERE);
 
-			sb.append(_FINDER_COLUMN_C_ERC_COMPANYID_2);
-
 			boolean bindExternalReferenceCode = false;
 
 			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3);
 			}
 			else {
 				bindExternalReferenceCode = true;
 
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2);
 			}
+
+			sb.append(_FINDER_COLUMN_ERC_C_COMPANYID_2);
 
 			String sql = sb.toString();
 
@@ -7699,11 +7700,11 @@ public class CommerceDiscountPersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
-				queryPos.add(companyId);
-
 				if (bindExternalReferenceCode) {
 					queryPos.add(externalReferenceCode);
 				}
+
+				queryPos.add(companyId);
 
 				count = (Long)query.uniqueResult();
 
@@ -7720,14 +7721,14 @@ public class CommerceDiscountPersistenceImpl
 		return count.intValue();
 	}
 
-	private static final String _FINDER_COLUMN_C_ERC_COMPANYID_2 =
-		"commerceDiscount.companyId = ? AND ";
+	private static final String _FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2 =
+		"commerceDiscount.externalReferenceCode = ? AND ";
 
-	private static final String _FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2 =
-		"commerceDiscount.externalReferenceCode = ?";
+	private static final String _FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3 =
+		"(commerceDiscount.externalReferenceCode IS NULL OR commerceDiscount.externalReferenceCode = '') AND ";
 
-	private static final String _FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3 =
-		"(commerceDiscount.externalReferenceCode IS NULL OR commerceDiscount.externalReferenceCode = '')";
+	private static final String _FINDER_COLUMN_ERC_C_COMPANYID_2 =
+		"commerceDiscount.companyId = ?";
 
 	public CommerceDiscountPersistenceImpl() {
 		Map<String, String> dbColumnNames = new HashMap<String, String>();
@@ -7766,10 +7767,10 @@ public class CommerceDiscountPersistenceImpl
 			commerceDiscount);
 
 		finderCache.putResult(
-			_finderPathFetchByC_ERC,
+			_finderPathFetchByERC_C,
 			new Object[] {
-				commerceDiscount.getCompanyId(),
-				commerceDiscount.getExternalReferenceCode()
+				commerceDiscount.getExternalReferenceCode(),
+				commerceDiscount.getCompanyId()
 			},
 			commerceDiscount);
 	}
@@ -7858,13 +7859,13 @@ public class CommerceDiscountPersistenceImpl
 			_finderPathFetchByC_C_A, args, commerceDiscountModelImpl);
 
 		args = new Object[] {
-			commerceDiscountModelImpl.getCompanyId(),
-			commerceDiscountModelImpl.getExternalReferenceCode()
+			commerceDiscountModelImpl.getExternalReferenceCode(),
+			commerceDiscountModelImpl.getCompanyId()
 		};
 
-		finderCache.putResult(_finderPathCountByC_ERC, args, Long.valueOf(1));
+		finderCache.putResult(_finderPathCountByERC_C, args, Long.valueOf(1));
 		finderCache.putResult(
-			_finderPathFetchByC_ERC, args, commerceDiscountModelImpl);
+			_finderPathFetchByERC_C, args, commerceDiscountModelImpl);
 	}
 
 	/**
@@ -8008,6 +8009,29 @@ public class CommerceDiscountPersistenceImpl
 		if (Validator.isNull(commerceDiscount.getExternalReferenceCode())) {
 			commerceDiscount.setExternalReferenceCode(
 				commerceDiscount.getUuid());
+		}
+		else {
+			CommerceDiscount ercCommerceDiscount = fetchByERC_C(
+				commerceDiscount.getExternalReferenceCode(),
+				commerceDiscount.getCompanyId());
+
+			if (isNew) {
+				if (ercCommerceDiscount != null) {
+					throw new DuplicateCommerceDiscountExternalReferenceCodeException(
+						"Duplicate CommerceDiscount with external reference code " +
+							commerceDiscount.getExternalReferenceCode());
+				}
+			}
+			else {
+				if ((ercCommerceDiscount != null) &&
+					(commerceDiscount.getCommerceDiscountId() !=
+						ercCommerceDiscount.getCommerceDiscountId())) {
+
+					throw new DuplicateCommerceDiscountExternalReferenceCodeException(
+						"Duplicate CommerceDiscount with external reference code " +
+							commerceDiscount.getExternalReferenceCode());
+				}
+			}
 		}
 
 		ServiceContext serviceContext =
@@ -8490,15 +8514,15 @@ public class CommerceDiscountPersistenceImpl
 			new String[] {"companyId", "levelType", "active_", "status"},
 			false);
 
-		_finderPathFetchByC_ERC = new FinderPath(
-			FINDER_CLASS_NAME_ENTITY, "fetchByC_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"companyId", "externalReferenceCode"}, true);
+		_finderPathFetchByERC_C = new FinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, true);
 
-		_finderPathCountByC_ERC = new FinderPath(
-			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"companyId", "externalReferenceCode"}, false);
+		_finderPathCountByERC_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, false);
 
 		_setCommerceDiscountUtilPersistence(this);
 	}

--- a/modules/apps/commerce/commerce-discount-test/src/testIntegration/java/com/liferay/commerce/discount/service/persistence/test/CommerceDiscountPersistenceTest.java
+++ b/modules/apps/commerce/commerce-discount-test/src/testIntegration/java/com/liferay/commerce/discount/service/persistence/test/CommerceDiscountPersistenceTest.java
@@ -15,6 +15,7 @@
 package com.liferay.commerce.discount.service.persistence.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.commerce.discount.exception.DuplicateCommerceDiscountExternalReferenceCodeException;
 import com.liferay.commerce.discount.exception.NoSuchDiscountException;
 import com.liferay.commerce.discount.model.CommerceDiscount;
 import com.liferay.commerce.discount.service.CommerceDiscountLocalServiceUtil;
@@ -304,6 +305,28 @@ public class CommerceDiscountPersistenceTest {
 			Time.getShortTimestamp(newCommerceDiscount.getStatusDate()));
 	}
 
+	@Test(
+		expected = DuplicateCommerceDiscountExternalReferenceCodeException.class
+	)
+	public void testUpdateWithExistingExternalReferenceCode() throws Exception {
+		CommerceDiscount commerceDiscount = addCommerceDiscount();
+
+		CommerceDiscount newCommerceDiscount = addCommerceDiscount();
+
+		newCommerceDiscount.setCompanyId(commerceDiscount.getCompanyId());
+
+		newCommerceDiscount = _persistence.update(newCommerceDiscount);
+
+		Session session = _persistence.getCurrentSession();
+
+		session.evict(newCommerceDiscount);
+
+		newCommerceDiscount.setExternalReferenceCode(
+			commerceDiscount.getExternalReferenceCode());
+
+		_persistence.update(newCommerceDiscount);
+	}
+
 	@Test
 	public void testCountByUuid() throws Exception {
 		_persistence.countByUuid("");
@@ -379,12 +402,12 @@ public class CommerceDiscountPersistenceTest {
 	}
 
 	@Test
-	public void testCountByC_ERC() throws Exception {
-		_persistence.countByC_ERC(RandomTestUtil.nextLong(), "");
+	public void testCountByERC_C() throws Exception {
+		_persistence.countByERC_C("", RandomTestUtil.nextLong());
 
-		_persistence.countByC_ERC(0L, "null");
+		_persistence.countByERC_C("null", 0L);
 
-		_persistence.countByC_ERC(0L, (String)null);
+		_persistence.countByERC_C((String)null, 0L);
 	}
 
 	@Test
@@ -712,15 +735,15 @@ public class CommerceDiscountPersistenceTest {
 				new Class<?>[] {String.class}, "active_"));
 
 		Assert.assertEquals(
-			Long.valueOf(commerceDiscount.getCompanyId()),
-			ReflectionTestUtil.<Long>invoke(
-				commerceDiscount, "getColumnOriginalValue",
-				new Class<?>[] {String.class}, "companyId"));
-		Assert.assertEquals(
 			commerceDiscount.getExternalReferenceCode(),
 			ReflectionTestUtil.invoke(
 				commerceDiscount, "getColumnOriginalValue",
 				new Class<?>[] {String.class}, "externalReferenceCode"));
+		Assert.assertEquals(
+			Long.valueOf(commerceDiscount.getCompanyId()),
+			ReflectionTestUtil.<Long>invoke(
+				commerceDiscount, "getColumnOriginalValue",
+				new Class<?>[] {String.class}, "companyId"));
 	}
 
 	protected CommerceDiscount addCommerceDiscount() throws Exception {

--- a/modules/apps/commerce/commerce-order-rule-api/bnd.bnd
+++ b/modules/apps/commerce/commerce-order-rule-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Commerce Order Rule API
 Bundle-SymbolicName: com.liferay.commerce.order.rule.api
-Bundle-Version: 5.1.1
+Bundle-Version: 6.0.0
 Export-Package:\
 	com.liferay.commerce.order.rule.configuration,\
 	com.liferay.commerce.order.rule.constants,\

--- a/modules/apps/commerce/commerce-order-rule-api/src/main/java/com/liferay/commerce/order/rule/exception/DuplicateCOREntryExternalReferenceCodeException.java
+++ b/modules/apps/commerce/commerce-order-rule-api/src/main/java/com/liferay/commerce/order/rule/exception/DuplicateCOREntryExternalReferenceCodeException.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.commerce.order.rule.exception;
+
+import com.liferay.portal.kernel.exception.SystemException;
+
+/**
+ * @author Luca Pellizzon
+ */
+public class DuplicateCOREntryExternalReferenceCodeException
+	extends SystemException {
+
+	public DuplicateCOREntryExternalReferenceCodeException() {
+	}
+
+	public DuplicateCOREntryExternalReferenceCodeException(String msg) {
+		super(msg);
+	}
+
+	public DuplicateCOREntryExternalReferenceCodeException(
+		String msg, Throwable throwable) {
+
+		super(msg, throwable);
+	}
+
+	public DuplicateCOREntryExternalReferenceCodeException(
+		Throwable throwable) {
+
+		super(throwable);
+	}
+
+}

--- a/modules/apps/commerce/commerce-order-rule-api/src/main/java/com/liferay/commerce/order/rule/service/COREntryLocalService.java
+++ b/modules/apps/commerce/commerce-order-rule-api/src/main/java/com/liferay/commerce/order/rule/service/COREntryLocalService.java
@@ -220,24 +220,9 @@ public interface COREntryLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public COREntry fetchCOREntry(long COREntryId);
 
-	/**
-	 * Returns the cor entry with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the cor entry's external reference code
-	 * @return the matching cor entry, or <code>null</code> if a matching cor entry could not be found
-	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public COREntry fetchCOREntryByExternalReferenceCode(
-		long companyId, String externalReferenceCode);
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchCOREntryByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public COREntry fetchCOREntryByReferenceCode(
-		long companyId, String externalReferenceCode);
+		String externalReferenceCode, long companyId);
 
 	/**
 	 * Returns the cor entry with the matching UUID and company.
@@ -345,17 +330,9 @@ public interface COREntryLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public COREntry getCOREntry(long COREntryId) throws PortalException;
 
-	/**
-	 * Returns the cor entry with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the cor entry's external reference code
-	 * @return the matching cor entry
-	 * @throws PortalException if a matching cor entry could not be found
-	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public COREntry getCOREntryByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
+			String externalReferenceCode, long companyId)
 		throws PortalException;
 
 	/**

--- a/modules/apps/commerce/commerce-order-rule-api/src/main/java/com/liferay/commerce/order/rule/service/COREntryLocalServiceUtil.java
+++ b/modules/apps/commerce/commerce-order-rule-api/src/main/java/com/liferay/commerce/order/rule/service/COREntryLocalServiceUtil.java
@@ -235,29 +235,11 @@ public class COREntryLocalServiceUtil {
 		return getService().fetchCOREntry(COREntryId);
 	}
 
-	/**
-	 * Returns the cor entry with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the cor entry's external reference code
-	 * @return the matching cor entry, or <code>null</code> if a matching cor entry could not be found
-	 */
 	public static COREntry fetchCOREntryByExternalReferenceCode(
-		long companyId, String externalReferenceCode) {
+		String externalReferenceCode, long companyId) {
 
 		return getService().fetchCOREntryByExternalReferenceCode(
-			companyId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchCOREntryByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	public static COREntry fetchCOREntryByReferenceCode(
-		long companyId, String externalReferenceCode) {
-
-		return getService().fetchCOREntryByReferenceCode(
-			companyId, externalReferenceCode);
+			externalReferenceCode, companyId);
 	}
 
 	/**
@@ -418,20 +400,12 @@ public class COREntryLocalServiceUtil {
 		return getService().getCOREntry(COREntryId);
 	}
 
-	/**
-	 * Returns the cor entry with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the cor entry's external reference code
-	 * @return the matching cor entry
-	 * @throws PortalException if a matching cor entry could not be found
-	 */
 	public static COREntry getCOREntryByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
+			String externalReferenceCode, long companyId)
 		throws PortalException {
 
 		return getService().getCOREntryByExternalReferenceCode(
-			companyId, externalReferenceCode);
+			externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/commerce/commerce-order-rule-api/src/main/java/com/liferay/commerce/order/rule/service/COREntryLocalServiceWrapper.java
+++ b/modules/apps/commerce/commerce-order-rule-api/src/main/java/com/liferay/commerce/order/rule/service/COREntryLocalServiceWrapper.java
@@ -262,33 +262,13 @@ public class COREntryLocalServiceWrapper
 		return _corEntryLocalService.fetchCOREntry(COREntryId);
 	}
 
-	/**
-	 * Returns the cor entry with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the cor entry's external reference code
-	 * @return the matching cor entry, or <code>null</code> if a matching cor entry could not be found
-	 */
 	@Override
 	public com.liferay.commerce.order.rule.model.COREntry
 		fetchCOREntryByExternalReferenceCode(
-			long companyId, String externalReferenceCode) {
+			String externalReferenceCode, long companyId) {
 
 		return _corEntryLocalService.fetchCOREntryByExternalReferenceCode(
-			companyId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchCOREntryByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public com.liferay.commerce.order.rule.model.COREntry
-		fetchCOREntryByReferenceCode(
-			long companyId, String externalReferenceCode) {
-
-		return _corEntryLocalService.fetchCOREntryByReferenceCode(
-			companyId, externalReferenceCode);
+			externalReferenceCode, companyId);
 	}
 
 	/**
@@ -487,22 +467,14 @@ public class COREntryLocalServiceWrapper
 		return _corEntryLocalService.getCOREntry(COREntryId);
 	}
 
-	/**
-	 * Returns the cor entry with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the cor entry's external reference code
-	 * @return the matching cor entry
-	 * @throws PortalException if a matching cor entry could not be found
-	 */
 	@Override
 	public com.liferay.commerce.order.rule.model.COREntry
 			getCOREntryByExternalReferenceCode(
-				long companyId, String externalReferenceCode)
+				String externalReferenceCode, long companyId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _corEntryLocalService.getCOREntryByExternalReferenceCode(
-			companyId, externalReferenceCode);
+			externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/commerce/commerce-order-rule-api/src/main/java/com/liferay/commerce/order/rule/service/persistence/COREntryPersistence.java
+++ b/modules/apps/commerce/commerce-order-rule-api/src/main/java/com/liferay/commerce/order/rule/service/persistence/COREntryPersistence.java
@@ -1614,54 +1614,54 @@ public interface COREntryPersistence extends BasePersistence<COREntry> {
 		long companyId, boolean active, String type);
 
 	/**
-	 * Returns the cor entry where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchCOREntryException</code> if it could not be found.
+	 * Returns the cor entry where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchCOREntryException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching cor entry
 	 * @throws NoSuchCOREntryException if a matching cor entry could not be found
 	 */
-	public COREntry findByC_ERC(long companyId, String externalReferenceCode)
+	public COREntry findByERC_C(String externalReferenceCode, long companyId)
 		throws NoSuchCOREntryException;
 
 	/**
-	 * Returns the cor entry where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the cor entry where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching cor entry, or <code>null</code> if a matching cor entry could not be found
 	 */
-	public COREntry fetchByC_ERC(long companyId, String externalReferenceCode);
+	public COREntry fetchByERC_C(String externalReferenceCode, long companyId);
 
 	/**
-	 * Returns the cor entry where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the cor entry where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching cor entry, or <code>null</code> if a matching cor entry could not be found
 	 */
-	public COREntry fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache);
+	public COREntry fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache);
 
 	/**
-	 * Removes the cor entry where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the cor entry where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the cor entry that was removed
 	 */
-	public COREntry removeByC_ERC(long companyId, String externalReferenceCode)
+	public COREntry removeByERC_C(String externalReferenceCode, long companyId)
 		throws NoSuchCOREntryException;
 
 	/**
-	 * Returns the number of cor entries where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of cor entries where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching cor entries
 	 */
-	public int countByC_ERC(long companyId, String externalReferenceCode);
+	public int countByERC_C(String externalReferenceCode, long companyId);
 
 	/**
 	 * Caches the cor entry in the entity cache if it is enabled.

--- a/modules/apps/commerce/commerce-order-rule-api/src/main/java/com/liferay/commerce/order/rule/service/persistence/COREntryUtil.java
+++ b/modules/apps/commerce/commerce-order-rule-api/src/main/java/com/liferay/commerce/order/rule/service/persistence/COREntryUtil.java
@@ -2022,75 +2022,75 @@ public class COREntryUtil {
 	}
 
 	/**
-	 * Returns the cor entry where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchCOREntryException</code> if it could not be found.
+	 * Returns the cor entry where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchCOREntryException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching cor entry
 	 * @throws NoSuchCOREntryException if a matching cor entry could not be found
 	 */
-	public static COREntry findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public static COREntry findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws com.liferay.commerce.order.rule.exception.
 			NoSuchCOREntryException {
 
-		return getPersistence().findByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().findByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the cor entry where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the cor entry where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching cor entry, or <code>null</code> if a matching cor entry could not be found
 	 */
-	public static COREntry fetchByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public static COREntry fetchByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return getPersistence().fetchByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().fetchByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the cor entry where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the cor entry where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching cor entry, or <code>null</code> if a matching cor entry could not be found
 	 */
-	public static COREntry fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache) {
+	public static COREntry fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache) {
 
-		return getPersistence().fetchByC_ERC(
-			companyId, externalReferenceCode, useFinderCache);
+		return getPersistence().fetchByERC_C(
+			externalReferenceCode, companyId, useFinderCache);
 	}
 
 	/**
-	 * Removes the cor entry where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the cor entry where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the cor entry that was removed
 	 */
-	public static COREntry removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public static COREntry removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws com.liferay.commerce.order.rule.exception.
 			NoSuchCOREntryException {
 
-		return getPersistence().removeByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().removeByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the number of cor entries where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of cor entries where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching cor entries
 	 */
-	public static int countByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public static int countByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return getPersistence().countByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().countByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/commerce/commerce-order-rule-api/src/main/resources/com/liferay/commerce/order/rule/exception/packageinfo
+++ b/modules/apps/commerce/commerce-order-rule-api/src/main/resources/com/liferay/commerce/order/rule/exception/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0

--- a/modules/apps/commerce/commerce-order-rule-api/src/main/resources/com/liferay/commerce/order/rule/service/packageinfo
+++ b/modules/apps/commerce/commerce-order-rule-api/src/main/resources/com/liferay/commerce/order/rule/service/packageinfo
@@ -1,1 +1,1 @@
-version 2.5.0
+version 3.0.0

--- a/modules/apps/commerce/commerce-order-rule-api/src/main/resources/com/liferay/commerce/order/rule/service/persistence/packageinfo
+++ b/modules/apps/commerce/commerce-order-rule-api/src/main/resources/com/liferay/commerce/order/rule/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 2.1.0
+version 3.0.0

--- a/modules/apps/commerce/commerce-order-rule-service/src/main/java/com/liferay/commerce/order/rule/service/base/COREntryLocalServiceBaseImpl.java
+++ b/modules/apps/commerce/commerce-order-rule-service/src/main/java/com/liferay/commerce/order/rule/service/base/COREntryLocalServiceBaseImpl.java
@@ -273,48 +273,21 @@ public abstract class COREntryLocalServiceBaseImpl
 		return corEntryPersistence.fetchByUuid_C_First(uuid, companyId, null);
 	}
 
-	/**
-	 * Returns the cor entry with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the cor entry's external reference code
-	 * @return the matching cor entry, or <code>null</code> if a matching cor entry could not be found
-	 */
 	@Override
 	public COREntry fetchCOREntryByExternalReferenceCode(
-		long companyId, String externalReferenceCode) {
+		String externalReferenceCode, long companyId) {
 
-		return corEntryPersistence.fetchByC_ERC(
-			companyId, externalReferenceCode);
+		return corEntryPersistence.fetchByERC_C(
+			externalReferenceCode, companyId);
 	}
 
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchCOREntryByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public COREntry fetchCOREntryByReferenceCode(
-		long companyId, String externalReferenceCode) {
-
-		return fetchCOREntryByExternalReferenceCode(
-			companyId, externalReferenceCode);
-	}
-
-	/**
-	 * Returns the cor entry with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the cor entry's external reference code
-	 * @return the matching cor entry
-	 * @throws PortalException if a matching cor entry could not be found
-	 */
 	@Override
 	public COREntry getCOREntryByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
+			String externalReferenceCode, long companyId)
 		throws PortalException {
 
-		return corEntryPersistence.findByC_ERC(
-			companyId, externalReferenceCode);
+		return corEntryPersistence.findByERC_C(
+			externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/commerce/commerce-order-rule-service/src/main/java/com/liferay/commerce/order/rule/service/impl/COREntryServiceImpl.java
+++ b/modules/apps/commerce/commerce-order-rule-service/src/main/java/com/liferay/commerce/order/rule/service/impl/COREntryServiceImpl.java
@@ -82,7 +82,7 @@ public class COREntryServiceImpl extends COREntryServiceBaseImpl {
 
 		COREntry corEntry =
 			corEntryLocalService.fetchCOREntryByExternalReferenceCode(
-				companyId, externalReferenceCode);
+				externalReferenceCode, companyId);
 
 		if (corEntry != null) {
 			_corEntryModelResourcePermission.check(

--- a/modules/apps/commerce/commerce-order-rule-service/src/main/java/com/liferay/commerce/order/rule/service/persistence/impl/COREntryPersistenceImpl.java
+++ b/modules/apps/commerce/commerce-order-rule-service/src/main/java/com/liferay/commerce/order/rule/service/persistence/impl/COREntryPersistenceImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.commerce.order.rule.service.persistence.impl;
 
+import com.liferay.commerce.order.rule.exception.DuplicateCOREntryExternalReferenceCodeException;
 import com.liferay.commerce.order.rule.exception.NoSuchCOREntryException;
 import com.liferay.commerce.order.rule.model.COREntry;
 import com.liferay.commerce.order.rule.model.COREntryTable;
@@ -7032,33 +7033,33 @@ public class COREntryPersistenceImpl
 	private static final String _FINDER_COLUMN_C_A_LIKETYPE_TYPE_3_SQL =
 		"(corEntry.type_ IS NULL OR corEntry.type_ LIKE '')";
 
-	private FinderPath _finderPathFetchByC_ERC;
-	private FinderPath _finderPathCountByC_ERC;
+	private FinderPath _finderPathFetchByERC_C;
+	private FinderPath _finderPathCountByERC_C;
 
 	/**
-	 * Returns the cor entry where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchCOREntryException</code> if it could not be found.
+	 * Returns the cor entry where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchCOREntryException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching cor entry
 	 * @throws NoSuchCOREntryException if a matching cor entry could not be found
 	 */
 	@Override
-	public COREntry findByC_ERC(long companyId, String externalReferenceCode)
+	public COREntry findByERC_C(String externalReferenceCode, long companyId)
 		throws NoSuchCOREntryException {
 
-		COREntry corEntry = fetchByC_ERC(companyId, externalReferenceCode);
+		COREntry corEntry = fetchByERC_C(externalReferenceCode, companyId);
 
 		if (corEntry == null) {
 			StringBundler sb = new StringBundler(6);
 
 			sb.append(_NO_SUCH_ENTITY_WITH_KEY);
 
-			sb.append("companyId=");
-			sb.append(companyId);
-
-			sb.append(", externalReferenceCode=");
+			sb.append("externalReferenceCode=");
 			sb.append(externalReferenceCode);
+
+			sb.append(", companyId=");
+			sb.append(companyId);
 
 			sb.append("}");
 
@@ -7073,51 +7074,51 @@ public class COREntryPersistenceImpl
 	}
 
 	/**
-	 * Returns the cor entry where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the cor entry where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching cor entry, or <code>null</code> if a matching cor entry could not be found
 	 */
 	@Override
-	public COREntry fetchByC_ERC(long companyId, String externalReferenceCode) {
-		return fetchByC_ERC(companyId, externalReferenceCode, true);
+	public COREntry fetchByERC_C(String externalReferenceCode, long companyId) {
+		return fetchByERC_C(externalReferenceCode, companyId, true);
 	}
 
 	/**
-	 * Returns the cor entry where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the cor entry where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching cor entry, or <code>null</code> if a matching cor entry could not be found
 	 */
 	@Override
-	public COREntry fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache) {
+	public COREntry fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache) {
 
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
 		Object[] finderArgs = null;
 
 		if (useFinderCache) {
-			finderArgs = new Object[] {companyId, externalReferenceCode};
+			finderArgs = new Object[] {externalReferenceCode, companyId};
 		}
 
 		Object result = null;
 
 		if (useFinderCache) {
 			result = finderCache.getResult(
-				_finderPathFetchByC_ERC, finderArgs, this);
+				_finderPathFetchByERC_C, finderArgs, this);
 		}
 
 		if (result instanceof COREntry) {
 			COREntry corEntry = (COREntry)result;
 
-			if ((companyId != corEntry.getCompanyId()) ||
-				!Objects.equals(
+			if (!Objects.equals(
 					externalReferenceCode,
-					corEntry.getExternalReferenceCode())) {
+					corEntry.getExternalReferenceCode()) ||
+				(companyId != corEntry.getCompanyId())) {
 
 				result = null;
 			}
@@ -7128,18 +7129,18 @@ public class COREntryPersistenceImpl
 
 			sb.append(_SQL_SELECT_CORENTRY_WHERE);
 
-			sb.append(_FINDER_COLUMN_C_ERC_COMPANYID_2);
-
 			boolean bindExternalReferenceCode = false;
 
 			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3);
 			}
 			else {
 				bindExternalReferenceCode = true;
 
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2);
 			}
+
+			sb.append(_FINDER_COLUMN_ERC_C_COMPANYID_2);
 
 			String sql = sb.toString();
 
@@ -7152,18 +7153,18 @@ public class COREntryPersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
-				queryPos.add(companyId);
-
 				if (bindExternalReferenceCode) {
 					queryPos.add(externalReferenceCode);
 				}
+
+				queryPos.add(companyId);
 
 				List<COREntry> list = query.list();
 
 				if (list.isEmpty()) {
 					if (useFinderCache) {
 						finderCache.putResult(
-							_finderPathFetchByC_ERC, finderArgs, list);
+							_finderPathFetchByERC_C, finderArgs, list);
 					}
 				}
 				else {
@@ -7191,35 +7192,35 @@ public class COREntryPersistenceImpl
 	}
 
 	/**
-	 * Removes the cor entry where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the cor entry where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the cor entry that was removed
 	 */
 	@Override
-	public COREntry removeByC_ERC(long companyId, String externalReferenceCode)
+	public COREntry removeByERC_C(String externalReferenceCode, long companyId)
 		throws NoSuchCOREntryException {
 
-		COREntry corEntry = findByC_ERC(companyId, externalReferenceCode);
+		COREntry corEntry = findByERC_C(externalReferenceCode, companyId);
 
 		return remove(corEntry);
 	}
 
 	/**
-	 * Returns the number of cor entries where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of cor entries where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching cor entries
 	 */
 	@Override
-	public int countByC_ERC(long companyId, String externalReferenceCode) {
+	public int countByERC_C(String externalReferenceCode, long companyId) {
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
-		FinderPath finderPath = _finderPathCountByC_ERC;
+		FinderPath finderPath = _finderPathCountByERC_C;
 
-		Object[] finderArgs = new Object[] {companyId, externalReferenceCode};
+		Object[] finderArgs = new Object[] {externalReferenceCode, companyId};
 
 		Long count = (Long)finderCache.getResult(finderPath, finderArgs, this);
 
@@ -7228,18 +7229,18 @@ public class COREntryPersistenceImpl
 
 			sb.append(_SQL_COUNT_CORENTRY_WHERE);
 
-			sb.append(_FINDER_COLUMN_C_ERC_COMPANYID_2);
-
 			boolean bindExternalReferenceCode = false;
 
 			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3);
 			}
 			else {
 				bindExternalReferenceCode = true;
 
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2);
 			}
+
+			sb.append(_FINDER_COLUMN_ERC_C_COMPANYID_2);
 
 			String sql = sb.toString();
 
@@ -7252,11 +7253,11 @@ public class COREntryPersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
-				queryPos.add(companyId);
-
 				if (bindExternalReferenceCode) {
 					queryPos.add(externalReferenceCode);
 				}
+
+				queryPos.add(companyId);
 
 				count = (Long)query.uniqueResult();
 
@@ -7273,14 +7274,14 @@ public class COREntryPersistenceImpl
 		return count.intValue();
 	}
 
-	private static final String _FINDER_COLUMN_C_ERC_COMPANYID_2 =
-		"corEntry.companyId = ? AND ";
+	private static final String _FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2 =
+		"corEntry.externalReferenceCode = ? AND ";
 
-	private static final String _FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2 =
-		"corEntry.externalReferenceCode = ?";
+	private static final String _FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3 =
+		"(corEntry.externalReferenceCode IS NULL OR corEntry.externalReferenceCode = '') AND ";
 
-	private static final String _FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3 =
-		"(corEntry.externalReferenceCode IS NULL OR corEntry.externalReferenceCode = '')";
+	private static final String _FINDER_COLUMN_ERC_C_COMPANYID_2 =
+		"corEntry.companyId = ?";
 
 	public COREntryPersistenceImpl() {
 		Map<String, String> dbColumnNames = new HashMap<String, String>();
@@ -7310,9 +7311,9 @@ public class COREntryPersistenceImpl
 			COREntryImpl.class, corEntry.getPrimaryKey(), corEntry);
 
 		finderCache.putResult(
-			_finderPathFetchByC_ERC,
+			_finderPathFetchByERC_C,
 			new Object[] {
-				corEntry.getCompanyId(), corEntry.getExternalReferenceCode()
+				corEntry.getExternalReferenceCode(), corEntry.getCompanyId()
 			},
 			corEntry);
 	}
@@ -7388,12 +7389,12 @@ public class COREntryPersistenceImpl
 		COREntryModelImpl corEntryModelImpl) {
 
 		Object[] args = new Object[] {
-			corEntryModelImpl.getCompanyId(),
-			corEntryModelImpl.getExternalReferenceCode()
+			corEntryModelImpl.getExternalReferenceCode(),
+			corEntryModelImpl.getCompanyId()
 		};
 
-		finderCache.putResult(_finderPathCountByC_ERC, args, Long.valueOf(1));
-		finderCache.putResult(_finderPathFetchByC_ERC, args, corEntryModelImpl);
+		finderCache.putResult(_finderPathCountByERC_C, args, Long.valueOf(1));
+		finderCache.putResult(_finderPathFetchByERC_C, args, corEntryModelImpl);
 	}
 
 	/**
@@ -7531,6 +7532,27 @@ public class COREntryPersistenceImpl
 
 		if (Validator.isNull(corEntry.getExternalReferenceCode())) {
 			corEntry.setExternalReferenceCode(corEntry.getUuid());
+		}
+		else {
+			COREntry ercCOREntry = fetchByERC_C(
+				corEntry.getExternalReferenceCode(), corEntry.getCompanyId());
+
+			if (isNew) {
+				if (ercCOREntry != null) {
+					throw new DuplicateCOREntryExternalReferenceCodeException(
+						"Duplicate COREntry with external reference code " +
+							corEntry.getExternalReferenceCode());
+				}
+			}
+			else {
+				if ((ercCOREntry != null) &&
+					(corEntry.getCOREntryId() != ercCOREntry.getCOREntryId())) {
+
+					throw new DuplicateCOREntryExternalReferenceCodeException(
+						"Duplicate COREntry with external reference code " +
+							corEntry.getExternalReferenceCode());
+				}
+			}
 		}
 
 		ServiceContext serviceContext =
@@ -7978,15 +8000,15 @@ public class COREntryPersistenceImpl
 			},
 			new String[] {"companyId", "active_", "type_"}, false);
 
-		_finderPathFetchByC_ERC = new FinderPath(
-			FINDER_CLASS_NAME_ENTITY, "fetchByC_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"companyId", "externalReferenceCode"}, true);
+		_finderPathFetchByERC_C = new FinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, true);
 
-		_finderPathCountByC_ERC = new FinderPath(
-			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"companyId", "externalReferenceCode"}, false);
+		_finderPathCountByERC_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, false);
 
 		_setCOREntryUtilPersistence(this);
 	}

--- a/modules/apps/commerce/commerce-order-rule-test/src/testIntegration/java/com/liferay/commerce/order/rule/service/persistence/test/COREntryPersistenceTest.java
+++ b/modules/apps/commerce/commerce-order-rule-test/src/testIntegration/java/com/liferay/commerce/order/rule/service/persistence/test/COREntryPersistenceTest.java
@@ -15,6 +15,7 @@
 package com.liferay.commerce.order.rule.service.persistence.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.commerce.order.rule.exception.DuplicateCOREntryExternalReferenceCodeException;
 import com.liferay.commerce.order.rule.exception.NoSuchCOREntryException;
 import com.liferay.commerce.order.rule.model.COREntry;
 import com.liferay.commerce.order.rule.service.COREntryLocalServiceUtil;
@@ -224,6 +225,26 @@ public class COREntryPersistenceTest {
 			Time.getShortTimestamp(newCOREntry.getStatusDate()));
 	}
 
+	@Test(expected = DuplicateCOREntryExternalReferenceCodeException.class)
+	public void testUpdateWithExistingExternalReferenceCode() throws Exception {
+		COREntry corEntry = addCOREntry();
+
+		COREntry newCOREntry = addCOREntry();
+
+		newCOREntry.setCompanyId(corEntry.getCompanyId());
+
+		newCOREntry = _persistence.update(newCOREntry);
+
+		Session session = _persistence.getCurrentSession();
+
+		session.evict(newCOREntry);
+
+		newCOREntry.setExternalReferenceCode(
+			corEntry.getExternalReferenceCode());
+
+		_persistence.update(newCOREntry);
+	}
+
 	@Test
 	public void testCountByUuid() throws Exception {
 		_persistence.countByUuid("");
@@ -288,12 +309,12 @@ public class COREntryPersistenceTest {
 	}
 
 	@Test
-	public void testCountByC_ERC() throws Exception {
-		_persistence.countByC_ERC(RandomTestUtil.nextLong(), "");
+	public void testCountByERC_C() throws Exception {
+		_persistence.countByERC_C("", RandomTestUtil.nextLong());
 
-		_persistence.countByC_ERC(0L, "null");
+		_persistence.countByERC_C("null", 0L);
 
-		_persistence.countByC_ERC(0L, (String)null);
+		_persistence.countByERC_C((String)null, 0L);
 	}
 
 	@Test
@@ -589,15 +610,15 @@ public class COREntryPersistenceTest {
 
 	private void _assertOriginalValues(COREntry corEntry) {
 		Assert.assertEquals(
-			Long.valueOf(corEntry.getCompanyId()),
-			ReflectionTestUtil.<Long>invoke(
-				corEntry, "getColumnOriginalValue",
-				new Class<?>[] {String.class}, "companyId"));
-		Assert.assertEquals(
 			corEntry.getExternalReferenceCode(),
 			ReflectionTestUtil.invoke(
 				corEntry, "getColumnOriginalValue",
 				new Class<?>[] {String.class}, "externalReferenceCode"));
+		Assert.assertEquals(
+			Long.valueOf(corEntry.getCompanyId()),
+			ReflectionTestUtil.<Long>invoke(
+				corEntry, "getColumnOriginalValue",
+				new Class<?>[] {String.class}, "companyId"));
 	}
 
 	protected COREntry addCOREntry() throws Exception {

--- a/modules/apps/commerce/commerce-pricing-api/bnd.bnd
+++ b/modules/apps/commerce/commerce-pricing-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Commerce Pricing API
 Bundle-SymbolicName: com.liferay.commerce.pricing.api
-Bundle-Version: 12.2.1
+Bundle-Version: 13.0.0
 Export-Package:\
 	com.liferay.commerce.pricing.configuration,\
 	com.liferay.commerce.pricing.constants,\

--- a/modules/apps/commerce/commerce-pricing-api/src/main/java/com/liferay/commerce/pricing/exception/DuplicateCommercePriceModifierExternalReferenceCodeException.java
+++ b/modules/apps/commerce/commerce-pricing-api/src/main/java/com/liferay/commerce/pricing/exception/DuplicateCommercePriceModifierExternalReferenceCodeException.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.commerce.pricing.exception;
+
+import com.liferay.portal.kernel.exception.SystemException;
+
+/**
+ * @author Riccardo Alberti
+ */
+public class DuplicateCommercePriceModifierExternalReferenceCodeException
+	extends SystemException {
+
+	public DuplicateCommercePriceModifierExternalReferenceCodeException() {
+	}
+
+	public DuplicateCommercePriceModifierExternalReferenceCodeException(
+		String msg) {
+
+		super(msg);
+	}
+
+	public DuplicateCommercePriceModifierExternalReferenceCodeException(
+		String msg, Throwable throwable) {
+
+		super(msg, throwable);
+	}
+
+	public DuplicateCommercePriceModifierExternalReferenceCodeException(
+		Throwable throwable) {
+
+		super(throwable);
+	}
+
+}

--- a/modules/apps/commerce/commerce-pricing-api/src/main/java/com/liferay/commerce/pricing/exception/DuplicateCommercePricingClassExternalReferenceCodeException.java
+++ b/modules/apps/commerce/commerce-pricing-api/src/main/java/com/liferay/commerce/pricing/exception/DuplicateCommercePricingClassExternalReferenceCodeException.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.commerce.pricing.exception;
+
+import com.liferay.portal.kernel.exception.SystemException;
+
+/**
+ * @author Riccardo Alberti
+ */
+public class DuplicateCommercePricingClassExternalReferenceCodeException
+	extends SystemException {
+
+	public DuplicateCommercePricingClassExternalReferenceCodeException() {
+	}
+
+	public DuplicateCommercePricingClassExternalReferenceCodeException(
+		String msg) {
+
+		super(msg);
+	}
+
+	public DuplicateCommercePricingClassExternalReferenceCodeException(
+		String msg, Throwable throwable) {
+
+		super(msg, throwable);
+	}
+
+	public DuplicateCommercePricingClassExternalReferenceCodeException(
+		Throwable throwable) {
+
+		super(throwable);
+	}
+
+}

--- a/modules/apps/commerce/commerce-pricing-api/src/main/java/com/liferay/commerce/pricing/service/CommercePriceModifierLocalService.java
+++ b/modules/apps/commerce/commerce-pricing-api/src/main/java/com/liferay/commerce/pricing/service/CommercePriceModifierLocalService.java
@@ -280,25 +280,10 @@ public interface CommercePriceModifierLocalService
 	public CommercePriceModifier fetchCommercePriceModifier(
 		long commercePriceModifierId);
 
-	/**
-	 * Returns the commerce price modifier with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce price modifier's external reference code
-	 * @return the matching commerce price modifier, or <code>null</code> if a matching commerce price modifier could not be found
-	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public CommercePriceModifier
 		fetchCommercePriceModifierByExternalReferenceCode(
-			long companyId, String externalReferenceCode);
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchCommercePriceModifierByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CommercePriceModifier fetchCommercePriceModifierByReferenceCode(
-		long companyId, String externalReferenceCode);
+			String externalReferenceCode, long companyId);
 
 	/**
 	 * Returns the commerce price modifier matching the UUID and group.
@@ -326,18 +311,10 @@ public interface CommercePriceModifierLocalService
 			long commercePriceModifierId)
 		throws PortalException;
 
-	/**
-	 * Returns the commerce price modifier with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce price modifier's external reference code
-	 * @return the matching commerce price modifier
-	 * @throws PortalException if a matching commerce price modifier could not be found
-	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public CommercePriceModifier
 			getCommercePriceModifierByExternalReferenceCode(
-				long companyId, String externalReferenceCode)
+				String externalReferenceCode, long companyId)
 		throws PortalException;
 
 	/**

--- a/modules/apps/commerce/commerce-pricing-api/src/main/java/com/liferay/commerce/pricing/service/CommercePriceModifierLocalServiceUtil.java
+++ b/modules/apps/commerce/commerce-pricing-api/src/main/java/com/liferay/commerce/pricing/service/CommercePriceModifierLocalServiceUtil.java
@@ -332,31 +332,12 @@ public class CommercePriceModifierLocalServiceUtil {
 		return getService().fetchCommercePriceModifier(commercePriceModifierId);
 	}
 
-	/**
-	 * Returns the commerce price modifier with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce price modifier's external reference code
-	 * @return the matching commerce price modifier, or <code>null</code> if a matching commerce price modifier could not be found
-	 */
 	public static CommercePriceModifier
 		fetchCommercePriceModifierByExternalReferenceCode(
-			long companyId, String externalReferenceCode) {
+			String externalReferenceCode, long companyId) {
 
 		return getService().fetchCommercePriceModifierByExternalReferenceCode(
-			companyId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchCommercePriceModifierByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	public static CommercePriceModifier
-		fetchCommercePriceModifierByReferenceCode(
-			long companyId, String externalReferenceCode) {
-
-		return getService().fetchCommercePriceModifierByReferenceCode(
-			companyId, externalReferenceCode);
+			externalReferenceCode, companyId);
 	}
 
 	/**
@@ -393,21 +374,13 @@ public class CommercePriceModifierLocalServiceUtil {
 		return getService().getCommercePriceModifier(commercePriceModifierId);
 	}
 
-	/**
-	 * Returns the commerce price modifier with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce price modifier's external reference code
-	 * @return the matching commerce price modifier
-	 * @throws PortalException if a matching commerce price modifier could not be found
-	 */
 	public static CommercePriceModifier
 			getCommercePriceModifierByExternalReferenceCode(
-				long companyId, String externalReferenceCode)
+				String externalReferenceCode, long companyId)
 		throws PortalException {
 
 		return getService().getCommercePriceModifierByExternalReferenceCode(
-			companyId, externalReferenceCode);
+			externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/commerce/commerce-pricing-api/src/main/java/com/liferay/commerce/pricing/service/CommercePriceModifierLocalServiceWrapper.java
+++ b/modules/apps/commerce/commerce-pricing-api/src/main/java/com/liferay/commerce/pricing/service/CommercePriceModifierLocalServiceWrapper.java
@@ -371,34 +371,14 @@ public class CommercePriceModifierLocalServiceWrapper
 			commercePriceModifierId);
 	}
 
-	/**
-	 * Returns the commerce price modifier with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce price modifier's external reference code
-	 * @return the matching commerce price modifier, or <code>null</code> if a matching commerce price modifier could not be found
-	 */
 	@Override
 	public CommercePriceModifier
 		fetchCommercePriceModifierByExternalReferenceCode(
-			long companyId, String externalReferenceCode) {
+			String externalReferenceCode, long companyId) {
 
 		return _commercePriceModifierLocalService.
 			fetchCommercePriceModifierByExternalReferenceCode(
-				companyId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchCommercePriceModifierByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public CommercePriceModifier fetchCommercePriceModifierByReferenceCode(
-		long companyId, String externalReferenceCode) {
-
-		return _commercePriceModifierLocalService.
-			fetchCommercePriceModifierByReferenceCode(
-				companyId, externalReferenceCode);
+				externalReferenceCode, companyId);
 	}
 
 	/**
@@ -439,23 +419,15 @@ public class CommercePriceModifierLocalServiceWrapper
 			commercePriceModifierId);
 	}
 
-	/**
-	 * Returns the commerce price modifier with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce price modifier's external reference code
-	 * @return the matching commerce price modifier
-	 * @throws PortalException if a matching commerce price modifier could not be found
-	 */
 	@Override
 	public CommercePriceModifier
 			getCommercePriceModifierByExternalReferenceCode(
-				long companyId, String externalReferenceCode)
+				String externalReferenceCode, long companyId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _commercePriceModifierLocalService.
 			getCommercePriceModifierByExternalReferenceCode(
-				companyId, externalReferenceCode);
+				externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/commerce/commerce-pricing-api/src/main/java/com/liferay/commerce/pricing/service/CommercePricingClassLocalService.java
+++ b/modules/apps/commerce/commerce-pricing-api/src/main/java/com/liferay/commerce/pricing/service/CommercePricingClassLocalService.java
@@ -249,25 +249,10 @@ public interface CommercePricingClassLocalService
 	public CommercePricingClass fetchCommercePricingClass(
 		long commercePricingClassId);
 
-	/**
-	 * Returns the commerce pricing class with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce pricing class's external reference code
-	 * @return the matching commerce pricing class, or <code>null</code> if a matching commerce pricing class could not be found
-	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public CommercePricingClass
 		fetchCommercePricingClassByExternalReferenceCode(
-			long companyId, String externalReferenceCode);
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchCommercePricingClassByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CommercePricingClass fetchCommercePricingClassByReferenceCode(
-		long companyId, String externalReferenceCode);
+			String externalReferenceCode, long companyId);
 
 	/**
 	 * Returns the commerce pricing class with the matching UUID and company.
@@ -298,17 +283,9 @@ public interface CommercePricingClassLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public long[] getCommercePricingClassByCPDefinition(long cpDefinitionId);
 
-	/**
-	 * Returns the commerce pricing class with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce pricing class's external reference code
-	 * @return the matching commerce pricing class
-	 * @throws PortalException if a matching commerce pricing class could not be found
-	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public CommercePricingClass getCommercePricingClassByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
+			String externalReferenceCode, long companyId)
 		throws PortalException;
 
 	/**

--- a/modules/apps/commerce/commerce-pricing-api/src/main/java/com/liferay/commerce/pricing/service/CommercePricingClassLocalServiceUtil.java
+++ b/modules/apps/commerce/commerce-pricing-api/src/main/java/com/liferay/commerce/pricing/service/CommercePricingClassLocalServiceUtil.java
@@ -268,30 +268,12 @@ public class CommercePricingClassLocalServiceUtil {
 		return getService().fetchCommercePricingClass(commercePricingClassId);
 	}
 
-	/**
-	 * Returns the commerce pricing class with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce pricing class's external reference code
-	 * @return the matching commerce pricing class, or <code>null</code> if a matching commerce pricing class could not be found
-	 */
 	public static CommercePricingClass
 		fetchCommercePricingClassByExternalReferenceCode(
-			long companyId, String externalReferenceCode) {
+			String externalReferenceCode, long companyId) {
 
 		return getService().fetchCommercePricingClassByExternalReferenceCode(
-			companyId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchCommercePricingClassByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	public static CommercePricingClass fetchCommercePricingClassByReferenceCode(
-		long companyId, String externalReferenceCode) {
-
-		return getService().fetchCommercePricingClassByReferenceCode(
-			companyId, externalReferenceCode);
+			externalReferenceCode, companyId);
 	}
 
 	/**
@@ -336,21 +318,13 @@ public class CommercePricingClassLocalServiceUtil {
 			cpDefinitionId);
 	}
 
-	/**
-	 * Returns the commerce pricing class with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce pricing class's external reference code
-	 * @return the matching commerce pricing class
-	 * @throws PortalException if a matching commerce pricing class could not be found
-	 */
 	public static CommercePricingClass
 			getCommercePricingClassByExternalReferenceCode(
-				long companyId, String externalReferenceCode)
+				String externalReferenceCode, long companyId)
 		throws PortalException {
 
 		return getService().getCommercePricingClassByExternalReferenceCode(
-			companyId, externalReferenceCode);
+			externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/commerce/commerce-pricing-api/src/main/java/com/liferay/commerce/pricing/service/CommercePricingClassLocalServiceWrapper.java
+++ b/modules/apps/commerce/commerce-pricing-api/src/main/java/com/liferay/commerce/pricing/service/CommercePricingClassLocalServiceWrapper.java
@@ -302,34 +302,14 @@ public class CommercePricingClassLocalServiceWrapper
 			commercePricingClassId);
 	}
 
-	/**
-	 * Returns the commerce pricing class with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce pricing class's external reference code
-	 * @return the matching commerce pricing class, or <code>null</code> if a matching commerce pricing class could not be found
-	 */
 	@Override
 	public CommercePricingClass
 		fetchCommercePricingClassByExternalReferenceCode(
-			long companyId, String externalReferenceCode) {
+			String externalReferenceCode, long companyId) {
 
 		return _commercePricingClassLocalService.
 			fetchCommercePricingClassByExternalReferenceCode(
-				companyId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchCommercePricingClassByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public CommercePricingClass fetchCommercePricingClassByReferenceCode(
-		long companyId, String externalReferenceCode) {
-
-		return _commercePricingClassLocalService.
-			fetchCommercePricingClassByReferenceCode(
-				companyId, externalReferenceCode);
+				externalReferenceCode, companyId);
 	}
 
 	/**
@@ -376,22 +356,14 @@ public class CommercePricingClassLocalServiceWrapper
 			getCommercePricingClassByCPDefinition(cpDefinitionId);
 	}
 
-	/**
-	 * Returns the commerce pricing class with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce pricing class's external reference code
-	 * @return the matching commerce pricing class
-	 * @throws PortalException if a matching commerce pricing class could not be found
-	 */
 	@Override
 	public CommercePricingClass getCommercePricingClassByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
+			String externalReferenceCode, long companyId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _commercePricingClassLocalService.
 			getCommercePricingClassByExternalReferenceCode(
-				companyId, externalReferenceCode);
+				externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/commerce/commerce-pricing-api/src/main/java/com/liferay/commerce/pricing/service/persistence/CommercePriceModifierPersistence.java
+++ b/modules/apps/commerce/commerce-pricing-api/src/main/java/com/liferay/commerce/pricing/service/persistence/CommercePriceModifierPersistence.java
@@ -1649,57 +1649,57 @@ public interface CommercePriceModifierPersistence
 	public int countByG_C_NotS(long[] groupIds, long companyId, int status);
 
 	/**
-	 * Returns the commerce price modifier where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchPriceModifierException</code> if it could not be found.
+	 * Returns the commerce price modifier where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchPriceModifierException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce price modifier
 	 * @throws NoSuchPriceModifierException if a matching commerce price modifier could not be found
 	 */
-	public CommercePriceModifier findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public CommercePriceModifier findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchPriceModifierException;
 
 	/**
-	 * Returns the commerce price modifier where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the commerce price modifier where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce price modifier, or <code>null</code> if a matching commerce price modifier could not be found
 	 */
-	public CommercePriceModifier fetchByC_ERC(
-		long companyId, String externalReferenceCode);
+	public CommercePriceModifier fetchByERC_C(
+		String externalReferenceCode, long companyId);
 
 	/**
-	 * Returns the commerce price modifier where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the commerce price modifier where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching commerce price modifier, or <code>null</code> if a matching commerce price modifier could not be found
 	 */
-	public CommercePriceModifier fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache);
+	public CommercePriceModifier fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache);
 
 	/**
-	 * Removes the commerce price modifier where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the commerce price modifier where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the commerce price modifier that was removed
 	 */
-	public CommercePriceModifier removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public CommercePriceModifier removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchPriceModifierException;
 
 	/**
-	 * Returns the number of commerce price modifiers where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of commerce price modifiers where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching commerce price modifiers
 	 */
-	public int countByC_ERC(long companyId, String externalReferenceCode);
+	public int countByERC_C(String externalReferenceCode, long companyId);
 
 	/**
 	 * Caches the commerce price modifier in the entity cache if it is enabled.

--- a/modules/apps/commerce/commerce-pricing-api/src/main/java/com/liferay/commerce/pricing/service/persistence/CommercePriceModifierUtil.java
+++ b/modules/apps/commerce/commerce-pricing-api/src/main/java/com/liferay/commerce/pricing/service/persistence/CommercePriceModifierUtil.java
@@ -2091,75 +2091,75 @@ public class CommercePriceModifierUtil {
 	}
 
 	/**
-	 * Returns the commerce price modifier where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchPriceModifierException</code> if it could not be found.
+	 * Returns the commerce price modifier where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchPriceModifierException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce price modifier
 	 * @throws NoSuchPriceModifierException if a matching commerce price modifier could not be found
 	 */
-	public static CommercePriceModifier findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public static CommercePriceModifier findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws com.liferay.commerce.pricing.exception.
 			NoSuchPriceModifierException {
 
-		return getPersistence().findByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().findByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the commerce price modifier where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the commerce price modifier where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce price modifier, or <code>null</code> if a matching commerce price modifier could not be found
 	 */
-	public static CommercePriceModifier fetchByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public static CommercePriceModifier fetchByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return getPersistence().fetchByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().fetchByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the commerce price modifier where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the commerce price modifier where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching commerce price modifier, or <code>null</code> if a matching commerce price modifier could not be found
 	 */
-	public static CommercePriceModifier fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache) {
+	public static CommercePriceModifier fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache) {
 
-		return getPersistence().fetchByC_ERC(
-			companyId, externalReferenceCode, useFinderCache);
+		return getPersistence().fetchByERC_C(
+			externalReferenceCode, companyId, useFinderCache);
 	}
 
 	/**
-	 * Removes the commerce price modifier where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the commerce price modifier where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the commerce price modifier that was removed
 	 */
-	public static CommercePriceModifier removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public static CommercePriceModifier removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws com.liferay.commerce.pricing.exception.
 			NoSuchPriceModifierException {
 
-		return getPersistence().removeByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().removeByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the number of commerce price modifiers where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of commerce price modifiers where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching commerce price modifiers
 	 */
-	public static int countByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public static int countByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return getPersistence().countByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().countByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/commerce/commerce-pricing-api/src/main/java/com/liferay/commerce/pricing/service/persistence/CommercePricingClassPersistence.java
+++ b/modules/apps/commerce/commerce-pricing-api/src/main/java/com/liferay/commerce/pricing/service/persistence/CommercePricingClassPersistence.java
@@ -684,57 +684,57 @@ public interface CommercePricingClassPersistence
 	public int filterCountByCompanyId(long companyId);
 
 	/**
-	 * Returns the commerce pricing class where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchPricingClassException</code> if it could not be found.
+	 * Returns the commerce pricing class where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchPricingClassException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce pricing class
 	 * @throws NoSuchPricingClassException if a matching commerce pricing class could not be found
 	 */
-	public CommercePricingClass findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public CommercePricingClass findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchPricingClassException;
 
 	/**
-	 * Returns the commerce pricing class where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the commerce pricing class where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce pricing class, or <code>null</code> if a matching commerce pricing class could not be found
 	 */
-	public CommercePricingClass fetchByC_ERC(
-		long companyId, String externalReferenceCode);
+	public CommercePricingClass fetchByERC_C(
+		String externalReferenceCode, long companyId);
 
 	/**
-	 * Returns the commerce pricing class where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the commerce pricing class where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching commerce pricing class, or <code>null</code> if a matching commerce pricing class could not be found
 	 */
-	public CommercePricingClass fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache);
+	public CommercePricingClass fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache);
 
 	/**
-	 * Removes the commerce pricing class where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the commerce pricing class where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the commerce pricing class that was removed
 	 */
-	public CommercePricingClass removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public CommercePricingClass removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchPricingClassException;
 
 	/**
-	 * Returns the number of commerce pricing classes where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of commerce pricing classes where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching commerce pricing classes
 	 */
-	public int countByC_ERC(long companyId, String externalReferenceCode);
+	public int countByERC_C(String externalReferenceCode, long companyId);
 
 	/**
 	 * Caches the commerce pricing class in the entity cache if it is enabled.

--- a/modules/apps/commerce/commerce-pricing-api/src/main/java/com/liferay/commerce/pricing/service/persistence/CommercePricingClassUtil.java
+++ b/modules/apps/commerce/commerce-pricing-api/src/main/java/com/liferay/commerce/pricing/service/persistence/CommercePricingClassUtil.java
@@ -902,75 +902,75 @@ public class CommercePricingClassUtil {
 	}
 
 	/**
-	 * Returns the commerce pricing class where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchPricingClassException</code> if it could not be found.
+	 * Returns the commerce pricing class where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchPricingClassException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce pricing class
 	 * @throws NoSuchPricingClassException if a matching commerce pricing class could not be found
 	 */
-	public static CommercePricingClass findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public static CommercePricingClass findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws com.liferay.commerce.pricing.exception.
 			NoSuchPricingClassException {
 
-		return getPersistence().findByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().findByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the commerce pricing class where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the commerce pricing class where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce pricing class, or <code>null</code> if a matching commerce pricing class could not be found
 	 */
-	public static CommercePricingClass fetchByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public static CommercePricingClass fetchByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return getPersistence().fetchByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().fetchByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the commerce pricing class where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the commerce pricing class where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching commerce pricing class, or <code>null</code> if a matching commerce pricing class could not be found
 	 */
-	public static CommercePricingClass fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache) {
+	public static CommercePricingClass fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache) {
 
-		return getPersistence().fetchByC_ERC(
-			companyId, externalReferenceCode, useFinderCache);
+		return getPersistence().fetchByERC_C(
+			externalReferenceCode, companyId, useFinderCache);
 	}
 
 	/**
-	 * Removes the commerce pricing class where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the commerce pricing class where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the commerce pricing class that was removed
 	 */
-	public static CommercePricingClass removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public static CommercePricingClass removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws com.liferay.commerce.pricing.exception.
 			NoSuchPricingClassException {
 
-		return getPersistence().removeByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().removeByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the number of commerce pricing classes where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of commerce pricing classes where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching commerce pricing classes
 	 */
-	public static int countByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public static int countByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return getPersistence().countByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().countByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/commerce/commerce-pricing-api/src/main/resources/com/liferay/commerce/pricing/exception/packageinfo
+++ b/modules/apps/commerce/commerce-pricing-api/src/main/resources/com/liferay/commerce/pricing/exception/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 1.2.0

--- a/modules/apps/commerce/commerce-pricing-api/src/main/resources/com/liferay/commerce/pricing/service/packageinfo
+++ b/modules/apps/commerce/commerce-pricing-api/src/main/resources/com/liferay/commerce/pricing/service/packageinfo
@@ -1,1 +1,1 @@
-version 5.2.1
+version 6.0.0

--- a/modules/apps/commerce/commerce-pricing-api/src/main/resources/com/liferay/commerce/pricing/service/persistence/packageinfo
+++ b/modules/apps/commerce/commerce-pricing-api/src/main/resources/com/liferay/commerce/pricing/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 3.1.0
+version 4.0.0

--- a/modules/apps/commerce/commerce-pricing-service/src/main/java/com/liferay/commerce/pricing/service/base/CommercePriceModifierLocalServiceBaseImpl.java
+++ b/modules/apps/commerce/commerce-pricing-service/src/main/java/com/liferay/commerce/pricing/service/base/CommercePriceModifierLocalServiceBaseImpl.java
@@ -294,50 +294,23 @@ public abstract class CommercePriceModifierLocalServiceBaseImpl
 		return commercePriceModifierPersistence.fetchByUUID_G(uuid, groupId);
 	}
 
-	/**
-	 * Returns the commerce price modifier with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce price modifier's external reference code
-	 * @return the matching commerce price modifier, or <code>null</code> if a matching commerce price modifier could not be found
-	 */
 	@Override
 	public CommercePriceModifier
 		fetchCommercePriceModifierByExternalReferenceCode(
-			long companyId, String externalReferenceCode) {
+			String externalReferenceCode, long companyId) {
 
-		return commercePriceModifierPersistence.fetchByC_ERC(
-			companyId, externalReferenceCode);
+		return commercePriceModifierPersistence.fetchByERC_C(
+			externalReferenceCode, companyId);
 	}
 
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchCommercePriceModifierByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public CommercePriceModifier fetchCommercePriceModifierByReferenceCode(
-		long companyId, String externalReferenceCode) {
-
-		return fetchCommercePriceModifierByExternalReferenceCode(
-			companyId, externalReferenceCode);
-	}
-
-	/**
-	 * Returns the commerce price modifier with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce price modifier's external reference code
-	 * @return the matching commerce price modifier
-	 * @throws PortalException if a matching commerce price modifier could not be found
-	 */
 	@Override
 	public CommercePriceModifier
 			getCommercePriceModifierByExternalReferenceCode(
-				long companyId, String externalReferenceCode)
+				String externalReferenceCode, long companyId)
 		throws PortalException {
 
-		return commercePriceModifierPersistence.findByC_ERC(
-			companyId, externalReferenceCode);
+		return commercePriceModifierPersistence.findByERC_C(
+			externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/commerce/commerce-pricing-service/src/main/java/com/liferay/commerce/pricing/service/base/CommercePricingClassLocalServiceBaseImpl.java
+++ b/modules/apps/commerce/commerce-pricing-service/src/main/java/com/liferay/commerce/pricing/service/base/CommercePricingClassLocalServiceBaseImpl.java
@@ -286,49 +286,22 @@ public abstract class CommercePricingClassLocalServiceBaseImpl
 			uuid, companyId, null);
 	}
 
-	/**
-	 * Returns the commerce pricing class with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce pricing class's external reference code
-	 * @return the matching commerce pricing class, or <code>null</code> if a matching commerce pricing class could not be found
-	 */
 	@Override
 	public CommercePricingClass
 		fetchCommercePricingClassByExternalReferenceCode(
-			long companyId, String externalReferenceCode) {
+			String externalReferenceCode, long companyId) {
 
-		return commercePricingClassPersistence.fetchByC_ERC(
-			companyId, externalReferenceCode);
+		return commercePricingClassPersistence.fetchByERC_C(
+			externalReferenceCode, companyId);
 	}
 
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchCommercePricingClassByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public CommercePricingClass fetchCommercePricingClassByReferenceCode(
-		long companyId, String externalReferenceCode) {
-
-		return fetchCommercePricingClassByExternalReferenceCode(
-			companyId, externalReferenceCode);
-	}
-
-	/**
-	 * Returns the commerce pricing class with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce pricing class's external reference code
-	 * @return the matching commerce pricing class
-	 * @throws PortalException if a matching commerce pricing class could not be found
-	 */
 	@Override
 	public CommercePricingClass getCommercePricingClassByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
+			String externalReferenceCode, long companyId)
 		throws PortalException {
 
-		return commercePricingClassPersistence.findByC_ERC(
-			companyId, externalReferenceCode);
+		return commercePricingClassPersistence.findByERC_C(
+			externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/commerce/commerce-pricing-service/src/main/java/com/liferay/commerce/pricing/service/impl/CommercePriceModifierLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-pricing-service/src/main/java/com/liferay/commerce/pricing/service/impl/CommercePriceModifierLocalServiceImpl.java
@@ -24,7 +24,6 @@ import com.liferay.commerce.pricing.exception.CommercePriceModifierExpirationDat
 import com.liferay.commerce.pricing.exception.CommercePriceModifierTargetException;
 import com.liferay.commerce.pricing.exception.CommercePriceModifierTitleException;
 import com.liferay.commerce.pricing.exception.CommercePriceModifierTypeException;
-import com.liferay.commerce.pricing.exception.DuplicateCommercePriceModifierException;
 import com.liferay.commerce.pricing.exception.NoSuchPriceModifierException;
 import com.liferay.commerce.pricing.model.CommercePriceModifier;
 import com.liferay.commerce.pricing.service.CommercePriceModifierRelLocalService;
@@ -134,9 +133,6 @@ public class CommercePriceModifierLocalServiceImpl
 		if (Validator.isBlank(externalReferenceCode)) {
 			externalReferenceCode = null;
 		}
-
-		_validateExternalReferenceCode(
-			externalReferenceCode, serviceContext.getCompanyId());
 
 		// Commerce price modifier
 
@@ -657,25 +653,6 @@ public class CommercePriceModifierLocalServiceImpl
 
 		if (modifierAmount == null) {
 			throw new CommercePriceModifierAmountException();
-		}
-	}
-
-	private void _validateExternalReferenceCode(
-			String externalReferenceCode, long companyId)
-		throws PortalException {
-
-		if (Validator.isNull(externalReferenceCode)) {
-			return;
-		}
-
-		CommercePriceModifier commercePriceModifier =
-			commercePriceModifierPersistence.fetchByERC_C(
-				externalReferenceCode, companyId);
-
-		if (commercePriceModifier != null) {
-			throw new DuplicateCommercePriceModifierException(
-				"There is another commerce price modifier with external " +
-					"reference code " + externalReferenceCode);
 		}
 	}
 

--- a/modules/apps/commerce/commerce-pricing-service/src/main/java/com/liferay/commerce/pricing/service/impl/CommercePriceModifierLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-pricing-service/src/main/java/com/liferay/commerce/pricing/service/impl/CommercePriceModifierLocalServiceImpl.java
@@ -240,8 +240,8 @@ public class CommercePriceModifierLocalServiceImpl
 
 		if (!Validator.isBlank(externalReferenceCode)) {
 			CommercePriceModifier commercePriceModifier =
-				commercePriceModifierPersistence.fetchByC_ERC(
-					serviceContext.getCompanyId(), externalReferenceCode);
+				commercePriceModifierPersistence.fetchByERC_C(
+					externalReferenceCode, serviceContext.getCompanyId());
 
 			if (commercePriceModifier != null) {
 				return commercePriceModifierLocalService.
@@ -356,8 +356,8 @@ public class CommercePriceModifierLocalServiceImpl
 			return null;
 		}
 
-		return commercePriceModifierPersistence.fetchByC_ERC(
-			companyId, externalReferenceCode);
+		return commercePriceModifierPersistence.fetchByERC_C(
+			externalReferenceCode, companyId);
 	}
 
 	@Override
@@ -669,8 +669,8 @@ public class CommercePriceModifierLocalServiceImpl
 		}
 
 		CommercePriceModifier commercePriceModifier =
-			commercePriceModifierPersistence.fetchByC_ERC(
-				companyId, externalReferenceCode);
+			commercePriceModifierPersistence.fetchByERC_C(
+				externalReferenceCode, companyId);
 
 		if (commercePriceModifier != null) {
 			throw new DuplicateCommercePriceModifierException(

--- a/modules/apps/commerce/commerce-pricing-service/src/main/java/com/liferay/commerce/pricing/service/impl/CommercePricingClassLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-pricing-service/src/main/java/com/liferay/commerce/pricing/service/impl/CommercePricingClassLocalServiceImpl.java
@@ -155,8 +155,8 @@ public class CommercePricingClassLocalServiceImpl
 
 		if (!Validator.isBlank(externalReferenceCode)) {
 			CommercePricingClass commercePricingClass =
-				commercePricingClassPersistence.fetchByC_ERC(
-					serviceContext.getCompanyId(), externalReferenceCode);
+				commercePricingClassPersistence.fetchByERC_C(
+					externalReferenceCode, serviceContext.getCompanyId());
 
 			if (commercePricingClass != null) {
 				return commercePricingClassLocalService.
@@ -234,8 +234,8 @@ public class CommercePricingClassLocalServiceImpl
 			return null;
 		}
 
-		return commercePricingClassPersistence.fetchByC_ERC(
-			companyId, externalReferenceCode);
+		return commercePricingClassPersistence.fetchByERC_C(
+			externalReferenceCode, companyId);
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-pricing-service/src/main/java/com/liferay/commerce/pricing/service/impl/CommercePricingClassServiceImpl.java
+++ b/modules/apps/commerce/commerce-pricing-service/src/main/java/com/liferay/commerce/pricing/service/impl/CommercePricingClassServiceImpl.java
@@ -95,8 +95,8 @@ public class CommercePricingClassServiceImpl
 
 		if (!Validator.isBlank(externalReferenceCode)) {
 			CommercePricingClass commercePricingClass =
-				commercePricingClassPersistence.fetchByC_ERC(
-					serviceContext.getCompanyId(), externalReferenceCode);
+				commercePricingClassPersistence.fetchByERC_C(
+					externalReferenceCode, serviceContext.getCompanyId());
 
 			if (commercePricingClass != null) {
 				return commercePricingClassLocalService.

--- a/modules/apps/commerce/commerce-pricing-service/src/main/java/com/liferay/commerce/pricing/service/persistence/impl/CommercePriceModifierPersistenceImpl.java
+++ b/modules/apps/commerce/commerce-pricing-service/src/main/java/com/liferay/commerce/pricing/service/persistence/impl/CommercePriceModifierPersistenceImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.commerce.pricing.service.persistence.impl;
 
+import com.liferay.commerce.pricing.exception.DuplicateCommercePriceModifierExternalReferenceCodeException;
 import com.liferay.commerce.pricing.exception.NoSuchPriceModifierException;
 import com.liferay.commerce.pricing.model.CommercePriceModifier;
 import com.liferay.commerce.pricing.model.CommercePriceModifierTable;
@@ -6152,35 +6153,35 @@ public class CommercePriceModifierPersistenceImpl
 	private static final String _FINDER_COLUMN_G_C_NOTS_STATUS_2 =
 		"commercePriceModifier.status != ?";
 
-	private FinderPath _finderPathFetchByC_ERC;
-	private FinderPath _finderPathCountByC_ERC;
+	private FinderPath _finderPathFetchByERC_C;
+	private FinderPath _finderPathCountByERC_C;
 
 	/**
-	 * Returns the commerce price modifier where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchPriceModifierException</code> if it could not be found.
+	 * Returns the commerce price modifier where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchPriceModifierException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce price modifier
 	 * @throws NoSuchPriceModifierException if a matching commerce price modifier could not be found
 	 */
 	@Override
-	public CommercePriceModifier findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public CommercePriceModifier findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchPriceModifierException {
 
-		CommercePriceModifier commercePriceModifier = fetchByC_ERC(
-			companyId, externalReferenceCode);
+		CommercePriceModifier commercePriceModifier = fetchByERC_C(
+			externalReferenceCode, companyId);
 
 		if (commercePriceModifier == null) {
 			StringBundler sb = new StringBundler(6);
 
 			sb.append(_NO_SUCH_ENTITY_WITH_KEY);
 
-			sb.append("companyId=");
-			sb.append(companyId);
-
-			sb.append(", externalReferenceCode=");
+			sb.append("externalReferenceCode=");
 			sb.append(externalReferenceCode);
+
+			sb.append(", companyId=");
+			sb.append(companyId);
 
 			sb.append("}");
 
@@ -6195,30 +6196,30 @@ public class CommercePriceModifierPersistenceImpl
 	}
 
 	/**
-	 * Returns the commerce price modifier where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the commerce price modifier where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce price modifier, or <code>null</code> if a matching commerce price modifier could not be found
 	 */
 	@Override
-	public CommercePriceModifier fetchByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public CommercePriceModifier fetchByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return fetchByC_ERC(companyId, externalReferenceCode, true);
+		return fetchByERC_C(externalReferenceCode, companyId, true);
 	}
 
 	/**
-	 * Returns the commerce price modifier where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the commerce price modifier where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching commerce price modifier, or <code>null</code> if a matching commerce price modifier could not be found
 	 */
 	@Override
-	public CommercePriceModifier fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache) {
+	public CommercePriceModifier fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache) {
 
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
@@ -6228,24 +6229,24 @@ public class CommercePriceModifierPersistenceImpl
 		Object[] finderArgs = null;
 
 		if (useFinderCache && productionMode) {
-			finderArgs = new Object[] {companyId, externalReferenceCode};
+			finderArgs = new Object[] {externalReferenceCode, companyId};
 		}
 
 		Object result = null;
 
 		if (useFinderCache && productionMode) {
 			result = finderCache.getResult(
-				_finderPathFetchByC_ERC, finderArgs, this);
+				_finderPathFetchByERC_C, finderArgs, this);
 		}
 
 		if (result instanceof CommercePriceModifier) {
 			CommercePriceModifier commercePriceModifier =
 				(CommercePriceModifier)result;
 
-			if ((companyId != commercePriceModifier.getCompanyId()) ||
-				!Objects.equals(
+			if (!Objects.equals(
 					externalReferenceCode,
-					commercePriceModifier.getExternalReferenceCode())) {
+					commercePriceModifier.getExternalReferenceCode()) ||
+				(companyId != commercePriceModifier.getCompanyId())) {
 
 				result = null;
 			}
@@ -6256,18 +6257,18 @@ public class CommercePriceModifierPersistenceImpl
 
 			sb.append(_SQL_SELECT_COMMERCEPRICEMODIFIER_WHERE);
 
-			sb.append(_FINDER_COLUMN_C_ERC_COMPANYID_2);
-
 			boolean bindExternalReferenceCode = false;
 
 			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3);
 			}
 			else {
 				bindExternalReferenceCode = true;
 
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2);
 			}
+
+			sb.append(_FINDER_COLUMN_ERC_C_COMPANYID_2);
 
 			String sql = sb.toString();
 
@@ -6280,18 +6281,18 @@ public class CommercePriceModifierPersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
-				queryPos.add(companyId);
-
 				if (bindExternalReferenceCode) {
 					queryPos.add(externalReferenceCode);
 				}
+
+				queryPos.add(companyId);
 
 				List<CommercePriceModifier> list = query.list();
 
 				if (list.isEmpty()) {
 					if (useFinderCache && productionMode) {
 						finderCache.putResult(
-							_finderPathFetchByC_ERC, finderArgs, list);
+							_finderPathFetchByERC_C, finderArgs, list);
 					}
 				}
 				else {
@@ -6319,32 +6320,32 @@ public class CommercePriceModifierPersistenceImpl
 	}
 
 	/**
-	 * Removes the commerce price modifier where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the commerce price modifier where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the commerce price modifier that was removed
 	 */
 	@Override
-	public CommercePriceModifier removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public CommercePriceModifier removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchPriceModifierException {
 
-		CommercePriceModifier commercePriceModifier = findByC_ERC(
-			companyId, externalReferenceCode);
+		CommercePriceModifier commercePriceModifier = findByERC_C(
+			externalReferenceCode, companyId);
 
 		return remove(commercePriceModifier);
 	}
 
 	/**
-	 * Returns the number of commerce price modifiers where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of commerce price modifiers where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching commerce price modifiers
 	 */
 	@Override
-	public int countByC_ERC(long companyId, String externalReferenceCode) {
+	public int countByERC_C(String externalReferenceCode, long companyId) {
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
 		boolean productionMode = ctPersistenceHelper.isProductionMode(
@@ -6356,9 +6357,9 @@ public class CommercePriceModifierPersistenceImpl
 		Long count = null;
 
 		if (productionMode) {
-			finderPath = _finderPathCountByC_ERC;
+			finderPath = _finderPathCountByERC_C;
 
-			finderArgs = new Object[] {companyId, externalReferenceCode};
+			finderArgs = new Object[] {externalReferenceCode, companyId};
 
 			count = (Long)finderCache.getResult(finderPath, finderArgs, this);
 		}
@@ -6368,18 +6369,18 @@ public class CommercePriceModifierPersistenceImpl
 
 			sb.append(_SQL_COUNT_COMMERCEPRICEMODIFIER_WHERE);
 
-			sb.append(_FINDER_COLUMN_C_ERC_COMPANYID_2);
-
 			boolean bindExternalReferenceCode = false;
 
 			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3);
 			}
 			else {
 				bindExternalReferenceCode = true;
 
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2);
 			}
+
+			sb.append(_FINDER_COLUMN_ERC_C_COMPANYID_2);
 
 			String sql = sb.toString();
 
@@ -6392,11 +6393,11 @@ public class CommercePriceModifierPersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
-				queryPos.add(companyId);
-
 				if (bindExternalReferenceCode) {
 					queryPos.add(externalReferenceCode);
 				}
+
+				queryPos.add(companyId);
 
 				count = (Long)query.uniqueResult();
 
@@ -6415,14 +6416,14 @@ public class CommercePriceModifierPersistenceImpl
 		return count.intValue();
 	}
 
-	private static final String _FINDER_COLUMN_C_ERC_COMPANYID_2 =
-		"commercePriceModifier.companyId = ? AND ";
+	private static final String _FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2 =
+		"commercePriceModifier.externalReferenceCode = ? AND ";
 
-	private static final String _FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2 =
-		"commercePriceModifier.externalReferenceCode = ?";
+	private static final String _FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3 =
+		"(commercePriceModifier.externalReferenceCode IS NULL OR commercePriceModifier.externalReferenceCode = '') AND ";
 
-	private static final String _FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3 =
-		"(commercePriceModifier.externalReferenceCode IS NULL OR commercePriceModifier.externalReferenceCode = '')";
+	private static final String _FINDER_COLUMN_ERC_C_COMPANYID_2 =
+		"commercePriceModifier.companyId = ?";
 
 	public CommercePriceModifierPersistenceImpl() {
 		Map<String, String> dbColumnNames = new HashMap<String, String>();
@@ -6464,10 +6465,10 @@ public class CommercePriceModifierPersistenceImpl
 			commercePriceModifier);
 
 		finderCache.putResult(
-			_finderPathFetchByC_ERC,
+			_finderPathFetchByERC_C,
 			new Object[] {
-				commercePriceModifier.getCompanyId(),
-				commercePriceModifier.getExternalReferenceCode()
+				commercePriceModifier.getExternalReferenceCode(),
+				commercePriceModifier.getCompanyId()
 			},
 			commercePriceModifier);
 	}
@@ -6567,13 +6568,13 @@ public class CommercePriceModifierPersistenceImpl
 			_finderPathFetchByUUID_G, args, commercePriceModifierModelImpl);
 
 		args = new Object[] {
-			commercePriceModifierModelImpl.getCompanyId(),
-			commercePriceModifierModelImpl.getExternalReferenceCode()
+			commercePriceModifierModelImpl.getExternalReferenceCode(),
+			commercePriceModifierModelImpl.getCompanyId()
 		};
 
-		finderCache.putResult(_finderPathCountByC_ERC, args, Long.valueOf(1));
+		finderCache.putResult(_finderPathCountByERC_C, args, Long.valueOf(1));
 		finderCache.putResult(
-			_finderPathFetchByC_ERC, args, commercePriceModifierModelImpl);
+			_finderPathFetchByERC_C, args, commercePriceModifierModelImpl);
 	}
 
 	/**
@@ -6729,6 +6730,30 @@ public class CommercePriceModifierPersistenceImpl
 
 			commercePriceModifier.setExternalReferenceCode(
 				commercePriceModifier.getUuid());
+		}
+		else {
+			CommercePriceModifier ercCommercePriceModifier = fetchByERC_C(
+				commercePriceModifier.getExternalReferenceCode(),
+				commercePriceModifier.getCompanyId());
+
+			if (isNew) {
+				if (ercCommercePriceModifier != null) {
+					throw new DuplicateCommercePriceModifierExternalReferenceCodeException(
+						"Duplicate CommercePriceModifier with external reference code " +
+							commercePriceModifier.getExternalReferenceCode());
+				}
+			}
+			else {
+				if ((ercCommercePriceModifier != null) &&
+					(commercePriceModifier.getCommercePriceModifierId() !=
+						ercCommercePriceModifier.
+							getCommercePriceModifierId())) {
+
+					throw new DuplicateCommercePriceModifierExternalReferenceCodeException(
+						"Duplicate CommercePriceModifier with external reference code " +
+							commercePriceModifier.getExternalReferenceCode());
+				}
+			}
 		}
 
 		ServiceContext serviceContext =
@@ -7287,7 +7312,7 @@ public class CommercePriceModifierPersistenceImpl
 		_uniqueIndexColumnNames.add(new String[] {"uuid_", "groupId"});
 
 		_uniqueIndexColumnNames.add(
-			new String[] {"companyId", "externalReferenceCode"});
+			new String[] {"externalReferenceCode", "companyId"});
 	}
 
 	/**
@@ -7490,15 +7515,15 @@ public class CommercePriceModifierPersistenceImpl
 			},
 			new String[] {"groupId", "companyId", "status"}, false);
 
-		_finderPathFetchByC_ERC = new FinderPath(
-			FINDER_CLASS_NAME_ENTITY, "fetchByC_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"companyId", "externalReferenceCode"}, true);
+		_finderPathFetchByERC_C = new FinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, true);
 
-		_finderPathCountByC_ERC = new FinderPath(
-			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"companyId", "externalReferenceCode"}, false);
+		_finderPathCountByERC_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, false);
 
 		_setCommercePriceModifierUtilPersistence(this);
 	}

--- a/modules/apps/commerce/commerce-pricing-service/src/main/java/com/liferay/commerce/pricing/service/persistence/impl/CommercePricingClassPersistenceImpl.java
+++ b/modules/apps/commerce/commerce-pricing-service/src/main/java/com/liferay/commerce/pricing/service/persistence/impl/CommercePricingClassPersistenceImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.commerce.pricing.service.persistence.impl;
 
+import com.liferay.commerce.pricing.exception.DuplicateCommercePricingClassExternalReferenceCodeException;
 import com.liferay.commerce.pricing.exception.NoSuchPricingClassException;
 import com.liferay.commerce.pricing.model.CommercePricingClass;
 import com.liferay.commerce.pricing.model.CommercePricingClassTable;
@@ -3049,35 +3050,35 @@ public class CommercePricingClassPersistenceImpl
 	private static final String _FINDER_COLUMN_COMPANYID_COMPANYID_2 =
 		"commercePricingClass.companyId = ?";
 
-	private FinderPath _finderPathFetchByC_ERC;
-	private FinderPath _finderPathCountByC_ERC;
+	private FinderPath _finderPathFetchByERC_C;
+	private FinderPath _finderPathCountByERC_C;
 
 	/**
-	 * Returns the commerce pricing class where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchPricingClassException</code> if it could not be found.
+	 * Returns the commerce pricing class where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchPricingClassException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce pricing class
 	 * @throws NoSuchPricingClassException if a matching commerce pricing class could not be found
 	 */
 	@Override
-	public CommercePricingClass findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public CommercePricingClass findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchPricingClassException {
 
-		CommercePricingClass commercePricingClass = fetchByC_ERC(
-			companyId, externalReferenceCode);
+		CommercePricingClass commercePricingClass = fetchByERC_C(
+			externalReferenceCode, companyId);
 
 		if (commercePricingClass == null) {
 			StringBundler sb = new StringBundler(6);
 
 			sb.append(_NO_SUCH_ENTITY_WITH_KEY);
 
-			sb.append("companyId=");
-			sb.append(companyId);
-
-			sb.append(", externalReferenceCode=");
+			sb.append("externalReferenceCode=");
 			sb.append(externalReferenceCode);
+
+			sb.append(", companyId=");
+			sb.append(companyId);
 
 			sb.append("}");
 
@@ -3092,30 +3093,30 @@ public class CommercePricingClassPersistenceImpl
 	}
 
 	/**
-	 * Returns the commerce pricing class where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the commerce pricing class where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce pricing class, or <code>null</code> if a matching commerce pricing class could not be found
 	 */
 	@Override
-	public CommercePricingClass fetchByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public CommercePricingClass fetchByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return fetchByC_ERC(companyId, externalReferenceCode, true);
+		return fetchByERC_C(externalReferenceCode, companyId, true);
 	}
 
 	/**
-	 * Returns the commerce pricing class where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the commerce pricing class where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching commerce pricing class, or <code>null</code> if a matching commerce pricing class could not be found
 	 */
 	@Override
-	public CommercePricingClass fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache) {
+	public CommercePricingClass fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache) {
 
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
@@ -3125,24 +3126,24 @@ public class CommercePricingClassPersistenceImpl
 		Object[] finderArgs = null;
 
 		if (useFinderCache && productionMode) {
-			finderArgs = new Object[] {companyId, externalReferenceCode};
+			finderArgs = new Object[] {externalReferenceCode, companyId};
 		}
 
 		Object result = null;
 
 		if (useFinderCache && productionMode) {
 			result = finderCache.getResult(
-				_finderPathFetchByC_ERC, finderArgs, this);
+				_finderPathFetchByERC_C, finderArgs, this);
 		}
 
 		if (result instanceof CommercePricingClass) {
 			CommercePricingClass commercePricingClass =
 				(CommercePricingClass)result;
 
-			if ((companyId != commercePricingClass.getCompanyId()) ||
-				!Objects.equals(
+			if (!Objects.equals(
 					externalReferenceCode,
-					commercePricingClass.getExternalReferenceCode())) {
+					commercePricingClass.getExternalReferenceCode()) ||
+				(companyId != commercePricingClass.getCompanyId())) {
 
 				result = null;
 			}
@@ -3153,18 +3154,18 @@ public class CommercePricingClassPersistenceImpl
 
 			sb.append(_SQL_SELECT_COMMERCEPRICINGCLASS_WHERE);
 
-			sb.append(_FINDER_COLUMN_C_ERC_COMPANYID_2);
-
 			boolean bindExternalReferenceCode = false;
 
 			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3);
 			}
 			else {
 				bindExternalReferenceCode = true;
 
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2);
 			}
+
+			sb.append(_FINDER_COLUMN_ERC_C_COMPANYID_2);
 
 			String sql = sb.toString();
 
@@ -3177,18 +3178,18 @@ public class CommercePricingClassPersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
-				queryPos.add(companyId);
-
 				if (bindExternalReferenceCode) {
 					queryPos.add(externalReferenceCode);
 				}
+
+				queryPos.add(companyId);
 
 				List<CommercePricingClass> list = query.list();
 
 				if (list.isEmpty()) {
 					if (useFinderCache && productionMode) {
 						finderCache.putResult(
-							_finderPathFetchByC_ERC, finderArgs, list);
+							_finderPathFetchByERC_C, finderArgs, list);
 					}
 				}
 				else {
@@ -3216,32 +3217,32 @@ public class CommercePricingClassPersistenceImpl
 	}
 
 	/**
-	 * Removes the commerce pricing class where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the commerce pricing class where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the commerce pricing class that was removed
 	 */
 	@Override
-	public CommercePricingClass removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public CommercePricingClass removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchPricingClassException {
 
-		CommercePricingClass commercePricingClass = findByC_ERC(
-			companyId, externalReferenceCode);
+		CommercePricingClass commercePricingClass = findByERC_C(
+			externalReferenceCode, companyId);
 
 		return remove(commercePricingClass);
 	}
 
 	/**
-	 * Returns the number of commerce pricing classes where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of commerce pricing classes where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching commerce pricing classes
 	 */
 	@Override
-	public int countByC_ERC(long companyId, String externalReferenceCode) {
+	public int countByERC_C(String externalReferenceCode, long companyId) {
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
 		boolean productionMode = ctPersistenceHelper.isProductionMode(
@@ -3253,9 +3254,9 @@ public class CommercePricingClassPersistenceImpl
 		Long count = null;
 
 		if (productionMode) {
-			finderPath = _finderPathCountByC_ERC;
+			finderPath = _finderPathCountByERC_C;
 
-			finderArgs = new Object[] {companyId, externalReferenceCode};
+			finderArgs = new Object[] {externalReferenceCode, companyId};
 
 			count = (Long)finderCache.getResult(finderPath, finderArgs, this);
 		}
@@ -3265,18 +3266,18 @@ public class CommercePricingClassPersistenceImpl
 
 			sb.append(_SQL_COUNT_COMMERCEPRICINGCLASS_WHERE);
 
-			sb.append(_FINDER_COLUMN_C_ERC_COMPANYID_2);
-
 			boolean bindExternalReferenceCode = false;
 
 			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3);
 			}
 			else {
 				bindExternalReferenceCode = true;
 
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2);
 			}
+
+			sb.append(_FINDER_COLUMN_ERC_C_COMPANYID_2);
 
 			String sql = sb.toString();
 
@@ -3289,11 +3290,11 @@ public class CommercePricingClassPersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
-				queryPos.add(companyId);
-
 				if (bindExternalReferenceCode) {
 					queryPos.add(externalReferenceCode);
 				}
+
+				queryPos.add(companyId);
 
 				count = (Long)query.uniqueResult();
 
@@ -3312,14 +3313,14 @@ public class CommercePricingClassPersistenceImpl
 		return count.intValue();
 	}
 
-	private static final String _FINDER_COLUMN_C_ERC_COMPANYID_2 =
-		"commercePricingClass.companyId = ? AND ";
+	private static final String _FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2 =
+		"commercePricingClass.externalReferenceCode = ? AND ";
 
-	private static final String _FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2 =
-		"commercePricingClass.externalReferenceCode = ?";
+	private static final String _FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3 =
+		"(commercePricingClass.externalReferenceCode IS NULL OR commercePricingClass.externalReferenceCode = '') AND ";
 
-	private static final String _FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3 =
-		"(commercePricingClass.externalReferenceCode IS NULL OR commercePricingClass.externalReferenceCode = '')";
+	private static final String _FINDER_COLUMN_ERC_C_COMPANYID_2 =
+		"commercePricingClass.companyId = ?";
 
 	public CommercePricingClassPersistenceImpl() {
 		Map<String, String> dbColumnNames = new HashMap<String, String>();
@@ -3352,10 +3353,10 @@ public class CommercePricingClassPersistenceImpl
 			commercePricingClass.getPrimaryKey(), commercePricingClass);
 
 		finderCache.putResult(
-			_finderPathFetchByC_ERC,
+			_finderPathFetchByERC_C,
 			new Object[] {
-				commercePricingClass.getCompanyId(),
-				commercePricingClass.getExternalReferenceCode()
+				commercePricingClass.getExternalReferenceCode(),
+				commercePricingClass.getCompanyId()
 			},
 			commercePricingClass);
 	}
@@ -3444,13 +3445,13 @@ public class CommercePricingClassPersistenceImpl
 		CommercePricingClassModelImpl commercePricingClassModelImpl) {
 
 		Object[] args = new Object[] {
-			commercePricingClassModelImpl.getCompanyId(),
-			commercePricingClassModelImpl.getExternalReferenceCode()
+			commercePricingClassModelImpl.getExternalReferenceCode(),
+			commercePricingClassModelImpl.getCompanyId()
 		};
 
-		finderCache.putResult(_finderPathCountByC_ERC, args, Long.valueOf(1));
+		finderCache.putResult(_finderPathCountByERC_C, args, Long.valueOf(1));
 		finderCache.putResult(
-			_finderPathFetchByC_ERC, args, commercePricingClassModelImpl);
+			_finderPathFetchByERC_C, args, commercePricingClassModelImpl);
 	}
 
 	/**
@@ -3602,6 +3603,29 @@ public class CommercePricingClassPersistenceImpl
 		if (Validator.isNull(commercePricingClass.getExternalReferenceCode())) {
 			commercePricingClass.setExternalReferenceCode(
 				commercePricingClass.getUuid());
+		}
+		else {
+			CommercePricingClass ercCommercePricingClass = fetchByERC_C(
+				commercePricingClass.getExternalReferenceCode(),
+				commercePricingClass.getCompanyId());
+
+			if (isNew) {
+				if (ercCommercePricingClass != null) {
+					throw new DuplicateCommercePricingClassExternalReferenceCodeException(
+						"Duplicate CommercePricingClass with external reference code " +
+							commercePricingClass.getExternalReferenceCode());
+				}
+			}
+			else {
+				if ((ercCommercePricingClass != null) &&
+					(commercePricingClass.getCommercePricingClassId() !=
+						ercCommercePricingClass.getCommercePricingClassId())) {
+
+					throw new DuplicateCommercePricingClassExternalReferenceCodeException(
+						"Duplicate CommercePricingClass with external reference code " +
+							commercePricingClass.getExternalReferenceCode());
+				}
+			}
 		}
 
 		ServiceContext serviceContext =
@@ -4144,7 +4168,7 @@ public class CommercePricingClassPersistenceImpl
 			CTColumnResolutionType.STRICT, ctStrictColumnNames);
 
 		_uniqueIndexColumnNames.add(
-			new String[] {"companyId", "externalReferenceCode"});
+			new String[] {"externalReferenceCode", "companyId"});
 	}
 
 	/**
@@ -4222,15 +4246,15 @@ public class CommercePricingClassPersistenceImpl
 			new String[] {Long.class.getName()}, new String[] {"companyId"},
 			false);
 
-		_finderPathFetchByC_ERC = new FinderPath(
-			FINDER_CLASS_NAME_ENTITY, "fetchByC_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"companyId", "externalReferenceCode"}, true);
+		_finderPathFetchByERC_C = new FinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, true);
 
-		_finderPathCountByC_ERC = new FinderPath(
-			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"companyId", "externalReferenceCode"}, false);
+		_finderPathCountByERC_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, false);
 
 		_setCommercePricingClassUtilPersistence(this);
 	}

--- a/modules/apps/commerce/commerce-pricing-test/src/testIntegration/java/com/liferay/commerce/pricing/service/persistence/test/CommercePriceModifierPersistenceTest.java
+++ b/modules/apps/commerce/commerce-pricing-test/src/testIntegration/java/com/liferay/commerce/pricing/service/persistence/test/CommercePriceModifierPersistenceTest.java
@@ -15,6 +15,7 @@
 package com.liferay.commerce.pricing.service.persistence.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.commerce.pricing.exception.DuplicateCommercePriceModifierExternalReferenceCodeException;
 import com.liferay.commerce.pricing.exception.NoSuchPriceModifierException;
 import com.liferay.commerce.pricing.model.CommercePriceModifier;
 import com.liferay.commerce.pricing.service.CommercePriceModifierLocalServiceUtil;
@@ -275,6 +276,32 @@ public class CommercePriceModifierPersistenceTest {
 			Time.getShortTimestamp(newCommercePriceModifier.getStatusDate()));
 	}
 
+	@Test(
+		expected = DuplicateCommercePriceModifierExternalReferenceCodeException.class
+	)
+	public void testUpdateWithExistingExternalReferenceCode() throws Exception {
+		CommercePriceModifier commercePriceModifier =
+			addCommercePriceModifier();
+
+		CommercePriceModifier newCommercePriceModifier =
+			addCommercePriceModifier();
+
+		newCommercePriceModifier.setCompanyId(
+			commercePriceModifier.getCompanyId());
+
+		newCommercePriceModifier = _persistence.update(
+			newCommercePriceModifier);
+
+		Session session = _persistence.getCurrentSession();
+
+		session.evict(newCommercePriceModifier);
+
+		newCommercePriceModifier.setExternalReferenceCode(
+			commercePriceModifier.getExternalReferenceCode());
+
+		_persistence.update(newCommercePriceModifier);
+	}
+
 	@Test
 	public void testCountByUuid() throws Exception {
 		_persistence.countByUuid("");
@@ -374,12 +401,12 @@ public class CommercePriceModifierPersistenceTest {
 	}
 
 	@Test
-	public void testCountByC_ERC() throws Exception {
-		_persistence.countByC_ERC(RandomTestUtil.nextLong(), "");
+	public void testCountByERC_C() throws Exception {
+		_persistence.countByERC_C("", RandomTestUtil.nextLong());
 
-		_persistence.countByC_ERC(0L, "null");
+		_persistence.countByERC_C("null", 0L);
 
-		_persistence.countByC_ERC(0L, (String)null);
+		_persistence.countByERC_C((String)null, 0L);
 	}
 
 	@Test
@@ -727,15 +754,15 @@ public class CommercePriceModifierPersistenceTest {
 				new Class<?>[] {String.class}, "groupId"));
 
 		Assert.assertEquals(
-			Long.valueOf(commercePriceModifier.getCompanyId()),
-			ReflectionTestUtil.<Long>invoke(
-				commercePriceModifier, "getColumnOriginalValue",
-				new Class<?>[] {String.class}, "companyId"));
-		Assert.assertEquals(
 			commercePriceModifier.getExternalReferenceCode(),
 			ReflectionTestUtil.invoke(
 				commercePriceModifier, "getColumnOriginalValue",
 				new Class<?>[] {String.class}, "externalReferenceCode"));
+		Assert.assertEquals(
+			Long.valueOf(commercePriceModifier.getCompanyId()),
+			ReflectionTestUtil.<Long>invoke(
+				commercePriceModifier, "getColumnOriginalValue",
+				new Class<?>[] {String.class}, "companyId"));
 	}
 
 	protected CommercePriceModifier addCommercePriceModifier()

--- a/modules/apps/commerce/commerce-pricing-test/src/testIntegration/java/com/liferay/commerce/pricing/service/persistence/test/CommercePricingClassPersistenceTest.java
+++ b/modules/apps/commerce/commerce-pricing-test/src/testIntegration/java/com/liferay/commerce/pricing/service/persistence/test/CommercePricingClassPersistenceTest.java
@@ -15,6 +15,7 @@
 package com.liferay.commerce.pricing.service.persistence.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.commerce.pricing.exception.DuplicateCommercePricingClassExternalReferenceCodeException;
 import com.liferay.commerce.pricing.exception.NoSuchPricingClassException;
 import com.liferay.commerce.pricing.model.CommercePricingClass;
 import com.liferay.commerce.pricing.service.CommercePricingClassLocalServiceUtil;
@@ -204,6 +205,30 @@ public class CommercePricingClassPersistenceTest {
 				newCommercePricingClass.getLastPublishDate()));
 	}
 
+	@Test(
+		expected = DuplicateCommercePricingClassExternalReferenceCodeException.class
+	)
+	public void testUpdateWithExistingExternalReferenceCode() throws Exception {
+		CommercePricingClass commercePricingClass = addCommercePricingClass();
+
+		CommercePricingClass newCommercePricingClass =
+			addCommercePricingClass();
+
+		newCommercePricingClass.setCompanyId(
+			commercePricingClass.getCompanyId());
+
+		newCommercePricingClass = _persistence.update(newCommercePricingClass);
+
+		Session session = _persistence.getCurrentSession();
+
+		session.evict(newCommercePricingClass);
+
+		newCommercePricingClass.setExternalReferenceCode(
+			commercePricingClass.getExternalReferenceCode());
+
+		_persistence.update(newCommercePricingClass);
+	}
+
 	@Test
 	public void testCountByUuid() throws Exception {
 		_persistence.countByUuid("");
@@ -230,12 +255,12 @@ public class CommercePricingClassPersistenceTest {
 	}
 
 	@Test
-	public void testCountByC_ERC() throws Exception {
-		_persistence.countByC_ERC(RandomTestUtil.nextLong(), "");
+	public void testCountByERC_C() throws Exception {
+		_persistence.countByERC_C("", RandomTestUtil.nextLong());
 
-		_persistence.countByC_ERC(0L, "null");
+		_persistence.countByERC_C("null", 0L);
 
-		_persistence.countByC_ERC(0L, (String)null);
+		_persistence.countByERC_C((String)null, 0L);
 	}
 
 	@Test
@@ -567,15 +592,15 @@ public class CommercePricingClassPersistenceTest {
 		CommercePricingClass commercePricingClass) {
 
 		Assert.assertEquals(
-			Long.valueOf(commercePricingClass.getCompanyId()),
-			ReflectionTestUtil.<Long>invoke(
-				commercePricingClass, "getColumnOriginalValue",
-				new Class<?>[] {String.class}, "companyId"));
-		Assert.assertEquals(
 			commercePricingClass.getExternalReferenceCode(),
 			ReflectionTestUtil.invoke(
 				commercePricingClass, "getColumnOriginalValue",
 				new Class<?>[] {String.class}, "externalReferenceCode"));
+		Assert.assertEquals(
+			Long.valueOf(commercePricingClass.getCompanyId()),
+			ReflectionTestUtil.<Long>invoke(
+				commercePricingClass, "getColumnOriginalValue",
+				new Class<?>[] {String.class}, "companyId"));
 	}
 
 	protected CommercePricingClass addCommercePricingClass() throws Exception {

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/object/system/CommerceOrderSystemObjectDefinitionMetadata.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/object/system/CommerceOrderSystemObjectDefinitionMetadata.java
@@ -58,7 +58,7 @@ public class CommerceOrderSystemObjectDefinitionMetadata
 
 		return _commerceOrderLocalService.
 			getCommerceOrderByExternalReferenceCode(
-				companyId, externalReferenceCode);
+				externalReferenceCode, companyId);
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/object/system/CommercePricingClassSystemObjectDefinitionMetadata.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/object/system/CommercePricingClassSystemObjectDefinitionMetadata.java
@@ -57,7 +57,7 @@ public class CommercePricingClassSystemObjectDefinitionMetadata
 
 		return _commercePricingClassLocalService.
 			getCommercePricingClassByExternalReferenceCode(
-				companyId, externalReferenceCode);
+				externalReferenceCode, companyId);
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/base/CommerceOrderItemLocalServiceBaseImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/base/CommerceOrderItemLocalServiceBaseImpl.java
@@ -275,48 +275,21 @@ public abstract class CommerceOrderItemLocalServiceBaseImpl
 		return commerceOrderItemPersistence.fetchByUUID_G(uuid, groupId);
 	}
 
-	/**
-	 * Returns the commerce order item with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce order item's external reference code
-	 * @return the matching commerce order item, or <code>null</code> if a matching commerce order item could not be found
-	 */
 	@Override
 	public CommerceOrderItem fetchCommerceOrderItemByExternalReferenceCode(
-		long companyId, String externalReferenceCode) {
+		String externalReferenceCode, long companyId) {
 
-		return commerceOrderItemPersistence.fetchByC_ERC(
-			companyId, externalReferenceCode);
+		return commerceOrderItemPersistence.fetchByERC_C(
+			externalReferenceCode, companyId);
 	}
 
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchCommerceOrderItemByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public CommerceOrderItem fetchCommerceOrderItemByReferenceCode(
-		long companyId, String externalReferenceCode) {
-
-		return fetchCommerceOrderItemByExternalReferenceCode(
-			companyId, externalReferenceCode);
-	}
-
-	/**
-	 * Returns the commerce order item with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce order item's external reference code
-	 * @return the matching commerce order item
-	 * @throws PortalException if a matching commerce order item could not be found
-	 */
 	@Override
 	public CommerceOrderItem getCommerceOrderItemByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
+			String externalReferenceCode, long companyId)
 		throws PortalException {
 
-		return commerceOrderItemPersistence.findByC_ERC(
-			companyId, externalReferenceCode);
+		return commerceOrderItemPersistence.findByERC_C(
+			externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/base/CommerceOrderLocalServiceBaseImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/base/CommerceOrderLocalServiceBaseImpl.java
@@ -278,48 +278,21 @@ public abstract class CommerceOrderLocalServiceBaseImpl
 		return commerceOrderPersistence.fetchByUUID_G(uuid, groupId);
 	}
 
-	/**
-	 * Returns the commerce order with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce order's external reference code
-	 * @return the matching commerce order, or <code>null</code> if a matching commerce order could not be found
-	 */
 	@Override
 	public CommerceOrder fetchCommerceOrderByExternalReferenceCode(
-		long companyId, String externalReferenceCode) {
+		String externalReferenceCode, long companyId) {
 
-		return commerceOrderPersistence.fetchByC_ERC(
-			companyId, externalReferenceCode);
+		return commerceOrderPersistence.fetchByERC_C(
+			externalReferenceCode, companyId);
 	}
 
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchCommerceOrderByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public CommerceOrder fetchCommerceOrderByReferenceCode(
-		long companyId, String externalReferenceCode) {
-
-		return fetchCommerceOrderByExternalReferenceCode(
-			companyId, externalReferenceCode);
-	}
-
-	/**
-	 * Returns the commerce order with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce order's external reference code
-	 * @return the matching commerce order
-	 * @throws PortalException if a matching commerce order could not be found
-	 */
 	@Override
 	public CommerceOrder getCommerceOrderByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
+			String externalReferenceCode, long companyId)
 		throws PortalException {
 
-		return commerceOrderPersistence.findByC_ERC(
-			companyId, externalReferenceCode);
+		return commerceOrderPersistence.findByERC_C(
+			externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/base/CommerceOrderNoteLocalServiceBaseImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/base/CommerceOrderNoteLocalServiceBaseImpl.java
@@ -272,48 +272,21 @@ public abstract class CommerceOrderNoteLocalServiceBaseImpl
 		return commerceOrderNotePersistence.fetchByUUID_G(uuid, groupId);
 	}
 
-	/**
-	 * Returns the commerce order note with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce order note's external reference code
-	 * @return the matching commerce order note, or <code>null</code> if a matching commerce order note could not be found
-	 */
 	@Override
 	public CommerceOrderNote fetchCommerceOrderNoteByExternalReferenceCode(
-		long companyId, String externalReferenceCode) {
+		String externalReferenceCode, long companyId) {
 
-		return commerceOrderNotePersistence.fetchByC_ERC(
-			companyId, externalReferenceCode);
+		return commerceOrderNotePersistence.fetchByERC_C(
+			externalReferenceCode, companyId);
 	}
 
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchCommerceOrderNoteByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public CommerceOrderNote fetchCommerceOrderNoteByReferenceCode(
-		long companyId, String externalReferenceCode) {
-
-		return fetchCommerceOrderNoteByExternalReferenceCode(
-			companyId, externalReferenceCode);
-	}
-
-	/**
-	 * Returns the commerce order note with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce order note's external reference code
-	 * @return the matching commerce order note
-	 * @throws PortalException if a matching commerce order note could not be found
-	 */
 	@Override
 	public CommerceOrderNote getCommerceOrderNoteByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
+			String externalReferenceCode, long companyId)
 		throws PortalException {
 
-		return commerceOrderNotePersistence.findByC_ERC(
-			companyId, externalReferenceCode);
+		return commerceOrderNotePersistence.findByERC_C(
+			externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/base/CommerceOrderTypeLocalServiceBaseImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/base/CommerceOrderTypeLocalServiceBaseImpl.java
@@ -283,48 +283,21 @@ public abstract class CommerceOrderTypeLocalServiceBaseImpl
 			uuid, companyId, null);
 	}
 
-	/**
-	 * Returns the commerce order type with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce order type's external reference code
-	 * @return the matching commerce order type, or <code>null</code> if a matching commerce order type could not be found
-	 */
 	@Override
 	public CommerceOrderType fetchCommerceOrderTypeByExternalReferenceCode(
-		long companyId, String externalReferenceCode) {
+		String externalReferenceCode, long companyId) {
 
-		return commerceOrderTypePersistence.fetchByC_ERC(
-			companyId, externalReferenceCode);
+		return commerceOrderTypePersistence.fetchByERC_C(
+			externalReferenceCode, companyId);
 	}
 
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchCommerceOrderTypeByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public CommerceOrderType fetchCommerceOrderTypeByReferenceCode(
-		long companyId, String externalReferenceCode) {
-
-		return fetchCommerceOrderTypeByExternalReferenceCode(
-			companyId, externalReferenceCode);
-	}
-
-	/**
-	 * Returns the commerce order type with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce order type's external reference code
-	 * @return the matching commerce order type
-	 * @throws PortalException if a matching commerce order type could not be found
-	 */
 	@Override
 	public CommerceOrderType getCommerceOrderTypeByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
+			String externalReferenceCode, long companyId)
 		throws PortalException {
 
-		return commerceOrderTypePersistence.findByC_ERC(
-			companyId, externalReferenceCode);
+		return commerceOrderTypePersistence.findByERC_C(
+			externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/base/CommerceOrderTypeRelLocalServiceBaseImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/base/CommerceOrderTypeRelLocalServiceBaseImpl.java
@@ -282,49 +282,22 @@ public abstract class CommerceOrderTypeRelLocalServiceBaseImpl
 			uuid, companyId, null);
 	}
 
-	/**
-	 * Returns the commerce order type rel with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce order type rel's external reference code
-	 * @return the matching commerce order type rel, or <code>null</code> if a matching commerce order type rel could not be found
-	 */
 	@Override
 	public CommerceOrderTypeRel
 		fetchCommerceOrderTypeRelByExternalReferenceCode(
-			long companyId, String externalReferenceCode) {
+			String externalReferenceCode, long companyId) {
 
-		return commerceOrderTypeRelPersistence.fetchByC_ERC(
-			companyId, externalReferenceCode);
+		return commerceOrderTypeRelPersistence.fetchByERC_C(
+			externalReferenceCode, companyId);
 	}
 
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchCommerceOrderTypeRelByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public CommerceOrderTypeRel fetchCommerceOrderTypeRelByReferenceCode(
-		long companyId, String externalReferenceCode) {
-
-		return fetchCommerceOrderTypeRelByExternalReferenceCode(
-			companyId, externalReferenceCode);
-	}
-
-	/**
-	 * Returns the commerce order type rel with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce order type rel's external reference code
-	 * @return the matching commerce order type rel
-	 * @throws PortalException if a matching commerce order type rel could not be found
-	 */
 	@Override
 	public CommerceOrderTypeRel getCommerceOrderTypeRelByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
+			String externalReferenceCode, long companyId)
 		throws PortalException {
 
-		return commerceOrderTypeRelPersistence.findByC_ERC(
-			companyId, externalReferenceCode);
+		return commerceOrderTypeRelPersistence.findByERC_C(
+			externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/base/CommerceShipmentItemLocalServiceBaseImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/base/CommerceShipmentItemLocalServiceBaseImpl.java
@@ -280,49 +280,22 @@ public abstract class CommerceShipmentItemLocalServiceBaseImpl
 		return commerceShipmentItemPersistence.fetchByUUID_G(uuid, groupId);
 	}
 
-	/**
-	 * Returns the commerce shipment item with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce shipment item's external reference code
-	 * @return the matching commerce shipment item, or <code>null</code> if a matching commerce shipment item could not be found
-	 */
 	@Override
 	public CommerceShipmentItem
 		fetchCommerceShipmentItemByExternalReferenceCode(
-			long companyId, String externalReferenceCode) {
+			String externalReferenceCode, long companyId) {
 
-		return commerceShipmentItemPersistence.fetchByC_ERC(
-			companyId, externalReferenceCode);
+		return commerceShipmentItemPersistence.fetchByERC_C(
+			externalReferenceCode, companyId);
 	}
 
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchCommerceShipmentItemByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public CommerceShipmentItem fetchCommerceShipmentItemByReferenceCode(
-		long companyId, String externalReferenceCode) {
-
-		return fetchCommerceShipmentItemByExternalReferenceCode(
-			companyId, externalReferenceCode);
-	}
-
-	/**
-	 * Returns the commerce shipment item with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce shipment item's external reference code
-	 * @return the matching commerce shipment item
-	 * @throws PortalException if a matching commerce shipment item could not be found
-	 */
 	@Override
 	public CommerceShipmentItem getCommerceShipmentItemByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
+			String externalReferenceCode, long companyId)
 		throws PortalException {
 
-		return commerceShipmentItemPersistence.findByC_ERC(
-			companyId, externalReferenceCode);
+		return commerceShipmentItemPersistence.findByERC_C(
+			externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/base/CommerceShipmentLocalServiceBaseImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/base/CommerceShipmentLocalServiceBaseImpl.java
@@ -273,48 +273,21 @@ public abstract class CommerceShipmentLocalServiceBaseImpl
 		return commerceShipmentPersistence.fetchByUUID_G(uuid, groupId);
 	}
 
-	/**
-	 * Returns the commerce shipment with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce shipment's external reference code
-	 * @return the matching commerce shipment, or <code>null</code> if a matching commerce shipment could not be found
-	 */
 	@Override
 	public CommerceShipment fetchCommerceShipmentByExternalReferenceCode(
-		long companyId, String externalReferenceCode) {
+		String externalReferenceCode, long companyId) {
 
-		return commerceShipmentPersistence.fetchByC_ERC(
-			companyId, externalReferenceCode);
+		return commerceShipmentPersistence.fetchByERC_C(
+			externalReferenceCode, companyId);
 	}
 
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchCommerceShipmentByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public CommerceShipment fetchCommerceShipmentByReferenceCode(
-		long companyId, String externalReferenceCode) {
-
-		return fetchCommerceShipmentByExternalReferenceCode(
-			companyId, externalReferenceCode);
-	}
-
-	/**
-	 * Returns the commerce shipment with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce shipment's external reference code
-	 * @return the matching commerce shipment
-	 * @throws PortalException if a matching commerce shipment could not be found
-	 */
 	@Override
 	public CommerceShipment getCommerceShipmentByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
+			String externalReferenceCode, long companyId)
 		throws PortalException {
 
-		return commerceShipmentPersistence.findByC_ERC(
-			companyId, externalReferenceCode);
+		return commerceShipmentPersistence.findByERC_C(
+			externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderItemLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderItemLocalServiceImpl.java
@@ -376,8 +376,8 @@ public class CommerceOrderItemLocalServiceImpl
 			return null;
 		}
 
-		return commerceOrderItemPersistence.fetchByC_ERC(
-			companyId, externalReferenceCode);
+		return commerceOrderItemPersistence.fetchByERC_C(
+			externalReferenceCode, companyId);
 	}
 
 	@Override
@@ -526,8 +526,8 @@ public class CommerceOrderItemLocalServiceImpl
 		if ((commerceOrderItem == null) &&
 			!Validator.isBlank(externalReferenceCode)) {
 
-			commerceOrderItem = commerceOrderItemPersistence.fetchByC_ERC(
-				serviceContext.getCompanyId(), externalReferenceCode);
+			commerceOrderItem = commerceOrderItemPersistence.fetchByERC_C(
+				externalReferenceCode, serviceContext.getCompanyId());
 		}
 
 		if (commerceOrderItem == null) {

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderLocalServiceImpl.java
@@ -336,8 +336,8 @@ public class CommerceOrderLocalServiceImpl
 		CommerceOrder commerceOrder = null;
 
 		if (Validator.isNotNull(externalReferenceCode)) {
-			commerceOrder = commerceOrderPersistence.fetchByC_ERC(
-				serviceContext.getCompanyId(), externalReferenceCode);
+			commerceOrder = commerceOrderPersistence.fetchByERC_C(
+				externalReferenceCode, serviceContext.getCompanyId());
 		}
 
 		if (commerceOrder != null) {
@@ -581,8 +581,8 @@ public class CommerceOrderLocalServiceImpl
 			return null;
 		}
 
-		return commerceOrderPersistence.fetchByC_ERC(
-			companyId, externalReferenceCode);
+		return commerceOrderPersistence.fetchByERC_C(
+			externalReferenceCode, companyId);
 	}
 
 	/**
@@ -1717,8 +1717,8 @@ public class CommerceOrderLocalServiceImpl
 		CommerceOrder commerceOrder = null;
 
 		if (Validator.isNotNull(externalReferenceCode)) {
-			commerceOrder = commerceOrderPersistence.fetchByC_ERC(
-				serviceContext.getCompanyId(), externalReferenceCode);
+			commerceOrder = commerceOrderPersistence.fetchByERC_C(
+				externalReferenceCode, serviceContext.getCompanyId());
 		}
 
 		if (commerceOrder != null) {

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderNoteLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderNoteLocalServiceImpl.java
@@ -15,7 +15,6 @@
 package com.liferay.commerce.service.impl;
 
 import com.liferay.commerce.exception.CommerceOrderNoteContentException;
-import com.liferay.commerce.exception.DuplicateCommerceOrderNoteException;
 import com.liferay.commerce.model.CommerceOrder;
 import com.liferay.commerce.model.CommerceOrderNote;
 import com.liferay.commerce.service.base.CommerceOrderNoteLocalServiceBaseImpl;
@@ -67,9 +66,6 @@ public class CommerceOrderNoteLocalServiceImpl
 		if (Validator.isBlank(externalReferenceCode)) {
 			externalReferenceCode = null;
 		}
-
-		_validateExternalReferenceCode(
-			externalReferenceCode, serviceContext.getCompanyId());
 
 		long commerceOrderNoteId = counterLocalService.increment();
 
@@ -214,25 +210,6 @@ public class CommerceOrderNoteLocalServiceImpl
 	private void _validate(String content) throws PortalException {
 		if (Validator.isNull(content)) {
 			throw new CommerceOrderNoteContentException();
-		}
-	}
-
-	private void _validateExternalReferenceCode(
-			String externalReferenceCode, long companyId)
-		throws PortalException {
-
-		if (Validator.isNull(externalReferenceCode)) {
-			return;
-		}
-
-		CommerceOrderNote commerceOrderNote =
-			commerceOrderNotePersistence.fetchByERC_C(
-				externalReferenceCode, companyId);
-
-		if (commerceOrderNote != null) {
-			throw new DuplicateCommerceOrderNoteException(
-				"There is another commerce order note with external " +
-					"reference code " + externalReferenceCode);
 		}
 	}
 

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderNoteLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderNoteLocalServiceImpl.java
@@ -106,8 +106,8 @@ public class CommerceOrderNoteLocalServiceImpl
 			commerceOrderNote = getCommerceOrderNote(commerceOrderNoteId);
 		}
 		else {
-			commerceOrderNote = commerceOrderNotePersistence.fetchByC_ERC(
-				serviceContext.getCompanyId(), externalReferenceCode);
+			commerceOrderNote = commerceOrderNotePersistence.fetchByERC_C(
+				externalReferenceCode, serviceContext.getCompanyId());
 		}
 
 		if (commerceOrderNote != null) {
@@ -135,8 +135,8 @@ public class CommerceOrderNoteLocalServiceImpl
 			return null;
 		}
 
-		return commerceOrderNotePersistence.fetchByC_ERC(
-			companyId, externalReferenceCode);
+		return commerceOrderNotePersistence.fetchByERC_C(
+			externalReferenceCode, companyId);
 	}
 
 	@Override
@@ -226,8 +226,8 @@ public class CommerceOrderNoteLocalServiceImpl
 		}
 
 		CommerceOrderNote commerceOrderNote =
-			commerceOrderNotePersistence.fetchByC_ERC(
-				companyId, externalReferenceCode);
+			commerceOrderNotePersistence.fetchByERC_C(
+				externalReferenceCode, companyId);
 
 		if (commerceOrderNote != null) {
 			throw new DuplicateCommerceOrderNoteException(

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderTypeLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderTypeLocalServiceImpl.java
@@ -205,8 +205,8 @@ public class CommerceOrderTypeLocalServiceImpl
 			return null;
 		}
 
-		return commerceOrderTypePersistence.fetchByC_ERC(
-			companyId, externalReferenceCode);
+		return commerceOrderTypePersistence.fetchByERC_C(
+			externalReferenceCode, companyId);
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceShipmentItemLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceShipmentItemLocalServiceImpl.java
@@ -170,8 +170,8 @@ public class CommerceShipmentItemLocalServiceImpl
 		CommerceShipmentItem commerceShipmentItem = null;
 
 		if (Validator.isNotNull(externalReferenceCode)) {
-			commerceShipmentItem = commerceShipmentItemPersistence.fetchByC_ERC(
-				serviceContext.getCompanyId(), externalReferenceCode);
+			commerceShipmentItem = commerceShipmentItemPersistence.fetchByERC_C(
+				externalReferenceCode, serviceContext.getCompanyId());
 		}
 
 		if (commerceShipmentItem == null) {
@@ -569,8 +569,8 @@ public class CommerceShipmentItemLocalServiceImpl
 		}
 
 		CommerceShipmentItem commerceShipmentItem =
-			commerceShipmentItemPersistence.fetchByC_ERC(
-				companyId, externalReferenceCode);
+			commerceShipmentItemPersistence.fetchByERC_C(
+				externalReferenceCode, companyId);
 
 		if (commerceShipmentItem == null) {
 			return;

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceShipmentItemServiceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceShipmentItemServiceImpl.java
@@ -151,7 +151,7 @@ public class CommerceShipmentItemServiceImpl
 
 		return commerceShipmentItemLocalService.
 			fetchCommerceShipmentItemByExternalReferenceCode(
-				companyId, externalReferenceCode);
+				externalReferenceCode, companyId);
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceShipmentLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceShipmentLocalServiceImpl.java
@@ -891,8 +891,8 @@ public class CommerceShipmentLocalServiceImpl
 		}
 
 		CommerceShipment commerceShipment =
-			commerceShipmentPersistence.fetchByC_ERC(
-				companyId, externalReferenceCode);
+			commerceShipmentPersistence.fetchByERC_C(
+				externalReferenceCode, companyId);
 
 		if (commerceShipment == null) {
 			return;

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceShipmentServiceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceShipmentServiceImpl.java
@@ -114,7 +114,7 @@ public class CommerceShipmentServiceImpl
 
 		return commerceShipmentLocalService.
 			fetchCommerceShipmentByExternalReferenceCode(
-				companyId, externalReferenceCode);
+				externalReferenceCode, companyId);
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/persistence/impl/CommerceOrderItemPersistenceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/persistence/impl/CommerceOrderItemPersistenceImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.commerce.service.persistence.impl;
 
+import com.liferay.commerce.exception.DuplicateCommerceOrderItemExternalReferenceCodeException;
 import com.liferay.commerce.exception.NoSuchOrderItemException;
 import com.liferay.commerce.model.CommerceOrderItem;
 import com.liferay.commerce.model.CommerceOrderItemTable;
@@ -4826,35 +4827,35 @@ public class CommerceOrderItemPersistenceImpl
 	private static final String _FINDER_COLUMN_C_S_SUBSCRIPTION_2 =
 		"commerceOrderItem.subscription = ?";
 
-	private FinderPath _finderPathFetchByC_ERC;
-	private FinderPath _finderPathCountByC_ERC;
+	private FinderPath _finderPathFetchByERC_C;
+	private FinderPath _finderPathCountByERC_C;
 
 	/**
-	 * Returns the commerce order item where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchOrderItemException</code> if it could not be found.
+	 * Returns the commerce order item where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchOrderItemException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce order item
 	 * @throws NoSuchOrderItemException if a matching commerce order item could not be found
 	 */
 	@Override
-	public CommerceOrderItem findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public CommerceOrderItem findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchOrderItemException {
 
-		CommerceOrderItem commerceOrderItem = fetchByC_ERC(
-			companyId, externalReferenceCode);
+		CommerceOrderItem commerceOrderItem = fetchByERC_C(
+			externalReferenceCode, companyId);
 
 		if (commerceOrderItem == null) {
 			StringBundler sb = new StringBundler(6);
 
 			sb.append(_NO_SUCH_ENTITY_WITH_KEY);
 
-			sb.append("companyId=");
-			sb.append(companyId);
-
-			sb.append(", externalReferenceCode=");
+			sb.append("externalReferenceCode=");
 			sb.append(externalReferenceCode);
+
+			sb.append(", companyId=");
+			sb.append(companyId);
 
 			sb.append("}");
 
@@ -4869,53 +4870,53 @@ public class CommerceOrderItemPersistenceImpl
 	}
 
 	/**
-	 * Returns the commerce order item where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the commerce order item where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce order item, or <code>null</code> if a matching commerce order item could not be found
 	 */
 	@Override
-	public CommerceOrderItem fetchByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public CommerceOrderItem fetchByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return fetchByC_ERC(companyId, externalReferenceCode, true);
+		return fetchByERC_C(externalReferenceCode, companyId, true);
 	}
 
 	/**
-	 * Returns the commerce order item where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the commerce order item where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching commerce order item, or <code>null</code> if a matching commerce order item could not be found
 	 */
 	@Override
-	public CommerceOrderItem fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache) {
+	public CommerceOrderItem fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache) {
 
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
 		Object[] finderArgs = null;
 
 		if (useFinderCache) {
-			finderArgs = new Object[] {companyId, externalReferenceCode};
+			finderArgs = new Object[] {externalReferenceCode, companyId};
 		}
 
 		Object result = null;
 
 		if (useFinderCache) {
 			result = finderCache.getResult(
-				_finderPathFetchByC_ERC, finderArgs, this);
+				_finderPathFetchByERC_C, finderArgs, this);
 		}
 
 		if (result instanceof CommerceOrderItem) {
 			CommerceOrderItem commerceOrderItem = (CommerceOrderItem)result;
 
-			if ((companyId != commerceOrderItem.getCompanyId()) ||
-				!Objects.equals(
+			if (!Objects.equals(
 					externalReferenceCode,
-					commerceOrderItem.getExternalReferenceCode())) {
+					commerceOrderItem.getExternalReferenceCode()) ||
+				(companyId != commerceOrderItem.getCompanyId())) {
 
 				result = null;
 			}
@@ -4926,18 +4927,18 @@ public class CommerceOrderItemPersistenceImpl
 
 			sb.append(_SQL_SELECT_COMMERCEORDERITEM_WHERE);
 
-			sb.append(_FINDER_COLUMN_C_ERC_COMPANYID_2);
-
 			boolean bindExternalReferenceCode = false;
 
 			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3);
 			}
 			else {
 				bindExternalReferenceCode = true;
 
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2);
 			}
+
+			sb.append(_FINDER_COLUMN_ERC_C_COMPANYID_2);
 
 			String sql = sb.toString();
 
@@ -4950,18 +4951,18 @@ public class CommerceOrderItemPersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
-				queryPos.add(companyId);
-
 				if (bindExternalReferenceCode) {
 					queryPos.add(externalReferenceCode);
 				}
+
+				queryPos.add(companyId);
 
 				List<CommerceOrderItem> list = query.list();
 
 				if (list.isEmpty()) {
 					if (useFinderCache) {
 						finderCache.putResult(
-							_finderPathFetchByC_ERC, finderArgs, list);
+							_finderPathFetchByERC_C, finderArgs, list);
 					}
 				}
 				else {
@@ -4989,37 +4990,37 @@ public class CommerceOrderItemPersistenceImpl
 	}
 
 	/**
-	 * Removes the commerce order item where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the commerce order item where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the commerce order item that was removed
 	 */
 	@Override
-	public CommerceOrderItem removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public CommerceOrderItem removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchOrderItemException {
 
-		CommerceOrderItem commerceOrderItem = findByC_ERC(
-			companyId, externalReferenceCode);
+		CommerceOrderItem commerceOrderItem = findByERC_C(
+			externalReferenceCode, companyId);
 
 		return remove(commerceOrderItem);
 	}
 
 	/**
-	 * Returns the number of commerce order items where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of commerce order items where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching commerce order items
 	 */
 	@Override
-	public int countByC_ERC(long companyId, String externalReferenceCode) {
+	public int countByERC_C(String externalReferenceCode, long companyId) {
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
-		FinderPath finderPath = _finderPathCountByC_ERC;
+		FinderPath finderPath = _finderPathCountByERC_C;
 
-		Object[] finderArgs = new Object[] {companyId, externalReferenceCode};
+		Object[] finderArgs = new Object[] {externalReferenceCode, companyId};
 
 		Long count = (Long)finderCache.getResult(finderPath, finderArgs, this);
 
@@ -5028,18 +5029,18 @@ public class CommerceOrderItemPersistenceImpl
 
 			sb.append(_SQL_COUNT_COMMERCEORDERITEM_WHERE);
 
-			sb.append(_FINDER_COLUMN_C_ERC_COMPANYID_2);
-
 			boolean bindExternalReferenceCode = false;
 
 			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3);
 			}
 			else {
 				bindExternalReferenceCode = true;
 
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2);
 			}
+
+			sb.append(_FINDER_COLUMN_ERC_C_COMPANYID_2);
 
 			String sql = sb.toString();
 
@@ -5052,11 +5053,11 @@ public class CommerceOrderItemPersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
-				queryPos.add(companyId);
-
 				if (bindExternalReferenceCode) {
 					queryPos.add(externalReferenceCode);
 				}
+
+				queryPos.add(companyId);
 
 				count = (Long)query.uniqueResult();
 
@@ -5073,14 +5074,14 @@ public class CommerceOrderItemPersistenceImpl
 		return count.intValue();
 	}
 
-	private static final String _FINDER_COLUMN_C_ERC_COMPANYID_2 =
-		"commerceOrderItem.companyId = ? AND ";
+	private static final String _FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2 =
+		"commerceOrderItem.externalReferenceCode = ? AND ";
 
-	private static final String _FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2 =
-		"commerceOrderItem.externalReferenceCode = ?";
+	private static final String _FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3 =
+		"(commerceOrderItem.externalReferenceCode IS NULL OR commerceOrderItem.externalReferenceCode = '') AND ";
 
-	private static final String _FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3 =
-		"(commerceOrderItem.externalReferenceCode IS NULL OR commerceOrderItem.externalReferenceCode = '')";
+	private static final String _FINDER_COLUMN_ERC_C_COMPANYID_2 =
+		"commerceOrderItem.companyId = ?";
 
 	public CommerceOrderItemPersistenceImpl() {
 		Map<String, String> dbColumnNames = new HashMap<String, String>();
@@ -5135,10 +5136,10 @@ public class CommerceOrderItemPersistenceImpl
 			commerceOrderItem);
 
 		finderCache.putResult(
-			_finderPathFetchByC_ERC,
+			_finderPathFetchByERC_C,
 			new Object[] {
-				commerceOrderItem.getCompanyId(),
-				commerceOrderItem.getExternalReferenceCode()
+				commerceOrderItem.getExternalReferenceCode(),
+				commerceOrderItem.getCompanyId()
 			},
 			commerceOrderItem);
 	}
@@ -5235,13 +5236,13 @@ public class CommerceOrderItemPersistenceImpl
 			commerceOrderItemModelImpl);
 
 		args = new Object[] {
-			commerceOrderItemModelImpl.getCompanyId(),
-			commerceOrderItemModelImpl.getExternalReferenceCode()
+			commerceOrderItemModelImpl.getExternalReferenceCode(),
+			commerceOrderItemModelImpl.getCompanyId()
 		};
 
-		finderCache.putResult(_finderPathCountByC_ERC, args, Long.valueOf(1));
+		finderCache.putResult(_finderPathCountByERC_C, args, Long.valueOf(1));
 		finderCache.putResult(
-			_finderPathFetchByC_ERC, args, commerceOrderItemModelImpl);
+			_finderPathFetchByERC_C, args, commerceOrderItemModelImpl);
 	}
 
 	/**
@@ -5388,6 +5389,29 @@ public class CommerceOrderItemPersistenceImpl
 		if (Validator.isNull(commerceOrderItem.getExternalReferenceCode())) {
 			commerceOrderItem.setExternalReferenceCode(
 				commerceOrderItem.getUuid());
+		}
+		else {
+			CommerceOrderItem ercCommerceOrderItem = fetchByERC_C(
+				commerceOrderItem.getExternalReferenceCode(),
+				commerceOrderItem.getCompanyId());
+
+			if (isNew) {
+				if (ercCommerceOrderItem != null) {
+					throw new DuplicateCommerceOrderItemExternalReferenceCodeException(
+						"Duplicate CommerceOrderItem with external reference code " +
+							commerceOrderItem.getExternalReferenceCode());
+				}
+			}
+			else {
+				if ((ercCommerceOrderItem != null) &&
+					(commerceOrderItem.getCommerceOrderItemId() !=
+						ercCommerceOrderItem.getCommerceOrderItemId())) {
+
+					throw new DuplicateCommerceOrderItemExternalReferenceCodeException(
+						"Duplicate CommerceOrderItem with external reference code " +
+							commerceOrderItem.getExternalReferenceCode());
+				}
+			}
 		}
 
 		ServiceContext serviceContext =
@@ -5898,15 +5922,15 @@ public class CommerceOrderItemPersistenceImpl
 			new String[] {Long.class.getName(), Boolean.class.getName()},
 			new String[] {"commerceOrderId", "subscription"}, false);
 
-		_finderPathFetchByC_ERC = new FinderPath(
-			FINDER_CLASS_NAME_ENTITY, "fetchByC_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"companyId", "externalReferenceCode"}, true);
+		_finderPathFetchByERC_C = new FinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, true);
 
-		_finderPathCountByC_ERC = new FinderPath(
-			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"companyId", "externalReferenceCode"}, false);
+		_finderPathCountByERC_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, false);
 
 		_setCommerceOrderItemUtilPersistence(this);
 	}

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/persistence/impl/CommerceOrderNotePersistenceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/persistence/impl/CommerceOrderNotePersistenceImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.commerce.service.persistence.impl;
 
+import com.liferay.commerce.exception.DuplicateCommerceOrderNoteExternalReferenceCodeException;
 import com.liferay.commerce.exception.NoSuchOrderNoteException;
 import com.liferay.commerce.model.CommerceOrderNote;
 import com.liferay.commerce.model.CommerceOrderNoteTable;
@@ -2521,35 +2522,35 @@ public class CommerceOrderNotePersistenceImpl
 	private static final String _FINDER_COLUMN_C_R_RESTRICTED_2 =
 		"commerceOrderNote.restricted = ?";
 
-	private FinderPath _finderPathFetchByC_ERC;
-	private FinderPath _finderPathCountByC_ERC;
+	private FinderPath _finderPathFetchByERC_C;
+	private FinderPath _finderPathCountByERC_C;
 
 	/**
-	 * Returns the commerce order note where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchOrderNoteException</code> if it could not be found.
+	 * Returns the commerce order note where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchOrderNoteException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce order note
 	 * @throws NoSuchOrderNoteException if a matching commerce order note could not be found
 	 */
 	@Override
-	public CommerceOrderNote findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public CommerceOrderNote findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchOrderNoteException {
 
-		CommerceOrderNote commerceOrderNote = fetchByC_ERC(
-			companyId, externalReferenceCode);
+		CommerceOrderNote commerceOrderNote = fetchByERC_C(
+			externalReferenceCode, companyId);
 
 		if (commerceOrderNote == null) {
 			StringBundler sb = new StringBundler(6);
 
 			sb.append(_NO_SUCH_ENTITY_WITH_KEY);
 
-			sb.append("companyId=");
-			sb.append(companyId);
-
-			sb.append(", externalReferenceCode=");
+			sb.append("externalReferenceCode=");
 			sb.append(externalReferenceCode);
+
+			sb.append(", companyId=");
+			sb.append(companyId);
 
 			sb.append("}");
 
@@ -2564,53 +2565,53 @@ public class CommerceOrderNotePersistenceImpl
 	}
 
 	/**
-	 * Returns the commerce order note where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the commerce order note where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce order note, or <code>null</code> if a matching commerce order note could not be found
 	 */
 	@Override
-	public CommerceOrderNote fetchByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public CommerceOrderNote fetchByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return fetchByC_ERC(companyId, externalReferenceCode, true);
+		return fetchByERC_C(externalReferenceCode, companyId, true);
 	}
 
 	/**
-	 * Returns the commerce order note where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the commerce order note where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching commerce order note, or <code>null</code> if a matching commerce order note could not be found
 	 */
 	@Override
-	public CommerceOrderNote fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache) {
+	public CommerceOrderNote fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache) {
 
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
 		Object[] finderArgs = null;
 
 		if (useFinderCache) {
-			finderArgs = new Object[] {companyId, externalReferenceCode};
+			finderArgs = new Object[] {externalReferenceCode, companyId};
 		}
 
 		Object result = null;
 
 		if (useFinderCache) {
 			result = finderCache.getResult(
-				_finderPathFetchByC_ERC, finderArgs, this);
+				_finderPathFetchByERC_C, finderArgs, this);
 		}
 
 		if (result instanceof CommerceOrderNote) {
 			CommerceOrderNote commerceOrderNote = (CommerceOrderNote)result;
 
-			if ((companyId != commerceOrderNote.getCompanyId()) ||
-				!Objects.equals(
+			if (!Objects.equals(
 					externalReferenceCode,
-					commerceOrderNote.getExternalReferenceCode())) {
+					commerceOrderNote.getExternalReferenceCode()) ||
+				(companyId != commerceOrderNote.getCompanyId())) {
 
 				result = null;
 			}
@@ -2621,18 +2622,18 @@ public class CommerceOrderNotePersistenceImpl
 
 			sb.append(_SQL_SELECT_COMMERCEORDERNOTE_WHERE);
 
-			sb.append(_FINDER_COLUMN_C_ERC_COMPANYID_2);
-
 			boolean bindExternalReferenceCode = false;
 
 			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3);
 			}
 			else {
 				bindExternalReferenceCode = true;
 
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2);
 			}
+
+			sb.append(_FINDER_COLUMN_ERC_C_COMPANYID_2);
 
 			String sql = sb.toString();
 
@@ -2645,18 +2646,18 @@ public class CommerceOrderNotePersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
-				queryPos.add(companyId);
-
 				if (bindExternalReferenceCode) {
 					queryPos.add(externalReferenceCode);
 				}
+
+				queryPos.add(companyId);
 
 				List<CommerceOrderNote> list = query.list();
 
 				if (list.isEmpty()) {
 					if (useFinderCache) {
 						finderCache.putResult(
-							_finderPathFetchByC_ERC, finderArgs, list);
+							_finderPathFetchByERC_C, finderArgs, list);
 					}
 				}
 				else {
@@ -2684,37 +2685,37 @@ public class CommerceOrderNotePersistenceImpl
 	}
 
 	/**
-	 * Removes the commerce order note where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the commerce order note where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the commerce order note that was removed
 	 */
 	@Override
-	public CommerceOrderNote removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public CommerceOrderNote removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchOrderNoteException {
 
-		CommerceOrderNote commerceOrderNote = findByC_ERC(
-			companyId, externalReferenceCode);
+		CommerceOrderNote commerceOrderNote = findByERC_C(
+			externalReferenceCode, companyId);
 
 		return remove(commerceOrderNote);
 	}
 
 	/**
-	 * Returns the number of commerce order notes where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of commerce order notes where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching commerce order notes
 	 */
 	@Override
-	public int countByC_ERC(long companyId, String externalReferenceCode) {
+	public int countByERC_C(String externalReferenceCode, long companyId) {
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
-		FinderPath finderPath = _finderPathCountByC_ERC;
+		FinderPath finderPath = _finderPathCountByERC_C;
 
-		Object[] finderArgs = new Object[] {companyId, externalReferenceCode};
+		Object[] finderArgs = new Object[] {externalReferenceCode, companyId};
 
 		Long count = (Long)finderCache.getResult(finderPath, finderArgs, this);
 
@@ -2723,18 +2724,18 @@ public class CommerceOrderNotePersistenceImpl
 
 			sb.append(_SQL_COUNT_COMMERCEORDERNOTE_WHERE);
 
-			sb.append(_FINDER_COLUMN_C_ERC_COMPANYID_2);
-
 			boolean bindExternalReferenceCode = false;
 
 			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3);
 			}
 			else {
 				bindExternalReferenceCode = true;
 
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2);
 			}
+
+			sb.append(_FINDER_COLUMN_ERC_C_COMPANYID_2);
 
 			String sql = sb.toString();
 
@@ -2747,11 +2748,11 @@ public class CommerceOrderNotePersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
-				queryPos.add(companyId);
-
 				if (bindExternalReferenceCode) {
 					queryPos.add(externalReferenceCode);
 				}
+
+				queryPos.add(companyId);
 
 				count = (Long)query.uniqueResult();
 
@@ -2768,14 +2769,14 @@ public class CommerceOrderNotePersistenceImpl
 		return count.intValue();
 	}
 
-	private static final String _FINDER_COLUMN_C_ERC_COMPANYID_2 =
-		"commerceOrderNote.companyId = ? AND ";
+	private static final String _FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2 =
+		"commerceOrderNote.externalReferenceCode = ? AND ";
 
-	private static final String _FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2 =
-		"commerceOrderNote.externalReferenceCode = ?";
+	private static final String _FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3 =
+		"(commerceOrderNote.externalReferenceCode IS NULL OR commerceOrderNote.externalReferenceCode = '') AND ";
 
-	private static final String _FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3 =
-		"(commerceOrderNote.externalReferenceCode IS NULL OR commerceOrderNote.externalReferenceCode = '')";
+	private static final String _FINDER_COLUMN_ERC_C_COMPANYID_2 =
+		"commerceOrderNote.companyId = ?";
 
 	public CommerceOrderNotePersistenceImpl() {
 		Map<String, String> dbColumnNames = new HashMap<String, String>();
@@ -2811,10 +2812,10 @@ public class CommerceOrderNotePersistenceImpl
 			commerceOrderNote);
 
 		finderCache.putResult(
-			_finderPathFetchByC_ERC,
+			_finderPathFetchByERC_C,
 			new Object[] {
-				commerceOrderNote.getCompanyId(),
-				commerceOrderNote.getExternalReferenceCode()
+				commerceOrderNote.getExternalReferenceCode(),
+				commerceOrderNote.getCompanyId()
 			},
 			commerceOrderNote);
 	}
@@ -2903,13 +2904,13 @@ public class CommerceOrderNotePersistenceImpl
 			_finderPathFetchByUUID_G, args, commerceOrderNoteModelImpl);
 
 		args = new Object[] {
-			commerceOrderNoteModelImpl.getCompanyId(),
-			commerceOrderNoteModelImpl.getExternalReferenceCode()
+			commerceOrderNoteModelImpl.getExternalReferenceCode(),
+			commerceOrderNoteModelImpl.getCompanyId()
 		};
 
-		finderCache.putResult(_finderPathCountByC_ERC, args, Long.valueOf(1));
+		finderCache.putResult(_finderPathCountByERC_C, args, Long.valueOf(1));
 		finderCache.putResult(
-			_finderPathFetchByC_ERC, args, commerceOrderNoteModelImpl);
+			_finderPathFetchByERC_C, args, commerceOrderNoteModelImpl);
 	}
 
 	/**
@@ -3056,6 +3057,29 @@ public class CommerceOrderNotePersistenceImpl
 		if (Validator.isNull(commerceOrderNote.getExternalReferenceCode())) {
 			commerceOrderNote.setExternalReferenceCode(
 				commerceOrderNote.getUuid());
+		}
+		else {
+			CommerceOrderNote ercCommerceOrderNote = fetchByERC_C(
+				commerceOrderNote.getExternalReferenceCode(),
+				commerceOrderNote.getCompanyId());
+
+			if (isNew) {
+				if (ercCommerceOrderNote != null) {
+					throw new DuplicateCommerceOrderNoteExternalReferenceCodeException(
+						"Duplicate CommerceOrderNote with external reference code " +
+							commerceOrderNote.getExternalReferenceCode());
+				}
+			}
+			else {
+				if ((ercCommerceOrderNote != null) &&
+					(commerceOrderNote.getCommerceOrderNoteId() !=
+						ercCommerceOrderNote.getCommerceOrderNoteId())) {
+
+					throw new DuplicateCommerceOrderNoteExternalReferenceCodeException(
+						"Duplicate CommerceOrderNote with external reference code " +
+							commerceOrderNote.getExternalReferenceCode());
+				}
+			}
 		}
 
 		ServiceContext serviceContext =
@@ -3478,15 +3502,15 @@ public class CommerceOrderNotePersistenceImpl
 			new String[] {Long.class.getName(), Boolean.class.getName()},
 			new String[] {"commerceOrderId", "restricted"}, false);
 
-		_finderPathFetchByC_ERC = new FinderPath(
-			FINDER_CLASS_NAME_ENTITY, "fetchByC_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"companyId", "externalReferenceCode"}, true);
+		_finderPathFetchByERC_C = new FinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, true);
 
-		_finderPathCountByC_ERC = new FinderPath(
-			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"companyId", "externalReferenceCode"}, false);
+		_finderPathCountByERC_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, false);
 
 		_setCommerceOrderNoteUtilPersistence(this);
 	}

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/persistence/impl/CommerceOrderPersistenceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/persistence/impl/CommerceOrderPersistenceImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.commerce.service.persistence.impl;
 
+import com.liferay.commerce.exception.DuplicateCommerceOrderExternalReferenceCodeException;
 import com.liferay.commerce.exception.NoSuchOrderException;
 import com.liferay.commerce.model.CommerceOrder;
 import com.liferay.commerce.model.CommerceOrderTable;
@@ -7499,35 +7500,35 @@ public class CommerceOrderPersistenceImpl
 	private static final String _FINDER_COLUMN_C_LTC_O_ORDERSTATUS_2 =
 		"commerceOrder.orderStatus = ?";
 
-	private FinderPath _finderPathFetchByC_ERC;
-	private FinderPath _finderPathCountByC_ERC;
+	private FinderPath _finderPathFetchByERC_C;
+	private FinderPath _finderPathCountByERC_C;
 
 	/**
-	 * Returns the commerce order where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchOrderException</code> if it could not be found.
+	 * Returns the commerce order where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchOrderException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce order
 	 * @throws NoSuchOrderException if a matching commerce order could not be found
 	 */
 	@Override
-	public CommerceOrder findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public CommerceOrder findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchOrderException {
 
-		CommerceOrder commerceOrder = fetchByC_ERC(
-			companyId, externalReferenceCode);
+		CommerceOrder commerceOrder = fetchByERC_C(
+			externalReferenceCode, companyId);
 
 		if (commerceOrder == null) {
 			StringBundler sb = new StringBundler(6);
 
 			sb.append(_NO_SUCH_ENTITY_WITH_KEY);
 
-			sb.append("companyId=");
-			sb.append(companyId);
-
-			sb.append(", externalReferenceCode=");
+			sb.append("externalReferenceCode=");
 			sb.append(externalReferenceCode);
+
+			sb.append(", companyId=");
+			sb.append(companyId);
 
 			sb.append("}");
 
@@ -7542,53 +7543,53 @@ public class CommerceOrderPersistenceImpl
 	}
 
 	/**
-	 * Returns the commerce order where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the commerce order where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce order, or <code>null</code> if a matching commerce order could not be found
 	 */
 	@Override
-	public CommerceOrder fetchByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public CommerceOrder fetchByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return fetchByC_ERC(companyId, externalReferenceCode, true);
+		return fetchByERC_C(externalReferenceCode, companyId, true);
 	}
 
 	/**
-	 * Returns the commerce order where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the commerce order where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching commerce order, or <code>null</code> if a matching commerce order could not be found
 	 */
 	@Override
-	public CommerceOrder fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache) {
+	public CommerceOrder fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache) {
 
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
 		Object[] finderArgs = null;
 
 		if (useFinderCache) {
-			finderArgs = new Object[] {companyId, externalReferenceCode};
+			finderArgs = new Object[] {externalReferenceCode, companyId};
 		}
 
 		Object result = null;
 
 		if (useFinderCache) {
 			result = finderCache.getResult(
-				_finderPathFetchByC_ERC, finderArgs, this);
+				_finderPathFetchByERC_C, finderArgs, this);
 		}
 
 		if (result instanceof CommerceOrder) {
 			CommerceOrder commerceOrder = (CommerceOrder)result;
 
-			if ((companyId != commerceOrder.getCompanyId()) ||
-				!Objects.equals(
+			if (!Objects.equals(
 					externalReferenceCode,
-					commerceOrder.getExternalReferenceCode())) {
+					commerceOrder.getExternalReferenceCode()) ||
+				(companyId != commerceOrder.getCompanyId())) {
 
 				result = null;
 			}
@@ -7599,18 +7600,18 @@ public class CommerceOrderPersistenceImpl
 
 			sb.append(_SQL_SELECT_COMMERCEORDER_WHERE);
 
-			sb.append(_FINDER_COLUMN_C_ERC_COMPANYID_2);
-
 			boolean bindExternalReferenceCode = false;
 
 			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3);
 			}
 			else {
 				bindExternalReferenceCode = true;
 
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2);
 			}
+
+			sb.append(_FINDER_COLUMN_ERC_C_COMPANYID_2);
 
 			String sql = sb.toString();
 
@@ -7623,18 +7624,18 @@ public class CommerceOrderPersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
-				queryPos.add(companyId);
-
 				if (bindExternalReferenceCode) {
 					queryPos.add(externalReferenceCode);
 				}
+
+				queryPos.add(companyId);
 
 				List<CommerceOrder> list = query.list();
 
 				if (list.isEmpty()) {
 					if (useFinderCache) {
 						finderCache.putResult(
-							_finderPathFetchByC_ERC, finderArgs, list);
+							_finderPathFetchByERC_C, finderArgs, list);
 					}
 				}
 				else {
@@ -7662,37 +7663,37 @@ public class CommerceOrderPersistenceImpl
 	}
 
 	/**
-	 * Removes the commerce order where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the commerce order where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the commerce order that was removed
 	 */
 	@Override
-	public CommerceOrder removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public CommerceOrder removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchOrderException {
 
-		CommerceOrder commerceOrder = findByC_ERC(
-			companyId, externalReferenceCode);
+		CommerceOrder commerceOrder = findByERC_C(
+			externalReferenceCode, companyId);
 
 		return remove(commerceOrder);
 	}
 
 	/**
-	 * Returns the number of commerce orders where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of commerce orders where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching commerce orders
 	 */
 	@Override
-	public int countByC_ERC(long companyId, String externalReferenceCode) {
+	public int countByERC_C(String externalReferenceCode, long companyId) {
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
-		FinderPath finderPath = _finderPathCountByC_ERC;
+		FinderPath finderPath = _finderPathCountByERC_C;
 
-		Object[] finderArgs = new Object[] {companyId, externalReferenceCode};
+		Object[] finderArgs = new Object[] {externalReferenceCode, companyId};
 
 		Long count = (Long)finderCache.getResult(finderPath, finderArgs, this);
 
@@ -7701,18 +7702,18 @@ public class CommerceOrderPersistenceImpl
 
 			sb.append(_SQL_COUNT_COMMERCEORDER_WHERE);
 
-			sb.append(_FINDER_COLUMN_C_ERC_COMPANYID_2);
-
 			boolean bindExternalReferenceCode = false;
 
 			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3);
 			}
 			else {
 				bindExternalReferenceCode = true;
 
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2);
 			}
+
+			sb.append(_FINDER_COLUMN_ERC_C_COMPANYID_2);
 
 			String sql = sb.toString();
 
@@ -7725,11 +7726,11 @@ public class CommerceOrderPersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
-				queryPos.add(companyId);
-
 				if (bindExternalReferenceCode) {
 					queryPos.add(externalReferenceCode);
 				}
+
+				queryPos.add(companyId);
 
 				count = (Long)query.uniqueResult();
 
@@ -7746,14 +7747,14 @@ public class CommerceOrderPersistenceImpl
 		return count.intValue();
 	}
 
-	private static final String _FINDER_COLUMN_C_ERC_COMPANYID_2 =
-		"commerceOrder.companyId = ? AND ";
+	private static final String _FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2 =
+		"commerceOrder.externalReferenceCode = ? AND ";
 
-	private static final String _FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2 =
-		"commerceOrder.externalReferenceCode = ?";
+	private static final String _FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3 =
+		"(commerceOrder.externalReferenceCode IS NULL OR commerceOrder.externalReferenceCode = '') AND ";
 
-	private static final String _FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3 =
-		"(commerceOrder.externalReferenceCode IS NULL OR commerceOrder.externalReferenceCode = '')";
+	private static final String _FINDER_COLUMN_ERC_C_COMPANYID_2 =
+		"commerceOrder.companyId = ?";
 
 	public CommerceOrderPersistenceImpl() {
 		Map<String, String> dbColumnNames = new HashMap<String, String>();
@@ -7853,10 +7854,10 @@ public class CommerceOrderPersistenceImpl
 			commerceOrder);
 
 		finderCache.putResult(
-			_finderPathFetchByC_ERC,
+			_finderPathFetchByERC_C,
 			new Object[] {
-				commerceOrder.getCompanyId(),
-				commerceOrder.getExternalReferenceCode()
+				commerceOrder.getExternalReferenceCode(),
+				commerceOrder.getCompanyId()
 			},
 			commerceOrder);
 	}
@@ -7942,13 +7943,13 @@ public class CommerceOrderPersistenceImpl
 			_finderPathFetchByUUID_G, args, commerceOrderModelImpl);
 
 		args = new Object[] {
-			commerceOrderModelImpl.getCompanyId(),
-			commerceOrderModelImpl.getExternalReferenceCode()
+			commerceOrderModelImpl.getExternalReferenceCode(),
+			commerceOrderModelImpl.getCompanyId()
 		};
 
-		finderCache.putResult(_finderPathCountByC_ERC, args, Long.valueOf(1));
+		finderCache.putResult(_finderPathCountByERC_C, args, Long.valueOf(1));
 		finderCache.putResult(
-			_finderPathFetchByC_ERC, args, commerceOrderModelImpl);
+			_finderPathFetchByERC_C, args, commerceOrderModelImpl);
 	}
 
 	/**
@@ -8090,6 +8091,29 @@ public class CommerceOrderPersistenceImpl
 
 		if (Validator.isNull(commerceOrder.getExternalReferenceCode())) {
 			commerceOrder.setExternalReferenceCode(commerceOrder.getUuid());
+		}
+		else {
+			CommerceOrder ercCommerceOrder = fetchByERC_C(
+				commerceOrder.getExternalReferenceCode(),
+				commerceOrder.getCompanyId());
+
+			if (isNew) {
+				if (ercCommerceOrder != null) {
+					throw new DuplicateCommerceOrderExternalReferenceCodeException(
+						"Duplicate CommerceOrder with external reference code " +
+							commerceOrder.getExternalReferenceCode());
+				}
+			}
+			else {
+				if ((ercCommerceOrder != null) &&
+					(commerceOrder.getCommerceOrderId() !=
+						ercCommerceOrder.getCommerceOrderId())) {
+
+					throw new DuplicateCommerceOrderExternalReferenceCodeException(
+						"Duplicate CommerceOrder with external reference code " +
+							commerceOrder.getExternalReferenceCode());
+				}
+			}
 		}
 
 		ServiceContext serviceContext =
@@ -8720,15 +8744,15 @@ public class CommerceOrderPersistenceImpl
 			new String[] {"createDate", "commerceAccountId", "orderStatus"},
 			false);
 
-		_finderPathFetchByC_ERC = new FinderPath(
-			FINDER_CLASS_NAME_ENTITY, "fetchByC_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"companyId", "externalReferenceCode"}, true);
+		_finderPathFetchByERC_C = new FinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, true);
 
-		_finderPathCountByC_ERC = new FinderPath(
-			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"companyId", "externalReferenceCode"}, false);
+		_finderPathCountByERC_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, false);
 
 		_setCommerceOrderUtilPersistence(this);
 	}

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/persistence/impl/CommerceOrderTypePersistenceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/persistence/impl/CommerceOrderTypePersistenceImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.commerce.service.persistence.impl;
 
+import com.liferay.commerce.exception.DuplicateCommerceOrderTypeExternalReferenceCodeException;
 import com.liferay.commerce.exception.NoSuchOrderTypeException;
 import com.liferay.commerce.model.CommerceOrderType;
 import com.liferay.commerce.model.CommerceOrderTypeTable;
@@ -5949,35 +5950,35 @@ public class CommerceOrderTypePersistenceImpl
 	private static final String _FINDER_COLUMN_LTE_S_STATUS_2 =
 		"commerceOrderType.status = ?";
 
-	private FinderPath _finderPathFetchByC_ERC;
-	private FinderPath _finderPathCountByC_ERC;
+	private FinderPath _finderPathFetchByERC_C;
+	private FinderPath _finderPathCountByERC_C;
 
 	/**
-	 * Returns the commerce order type where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchOrderTypeException</code> if it could not be found.
+	 * Returns the commerce order type where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchOrderTypeException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce order type
 	 * @throws NoSuchOrderTypeException if a matching commerce order type could not be found
 	 */
 	@Override
-	public CommerceOrderType findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public CommerceOrderType findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchOrderTypeException {
 
-		CommerceOrderType commerceOrderType = fetchByC_ERC(
-			companyId, externalReferenceCode);
+		CommerceOrderType commerceOrderType = fetchByERC_C(
+			externalReferenceCode, companyId);
 
 		if (commerceOrderType == null) {
 			StringBundler sb = new StringBundler(6);
 
 			sb.append(_NO_SUCH_ENTITY_WITH_KEY);
 
-			sb.append("companyId=");
-			sb.append(companyId);
-
-			sb.append(", externalReferenceCode=");
+			sb.append("externalReferenceCode=");
 			sb.append(externalReferenceCode);
+
+			sb.append(", companyId=");
+			sb.append(companyId);
 
 			sb.append("}");
 
@@ -5992,53 +5993,53 @@ public class CommerceOrderTypePersistenceImpl
 	}
 
 	/**
-	 * Returns the commerce order type where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the commerce order type where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce order type, or <code>null</code> if a matching commerce order type could not be found
 	 */
 	@Override
-	public CommerceOrderType fetchByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public CommerceOrderType fetchByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return fetchByC_ERC(companyId, externalReferenceCode, true);
+		return fetchByERC_C(externalReferenceCode, companyId, true);
 	}
 
 	/**
-	 * Returns the commerce order type where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the commerce order type where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching commerce order type, or <code>null</code> if a matching commerce order type could not be found
 	 */
 	@Override
-	public CommerceOrderType fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache) {
+	public CommerceOrderType fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache) {
 
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
 		Object[] finderArgs = null;
 
 		if (useFinderCache) {
-			finderArgs = new Object[] {companyId, externalReferenceCode};
+			finderArgs = new Object[] {externalReferenceCode, companyId};
 		}
 
 		Object result = null;
 
 		if (useFinderCache) {
 			result = finderCache.getResult(
-				_finderPathFetchByC_ERC, finderArgs, this);
+				_finderPathFetchByERC_C, finderArgs, this);
 		}
 
 		if (result instanceof CommerceOrderType) {
 			CommerceOrderType commerceOrderType = (CommerceOrderType)result;
 
-			if ((companyId != commerceOrderType.getCompanyId()) ||
-				!Objects.equals(
+			if (!Objects.equals(
 					externalReferenceCode,
-					commerceOrderType.getExternalReferenceCode())) {
+					commerceOrderType.getExternalReferenceCode()) ||
+				(companyId != commerceOrderType.getCompanyId())) {
 
 				result = null;
 			}
@@ -6049,18 +6050,18 @@ public class CommerceOrderTypePersistenceImpl
 
 			sb.append(_SQL_SELECT_COMMERCEORDERTYPE_WHERE);
 
-			sb.append(_FINDER_COLUMN_C_ERC_COMPANYID_2);
-
 			boolean bindExternalReferenceCode = false;
 
 			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3);
 			}
 			else {
 				bindExternalReferenceCode = true;
 
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2);
 			}
+
+			sb.append(_FINDER_COLUMN_ERC_C_COMPANYID_2);
 
 			String sql = sb.toString();
 
@@ -6073,18 +6074,18 @@ public class CommerceOrderTypePersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
-				queryPos.add(companyId);
-
 				if (bindExternalReferenceCode) {
 					queryPos.add(externalReferenceCode);
 				}
+
+				queryPos.add(companyId);
 
 				List<CommerceOrderType> list = query.list();
 
 				if (list.isEmpty()) {
 					if (useFinderCache) {
 						finderCache.putResult(
-							_finderPathFetchByC_ERC, finderArgs, list);
+							_finderPathFetchByERC_C, finderArgs, list);
 					}
 				}
 				else {
@@ -6112,37 +6113,37 @@ public class CommerceOrderTypePersistenceImpl
 	}
 
 	/**
-	 * Removes the commerce order type where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the commerce order type where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the commerce order type that was removed
 	 */
 	@Override
-	public CommerceOrderType removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public CommerceOrderType removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchOrderTypeException {
 
-		CommerceOrderType commerceOrderType = findByC_ERC(
-			companyId, externalReferenceCode);
+		CommerceOrderType commerceOrderType = findByERC_C(
+			externalReferenceCode, companyId);
 
 		return remove(commerceOrderType);
 	}
 
 	/**
-	 * Returns the number of commerce order types where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of commerce order types where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching commerce order types
 	 */
 	@Override
-	public int countByC_ERC(long companyId, String externalReferenceCode) {
+	public int countByERC_C(String externalReferenceCode, long companyId) {
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
-		FinderPath finderPath = _finderPathCountByC_ERC;
+		FinderPath finderPath = _finderPathCountByERC_C;
 
-		Object[] finderArgs = new Object[] {companyId, externalReferenceCode};
+		Object[] finderArgs = new Object[] {externalReferenceCode, companyId};
 
 		Long count = (Long)finderCache.getResult(finderPath, finderArgs, this);
 
@@ -6151,18 +6152,18 @@ public class CommerceOrderTypePersistenceImpl
 
 			sb.append(_SQL_COUNT_COMMERCEORDERTYPE_WHERE);
 
-			sb.append(_FINDER_COLUMN_C_ERC_COMPANYID_2);
-
 			boolean bindExternalReferenceCode = false;
 
 			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3);
 			}
 			else {
 				bindExternalReferenceCode = true;
 
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2);
 			}
+
+			sb.append(_FINDER_COLUMN_ERC_C_COMPANYID_2);
 
 			String sql = sb.toString();
 
@@ -6175,11 +6176,11 @@ public class CommerceOrderTypePersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
-				queryPos.add(companyId);
-
 				if (bindExternalReferenceCode) {
 					queryPos.add(externalReferenceCode);
 				}
+
+				queryPos.add(companyId);
 
 				count = (Long)query.uniqueResult();
 
@@ -6196,14 +6197,14 @@ public class CommerceOrderTypePersistenceImpl
 		return count.intValue();
 	}
 
-	private static final String _FINDER_COLUMN_C_ERC_COMPANYID_2 =
-		"commerceOrderType.companyId = ? AND ";
+	private static final String _FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2 =
+		"commerceOrderType.externalReferenceCode = ? AND ";
 
-	private static final String _FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2 =
-		"commerceOrderType.externalReferenceCode = ?";
+	private static final String _FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3 =
+		"(commerceOrderType.externalReferenceCode IS NULL OR commerceOrderType.externalReferenceCode = '') AND ";
 
-	private static final String _FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3 =
-		"(commerceOrderType.externalReferenceCode IS NULL OR commerceOrderType.externalReferenceCode = '')";
+	private static final String _FINDER_COLUMN_ERC_C_COMPANYID_2 =
+		"commerceOrderType.companyId = ?";
 
 	public CommerceOrderTypePersistenceImpl() {
 		Map<String, String> dbColumnNames = new HashMap<String, String>();
@@ -6233,10 +6234,10 @@ public class CommerceOrderTypePersistenceImpl
 			commerceOrderType);
 
 		finderCache.putResult(
-			_finderPathFetchByC_ERC,
+			_finderPathFetchByERC_C,
 			new Object[] {
-				commerceOrderType.getCompanyId(),
-				commerceOrderType.getExternalReferenceCode()
+				commerceOrderType.getExternalReferenceCode(),
+				commerceOrderType.getCompanyId()
 			},
 			commerceOrderType);
 	}
@@ -6316,13 +6317,13 @@ public class CommerceOrderTypePersistenceImpl
 		CommerceOrderTypeModelImpl commerceOrderTypeModelImpl) {
 
 		Object[] args = new Object[] {
-			commerceOrderTypeModelImpl.getCompanyId(),
-			commerceOrderTypeModelImpl.getExternalReferenceCode()
+			commerceOrderTypeModelImpl.getExternalReferenceCode(),
+			commerceOrderTypeModelImpl.getCompanyId()
 		};
 
-		finderCache.putResult(_finderPathCountByC_ERC, args, Long.valueOf(1));
+		finderCache.putResult(_finderPathCountByERC_C, args, Long.valueOf(1));
 		finderCache.putResult(
-			_finderPathFetchByC_ERC, args, commerceOrderTypeModelImpl);
+			_finderPathFetchByERC_C, args, commerceOrderTypeModelImpl);
 	}
 
 	/**
@@ -6469,6 +6470,29 @@ public class CommerceOrderTypePersistenceImpl
 		if (Validator.isNull(commerceOrderType.getExternalReferenceCode())) {
 			commerceOrderType.setExternalReferenceCode(
 				commerceOrderType.getUuid());
+		}
+		else {
+			CommerceOrderType ercCommerceOrderType = fetchByERC_C(
+				commerceOrderType.getExternalReferenceCode(),
+				commerceOrderType.getCompanyId());
+
+			if (isNew) {
+				if (ercCommerceOrderType != null) {
+					throw new DuplicateCommerceOrderTypeExternalReferenceCodeException(
+						"Duplicate CommerceOrderType with external reference code " +
+							commerceOrderType.getExternalReferenceCode());
+				}
+			}
+			else {
+				if ((ercCommerceOrderType != null) &&
+					(commerceOrderType.getCommerceOrderTypeId() !=
+						ercCommerceOrderType.getCommerceOrderTypeId())) {
+
+					throw new DuplicateCommerceOrderTypeExternalReferenceCodeException(
+						"Duplicate CommerceOrderType with external reference code " +
+							commerceOrderType.getExternalReferenceCode());
+				}
+			}
 		}
 
 		ServiceContext serviceContext =
@@ -6909,15 +6933,15 @@ public class CommerceOrderTypePersistenceImpl
 			new String[] {Date.class.getName(), Integer.class.getName()},
 			new String[] {"expirationDate", "status"}, false);
 
-		_finderPathFetchByC_ERC = new FinderPath(
-			FINDER_CLASS_NAME_ENTITY, "fetchByC_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"companyId", "externalReferenceCode"}, true);
+		_finderPathFetchByERC_C = new FinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, true);
 
-		_finderPathCountByC_ERC = new FinderPath(
-			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"companyId", "externalReferenceCode"}, false);
+		_finderPathCountByERC_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, false);
 
 		_setCommerceOrderTypeUtilPersistence(this);
 	}

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/persistence/impl/CommerceOrderTypeRelPersistenceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/persistence/impl/CommerceOrderTypeRelPersistenceImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.commerce.service.persistence.impl;
 
+import com.liferay.commerce.exception.DuplicateCommerceOrderTypeRelExternalReferenceCodeException;
 import com.liferay.commerce.exception.NoSuchOrderTypeRelException;
 import com.liferay.commerce.model.CommerceOrderTypeRel;
 import com.liferay.commerce.model.CommerceOrderTypeRelTable;
@@ -2545,35 +2546,35 @@ public class CommerceOrderTypeRelPersistenceImpl
 	private static final String _FINDER_COLUMN_C_C_C_COMMERCEORDERTYPEID_2 =
 		"commerceOrderTypeRel.commerceOrderTypeId = ?";
 
-	private FinderPath _finderPathFetchByC_ERC;
-	private FinderPath _finderPathCountByC_ERC;
+	private FinderPath _finderPathFetchByERC_C;
+	private FinderPath _finderPathCountByERC_C;
 
 	/**
-	 * Returns the commerce order type rel where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchOrderTypeRelException</code> if it could not be found.
+	 * Returns the commerce order type rel where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchOrderTypeRelException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce order type rel
 	 * @throws NoSuchOrderTypeRelException if a matching commerce order type rel could not be found
 	 */
 	@Override
-	public CommerceOrderTypeRel findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public CommerceOrderTypeRel findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchOrderTypeRelException {
 
-		CommerceOrderTypeRel commerceOrderTypeRel = fetchByC_ERC(
-			companyId, externalReferenceCode);
+		CommerceOrderTypeRel commerceOrderTypeRel = fetchByERC_C(
+			externalReferenceCode, companyId);
 
 		if (commerceOrderTypeRel == null) {
 			StringBundler sb = new StringBundler(6);
 
 			sb.append(_NO_SUCH_ENTITY_WITH_KEY);
 
-			sb.append("companyId=");
-			sb.append(companyId);
-
-			sb.append(", externalReferenceCode=");
+			sb.append("externalReferenceCode=");
 			sb.append(externalReferenceCode);
+
+			sb.append(", companyId=");
+			sb.append(companyId);
 
 			sb.append("}");
 
@@ -2588,54 +2589,54 @@ public class CommerceOrderTypeRelPersistenceImpl
 	}
 
 	/**
-	 * Returns the commerce order type rel where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the commerce order type rel where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce order type rel, or <code>null</code> if a matching commerce order type rel could not be found
 	 */
 	@Override
-	public CommerceOrderTypeRel fetchByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public CommerceOrderTypeRel fetchByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return fetchByC_ERC(companyId, externalReferenceCode, true);
+		return fetchByERC_C(externalReferenceCode, companyId, true);
 	}
 
 	/**
-	 * Returns the commerce order type rel where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the commerce order type rel where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching commerce order type rel, or <code>null</code> if a matching commerce order type rel could not be found
 	 */
 	@Override
-	public CommerceOrderTypeRel fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache) {
+	public CommerceOrderTypeRel fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache) {
 
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
 		Object[] finderArgs = null;
 
 		if (useFinderCache) {
-			finderArgs = new Object[] {companyId, externalReferenceCode};
+			finderArgs = new Object[] {externalReferenceCode, companyId};
 		}
 
 		Object result = null;
 
 		if (useFinderCache) {
 			result = finderCache.getResult(
-				_finderPathFetchByC_ERC, finderArgs, this);
+				_finderPathFetchByERC_C, finderArgs, this);
 		}
 
 		if (result instanceof CommerceOrderTypeRel) {
 			CommerceOrderTypeRel commerceOrderTypeRel =
 				(CommerceOrderTypeRel)result;
 
-			if ((companyId != commerceOrderTypeRel.getCompanyId()) ||
-				!Objects.equals(
+			if (!Objects.equals(
 					externalReferenceCode,
-					commerceOrderTypeRel.getExternalReferenceCode())) {
+					commerceOrderTypeRel.getExternalReferenceCode()) ||
+				(companyId != commerceOrderTypeRel.getCompanyId())) {
 
 				result = null;
 			}
@@ -2646,18 +2647,18 @@ public class CommerceOrderTypeRelPersistenceImpl
 
 			sb.append(_SQL_SELECT_COMMERCEORDERTYPEREL_WHERE);
 
-			sb.append(_FINDER_COLUMN_C_ERC_COMPANYID_2);
-
 			boolean bindExternalReferenceCode = false;
 
 			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3);
 			}
 			else {
 				bindExternalReferenceCode = true;
 
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2);
 			}
+
+			sb.append(_FINDER_COLUMN_ERC_C_COMPANYID_2);
 
 			String sql = sb.toString();
 
@@ -2670,18 +2671,18 @@ public class CommerceOrderTypeRelPersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
-				queryPos.add(companyId);
-
 				if (bindExternalReferenceCode) {
 					queryPos.add(externalReferenceCode);
 				}
+
+				queryPos.add(companyId);
 
 				List<CommerceOrderTypeRel> list = query.list();
 
 				if (list.isEmpty()) {
 					if (useFinderCache) {
 						finderCache.putResult(
-							_finderPathFetchByC_ERC, finderArgs, list);
+							_finderPathFetchByERC_C, finderArgs, list);
 					}
 				}
 				else {
@@ -2709,37 +2710,37 @@ public class CommerceOrderTypeRelPersistenceImpl
 	}
 
 	/**
-	 * Removes the commerce order type rel where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the commerce order type rel where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the commerce order type rel that was removed
 	 */
 	@Override
-	public CommerceOrderTypeRel removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public CommerceOrderTypeRel removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchOrderTypeRelException {
 
-		CommerceOrderTypeRel commerceOrderTypeRel = findByC_ERC(
-			companyId, externalReferenceCode);
+		CommerceOrderTypeRel commerceOrderTypeRel = findByERC_C(
+			externalReferenceCode, companyId);
 
 		return remove(commerceOrderTypeRel);
 	}
 
 	/**
-	 * Returns the number of commerce order type rels where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of commerce order type rels where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching commerce order type rels
 	 */
 	@Override
-	public int countByC_ERC(long companyId, String externalReferenceCode) {
+	public int countByERC_C(String externalReferenceCode, long companyId) {
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
-		FinderPath finderPath = _finderPathCountByC_ERC;
+		FinderPath finderPath = _finderPathCountByERC_C;
 
-		Object[] finderArgs = new Object[] {companyId, externalReferenceCode};
+		Object[] finderArgs = new Object[] {externalReferenceCode, companyId};
 
 		Long count = (Long)finderCache.getResult(finderPath, finderArgs, this);
 
@@ -2748,18 +2749,18 @@ public class CommerceOrderTypeRelPersistenceImpl
 
 			sb.append(_SQL_COUNT_COMMERCEORDERTYPEREL_WHERE);
 
-			sb.append(_FINDER_COLUMN_C_ERC_COMPANYID_2);
-
 			boolean bindExternalReferenceCode = false;
 
 			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3);
 			}
 			else {
 				bindExternalReferenceCode = true;
 
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2);
 			}
+
+			sb.append(_FINDER_COLUMN_ERC_C_COMPANYID_2);
 
 			String sql = sb.toString();
 
@@ -2772,11 +2773,11 @@ public class CommerceOrderTypeRelPersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
-				queryPos.add(companyId);
-
 				if (bindExternalReferenceCode) {
 					queryPos.add(externalReferenceCode);
 				}
+
+				queryPos.add(companyId);
 
 				count = (Long)query.uniqueResult();
 
@@ -2793,14 +2794,14 @@ public class CommerceOrderTypeRelPersistenceImpl
 		return count.intValue();
 	}
 
-	private static final String _FINDER_COLUMN_C_ERC_COMPANYID_2 =
-		"commerceOrderTypeRel.companyId = ? AND ";
+	private static final String _FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2 =
+		"commerceOrderTypeRel.externalReferenceCode = ? AND ";
 
-	private static final String _FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2 =
-		"commerceOrderTypeRel.externalReferenceCode = ?";
+	private static final String _FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3 =
+		"(commerceOrderTypeRel.externalReferenceCode IS NULL OR commerceOrderTypeRel.externalReferenceCode = '') AND ";
 
-	private static final String _FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3 =
-		"(commerceOrderTypeRel.externalReferenceCode IS NULL OR commerceOrderTypeRel.externalReferenceCode = '')";
+	private static final String _FINDER_COLUMN_ERC_C_COMPANYID_2 =
+		"commerceOrderTypeRel.companyId = ?";
 
 	public CommerceOrderTypeRelPersistenceImpl() {
 		Map<String, String> dbColumnNames = new HashMap<String, String>();
@@ -2838,10 +2839,10 @@ public class CommerceOrderTypeRelPersistenceImpl
 			commerceOrderTypeRel);
 
 		finderCache.putResult(
-			_finderPathFetchByC_ERC,
+			_finderPathFetchByERC_C,
 			new Object[] {
-				commerceOrderTypeRel.getCompanyId(),
-				commerceOrderTypeRel.getExternalReferenceCode()
+				commerceOrderTypeRel.getExternalReferenceCode(),
+				commerceOrderTypeRel.getCompanyId()
 			},
 			commerceOrderTypeRel);
 	}
@@ -2936,13 +2937,13 @@ public class CommerceOrderTypeRelPersistenceImpl
 			_finderPathFetchByC_C_C, args, commerceOrderTypeRelModelImpl);
 
 		args = new Object[] {
-			commerceOrderTypeRelModelImpl.getCompanyId(),
-			commerceOrderTypeRelModelImpl.getExternalReferenceCode()
+			commerceOrderTypeRelModelImpl.getExternalReferenceCode(),
+			commerceOrderTypeRelModelImpl.getCompanyId()
 		};
 
-		finderCache.putResult(_finderPathCountByC_ERC, args, Long.valueOf(1));
+		finderCache.putResult(_finderPathCountByERC_C, args, Long.valueOf(1));
 		finderCache.putResult(
-			_finderPathFetchByC_ERC, args, commerceOrderTypeRelModelImpl);
+			_finderPathFetchByERC_C, args, commerceOrderTypeRelModelImpl);
 	}
 
 	/**
@@ -3092,6 +3093,29 @@ public class CommerceOrderTypeRelPersistenceImpl
 		if (Validator.isNull(commerceOrderTypeRel.getExternalReferenceCode())) {
 			commerceOrderTypeRel.setExternalReferenceCode(
 				commerceOrderTypeRel.getUuid());
+		}
+		else {
+			CommerceOrderTypeRel ercCommerceOrderTypeRel = fetchByERC_C(
+				commerceOrderTypeRel.getExternalReferenceCode(),
+				commerceOrderTypeRel.getCompanyId());
+
+			if (isNew) {
+				if (ercCommerceOrderTypeRel != null) {
+					throw new DuplicateCommerceOrderTypeRelExternalReferenceCodeException(
+						"Duplicate CommerceOrderTypeRel with external reference code " +
+							commerceOrderTypeRel.getExternalReferenceCode());
+				}
+			}
+			else {
+				if ((ercCommerceOrderTypeRel != null) &&
+					(commerceOrderTypeRel.getCommerceOrderTypeRelId() !=
+						ercCommerceOrderTypeRel.getCommerceOrderTypeRelId())) {
+
+					throw new DuplicateCommerceOrderTypeRelExternalReferenceCodeException(
+						"Duplicate CommerceOrderTypeRel with external reference code " +
+							commerceOrderTypeRel.getExternalReferenceCode());
+				}
+			}
 		}
 
 		ServiceContext serviceContext =
@@ -3522,15 +3546,15 @@ public class CommerceOrderTypeRelPersistenceImpl
 			new String[] {"classNameId", "classPK", "commerceOrderTypeId"},
 			false);
 
-		_finderPathFetchByC_ERC = new FinderPath(
-			FINDER_CLASS_NAME_ENTITY, "fetchByC_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"companyId", "externalReferenceCode"}, true);
+		_finderPathFetchByERC_C = new FinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, true);
 
-		_finderPathCountByC_ERC = new FinderPath(
-			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"companyId", "externalReferenceCode"}, false);
+		_finderPathCountByERC_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, false);
 
 		_setCommerceOrderTypeRelUtilPersistence(this);
 	}

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/persistence/impl/CommerceShipmentItemPersistenceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/persistence/impl/CommerceShipmentItemPersistenceImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.commerce.service.persistence.impl;
 
+import com.liferay.commerce.exception.DuplicateCommerceShipmentItemExternalReferenceCodeException;
 import com.liferay.commerce.exception.NoSuchShipmentItemException;
 import com.liferay.commerce.model.CommerceShipmentItem;
 import com.liferay.commerce.model.CommerceShipmentItemTable;
@@ -3833,35 +3834,35 @@ public class CommerceShipmentItemPersistenceImpl
 		_FINDER_COLUMN_C_C_C_COMMERCEINVENTORYWAREHOUSEID_2 =
 			"commerceShipmentItem.commerceInventoryWarehouseId = ?";
 
-	private FinderPath _finderPathFetchByC_ERC;
-	private FinderPath _finderPathCountByC_ERC;
+	private FinderPath _finderPathFetchByERC_C;
+	private FinderPath _finderPathCountByERC_C;
 
 	/**
-	 * Returns the commerce shipment item where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchShipmentItemException</code> if it could not be found.
+	 * Returns the commerce shipment item where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchShipmentItemException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce shipment item
 	 * @throws NoSuchShipmentItemException if a matching commerce shipment item could not be found
 	 */
 	@Override
-	public CommerceShipmentItem findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public CommerceShipmentItem findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchShipmentItemException {
 
-		CommerceShipmentItem commerceShipmentItem = fetchByC_ERC(
-			companyId, externalReferenceCode);
+		CommerceShipmentItem commerceShipmentItem = fetchByERC_C(
+			externalReferenceCode, companyId);
 
 		if (commerceShipmentItem == null) {
 			StringBundler sb = new StringBundler(6);
 
 			sb.append(_NO_SUCH_ENTITY_WITH_KEY);
 
-			sb.append("companyId=");
-			sb.append(companyId);
-
-			sb.append(", externalReferenceCode=");
+			sb.append("externalReferenceCode=");
 			sb.append(externalReferenceCode);
+
+			sb.append(", companyId=");
+			sb.append(companyId);
 
 			sb.append("}");
 
@@ -3876,54 +3877,54 @@ public class CommerceShipmentItemPersistenceImpl
 	}
 
 	/**
-	 * Returns the commerce shipment item where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the commerce shipment item where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce shipment item, or <code>null</code> if a matching commerce shipment item could not be found
 	 */
 	@Override
-	public CommerceShipmentItem fetchByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public CommerceShipmentItem fetchByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return fetchByC_ERC(companyId, externalReferenceCode, true);
+		return fetchByERC_C(externalReferenceCode, companyId, true);
 	}
 
 	/**
-	 * Returns the commerce shipment item where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the commerce shipment item where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching commerce shipment item, or <code>null</code> if a matching commerce shipment item could not be found
 	 */
 	@Override
-	public CommerceShipmentItem fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache) {
+	public CommerceShipmentItem fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache) {
 
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
 		Object[] finderArgs = null;
 
 		if (useFinderCache) {
-			finderArgs = new Object[] {companyId, externalReferenceCode};
+			finderArgs = new Object[] {externalReferenceCode, companyId};
 		}
 
 		Object result = null;
 
 		if (useFinderCache) {
 			result = finderCache.getResult(
-				_finderPathFetchByC_ERC, finderArgs, this);
+				_finderPathFetchByERC_C, finderArgs, this);
 		}
 
 		if (result instanceof CommerceShipmentItem) {
 			CommerceShipmentItem commerceShipmentItem =
 				(CommerceShipmentItem)result;
 
-			if ((companyId != commerceShipmentItem.getCompanyId()) ||
-				!Objects.equals(
+			if (!Objects.equals(
 					externalReferenceCode,
-					commerceShipmentItem.getExternalReferenceCode())) {
+					commerceShipmentItem.getExternalReferenceCode()) ||
+				(companyId != commerceShipmentItem.getCompanyId())) {
 
 				result = null;
 			}
@@ -3934,18 +3935,18 @@ public class CommerceShipmentItemPersistenceImpl
 
 			sb.append(_SQL_SELECT_COMMERCESHIPMENTITEM_WHERE);
 
-			sb.append(_FINDER_COLUMN_C_ERC_COMPANYID_2);
-
 			boolean bindExternalReferenceCode = false;
 
 			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3);
 			}
 			else {
 				bindExternalReferenceCode = true;
 
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2);
 			}
+
+			sb.append(_FINDER_COLUMN_ERC_C_COMPANYID_2);
 
 			String sql = sb.toString();
 
@@ -3958,18 +3959,18 @@ public class CommerceShipmentItemPersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
-				queryPos.add(companyId);
-
 				if (bindExternalReferenceCode) {
 					queryPos.add(externalReferenceCode);
 				}
+
+				queryPos.add(companyId);
 
 				List<CommerceShipmentItem> list = query.list();
 
 				if (list.isEmpty()) {
 					if (useFinderCache) {
 						finderCache.putResult(
-							_finderPathFetchByC_ERC, finderArgs, list);
+							_finderPathFetchByERC_C, finderArgs, list);
 					}
 				}
 				else {
@@ -3997,37 +3998,37 @@ public class CommerceShipmentItemPersistenceImpl
 	}
 
 	/**
-	 * Removes the commerce shipment item where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the commerce shipment item where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the commerce shipment item that was removed
 	 */
 	@Override
-	public CommerceShipmentItem removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public CommerceShipmentItem removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchShipmentItemException {
 
-		CommerceShipmentItem commerceShipmentItem = findByC_ERC(
-			companyId, externalReferenceCode);
+		CommerceShipmentItem commerceShipmentItem = findByERC_C(
+			externalReferenceCode, companyId);
 
 		return remove(commerceShipmentItem);
 	}
 
 	/**
-	 * Returns the number of commerce shipment items where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of commerce shipment items where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching commerce shipment items
 	 */
 	@Override
-	public int countByC_ERC(long companyId, String externalReferenceCode) {
+	public int countByERC_C(String externalReferenceCode, long companyId) {
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
-		FinderPath finderPath = _finderPathCountByC_ERC;
+		FinderPath finderPath = _finderPathCountByERC_C;
 
-		Object[] finderArgs = new Object[] {companyId, externalReferenceCode};
+		Object[] finderArgs = new Object[] {externalReferenceCode, companyId};
 
 		Long count = (Long)finderCache.getResult(finderPath, finderArgs, this);
 
@@ -4036,18 +4037,18 @@ public class CommerceShipmentItemPersistenceImpl
 
 			sb.append(_SQL_COUNT_COMMERCESHIPMENTITEM_WHERE);
 
-			sb.append(_FINDER_COLUMN_C_ERC_COMPANYID_2);
-
 			boolean bindExternalReferenceCode = false;
 
 			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3);
 			}
 			else {
 				bindExternalReferenceCode = true;
 
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2);
 			}
+
+			sb.append(_FINDER_COLUMN_ERC_C_COMPANYID_2);
 
 			String sql = sb.toString();
 
@@ -4060,11 +4061,11 @@ public class CommerceShipmentItemPersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
-				queryPos.add(companyId);
-
 				if (bindExternalReferenceCode) {
 					queryPos.add(externalReferenceCode);
 				}
+
+				queryPos.add(companyId);
 
 				count = (Long)query.uniqueResult();
 
@@ -4081,14 +4082,14 @@ public class CommerceShipmentItemPersistenceImpl
 		return count.intValue();
 	}
 
-	private static final String _FINDER_COLUMN_C_ERC_COMPANYID_2 =
-		"commerceShipmentItem.companyId = ? AND ";
+	private static final String _FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2 =
+		"commerceShipmentItem.externalReferenceCode = ? AND ";
 
-	private static final String _FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2 =
-		"commerceShipmentItem.externalReferenceCode = ?";
+	private static final String _FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3 =
+		"(commerceShipmentItem.externalReferenceCode IS NULL OR commerceShipmentItem.externalReferenceCode = '') AND ";
 
-	private static final String _FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3 =
-		"(commerceShipmentItem.externalReferenceCode IS NULL OR commerceShipmentItem.externalReferenceCode = '')";
+	private static final String _FINDER_COLUMN_ERC_C_COMPANYID_2 =
+		"commerceShipmentItem.companyId = ?";
 
 	public CommerceShipmentItemPersistenceImpl() {
 		Map<String, String> dbColumnNames = new HashMap<String, String>();
@@ -4134,10 +4135,10 @@ public class CommerceShipmentItemPersistenceImpl
 			commerceShipmentItem);
 
 		finderCache.putResult(
-			_finderPathFetchByC_ERC,
+			_finderPathFetchByERC_C,
 			new Object[] {
-				commerceShipmentItem.getCompanyId(),
-				commerceShipmentItem.getExternalReferenceCode()
+				commerceShipmentItem.getExternalReferenceCode(),
+				commerceShipmentItem.getCompanyId()
 			},
 			commerceShipmentItem);
 	}
@@ -4241,13 +4242,13 @@ public class CommerceShipmentItemPersistenceImpl
 			_finderPathFetchByC_C_C, args, commerceShipmentItemModelImpl);
 
 		args = new Object[] {
-			commerceShipmentItemModelImpl.getCompanyId(),
-			commerceShipmentItemModelImpl.getExternalReferenceCode()
+			commerceShipmentItemModelImpl.getExternalReferenceCode(),
+			commerceShipmentItemModelImpl.getCompanyId()
 		};
 
-		finderCache.putResult(_finderPathCountByC_ERC, args, Long.valueOf(1));
+		finderCache.putResult(_finderPathCountByERC_C, args, Long.valueOf(1));
 		finderCache.putResult(
-			_finderPathFetchByC_ERC, args, commerceShipmentItemModelImpl);
+			_finderPathFetchByERC_C, args, commerceShipmentItemModelImpl);
 	}
 
 	/**
@@ -4397,6 +4398,29 @@ public class CommerceShipmentItemPersistenceImpl
 		if (Validator.isNull(commerceShipmentItem.getExternalReferenceCode())) {
 			commerceShipmentItem.setExternalReferenceCode(
 				commerceShipmentItem.getUuid());
+		}
+		else {
+			CommerceShipmentItem ercCommerceShipmentItem = fetchByERC_C(
+				commerceShipmentItem.getExternalReferenceCode(),
+				commerceShipmentItem.getCompanyId());
+
+			if (isNew) {
+				if (ercCommerceShipmentItem != null) {
+					throw new DuplicateCommerceShipmentItemExternalReferenceCodeException(
+						"Duplicate CommerceShipmentItem with external reference code " +
+							commerceShipmentItem.getExternalReferenceCode());
+				}
+			}
+			else {
+				if ((ercCommerceShipmentItem != null) &&
+					(commerceShipmentItem.getCommerceShipmentItemId() !=
+						ercCommerceShipmentItem.getCommerceShipmentItemId())) {
+
+					throw new DuplicateCommerceShipmentItemExternalReferenceCodeException(
+						"Duplicate CommerceShipmentItem with external reference code " +
+							commerceShipmentItem.getExternalReferenceCode());
+				}
+			}
 		}
 
 		ServiceContext serviceContext =
@@ -4879,15 +4903,15 @@ public class CommerceShipmentItemPersistenceImpl
 			},
 			false);
 
-		_finderPathFetchByC_ERC = new FinderPath(
-			FINDER_CLASS_NAME_ENTITY, "fetchByC_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"companyId", "externalReferenceCode"}, true);
+		_finderPathFetchByERC_C = new FinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, true);
 
-		_finderPathCountByC_ERC = new FinderPath(
-			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"companyId", "externalReferenceCode"}, false);
+		_finderPathCountByERC_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, false);
 
 		_setCommerceShipmentItemUtilPersistence(this);
 	}

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/persistence/impl/CommerceShipmentPersistenceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/persistence/impl/CommerceShipmentPersistenceImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.commerce.service.persistence.impl;
 
+import com.liferay.commerce.exception.DuplicateCommerceShipmentExternalReferenceCodeException;
 import com.liferay.commerce.exception.NoSuchShipmentException;
 import com.liferay.commerce.model.CommerceShipment;
 import com.liferay.commerce.model.CommerceShipmentTable;
@@ -3850,35 +3851,35 @@ public class CommerceShipmentPersistenceImpl
 	private static final String _FINDER_COLUMN_G_S_STATUS_2 =
 		"commerceShipment.status = ?";
 
-	private FinderPath _finderPathFetchByC_ERC;
-	private FinderPath _finderPathCountByC_ERC;
+	private FinderPath _finderPathFetchByERC_C;
+	private FinderPath _finderPathCountByERC_C;
 
 	/**
-	 * Returns the commerce shipment where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchShipmentException</code> if it could not be found.
+	 * Returns the commerce shipment where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchShipmentException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce shipment
 	 * @throws NoSuchShipmentException if a matching commerce shipment could not be found
 	 */
 	@Override
-	public CommerceShipment findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public CommerceShipment findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchShipmentException {
 
-		CommerceShipment commerceShipment = fetchByC_ERC(
-			companyId, externalReferenceCode);
+		CommerceShipment commerceShipment = fetchByERC_C(
+			externalReferenceCode, companyId);
 
 		if (commerceShipment == null) {
 			StringBundler sb = new StringBundler(6);
 
 			sb.append(_NO_SUCH_ENTITY_WITH_KEY);
 
-			sb.append("companyId=");
-			sb.append(companyId);
-
-			sb.append(", externalReferenceCode=");
+			sb.append("externalReferenceCode=");
 			sb.append(externalReferenceCode);
+
+			sb.append(", companyId=");
+			sb.append(companyId);
 
 			sb.append("}");
 
@@ -3893,53 +3894,53 @@ public class CommerceShipmentPersistenceImpl
 	}
 
 	/**
-	 * Returns the commerce shipment where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the commerce shipment where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce shipment, or <code>null</code> if a matching commerce shipment could not be found
 	 */
 	@Override
-	public CommerceShipment fetchByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public CommerceShipment fetchByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return fetchByC_ERC(companyId, externalReferenceCode, true);
+		return fetchByERC_C(externalReferenceCode, companyId, true);
 	}
 
 	/**
-	 * Returns the commerce shipment where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the commerce shipment where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching commerce shipment, or <code>null</code> if a matching commerce shipment could not be found
 	 */
 	@Override
-	public CommerceShipment fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache) {
+	public CommerceShipment fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache) {
 
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
 		Object[] finderArgs = null;
 
 		if (useFinderCache) {
-			finderArgs = new Object[] {companyId, externalReferenceCode};
+			finderArgs = new Object[] {externalReferenceCode, companyId};
 		}
 
 		Object result = null;
 
 		if (useFinderCache) {
 			result = finderCache.getResult(
-				_finderPathFetchByC_ERC, finderArgs, this);
+				_finderPathFetchByERC_C, finderArgs, this);
 		}
 
 		if (result instanceof CommerceShipment) {
 			CommerceShipment commerceShipment = (CommerceShipment)result;
 
-			if ((companyId != commerceShipment.getCompanyId()) ||
-				!Objects.equals(
+			if (!Objects.equals(
 					externalReferenceCode,
-					commerceShipment.getExternalReferenceCode())) {
+					commerceShipment.getExternalReferenceCode()) ||
+				(companyId != commerceShipment.getCompanyId())) {
 
 				result = null;
 			}
@@ -3950,18 +3951,18 @@ public class CommerceShipmentPersistenceImpl
 
 			sb.append(_SQL_SELECT_COMMERCESHIPMENT_WHERE);
 
-			sb.append(_FINDER_COLUMN_C_ERC_COMPANYID_2);
-
 			boolean bindExternalReferenceCode = false;
 
 			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3);
 			}
 			else {
 				bindExternalReferenceCode = true;
 
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2);
 			}
+
+			sb.append(_FINDER_COLUMN_ERC_C_COMPANYID_2);
 
 			String sql = sb.toString();
 
@@ -3974,18 +3975,18 @@ public class CommerceShipmentPersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
-				queryPos.add(companyId);
-
 				if (bindExternalReferenceCode) {
 					queryPos.add(externalReferenceCode);
 				}
+
+				queryPos.add(companyId);
 
 				List<CommerceShipment> list = query.list();
 
 				if (list.isEmpty()) {
 					if (useFinderCache) {
 						finderCache.putResult(
-							_finderPathFetchByC_ERC, finderArgs, list);
+							_finderPathFetchByERC_C, finderArgs, list);
 					}
 				}
 				else {
@@ -4013,37 +4014,37 @@ public class CommerceShipmentPersistenceImpl
 	}
 
 	/**
-	 * Removes the commerce shipment where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the commerce shipment where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the commerce shipment that was removed
 	 */
 	@Override
-	public CommerceShipment removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public CommerceShipment removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchShipmentException {
 
-		CommerceShipment commerceShipment = findByC_ERC(
-			companyId, externalReferenceCode);
+		CommerceShipment commerceShipment = findByERC_C(
+			externalReferenceCode, companyId);
 
 		return remove(commerceShipment);
 	}
 
 	/**
-	 * Returns the number of commerce shipments where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of commerce shipments where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching commerce shipments
 	 */
 	@Override
-	public int countByC_ERC(long companyId, String externalReferenceCode) {
+	public int countByERC_C(String externalReferenceCode, long companyId) {
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
-		FinderPath finderPath = _finderPathCountByC_ERC;
+		FinderPath finderPath = _finderPathCountByERC_C;
 
-		Object[] finderArgs = new Object[] {companyId, externalReferenceCode};
+		Object[] finderArgs = new Object[] {externalReferenceCode, companyId};
 
 		Long count = (Long)finderCache.getResult(finderPath, finderArgs, this);
 
@@ -4052,18 +4053,18 @@ public class CommerceShipmentPersistenceImpl
 
 			sb.append(_SQL_COUNT_COMMERCESHIPMENT_WHERE);
 
-			sb.append(_FINDER_COLUMN_C_ERC_COMPANYID_2);
-
 			boolean bindExternalReferenceCode = false;
 
 			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3);
 			}
 			else {
 				bindExternalReferenceCode = true;
 
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2);
 			}
+
+			sb.append(_FINDER_COLUMN_ERC_C_COMPANYID_2);
 
 			String sql = sb.toString();
 
@@ -4076,11 +4077,11 @@ public class CommerceShipmentPersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
-				queryPos.add(companyId);
-
 				if (bindExternalReferenceCode) {
 					queryPos.add(externalReferenceCode);
 				}
+
+				queryPos.add(companyId);
 
 				count = (Long)query.uniqueResult();
 
@@ -4097,14 +4098,14 @@ public class CommerceShipmentPersistenceImpl
 		return count.intValue();
 	}
 
-	private static final String _FINDER_COLUMN_C_ERC_COMPANYID_2 =
-		"commerceShipment.companyId = ? AND ";
+	private static final String _FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2 =
+		"commerceShipment.externalReferenceCode = ? AND ";
 
-	private static final String _FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2 =
-		"commerceShipment.externalReferenceCode = ?";
+	private static final String _FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3 =
+		"(commerceShipment.externalReferenceCode IS NULL OR commerceShipment.externalReferenceCode = '') AND ";
 
-	private static final String _FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3 =
-		"(commerceShipment.externalReferenceCode IS NULL OR commerceShipment.externalReferenceCode = '')";
+	private static final String _FINDER_COLUMN_ERC_C_COMPANYID_2 =
+		"commerceShipment.companyId = ?";
 
 	public CommerceShipmentPersistenceImpl() {
 		Map<String, String> dbColumnNames = new HashMap<String, String>();
@@ -4140,10 +4141,10 @@ public class CommerceShipmentPersistenceImpl
 			commerceShipment);
 
 		finderCache.putResult(
-			_finderPathFetchByC_ERC,
+			_finderPathFetchByERC_C,
 			new Object[] {
-				commerceShipment.getCompanyId(),
-				commerceShipment.getExternalReferenceCode()
+				commerceShipment.getExternalReferenceCode(),
+				commerceShipment.getCompanyId()
 			},
 			commerceShipment);
 	}
@@ -4231,13 +4232,13 @@ public class CommerceShipmentPersistenceImpl
 			_finderPathFetchByUUID_G, args, commerceShipmentModelImpl);
 
 		args = new Object[] {
-			commerceShipmentModelImpl.getCompanyId(),
-			commerceShipmentModelImpl.getExternalReferenceCode()
+			commerceShipmentModelImpl.getExternalReferenceCode(),
+			commerceShipmentModelImpl.getCompanyId()
 		};
 
-		finderCache.putResult(_finderPathCountByC_ERC, args, Long.valueOf(1));
+		finderCache.putResult(_finderPathCountByERC_C, args, Long.valueOf(1));
 		finderCache.putResult(
-			_finderPathFetchByC_ERC, args, commerceShipmentModelImpl);
+			_finderPathFetchByERC_C, args, commerceShipmentModelImpl);
 	}
 
 	/**
@@ -4381,6 +4382,29 @@ public class CommerceShipmentPersistenceImpl
 		if (Validator.isNull(commerceShipment.getExternalReferenceCode())) {
 			commerceShipment.setExternalReferenceCode(
 				commerceShipment.getUuid());
+		}
+		else {
+			CommerceShipment ercCommerceShipment = fetchByERC_C(
+				commerceShipment.getExternalReferenceCode(),
+				commerceShipment.getCompanyId());
+
+			if (isNew) {
+				if (ercCommerceShipment != null) {
+					throw new DuplicateCommerceShipmentExternalReferenceCodeException(
+						"Duplicate CommerceShipment with external reference code " +
+							commerceShipment.getExternalReferenceCode());
+				}
+			}
+			else {
+				if ((ercCommerceShipment != null) &&
+					(commerceShipment.getCommerceShipmentId() !=
+						ercCommerceShipment.getCommerceShipmentId())) {
+
+					throw new DuplicateCommerceShipmentExternalReferenceCodeException(
+						"Duplicate CommerceShipment with external reference code " +
+							commerceShipment.getExternalReferenceCode());
+				}
+			}
 		}
 
 		ServiceContext serviceContext =
@@ -4836,15 +4860,15 @@ public class CommerceShipmentPersistenceImpl
 			new String[] {Long.class.getName(), Integer.class.getName()},
 			new String[] {"groupId", "status"}, false);
 
-		_finderPathFetchByC_ERC = new FinderPath(
-			FINDER_CLASS_NAME_ENTITY, "fetchByC_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"companyId", "externalReferenceCode"}, true);
+		_finderPathFetchByERC_C = new FinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, true);
 
-		_finderPathCountByC_ERC = new FinderPath(
-			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"companyId", "externalReferenceCode"}, false);
+		_finderPathCountByERC_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, false);
 
 		_setCommerceShipmentUtilPersistence(this);
 	}

--- a/modules/apps/commerce/commerce-term-api/bnd.bnd
+++ b/modules/apps/commerce/commerce-term-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Commerce Term API
 Bundle-SymbolicName: com.liferay.commerce.term.api
-Bundle-Version: 4.1.1
+Bundle-Version: 5.0.0
 Export-Package:\
 	com.liferay.commerce.term.configuration,\
 	com.liferay.commerce.term.constants,\

--- a/modules/apps/commerce/commerce-term-api/src/main/java/com/liferay/commerce/term/exception/DuplicateCommerceTermEntryExternalReferenceCodeException.java
+++ b/modules/apps/commerce/commerce-term-api/src/main/java/com/liferay/commerce/term/exception/DuplicateCommerceTermEntryExternalReferenceCodeException.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.commerce.term.exception;
+
+import com.liferay.portal.kernel.exception.SystemException;
+
+/**
+ * @author Luca Pellizzon
+ */
+public class DuplicateCommerceTermEntryExternalReferenceCodeException
+	extends SystemException {
+
+	public DuplicateCommerceTermEntryExternalReferenceCodeException() {
+	}
+
+	public DuplicateCommerceTermEntryExternalReferenceCodeException(
+		String msg) {
+
+		super(msg);
+	}
+
+	public DuplicateCommerceTermEntryExternalReferenceCodeException(
+		String msg, Throwable throwable) {
+
+		super(msg, throwable);
+	}
+
+	public DuplicateCommerceTermEntryExternalReferenceCodeException(
+		Throwable throwable) {
+
+		super(throwable);
+	}
+
+}

--- a/modules/apps/commerce/commerce-term-api/src/main/java/com/liferay/commerce/term/service/CommerceTermEntryLocalService.java
+++ b/modules/apps/commerce/commerce-term-api/src/main/java/com/liferay/commerce/term/service/CommerceTermEntryLocalService.java
@@ -232,24 +232,9 @@ public interface CommerceTermEntryLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public CommerceTermEntry fetchCommerceTermEntry(long commerceTermEntryId);
 
-	/**
-	 * Returns the commerce term entry with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce term entry's external reference code
-	 * @return the matching commerce term entry, or <code>null</code> if a matching commerce term entry could not be found
-	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public CommerceTermEntry fetchCommerceTermEntryByExternalReferenceCode(
-		long companyId, String externalReferenceCode);
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchCommerceTermEntryByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CommerceTermEntry fetchCommerceTermEntryByReferenceCode(
-		long companyId, String externalReferenceCode);
+		String externalReferenceCode, long companyId);
 
 	/**
 	 * Returns the commerce term entry with the matching UUID and company.
@@ -306,17 +291,9 @@ public interface CommerceTermEntryLocalService
 	public CommerceTermEntry getCommerceTermEntry(long commerceTermEntryId)
 		throws PortalException;
 
-	/**
-	 * Returns the commerce term entry with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce term entry's external reference code
-	 * @return the matching commerce term entry
-	 * @throws PortalException if a matching commerce term entry could not be found
-	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public CommerceTermEntry getCommerceTermEntryByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
+			String externalReferenceCode, long companyId)
 		throws PortalException;
 
 	/**

--- a/modules/apps/commerce/commerce-term-api/src/main/java/com/liferay/commerce/term/service/CommerceTermEntryLocalServiceUtil.java
+++ b/modules/apps/commerce/commerce-term-api/src/main/java/com/liferay/commerce/term/service/CommerceTermEntryLocalServiceUtil.java
@@ -246,30 +246,12 @@ public class CommerceTermEntryLocalServiceUtil {
 		return getService().fetchCommerceTermEntry(commerceTermEntryId);
 	}
 
-	/**
-	 * Returns the commerce term entry with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce term entry's external reference code
-	 * @return the matching commerce term entry, or <code>null</code> if a matching commerce term entry could not be found
-	 */
 	public static CommerceTermEntry
 		fetchCommerceTermEntryByExternalReferenceCode(
-			long companyId, String externalReferenceCode) {
+			String externalReferenceCode, long companyId) {
 
 		return getService().fetchCommerceTermEntryByExternalReferenceCode(
-			companyId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchCommerceTermEntryByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	public static CommerceTermEntry fetchCommerceTermEntryByReferenceCode(
-		long companyId, String externalReferenceCode) {
-
-		return getService().fetchCommerceTermEntryByReferenceCode(
-			companyId, externalReferenceCode);
+			externalReferenceCode, companyId);
 	}
 
 	/**
@@ -346,20 +328,12 @@ public class CommerceTermEntryLocalServiceUtil {
 		return getService().getCommerceTermEntry(commerceTermEntryId);
 	}
 
-	/**
-	 * Returns the commerce term entry with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce term entry's external reference code
-	 * @return the matching commerce term entry
-	 * @throws PortalException if a matching commerce term entry could not be found
-	 */
 	public static CommerceTermEntry getCommerceTermEntryByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
+			String externalReferenceCode, long companyId)
 		throws PortalException {
 
 		return getService().getCommerceTermEntryByExternalReferenceCode(
-			companyId, externalReferenceCode);
+			externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/commerce/commerce-term-api/src/main/java/com/liferay/commerce/term/service/CommerceTermEntryLocalServiceWrapper.java
+++ b/modules/apps/commerce/commerce-term-api/src/main/java/com/liferay/commerce/term/service/CommerceTermEntryLocalServiceWrapper.java
@@ -279,35 +279,14 @@ public class CommerceTermEntryLocalServiceWrapper
 			commerceTermEntryId);
 	}
 
-	/**
-	 * Returns the commerce term entry with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce term entry's external reference code
-	 * @return the matching commerce term entry, or <code>null</code> if a matching commerce term entry could not be found
-	 */
 	@Override
 	public com.liferay.commerce.term.model.CommerceTermEntry
 		fetchCommerceTermEntryByExternalReferenceCode(
-			long companyId, String externalReferenceCode) {
+			String externalReferenceCode, long companyId) {
 
 		return _commerceTermEntryLocalService.
 			fetchCommerceTermEntryByExternalReferenceCode(
-				companyId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchCommerceTermEntryByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public com.liferay.commerce.term.model.CommerceTermEntry
-		fetchCommerceTermEntryByReferenceCode(
-			long companyId, String externalReferenceCode) {
-
-		return _commerceTermEntryLocalService.
-			fetchCommerceTermEntryByReferenceCode(
-				companyId, externalReferenceCode);
+				externalReferenceCode, companyId);
 	}
 
 	/**
@@ -394,23 +373,15 @@ public class CommerceTermEntryLocalServiceWrapper
 			commerceTermEntryId);
 	}
 
-	/**
-	 * Returns the commerce term entry with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce term entry's external reference code
-	 * @return the matching commerce term entry
-	 * @throws PortalException if a matching commerce term entry could not be found
-	 */
 	@Override
 	public com.liferay.commerce.term.model.CommerceTermEntry
 			getCommerceTermEntryByExternalReferenceCode(
-				long companyId, String externalReferenceCode)
+				String externalReferenceCode, long companyId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _commerceTermEntryLocalService.
 			getCommerceTermEntryByExternalReferenceCode(
-				companyId, externalReferenceCode);
+				externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/commerce/commerce-term-api/src/main/java/com/liferay/commerce/term/service/persistence/CommerceTermEntryPersistence.java
+++ b/modules/apps/commerce/commerce-term-api/src/main/java/com/liferay/commerce/term/service/persistence/CommerceTermEntryPersistence.java
@@ -1729,57 +1729,57 @@ public interface CommerceTermEntryPersistence
 	public int countByC_P_T(long companyId, double priority, String type);
 
 	/**
-	 * Returns the commerce term entry where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchTermEntryException</code> if it could not be found.
+	 * Returns the commerce term entry where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchTermEntryException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce term entry
 	 * @throws NoSuchTermEntryException if a matching commerce term entry could not be found
 	 */
-	public CommerceTermEntry findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public CommerceTermEntry findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchTermEntryException;
 
 	/**
-	 * Returns the commerce term entry where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the commerce term entry where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce term entry, or <code>null</code> if a matching commerce term entry could not be found
 	 */
-	public CommerceTermEntry fetchByC_ERC(
-		long companyId, String externalReferenceCode);
+	public CommerceTermEntry fetchByERC_C(
+		String externalReferenceCode, long companyId);
 
 	/**
-	 * Returns the commerce term entry where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the commerce term entry where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching commerce term entry, or <code>null</code> if a matching commerce term entry could not be found
 	 */
-	public CommerceTermEntry fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache);
+	public CommerceTermEntry fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache);
 
 	/**
-	 * Removes the commerce term entry where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the commerce term entry where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the commerce term entry that was removed
 	 */
-	public CommerceTermEntry removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public CommerceTermEntry removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchTermEntryException;
 
 	/**
-	 * Returns the number of commerce term entries where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of commerce term entries where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching commerce term entries
 	 */
-	public int countByC_ERC(long companyId, String externalReferenceCode);
+	public int countByERC_C(String externalReferenceCode, long companyId);
 
 	/**
 	 * Caches the commerce term entry in the entity cache if it is enabled.

--- a/modules/apps/commerce/commerce-term-api/src/main/java/com/liferay/commerce/term/service/persistence/CommerceTermEntryUtil.java
+++ b/modules/apps/commerce/commerce-term-api/src/main/java/com/liferay/commerce/term/service/persistence/CommerceTermEntryUtil.java
@@ -2153,73 +2153,73 @@ public class CommerceTermEntryUtil {
 	}
 
 	/**
-	 * Returns the commerce term entry where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchTermEntryException</code> if it could not be found.
+	 * Returns the commerce term entry where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchTermEntryException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce term entry
 	 * @throws NoSuchTermEntryException if a matching commerce term entry could not be found
 	 */
-	public static CommerceTermEntry findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public static CommerceTermEntry findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws com.liferay.commerce.term.exception.NoSuchTermEntryException {
 
-		return getPersistence().findByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().findByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the commerce term entry where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the commerce term entry where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce term entry, or <code>null</code> if a matching commerce term entry could not be found
 	 */
-	public static CommerceTermEntry fetchByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public static CommerceTermEntry fetchByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return getPersistence().fetchByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().fetchByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the commerce term entry where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the commerce term entry where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching commerce term entry, or <code>null</code> if a matching commerce term entry could not be found
 	 */
-	public static CommerceTermEntry fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache) {
+	public static CommerceTermEntry fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache) {
 
-		return getPersistence().fetchByC_ERC(
-			companyId, externalReferenceCode, useFinderCache);
+		return getPersistence().fetchByERC_C(
+			externalReferenceCode, companyId, useFinderCache);
 	}
 
 	/**
-	 * Removes the commerce term entry where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the commerce term entry where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the commerce term entry that was removed
 	 */
-	public static CommerceTermEntry removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public static CommerceTermEntry removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws com.liferay.commerce.term.exception.NoSuchTermEntryException {
 
-		return getPersistence().removeByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().removeByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the number of commerce term entries where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of commerce term entries where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching commerce term entries
 	 */
-	public static int countByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public static int countByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return getPersistence().countByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().countByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/commerce/commerce-term-api/src/main/resources/com/liferay/commerce/term/exception/packageinfo
+++ b/modules/apps/commerce/commerce-term-api/src/main/resources/com/liferay/commerce/term/exception/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 1.2.0

--- a/modules/apps/commerce/commerce-term-api/src/main/resources/com/liferay/commerce/term/service/packageinfo
+++ b/modules/apps/commerce/commerce-term-api/src/main/resources/com/liferay/commerce/term/service/packageinfo
@@ -1,1 +1,1 @@
-version 2.3.0
+version 3.0.0

--- a/modules/apps/commerce/commerce-term-api/src/main/resources/com/liferay/commerce/term/service/persistence/packageinfo
+++ b/modules/apps/commerce/commerce-term-api/src/main/resources/com/liferay/commerce/term/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 2.0.0

--- a/modules/apps/commerce/commerce-term-service/src/main/java/com/liferay/commerce/term/service/base/CommerceTermEntryLocalServiceBaseImpl.java
+++ b/modules/apps/commerce/commerce-term-service/src/main/java/com/liferay/commerce/term/service/base/CommerceTermEntryLocalServiceBaseImpl.java
@@ -288,48 +288,21 @@ public abstract class CommerceTermEntryLocalServiceBaseImpl
 			uuid, companyId, null);
 	}
 
-	/**
-	 * Returns the commerce term entry with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce term entry's external reference code
-	 * @return the matching commerce term entry, or <code>null</code> if a matching commerce term entry could not be found
-	 */
 	@Override
 	public CommerceTermEntry fetchCommerceTermEntryByExternalReferenceCode(
-		long companyId, String externalReferenceCode) {
+		String externalReferenceCode, long companyId) {
 
-		return commerceTermEntryPersistence.fetchByC_ERC(
-			companyId, externalReferenceCode);
+		return commerceTermEntryPersistence.fetchByERC_C(
+			externalReferenceCode, companyId);
 	}
 
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchCommerceTermEntryByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public CommerceTermEntry fetchCommerceTermEntryByReferenceCode(
-		long companyId, String externalReferenceCode) {
-
-		return fetchCommerceTermEntryByExternalReferenceCode(
-			companyId, externalReferenceCode);
-	}
-
-	/**
-	 * Returns the commerce term entry with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the commerce term entry's external reference code
-	 * @return the matching commerce term entry
-	 * @throws PortalException if a matching commerce term entry could not be found
-	 */
 	@Override
 	public CommerceTermEntry getCommerceTermEntryByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
+			String externalReferenceCode, long companyId)
 		throws PortalException {
 
-		return commerceTermEntryPersistence.findByC_ERC(
-			companyId, externalReferenceCode);
+		return commerceTermEntryPersistence.findByERC_C(
+			externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/commerce/commerce-term-service/src/main/java/com/liferay/commerce/term/service/impl/CommerceTermEntryServiceImpl.java
+++ b/modules/apps/commerce/commerce-term-service/src/main/java/com/liferay/commerce/term/service/impl/CommerceTermEntryServiceImpl.java
@@ -96,7 +96,7 @@ public class CommerceTermEntryServiceImpl
 		CommerceTermEntry commerceTermEntry =
 			commerceTermEntryLocalService.
 				fetchCommerceTermEntryByExternalReferenceCode(
-					companyId, externalReferenceCode);
+					externalReferenceCode, companyId);
 
 		if (commerceTermEntry != null) {
 			_commerceTermEntryModelResourcePermission.check(

--- a/modules/apps/commerce/commerce-term-service/src/main/java/com/liferay/commerce/term/service/persistence/impl/CommerceTermEntryPersistenceImpl.java
+++ b/modules/apps/commerce/commerce-term-service/src/main/java/com/liferay/commerce/term/service/persistence/impl/CommerceTermEntryPersistenceImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.commerce.term.service.persistence.impl;
 
+import com.liferay.commerce.term.exception.DuplicateCommerceTermEntryExternalReferenceCodeException;
 import com.liferay.commerce.term.exception.NoSuchTermEntryException;
 import com.liferay.commerce.term.model.CommerceTermEntry;
 import com.liferay.commerce.term.model.CommerceTermEntryTable;
@@ -7702,35 +7703,35 @@ public class CommerceTermEntryPersistenceImpl
 	private static final String _FINDER_COLUMN_C_P_T_TYPE_3 =
 		"(commerceTermEntry.type IS NULL OR commerceTermEntry.type = '')";
 
-	private FinderPath _finderPathFetchByC_ERC;
-	private FinderPath _finderPathCountByC_ERC;
+	private FinderPath _finderPathFetchByERC_C;
+	private FinderPath _finderPathCountByERC_C;
 
 	/**
-	 * Returns the commerce term entry where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchTermEntryException</code> if it could not be found.
+	 * Returns the commerce term entry where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchTermEntryException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce term entry
 	 * @throws NoSuchTermEntryException if a matching commerce term entry could not be found
 	 */
 	@Override
-	public CommerceTermEntry findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public CommerceTermEntry findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchTermEntryException {
 
-		CommerceTermEntry commerceTermEntry = fetchByC_ERC(
-			companyId, externalReferenceCode);
+		CommerceTermEntry commerceTermEntry = fetchByERC_C(
+			externalReferenceCode, companyId);
 
 		if (commerceTermEntry == null) {
 			StringBundler sb = new StringBundler(6);
 
 			sb.append(_NO_SUCH_ENTITY_WITH_KEY);
 
-			sb.append("companyId=");
-			sb.append(companyId);
-
-			sb.append(", externalReferenceCode=");
+			sb.append("externalReferenceCode=");
 			sb.append(externalReferenceCode);
+
+			sb.append(", companyId=");
+			sb.append(companyId);
 
 			sb.append("}");
 
@@ -7745,53 +7746,53 @@ public class CommerceTermEntryPersistenceImpl
 	}
 
 	/**
-	 * Returns the commerce term entry where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the commerce term entry where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching commerce term entry, or <code>null</code> if a matching commerce term entry could not be found
 	 */
 	@Override
-	public CommerceTermEntry fetchByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public CommerceTermEntry fetchByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return fetchByC_ERC(companyId, externalReferenceCode, true);
+		return fetchByERC_C(externalReferenceCode, companyId, true);
 	}
 
 	/**
-	 * Returns the commerce term entry where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the commerce term entry where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching commerce term entry, or <code>null</code> if a matching commerce term entry could not be found
 	 */
 	@Override
-	public CommerceTermEntry fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache) {
+	public CommerceTermEntry fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache) {
 
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
 		Object[] finderArgs = null;
 
 		if (useFinderCache) {
-			finderArgs = new Object[] {companyId, externalReferenceCode};
+			finderArgs = new Object[] {externalReferenceCode, companyId};
 		}
 
 		Object result = null;
 
 		if (useFinderCache) {
 			result = finderCache.getResult(
-				_finderPathFetchByC_ERC, finderArgs, this);
+				_finderPathFetchByERC_C, finderArgs, this);
 		}
 
 		if (result instanceof CommerceTermEntry) {
 			CommerceTermEntry commerceTermEntry = (CommerceTermEntry)result;
 
-			if ((companyId != commerceTermEntry.getCompanyId()) ||
-				!Objects.equals(
+			if (!Objects.equals(
 					externalReferenceCode,
-					commerceTermEntry.getExternalReferenceCode())) {
+					commerceTermEntry.getExternalReferenceCode()) ||
+				(companyId != commerceTermEntry.getCompanyId())) {
 
 				result = null;
 			}
@@ -7802,18 +7803,18 @@ public class CommerceTermEntryPersistenceImpl
 
 			sb.append(_SQL_SELECT_COMMERCETERMENTRY_WHERE);
 
-			sb.append(_FINDER_COLUMN_C_ERC_COMPANYID_2);
-
 			boolean bindExternalReferenceCode = false;
 
 			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3);
 			}
 			else {
 				bindExternalReferenceCode = true;
 
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2);
 			}
+
+			sb.append(_FINDER_COLUMN_ERC_C_COMPANYID_2);
 
 			String sql = sb.toString();
 
@@ -7826,18 +7827,18 @@ public class CommerceTermEntryPersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
-				queryPos.add(companyId);
-
 				if (bindExternalReferenceCode) {
 					queryPos.add(externalReferenceCode);
 				}
+
+				queryPos.add(companyId);
 
 				List<CommerceTermEntry> list = query.list();
 
 				if (list.isEmpty()) {
 					if (useFinderCache) {
 						finderCache.putResult(
-							_finderPathFetchByC_ERC, finderArgs, list);
+							_finderPathFetchByERC_C, finderArgs, list);
 					}
 				}
 				else {
@@ -7865,37 +7866,37 @@ public class CommerceTermEntryPersistenceImpl
 	}
 
 	/**
-	 * Removes the commerce term entry where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the commerce term entry where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the commerce term entry that was removed
 	 */
 	@Override
-	public CommerceTermEntry removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public CommerceTermEntry removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchTermEntryException {
 
-		CommerceTermEntry commerceTermEntry = findByC_ERC(
-			companyId, externalReferenceCode);
+		CommerceTermEntry commerceTermEntry = findByERC_C(
+			externalReferenceCode, companyId);
 
 		return remove(commerceTermEntry);
 	}
 
 	/**
-	 * Returns the number of commerce term entries where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of commerce term entries where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching commerce term entries
 	 */
 	@Override
-	public int countByC_ERC(long companyId, String externalReferenceCode) {
+	public int countByERC_C(String externalReferenceCode, long companyId) {
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
-		FinderPath finderPath = _finderPathCountByC_ERC;
+		FinderPath finderPath = _finderPathCountByERC_C;
 
-		Object[] finderArgs = new Object[] {companyId, externalReferenceCode};
+		Object[] finderArgs = new Object[] {externalReferenceCode, companyId};
 
 		Long count = (Long)finderCache.getResult(finderPath, finderArgs, this);
 
@@ -7904,18 +7905,18 @@ public class CommerceTermEntryPersistenceImpl
 
 			sb.append(_SQL_COUNT_COMMERCETERMENTRY_WHERE);
 
-			sb.append(_FINDER_COLUMN_C_ERC_COMPANYID_2);
-
 			boolean bindExternalReferenceCode = false;
 
 			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3);
 			}
 			else {
 				bindExternalReferenceCode = true;
 
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2);
 			}
+
+			sb.append(_FINDER_COLUMN_ERC_C_COMPANYID_2);
 
 			String sql = sb.toString();
 
@@ -7928,11 +7929,11 @@ public class CommerceTermEntryPersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
-				queryPos.add(companyId);
-
 				if (bindExternalReferenceCode) {
 					queryPos.add(externalReferenceCode);
 				}
+
+				queryPos.add(companyId);
 
 				count = (Long)query.uniqueResult();
 
@@ -7949,14 +7950,14 @@ public class CommerceTermEntryPersistenceImpl
 		return count.intValue();
 	}
 
-	private static final String _FINDER_COLUMN_C_ERC_COMPANYID_2 =
-		"commerceTermEntry.companyId = ? AND ";
+	private static final String _FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2 =
+		"commerceTermEntry.externalReferenceCode = ? AND ";
 
-	private static final String _FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2 =
-		"commerceTermEntry.externalReferenceCode = ?";
+	private static final String _FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3 =
+		"(commerceTermEntry.externalReferenceCode IS NULL OR commerceTermEntry.externalReferenceCode = '') AND ";
 
-	private static final String _FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3 =
-		"(commerceTermEntry.externalReferenceCode IS NULL OR commerceTermEntry.externalReferenceCode = '')";
+	private static final String _FINDER_COLUMN_ERC_C_COMPANYID_2 =
+		"commerceTermEntry.companyId = ?";
 
 	public CommerceTermEntryPersistenceImpl() {
 		Map<String, String> dbColumnNames = new HashMap<String, String>();
@@ -8002,10 +8003,10 @@ public class CommerceTermEntryPersistenceImpl
 			commerceTermEntry);
 
 		finderCache.putResult(
-			_finderPathFetchByC_ERC,
+			_finderPathFetchByERC_C,
 			new Object[] {
-				commerceTermEntry.getCompanyId(),
-				commerceTermEntry.getExternalReferenceCode()
+				commerceTermEntry.getExternalReferenceCode(),
+				commerceTermEntry.getCompanyId()
 			},
 			commerceTermEntry);
 	}
@@ -8104,13 +8105,13 @@ public class CommerceTermEntryPersistenceImpl
 			_finderPathFetchByC_P_T, args, commerceTermEntryModelImpl);
 
 		args = new Object[] {
-			commerceTermEntryModelImpl.getCompanyId(),
-			commerceTermEntryModelImpl.getExternalReferenceCode()
+			commerceTermEntryModelImpl.getExternalReferenceCode(),
+			commerceTermEntryModelImpl.getCompanyId()
 		};
 
-		finderCache.putResult(_finderPathCountByC_ERC, args, Long.valueOf(1));
+		finderCache.putResult(_finderPathCountByERC_C, args, Long.valueOf(1));
 		finderCache.putResult(
-			_finderPathFetchByC_ERC, args, commerceTermEntryModelImpl);
+			_finderPathFetchByERC_C, args, commerceTermEntryModelImpl);
 	}
 
 	/**
@@ -8260,6 +8261,29 @@ public class CommerceTermEntryPersistenceImpl
 		if (Validator.isNull(commerceTermEntry.getExternalReferenceCode())) {
 			commerceTermEntry.setExternalReferenceCode(
 				commerceTermEntry.getUuid());
+		}
+		else {
+			CommerceTermEntry ercCommerceTermEntry = fetchByERC_C(
+				commerceTermEntry.getExternalReferenceCode(),
+				commerceTermEntry.getCompanyId());
+
+			if (isNew) {
+				if (ercCommerceTermEntry != null) {
+					throw new DuplicateCommerceTermEntryExternalReferenceCodeException(
+						"Duplicate CommerceTermEntry with external reference code " +
+							commerceTermEntry.getExternalReferenceCode());
+				}
+			}
+			else {
+				if ((ercCommerceTermEntry != null) &&
+					(commerceTermEntry.getCommerceTermEntryId() !=
+						ercCommerceTermEntry.getCommerceTermEntryId())) {
+
+					throw new DuplicateCommerceTermEntryExternalReferenceCodeException(
+						"Duplicate CommerceTermEntry with external reference code " +
+							commerceTermEntry.getExternalReferenceCode());
+				}
+			}
 		}
 
 		ServiceContext serviceContext =
@@ -8739,15 +8763,15 @@ public class CommerceTermEntryPersistenceImpl
 			},
 			new String[] {"companyId", "priority", "type_"}, false);
 
-		_finderPathFetchByC_ERC = new FinderPath(
-			FINDER_CLASS_NAME_ENTITY, "fetchByC_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"companyId", "externalReferenceCode"}, true);
+		_finderPathFetchByERC_C = new FinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, true);
 
-		_finderPathCountByC_ERC = new FinderPath(
-			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"companyId", "externalReferenceCode"}, false);
+		_finderPathCountByERC_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, false);
 
 		_setCommerceTermEntryUtilPersistence(this);
 	}

--- a/modules/apps/commerce/commerce-term-test/src/testIntegration/java/com/liferay/commerce/term/service/persistence/test/CommerceTermEntryPersistenceTest.java
+++ b/modules/apps/commerce/commerce-term-test/src/testIntegration/java/com/liferay/commerce/term/service/persistence/test/CommerceTermEntryPersistenceTest.java
@@ -15,6 +15,7 @@
 package com.liferay.commerce.term.service.persistence.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.commerce.term.exception.DuplicateCommerceTermEntryExternalReferenceCodeException;
 import com.liferay.commerce.term.exception.NoSuchTermEntryException;
 import com.liferay.commerce.term.model.CommerceTermEntry;
 import com.liferay.commerce.term.service.CommerceTermEntryLocalServiceUtil;
@@ -245,6 +246,28 @@ public class CommerceTermEntryPersistenceTest {
 			Time.getShortTimestamp(newCommerceTermEntry.getStatusDate()));
 	}
 
+	@Test(
+		expected = DuplicateCommerceTermEntryExternalReferenceCodeException.class
+	)
+	public void testUpdateWithExistingExternalReferenceCode() throws Exception {
+		CommerceTermEntry commerceTermEntry = addCommerceTermEntry();
+
+		CommerceTermEntry newCommerceTermEntry = addCommerceTermEntry();
+
+		newCommerceTermEntry.setCompanyId(commerceTermEntry.getCompanyId());
+
+		newCommerceTermEntry = _persistence.update(newCommerceTermEntry);
+
+		Session session = _persistence.getCurrentSession();
+
+		session.evict(newCommerceTermEntry);
+
+		newCommerceTermEntry.setExternalReferenceCode(
+			commerceTermEntry.getExternalReferenceCode());
+
+		_persistence.update(newCommerceTermEntry);
+	}
+
 	@Test
 	public void testCountByUuid() throws Exception {
 		_persistence.countByUuid("");
@@ -328,12 +351,12 @@ public class CommerceTermEntryPersistenceTest {
 	}
 
 	@Test
-	public void testCountByC_ERC() throws Exception {
-		_persistence.countByC_ERC(RandomTestUtil.nextLong(), "");
+	public void testCountByERC_C() throws Exception {
+		_persistence.countByERC_C("", RandomTestUtil.nextLong());
 
-		_persistence.countByC_ERC(0L, "null");
+		_persistence.countByERC_C("null", 0L);
 
-		_persistence.countByC_ERC(0L, (String)null);
+		_persistence.countByERC_C((String)null, 0L);
 	}
 
 	@Test
@@ -672,15 +695,15 @@ public class CommerceTermEntryPersistenceTest {
 				new Class<?>[] {String.class}, "type_"));
 
 		Assert.assertEquals(
-			Long.valueOf(commerceTermEntry.getCompanyId()),
-			ReflectionTestUtil.<Long>invoke(
-				commerceTermEntry, "getColumnOriginalValue",
-				new Class<?>[] {String.class}, "companyId"));
-		Assert.assertEquals(
 			commerceTermEntry.getExternalReferenceCode(),
 			ReflectionTestUtil.invoke(
 				commerceTermEntry, "getColumnOriginalValue",
 				new Class<?>[] {String.class}, "externalReferenceCode"));
+		Assert.assertEquals(
+			Long.valueOf(commerceTermEntry.getCompanyId()),
+			ReflectionTestUtil.<Long>invoke(
+				commerceTermEntry, "getColumnOriginalValue",
+				new Class<?>[] {String.class}, "companyId"));
 	}
 
 	protected CommerceTermEntry addCommerceTermEntry() throws Exception {

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceOrderItemPersistenceTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceOrderItemPersistenceTest.java
@@ -15,6 +15,7 @@
 package com.liferay.commerce.service.persistence.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.commerce.exception.DuplicateCommerceOrderItemExternalReferenceCodeException;
 import com.liferay.commerce.exception.NoSuchOrderItemException;
 import com.liferay.commerce.model.CommerceOrderItem;
 import com.liferay.commerce.service.CommerceOrderItemLocalServiceUtil;
@@ -482,6 +483,28 @@ public class CommerceOrderItemPersistenceTest {
 			newCommerceOrderItem.getWidth());
 	}
 
+	@Test(
+		expected = DuplicateCommerceOrderItemExternalReferenceCodeException.class
+	)
+	public void testUpdateWithExistingExternalReferenceCode() throws Exception {
+		CommerceOrderItem commerceOrderItem = addCommerceOrderItem();
+
+		CommerceOrderItem newCommerceOrderItem = addCommerceOrderItem();
+
+		newCommerceOrderItem.setCompanyId(commerceOrderItem.getCompanyId());
+
+		newCommerceOrderItem = _persistence.update(newCommerceOrderItem);
+
+		Session session = _persistence.getCurrentSession();
+
+		session.evict(newCommerceOrderItem);
+
+		newCommerceOrderItem.setExternalReferenceCode(
+			commerceOrderItem.getExternalReferenceCode());
+
+		_persistence.update(newCommerceOrderItem);
+	}
+
 	@Test
 	public void testCountByUuid() throws Exception {
 		_persistence.countByUuid("");
@@ -562,12 +585,12 @@ public class CommerceOrderItemPersistenceTest {
 	}
 
 	@Test
-	public void testCountByC_ERC() throws Exception {
-		_persistence.countByC_ERC(RandomTestUtil.nextLong(), "");
+	public void testCountByERC_C() throws Exception {
+		_persistence.countByERC_C("", RandomTestUtil.nextLong());
 
-		_persistence.countByC_ERC(0L, "null");
+		_persistence.countByERC_C("null", 0L);
 
-		_persistence.countByC_ERC(0L, (String)null);
+		_persistence.countByERC_C((String)null, 0L);
 	}
 
 	@Test
@@ -917,15 +940,15 @@ public class CommerceOrderItemPersistenceTest {
 				new Class<?>[] {String.class}, "bookedQuantityId"));
 
 		Assert.assertEquals(
-			Long.valueOf(commerceOrderItem.getCompanyId()),
-			ReflectionTestUtil.<Long>invoke(
-				commerceOrderItem, "getColumnOriginalValue",
-				new Class<?>[] {String.class}, "companyId"));
-		Assert.assertEquals(
 			commerceOrderItem.getExternalReferenceCode(),
 			ReflectionTestUtil.invoke(
 				commerceOrderItem, "getColumnOriginalValue",
 				new Class<?>[] {String.class}, "externalReferenceCode"));
+		Assert.assertEquals(
+			Long.valueOf(commerceOrderItem.getCompanyId()),
+			ReflectionTestUtil.<Long>invoke(
+				commerceOrderItem, "getColumnOriginalValue",
+				new Class<?>[] {String.class}, "companyId"));
 	}
 
 	protected CommerceOrderItem addCommerceOrderItem() throws Exception {

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceOrderNotePersistenceTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceOrderNotePersistenceTest.java
@@ -15,6 +15,7 @@
 package com.liferay.commerce.service.persistence.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.commerce.exception.DuplicateCommerceOrderNoteExternalReferenceCodeException;
 import com.liferay.commerce.exception.NoSuchOrderNoteException;
 import com.liferay.commerce.model.CommerceOrderNote;
 import com.liferay.commerce.service.CommerceOrderNoteLocalServiceUtil;
@@ -196,6 +197,28 @@ public class CommerceOrderNotePersistenceTest {
 			newCommerceOrderNote.isRestricted());
 	}
 
+	@Test(
+		expected = DuplicateCommerceOrderNoteExternalReferenceCodeException.class
+	)
+	public void testUpdateWithExistingExternalReferenceCode() throws Exception {
+		CommerceOrderNote commerceOrderNote = addCommerceOrderNote();
+
+		CommerceOrderNote newCommerceOrderNote = addCommerceOrderNote();
+
+		newCommerceOrderNote.setCompanyId(commerceOrderNote.getCompanyId());
+
+		newCommerceOrderNote = _persistence.update(newCommerceOrderNote);
+
+		Session session = _persistence.getCurrentSession();
+
+		session.evict(newCommerceOrderNote);
+
+		newCommerceOrderNote.setExternalReferenceCode(
+			commerceOrderNote.getExternalReferenceCode());
+
+		_persistence.update(newCommerceOrderNote);
+	}
+
 	@Test
 	public void testCountByUuid() throws Exception {
 		_persistence.countByUuid("");
@@ -239,12 +262,12 @@ public class CommerceOrderNotePersistenceTest {
 	}
 
 	@Test
-	public void testCountByC_ERC() throws Exception {
-		_persistence.countByC_ERC(RandomTestUtil.nextLong(), "");
+	public void testCountByERC_C() throws Exception {
+		_persistence.countByERC_C("", RandomTestUtil.nextLong());
 
-		_persistence.countByC_ERC(0L, "null");
+		_persistence.countByERC_C("null", 0L);
 
-		_persistence.countByC_ERC(0L, (String)null);
+		_persistence.countByERC_C((String)null, 0L);
 	}
 
 	@Test
@@ -564,15 +587,15 @@ public class CommerceOrderNotePersistenceTest {
 				new Class<?>[] {String.class}, "groupId"));
 
 		Assert.assertEquals(
-			Long.valueOf(commerceOrderNote.getCompanyId()),
-			ReflectionTestUtil.<Long>invoke(
-				commerceOrderNote, "getColumnOriginalValue",
-				new Class<?>[] {String.class}, "companyId"));
-		Assert.assertEquals(
 			commerceOrderNote.getExternalReferenceCode(),
 			ReflectionTestUtil.invoke(
 				commerceOrderNote, "getColumnOriginalValue",
 				new Class<?>[] {String.class}, "externalReferenceCode"));
+		Assert.assertEquals(
+			Long.valueOf(commerceOrderNote.getCompanyId()),
+			ReflectionTestUtil.<Long>invoke(
+				commerceOrderNote, "getColumnOriginalValue",
+				new Class<?>[] {String.class}, "companyId"));
 	}
 
 	protected CommerceOrderNote addCommerceOrderNote() throws Exception {

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceOrderPersistenceTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceOrderPersistenceTest.java
@@ -15,6 +15,7 @@
 package com.liferay.commerce.service.persistence.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.commerce.exception.DuplicateCommerceOrderExternalReferenceCodeException;
 import com.liferay.commerce.exception.NoSuchOrderException;
 import com.liferay.commerce.model.CommerceOrder;
 import com.liferay.commerce.service.CommerceOrderLocalServiceUtil;
@@ -573,6 +574,26 @@ public class CommerceOrderPersistenceTest {
 			Time.getShortTimestamp(newCommerceOrder.getStatusDate()));
 	}
 
+	@Test(expected = DuplicateCommerceOrderExternalReferenceCodeException.class)
+	public void testUpdateWithExistingExternalReferenceCode() throws Exception {
+		CommerceOrder commerceOrder = addCommerceOrder();
+
+		CommerceOrder newCommerceOrder = addCommerceOrder();
+
+		newCommerceOrder.setCompanyId(commerceOrder.getCompanyId());
+
+		newCommerceOrder = _persistence.update(newCommerceOrder);
+
+		Session session = _persistence.getCurrentSession();
+
+		session.evict(newCommerceOrder);
+
+		newCommerceOrder.setExternalReferenceCode(
+			commerceOrder.getExternalReferenceCode());
+
+		_persistence.update(newCommerceOrder);
+	}
+
 	@Test
 	public void testCountByUuid() throws Exception {
 		_persistence.countByUuid("");
@@ -689,12 +710,12 @@ public class CommerceOrderPersistenceTest {
 	}
 
 	@Test
-	public void testCountByC_ERC() throws Exception {
-		_persistence.countByC_ERC(RandomTestUtil.nextLong(), "");
+	public void testCountByERC_C() throws Exception {
+		_persistence.countByERC_C("", RandomTestUtil.nextLong());
 
-		_persistence.countByC_ERC(0L, "null");
+		_persistence.countByERC_C("null", 0L);
 
-		_persistence.countByC_ERC(0L, (String)null);
+		_persistence.countByERC_C((String)null, 0L);
 	}
 
 	@Test
@@ -1045,15 +1066,15 @@ public class CommerceOrderPersistenceTest {
 				new Class<?>[] {String.class}, "groupId"));
 
 		Assert.assertEquals(
-			Long.valueOf(commerceOrder.getCompanyId()),
-			ReflectionTestUtil.<Long>invoke(
-				commerceOrder, "getColumnOriginalValue",
-				new Class<?>[] {String.class}, "companyId"));
-		Assert.assertEquals(
 			commerceOrder.getExternalReferenceCode(),
 			ReflectionTestUtil.invoke(
 				commerceOrder, "getColumnOriginalValue",
 				new Class<?>[] {String.class}, "externalReferenceCode"));
+		Assert.assertEquals(
+			Long.valueOf(commerceOrder.getCompanyId()),
+			ReflectionTestUtil.<Long>invoke(
+				commerceOrder, "getColumnOriginalValue",
+				new Class<?>[] {String.class}, "companyId"));
 	}
 
 	protected CommerceOrder addCommerceOrder() throws Exception {

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceOrderTypePersistenceTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceOrderTypePersistenceTest.java
@@ -15,6 +15,7 @@
 package com.liferay.commerce.service.persistence.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.commerce.exception.DuplicateCommerceOrderTypeExternalReferenceCodeException;
 import com.liferay.commerce.exception.NoSuchOrderTypeException;
 import com.liferay.commerce.model.CommerceOrderType;
 import com.liferay.commerce.service.CommerceOrderTypeLocalServiceUtil;
@@ -233,6 +234,28 @@ public class CommerceOrderTypePersistenceTest {
 			Time.getShortTimestamp(newCommerceOrderType.getStatusDate()));
 	}
 
+	@Test(
+		expected = DuplicateCommerceOrderTypeExternalReferenceCodeException.class
+	)
+	public void testUpdateWithExistingExternalReferenceCode() throws Exception {
+		CommerceOrderType commerceOrderType = addCommerceOrderType();
+
+		CommerceOrderType newCommerceOrderType = addCommerceOrderType();
+
+		newCommerceOrderType.setCompanyId(commerceOrderType.getCompanyId());
+
+		newCommerceOrderType = _persistence.update(newCommerceOrderType);
+
+		Session session = _persistence.getCurrentSession();
+
+		session.evict(newCommerceOrderType);
+
+		newCommerceOrderType.setExternalReferenceCode(
+			commerceOrderType.getExternalReferenceCode());
+
+		_persistence.update(newCommerceOrderType);
+	}
+
 	@Test
 	public void testCountByUuid() throws Exception {
 		_persistence.countByUuid("");
@@ -283,12 +306,12 @@ public class CommerceOrderTypePersistenceTest {
 	}
 
 	@Test
-	public void testCountByC_ERC() throws Exception {
-		_persistence.countByC_ERC(RandomTestUtil.nextLong(), "");
+	public void testCountByERC_C() throws Exception {
+		_persistence.countByERC_C("", RandomTestUtil.nextLong());
 
-		_persistence.countByC_ERC(0L, "null");
+		_persistence.countByERC_C("null", 0L);
 
-		_persistence.countByC_ERC(0L, (String)null);
+		_persistence.countByERC_C((String)null, 0L);
 	}
 
 	@Test
@@ -600,15 +623,15 @@ public class CommerceOrderTypePersistenceTest {
 
 	private void _assertOriginalValues(CommerceOrderType commerceOrderType) {
 		Assert.assertEquals(
-			Long.valueOf(commerceOrderType.getCompanyId()),
-			ReflectionTestUtil.<Long>invoke(
-				commerceOrderType, "getColumnOriginalValue",
-				new Class<?>[] {String.class}, "companyId"));
-		Assert.assertEquals(
 			commerceOrderType.getExternalReferenceCode(),
 			ReflectionTestUtil.invoke(
 				commerceOrderType, "getColumnOriginalValue",
 				new Class<?>[] {String.class}, "externalReferenceCode"));
+		Assert.assertEquals(
+			Long.valueOf(commerceOrderType.getCompanyId()),
+			ReflectionTestUtil.<Long>invoke(
+				commerceOrderType, "getColumnOriginalValue",
+				new Class<?>[] {String.class}, "companyId"));
 	}
 
 	protected CommerceOrderType addCommerceOrderType() throws Exception {

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceOrderTypeRelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceOrderTypeRelPersistenceTest.java
@@ -15,6 +15,7 @@
 package com.liferay.commerce.service.persistence.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.commerce.exception.DuplicateCommerceOrderTypeRelExternalReferenceCodeException;
 import com.liferay.commerce.exception.NoSuchOrderTypeRelException;
 import com.liferay.commerce.model.CommerceOrderTypeRel;
 import com.liferay.commerce.service.CommerceOrderTypeRelLocalServiceUtil;
@@ -198,6 +199,30 @@ public class CommerceOrderTypeRelPersistenceTest {
 			newCommerceOrderTypeRel.getCommerceOrderTypeId());
 	}
 
+	@Test(
+		expected = DuplicateCommerceOrderTypeRelExternalReferenceCodeException.class
+	)
+	public void testUpdateWithExistingExternalReferenceCode() throws Exception {
+		CommerceOrderTypeRel commerceOrderTypeRel = addCommerceOrderTypeRel();
+
+		CommerceOrderTypeRel newCommerceOrderTypeRel =
+			addCommerceOrderTypeRel();
+
+		newCommerceOrderTypeRel.setCompanyId(
+			commerceOrderTypeRel.getCompanyId());
+
+		newCommerceOrderTypeRel = _persistence.update(newCommerceOrderTypeRel);
+
+		Session session = _persistence.getCurrentSession();
+
+		session.evict(newCommerceOrderTypeRel);
+
+		newCommerceOrderTypeRel.setExternalReferenceCode(
+			commerceOrderTypeRel.getExternalReferenceCode());
+
+		_persistence.update(newCommerceOrderTypeRel);
+	}
+
 	@Test
 	public void testCountByUuid() throws Exception {
 		_persistence.countByUuid("");
@@ -241,12 +266,12 @@ public class CommerceOrderTypeRelPersistenceTest {
 	}
 
 	@Test
-	public void testCountByC_ERC() throws Exception {
-		_persistence.countByC_ERC(RandomTestUtil.nextLong(), "");
+	public void testCountByERC_C() throws Exception {
+		_persistence.countByERC_C("", RandomTestUtil.nextLong());
 
-		_persistence.countByC_ERC(0L, "null");
+		_persistence.countByERC_C("null", 0L);
 
-		_persistence.countByC_ERC(0L, (String)null);
+		_persistence.countByERC_C((String)null, 0L);
 	}
 
 	@Test
@@ -592,15 +617,15 @@ public class CommerceOrderTypeRelPersistenceTest {
 				new Class<?>[] {String.class}, "commerceOrderTypeId"));
 
 		Assert.assertEquals(
-			Long.valueOf(commerceOrderTypeRel.getCompanyId()),
-			ReflectionTestUtil.<Long>invoke(
-				commerceOrderTypeRel, "getColumnOriginalValue",
-				new Class<?>[] {String.class}, "companyId"));
-		Assert.assertEquals(
 			commerceOrderTypeRel.getExternalReferenceCode(),
 			ReflectionTestUtil.invoke(
 				commerceOrderTypeRel, "getColumnOriginalValue",
 				new Class<?>[] {String.class}, "externalReferenceCode"));
+		Assert.assertEquals(
+			Long.valueOf(commerceOrderTypeRel.getCompanyId()),
+			ReflectionTestUtil.<Long>invoke(
+				commerceOrderTypeRel, "getColumnOriginalValue",
+				new Class<?>[] {String.class}, "companyId"));
 	}
 
 	protected CommerceOrderTypeRel addCommerceOrderTypeRel() throws Exception {

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceShipmentItemPersistenceTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceShipmentItemPersistenceTest.java
@@ -15,6 +15,7 @@
 package com.liferay.commerce.service.persistence.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.commerce.exception.DuplicateCommerceShipmentItemExternalReferenceCodeException;
 import com.liferay.commerce.exception.NoSuchShipmentItemException;
 import com.liferay.commerce.model.CommerceShipmentItem;
 import com.liferay.commerce.service.CommerceShipmentItemLocalServiceUtil;
@@ -210,6 +211,30 @@ public class CommerceShipmentItemPersistenceTest {
 			newCommerceShipmentItem.getQuantity());
 	}
 
+	@Test(
+		expected = DuplicateCommerceShipmentItemExternalReferenceCodeException.class
+	)
+	public void testUpdateWithExistingExternalReferenceCode() throws Exception {
+		CommerceShipmentItem commerceShipmentItem = addCommerceShipmentItem();
+
+		CommerceShipmentItem newCommerceShipmentItem =
+			addCommerceShipmentItem();
+
+		newCommerceShipmentItem.setCompanyId(
+			commerceShipmentItem.getCompanyId());
+
+		newCommerceShipmentItem = _persistence.update(newCommerceShipmentItem);
+
+		Session session = _persistence.getCurrentSession();
+
+		session.evict(newCommerceShipmentItem);
+
+		newCommerceShipmentItem.setExternalReferenceCode(
+			commerceShipmentItem.getExternalReferenceCode());
+
+		_persistence.update(newCommerceShipmentItem);
+	}
+
 	@Test
 	public void testCountByUuid() throws Exception {
 		_persistence.countByUuid("");
@@ -276,12 +301,12 @@ public class CommerceShipmentItemPersistenceTest {
 	}
 
 	@Test
-	public void testCountByC_ERC() throws Exception {
-		_persistence.countByC_ERC(RandomTestUtil.nextLong(), "");
+	public void testCountByERC_C() throws Exception {
+		_persistence.countByERC_C("", RandomTestUtil.nextLong());
 
-		_persistence.countByC_ERC(0L, "null");
+		_persistence.countByERC_C("null", 0L);
 
-		_persistence.countByC_ERC(0L, (String)null);
+		_persistence.countByERC_C((String)null, 0L);
 	}
 
 	@Test
@@ -640,15 +665,15 @@ public class CommerceShipmentItemPersistenceTest {
 				new Class<?>[] {String.class}, "commerceInventoryWarehouseId"));
 
 		Assert.assertEquals(
-			Long.valueOf(commerceShipmentItem.getCompanyId()),
-			ReflectionTestUtil.<Long>invoke(
-				commerceShipmentItem, "getColumnOriginalValue",
-				new Class<?>[] {String.class}, "companyId"));
-		Assert.assertEquals(
 			commerceShipmentItem.getExternalReferenceCode(),
 			ReflectionTestUtil.invoke(
 				commerceShipmentItem, "getColumnOriginalValue",
 				new Class<?>[] {String.class}, "externalReferenceCode"));
+		Assert.assertEquals(
+			Long.valueOf(commerceShipmentItem.getCompanyId()),
+			ReflectionTestUtil.<Long>invoke(
+				commerceShipmentItem, "getColumnOriginalValue",
+				new Class<?>[] {String.class}, "companyId"));
 	}
 
 	protected CommerceShipmentItem addCommerceShipmentItem() throws Exception {

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceShipmentPersistenceTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceShipmentPersistenceTest.java
@@ -15,6 +15,7 @@
 package com.liferay.commerce.service.persistence.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.commerce.exception.DuplicateCommerceShipmentExternalReferenceCodeException;
 import com.liferay.commerce.exception.NoSuchShipmentException;
 import com.liferay.commerce.model.CommerceShipment;
 import com.liferay.commerce.service.CommerceShipmentLocalServiceUtil;
@@ -231,6 +232,28 @@ public class CommerceShipmentPersistenceTest {
 			newCommerceShipment.getStatus());
 	}
 
+	@Test(
+		expected = DuplicateCommerceShipmentExternalReferenceCodeException.class
+	)
+	public void testUpdateWithExistingExternalReferenceCode() throws Exception {
+		CommerceShipment commerceShipment = addCommerceShipment();
+
+		CommerceShipment newCommerceShipment = addCommerceShipment();
+
+		newCommerceShipment.setCompanyId(commerceShipment.getCompanyId());
+
+		newCommerceShipment = _persistence.update(newCommerceShipment);
+
+		Session session = _persistence.getCurrentSession();
+
+		session.evict(newCommerceShipment);
+
+		newCommerceShipment.setExternalReferenceCode(
+			commerceShipment.getExternalReferenceCode());
+
+		_persistence.update(newCommerceShipment);
+	}
+
 	@Test
 	public void testCountByUuid() throws Exception {
 		_persistence.countByUuid("");
@@ -301,12 +324,12 @@ public class CommerceShipmentPersistenceTest {
 	}
 
 	@Test
-	public void testCountByC_ERC() throws Exception {
-		_persistence.countByC_ERC(RandomTestUtil.nextLong(), "");
+	public void testCountByERC_C() throws Exception {
+		_persistence.countByERC_C("", RandomTestUtil.nextLong());
 
-		_persistence.countByC_ERC(0L, "null");
+		_persistence.countByERC_C("null", 0L);
 
-		_persistence.countByC_ERC(0L, (String)null);
+		_persistence.countByERC_C((String)null, 0L);
 	}
 
 	@Test
@@ -624,15 +647,15 @@ public class CommerceShipmentPersistenceTest {
 				new Class<?>[] {String.class}, "groupId"));
 
 		Assert.assertEquals(
-			Long.valueOf(commerceShipment.getCompanyId()),
-			ReflectionTestUtil.<Long>invoke(
-				commerceShipment, "getColumnOriginalValue",
-				new Class<?>[] {String.class}, "companyId"));
-		Assert.assertEquals(
 			commerceShipment.getExternalReferenceCode(),
 			ReflectionTestUtil.invoke(
 				commerceShipment, "getColumnOriginalValue",
 				new Class<?>[] {String.class}, "externalReferenceCode"));
+		Assert.assertEquals(
+			Long.valueOf(commerceShipment.getCompanyId()),
+			ReflectionTestUtil.<Long>invoke(
+				commerceShipment, "getColumnOriginalValue",
+				new Class<?>[] {String.class}, "companyId"));
 	}
 
 	protected CommerceShipment addCommerceShipment() throws Exception {

--- a/modules/apps/dispatch/dispatch-api/bnd.bnd
+++ b/modules/apps/dispatch/dispatch-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Dispatch API
 Bundle-SymbolicName: com.liferay.dispatch.api
-Bundle-Version: 14.2.1
+Bundle-Version: 15.0.0
 Export-Package:\
 	com.liferay.dispatch.configuration,\
 	com.liferay.dispatch.constants,\

--- a/modules/apps/dispatch/dispatch-api/src/main/java/com/liferay/dispatch/exception/DuplicateDispatchTriggerExternalReferenceCodeException.java
+++ b/modules/apps/dispatch/dispatch-api/src/main/java/com/liferay/dispatch/exception/DuplicateDispatchTriggerExternalReferenceCodeException.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.dispatch.exception;
+
+import com.liferay.portal.kernel.exception.SystemException;
+
+/**
+ * @author Matija Petanjek
+ */
+public class DuplicateDispatchTriggerExternalReferenceCodeException
+	extends SystemException {
+
+	public DuplicateDispatchTriggerExternalReferenceCodeException() {
+	}
+
+	public DuplicateDispatchTriggerExternalReferenceCodeException(String msg) {
+		super(msg);
+	}
+
+	public DuplicateDispatchTriggerExternalReferenceCodeException(
+		String msg, Throwable throwable) {
+
+		super(msg, throwable);
+	}
+
+	public DuplicateDispatchTriggerExternalReferenceCodeException(
+		Throwable throwable) {
+
+		super(throwable);
+	}
+
+}

--- a/modules/apps/dispatch/dispatch-api/src/main/java/com/liferay/dispatch/service/DispatchTriggerLocalService.java
+++ b/modules/apps/dispatch/dispatch-api/src/main/java/com/liferay/dispatch/service/DispatchTriggerLocalService.java
@@ -221,24 +221,9 @@ public interface DispatchTriggerLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public DispatchTrigger fetchDispatchTrigger(long companyId, String name);
 
-	/**
-	 * Returns the dispatch trigger with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the dispatch trigger's external reference code
-	 * @return the matching dispatch trigger, or <code>null</code> if a matching dispatch trigger could not be found
-	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public DispatchTrigger fetchDispatchTriggerByExternalReferenceCode(
-		long companyId, String externalReferenceCode);
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchDispatchTriggerByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public DispatchTrigger fetchDispatchTriggerByReferenceCode(
-		long companyId, String externalReferenceCode);
+		String externalReferenceCode, long companyId);
 
 	/**
 	 * Returns the dispatch trigger with the matching UUID and company.
@@ -271,17 +256,9 @@ public interface DispatchTriggerLocalService
 	public DispatchTrigger getDispatchTrigger(long dispatchTriggerId)
 		throws PortalException;
 
-	/**
-	 * Returns the dispatch trigger with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the dispatch trigger's external reference code
-	 * @return the matching dispatch trigger
-	 * @throws PortalException if a matching dispatch trigger could not be found
-	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public DispatchTrigger getDispatchTriggerByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
+			String externalReferenceCode, long companyId)
 		throws PortalException;
 
 	/**

--- a/modules/apps/dispatch/dispatch-api/src/main/java/com/liferay/dispatch/service/DispatchTriggerLocalServiceUtil.java
+++ b/modules/apps/dispatch/dispatch-api/src/main/java/com/liferay/dispatch/service/DispatchTriggerLocalServiceUtil.java
@@ -236,29 +236,11 @@ public class DispatchTriggerLocalServiceUtil {
 		return getService().fetchDispatchTrigger(companyId, name);
 	}
 
-	/**
-	 * Returns the dispatch trigger with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the dispatch trigger's external reference code
-	 * @return the matching dispatch trigger, or <code>null</code> if a matching dispatch trigger could not be found
-	 */
 	public static DispatchTrigger fetchDispatchTriggerByExternalReferenceCode(
-		long companyId, String externalReferenceCode) {
+		String externalReferenceCode, long companyId) {
 
 		return getService().fetchDispatchTriggerByExternalReferenceCode(
-			companyId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchDispatchTriggerByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	public static DispatchTrigger fetchDispatchTriggerByReferenceCode(
-		long companyId, String externalReferenceCode) {
-
-		return getService().fetchDispatchTriggerByReferenceCode(
-			companyId, externalReferenceCode);
+			externalReferenceCode, companyId);
 	}
 
 	/**
@@ -302,20 +284,12 @@ public class DispatchTriggerLocalServiceUtil {
 		return getService().getDispatchTrigger(dispatchTriggerId);
 	}
 
-	/**
-	 * Returns the dispatch trigger with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the dispatch trigger's external reference code
-	 * @return the matching dispatch trigger
-	 * @throws PortalException if a matching dispatch trigger could not be found
-	 */
 	public static DispatchTrigger getDispatchTriggerByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
+			String externalReferenceCode, long companyId)
 		throws PortalException {
 
 		return getService().getDispatchTriggerByExternalReferenceCode(
-			companyId, externalReferenceCode);
+			externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/dispatch/dispatch-api/src/main/java/com/liferay/dispatch/service/DispatchTriggerLocalServiceWrapper.java
+++ b/modules/apps/dispatch/dispatch-api/src/main/java/com/liferay/dispatch/service/DispatchTriggerLocalServiceWrapper.java
@@ -264,34 +264,14 @@ public class DispatchTriggerLocalServiceWrapper
 			companyId, name);
 	}
 
-	/**
-	 * Returns the dispatch trigger with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the dispatch trigger's external reference code
-	 * @return the matching dispatch trigger, or <code>null</code> if a matching dispatch trigger could not be found
-	 */
 	@Override
 	public com.liferay.dispatch.model.DispatchTrigger
 		fetchDispatchTriggerByExternalReferenceCode(
-			long companyId, String externalReferenceCode) {
+			String externalReferenceCode, long companyId) {
 
 		return _dispatchTriggerLocalService.
 			fetchDispatchTriggerByExternalReferenceCode(
-				companyId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchDispatchTriggerByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public com.liferay.dispatch.model.DispatchTrigger
-		fetchDispatchTriggerByReferenceCode(
-			long companyId, String externalReferenceCode) {
-
-		return _dispatchTriggerLocalService.fetchDispatchTriggerByReferenceCode(
-			companyId, externalReferenceCode);
+				externalReferenceCode, companyId);
 	}
 
 	/**
@@ -344,23 +324,15 @@ public class DispatchTriggerLocalServiceWrapper
 			dispatchTriggerId);
 	}
 
-	/**
-	 * Returns the dispatch trigger with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the dispatch trigger's external reference code
-	 * @return the matching dispatch trigger
-	 * @throws PortalException if a matching dispatch trigger could not be found
-	 */
 	@Override
 	public com.liferay.dispatch.model.DispatchTrigger
 			getDispatchTriggerByExternalReferenceCode(
-				long companyId, String externalReferenceCode)
+				String externalReferenceCode, long companyId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _dispatchTriggerLocalService.
 			getDispatchTriggerByExternalReferenceCode(
-				companyId, externalReferenceCode);
+				externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/dispatch/dispatch-api/src/main/java/com/liferay/dispatch/service/persistence/DispatchTriggerPersistence.java
+++ b/modules/apps/dispatch/dispatch-api/src/main/java/com/liferay/dispatch/service/persistence/DispatchTriggerPersistence.java
@@ -1544,57 +1544,57 @@ public interface DispatchTriggerPersistence
 		boolean active, int[] dispatchTaskClusterModes);
 
 	/**
-	 * Returns the dispatch trigger where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchTriggerException</code> if it could not be found.
+	 * Returns the dispatch trigger where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchTriggerException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching dispatch trigger
 	 * @throws NoSuchTriggerException if a matching dispatch trigger could not be found
 	 */
-	public DispatchTrigger findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public DispatchTrigger findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchTriggerException;
 
 	/**
-	 * Returns the dispatch trigger where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the dispatch trigger where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching dispatch trigger, or <code>null</code> if a matching dispatch trigger could not be found
 	 */
-	public DispatchTrigger fetchByC_ERC(
-		long companyId, String externalReferenceCode);
+	public DispatchTrigger fetchByERC_C(
+		String externalReferenceCode, long companyId);
 
 	/**
-	 * Returns the dispatch trigger where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the dispatch trigger where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching dispatch trigger, or <code>null</code> if a matching dispatch trigger could not be found
 	 */
-	public DispatchTrigger fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache);
+	public DispatchTrigger fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache);
 
 	/**
-	 * Removes the dispatch trigger where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the dispatch trigger where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the dispatch trigger that was removed
 	 */
-	public DispatchTrigger removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public DispatchTrigger removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchTriggerException;
 
 	/**
-	 * Returns the number of dispatch triggers where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of dispatch triggers where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching dispatch triggers
 	 */
-	public int countByC_ERC(long companyId, String externalReferenceCode);
+	public int countByERC_C(String externalReferenceCode, long companyId);
 
 	/**
 	 * Caches the dispatch trigger in the entity cache if it is enabled.

--- a/modules/apps/dispatch/dispatch-api/src/main/java/com/liferay/dispatch/service/persistence/DispatchTriggerUtil.java
+++ b/modules/apps/dispatch/dispatch-api/src/main/java/com/liferay/dispatch/service/persistence/DispatchTriggerUtil.java
@@ -1947,73 +1947,73 @@ public class DispatchTriggerUtil {
 	}
 
 	/**
-	 * Returns the dispatch trigger where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchTriggerException</code> if it could not be found.
+	 * Returns the dispatch trigger where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchTriggerException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching dispatch trigger
 	 * @throws NoSuchTriggerException if a matching dispatch trigger could not be found
 	 */
-	public static DispatchTrigger findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public static DispatchTrigger findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws com.liferay.dispatch.exception.NoSuchTriggerException {
 
-		return getPersistence().findByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().findByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the dispatch trigger where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the dispatch trigger where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching dispatch trigger, or <code>null</code> if a matching dispatch trigger could not be found
 	 */
-	public static DispatchTrigger fetchByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public static DispatchTrigger fetchByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return getPersistence().fetchByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().fetchByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the dispatch trigger where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the dispatch trigger where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching dispatch trigger, or <code>null</code> if a matching dispatch trigger could not be found
 	 */
-	public static DispatchTrigger fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache) {
+	public static DispatchTrigger fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache) {
 
-		return getPersistence().fetchByC_ERC(
-			companyId, externalReferenceCode, useFinderCache);
+		return getPersistence().fetchByERC_C(
+			externalReferenceCode, companyId, useFinderCache);
 	}
 
 	/**
-	 * Removes the dispatch trigger where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the dispatch trigger where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the dispatch trigger that was removed
 	 */
-	public static DispatchTrigger removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public static DispatchTrigger removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws com.liferay.dispatch.exception.NoSuchTriggerException {
 
-		return getPersistence().removeByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().removeByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the number of dispatch triggers where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of dispatch triggers where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching dispatch triggers
 	 */
-	public static int countByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public static int countByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return getPersistence().countByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().countByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/dispatch/dispatch-api/src/main/resources/com/liferay/dispatch/exception/packageinfo
+++ b/modules/apps/dispatch/dispatch-api/src/main/resources/com/liferay/dispatch/exception/packageinfo
@@ -1,1 +1,1 @@
-version 1.2.0
+version 1.3.0

--- a/modules/apps/dispatch/dispatch-api/src/main/resources/com/liferay/dispatch/service/packageinfo
+++ b/modules/apps/dispatch/dispatch-api/src/main/resources/com/liferay/dispatch/service/packageinfo
@@ -1,1 +1,1 @@
-version 7.1.0
+version 8.0.0

--- a/modules/apps/dispatch/dispatch-api/src/main/resources/com/liferay/dispatch/service/persistence/packageinfo
+++ b/modules/apps/dispatch/dispatch-api/src/main/resources/com/liferay/dispatch/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 3.2.0
+version 4.0.0

--- a/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/service/base/DispatchTriggerLocalServiceBaseImpl.java
+++ b/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/service/base/DispatchTriggerLocalServiceBaseImpl.java
@@ -272,48 +272,21 @@ public abstract class DispatchTriggerLocalServiceBaseImpl
 			uuid, companyId, null);
 	}
 
-	/**
-	 * Returns the dispatch trigger with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the dispatch trigger's external reference code
-	 * @return the matching dispatch trigger, or <code>null</code> if a matching dispatch trigger could not be found
-	 */
 	@Override
 	public DispatchTrigger fetchDispatchTriggerByExternalReferenceCode(
-		long companyId, String externalReferenceCode) {
+		String externalReferenceCode, long companyId) {
 
-		return dispatchTriggerPersistence.fetchByC_ERC(
-			companyId, externalReferenceCode);
+		return dispatchTriggerPersistence.fetchByERC_C(
+			externalReferenceCode, companyId);
 	}
 
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchDispatchTriggerByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public DispatchTrigger fetchDispatchTriggerByReferenceCode(
-		long companyId, String externalReferenceCode) {
-
-		return fetchDispatchTriggerByExternalReferenceCode(
-			companyId, externalReferenceCode);
-	}
-
-	/**
-	 * Returns the dispatch trigger with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the dispatch trigger's external reference code
-	 * @return the matching dispatch trigger
-	 * @throws PortalException if a matching dispatch trigger could not be found
-	 */
 	@Override
 	public DispatchTrigger getDispatchTriggerByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
+			String externalReferenceCode, long companyId)
 		throws PortalException {
 
-		return dispatchTriggerPersistence.findByC_ERC(
-			companyId, externalReferenceCode);
+		return dispatchTriggerPersistence.findByERC_C(
+			externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/service/persistence/impl/DispatchTriggerPersistenceImpl.java
+++ b/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/service/persistence/impl/DispatchTriggerPersistenceImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.dispatch.service.persistence.impl;
 
+import com.liferay.dispatch.exception.DuplicateDispatchTriggerExternalReferenceCodeException;
 import com.liferay.dispatch.exception.NoSuchTriggerException;
 import com.liferay.dispatch.model.DispatchTrigger;
 import com.liferay.dispatch.model.DispatchTriggerTable;
@@ -6680,35 +6681,35 @@ public class DispatchTriggerPersistenceImpl
 		_FINDER_COLUMN_A_DTCM_DISPATCHTASKCLUSTERMODE_7 =
 			"dispatchTrigger.dispatchTaskClusterMode IN (";
 
-	private FinderPath _finderPathFetchByC_ERC;
-	private FinderPath _finderPathCountByC_ERC;
+	private FinderPath _finderPathFetchByERC_C;
+	private FinderPath _finderPathCountByERC_C;
 
 	/**
-	 * Returns the dispatch trigger where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchTriggerException</code> if it could not be found.
+	 * Returns the dispatch trigger where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchTriggerException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching dispatch trigger
 	 * @throws NoSuchTriggerException if a matching dispatch trigger could not be found
 	 */
 	@Override
-	public DispatchTrigger findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public DispatchTrigger findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchTriggerException {
 
-		DispatchTrigger dispatchTrigger = fetchByC_ERC(
-			companyId, externalReferenceCode);
+		DispatchTrigger dispatchTrigger = fetchByERC_C(
+			externalReferenceCode, companyId);
 
 		if (dispatchTrigger == null) {
 			StringBundler sb = new StringBundler(6);
 
 			sb.append(_NO_SUCH_ENTITY_WITH_KEY);
 
-			sb.append("companyId=");
-			sb.append(companyId);
-
-			sb.append(", externalReferenceCode=");
+			sb.append("externalReferenceCode=");
 			sb.append(externalReferenceCode);
+
+			sb.append(", companyId=");
+			sb.append(companyId);
 
 			sb.append("}");
 
@@ -6723,53 +6724,53 @@ public class DispatchTriggerPersistenceImpl
 	}
 
 	/**
-	 * Returns the dispatch trigger where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the dispatch trigger where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching dispatch trigger, or <code>null</code> if a matching dispatch trigger could not be found
 	 */
 	@Override
-	public DispatchTrigger fetchByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public DispatchTrigger fetchByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return fetchByC_ERC(companyId, externalReferenceCode, true);
+		return fetchByERC_C(externalReferenceCode, companyId, true);
 	}
 
 	/**
-	 * Returns the dispatch trigger where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the dispatch trigger where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching dispatch trigger, or <code>null</code> if a matching dispatch trigger could not be found
 	 */
 	@Override
-	public DispatchTrigger fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache) {
+	public DispatchTrigger fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache) {
 
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
 		Object[] finderArgs = null;
 
 		if (useFinderCache) {
-			finderArgs = new Object[] {companyId, externalReferenceCode};
+			finderArgs = new Object[] {externalReferenceCode, companyId};
 		}
 
 		Object result = null;
 
 		if (useFinderCache) {
 			result = finderCache.getResult(
-				_finderPathFetchByC_ERC, finderArgs, this);
+				_finderPathFetchByERC_C, finderArgs, this);
 		}
 
 		if (result instanceof DispatchTrigger) {
 			DispatchTrigger dispatchTrigger = (DispatchTrigger)result;
 
-			if ((companyId != dispatchTrigger.getCompanyId()) ||
-				!Objects.equals(
+			if (!Objects.equals(
 					externalReferenceCode,
-					dispatchTrigger.getExternalReferenceCode())) {
+					dispatchTrigger.getExternalReferenceCode()) ||
+				(companyId != dispatchTrigger.getCompanyId())) {
 
 				result = null;
 			}
@@ -6780,18 +6781,18 @@ public class DispatchTriggerPersistenceImpl
 
 			sb.append(_SQL_SELECT_DISPATCHTRIGGER_WHERE);
 
-			sb.append(_FINDER_COLUMN_C_ERC_COMPANYID_2);
-
 			boolean bindExternalReferenceCode = false;
 
 			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3);
 			}
 			else {
 				bindExternalReferenceCode = true;
 
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2);
 			}
+
+			sb.append(_FINDER_COLUMN_ERC_C_COMPANYID_2);
 
 			String sql = sb.toString();
 
@@ -6804,18 +6805,18 @@ public class DispatchTriggerPersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
-				queryPos.add(companyId);
-
 				if (bindExternalReferenceCode) {
 					queryPos.add(externalReferenceCode);
 				}
+
+				queryPos.add(companyId);
 
 				List<DispatchTrigger> list = query.list();
 
 				if (list.isEmpty()) {
 					if (useFinderCache) {
 						finderCache.putResult(
-							_finderPathFetchByC_ERC, finderArgs, list);
+							_finderPathFetchByERC_C, finderArgs, list);
 					}
 				}
 				else {
@@ -6843,37 +6844,37 @@ public class DispatchTriggerPersistenceImpl
 	}
 
 	/**
-	 * Removes the dispatch trigger where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the dispatch trigger where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the dispatch trigger that was removed
 	 */
 	@Override
-	public DispatchTrigger removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public DispatchTrigger removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchTriggerException {
 
-		DispatchTrigger dispatchTrigger = findByC_ERC(
-			companyId, externalReferenceCode);
+		DispatchTrigger dispatchTrigger = findByERC_C(
+			externalReferenceCode, companyId);
 
 		return remove(dispatchTrigger);
 	}
 
 	/**
-	 * Returns the number of dispatch triggers where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of dispatch triggers where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching dispatch triggers
 	 */
 	@Override
-	public int countByC_ERC(long companyId, String externalReferenceCode) {
+	public int countByERC_C(String externalReferenceCode, long companyId) {
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
-		FinderPath finderPath = _finderPathCountByC_ERC;
+		FinderPath finderPath = _finderPathCountByERC_C;
 
-		Object[] finderArgs = new Object[] {companyId, externalReferenceCode};
+		Object[] finderArgs = new Object[] {externalReferenceCode, companyId};
 
 		Long count = (Long)finderCache.getResult(finderPath, finderArgs, this);
 
@@ -6882,18 +6883,18 @@ public class DispatchTriggerPersistenceImpl
 
 			sb.append(_SQL_COUNT_DISPATCHTRIGGER_WHERE);
 
-			sb.append(_FINDER_COLUMN_C_ERC_COMPANYID_2);
-
 			boolean bindExternalReferenceCode = false;
 
 			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3);
 			}
 			else {
 				bindExternalReferenceCode = true;
 
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2);
 			}
+
+			sb.append(_FINDER_COLUMN_ERC_C_COMPANYID_2);
 
 			String sql = sb.toString();
 
@@ -6906,11 +6907,11 @@ public class DispatchTriggerPersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
-				queryPos.add(companyId);
-
 				if (bindExternalReferenceCode) {
 					queryPos.add(externalReferenceCode);
 				}
+
+				queryPos.add(companyId);
 
 				count = (Long)query.uniqueResult();
 
@@ -6927,14 +6928,14 @@ public class DispatchTriggerPersistenceImpl
 		return count.intValue();
 	}
 
-	private static final String _FINDER_COLUMN_C_ERC_COMPANYID_2 =
-		"dispatchTrigger.companyId = ? AND ";
+	private static final String _FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2 =
+		"dispatchTrigger.externalReferenceCode = ? AND ";
 
-	private static final String _FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2 =
-		"dispatchTrigger.externalReferenceCode = ?";
+	private static final String _FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3 =
+		"(dispatchTrigger.externalReferenceCode IS NULL OR dispatchTrigger.externalReferenceCode = '') AND ";
 
-	private static final String _FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3 =
-		"(dispatchTrigger.externalReferenceCode IS NULL OR dispatchTrigger.externalReferenceCode = '')";
+	private static final String _FINDER_COLUMN_ERC_C_COMPANYID_2 =
+		"dispatchTrigger.companyId = ?";
 
 	public DispatchTriggerPersistenceImpl() {
 		Map<String, String> dbColumnNames = new HashMap<String, String>();
@@ -6972,10 +6973,10 @@ public class DispatchTriggerPersistenceImpl
 			dispatchTrigger);
 
 		finderCache.putResult(
-			_finderPathFetchByC_ERC,
+			_finderPathFetchByERC_C,
 			new Object[] {
-				dispatchTrigger.getCompanyId(),
-				dispatchTrigger.getExternalReferenceCode()
+				dispatchTrigger.getExternalReferenceCode(),
+				dispatchTrigger.getCompanyId()
 			},
 			dispatchTrigger);
 	}
@@ -7063,13 +7064,13 @@ public class DispatchTriggerPersistenceImpl
 			_finderPathFetchByC_N, args, dispatchTriggerModelImpl);
 
 		args = new Object[] {
-			dispatchTriggerModelImpl.getCompanyId(),
-			dispatchTriggerModelImpl.getExternalReferenceCode()
+			dispatchTriggerModelImpl.getExternalReferenceCode(),
+			dispatchTriggerModelImpl.getCompanyId()
 		};
 
-		finderCache.putResult(_finderPathCountByC_ERC, args, Long.valueOf(1));
+		finderCache.putResult(_finderPathCountByERC_C, args, Long.valueOf(1));
 		finderCache.putResult(
-			_finderPathFetchByC_ERC, args, dispatchTriggerModelImpl);
+			_finderPathFetchByERC_C, args, dispatchTriggerModelImpl);
 	}
 
 	/**
@@ -7212,6 +7213,29 @@ public class DispatchTriggerPersistenceImpl
 
 		if (Validator.isNull(dispatchTrigger.getExternalReferenceCode())) {
 			dispatchTrigger.setExternalReferenceCode(dispatchTrigger.getUuid());
+		}
+		else {
+			DispatchTrigger ercDispatchTrigger = fetchByERC_C(
+				dispatchTrigger.getExternalReferenceCode(),
+				dispatchTrigger.getCompanyId());
+
+			if (isNew) {
+				if (ercDispatchTrigger != null) {
+					throw new DuplicateDispatchTriggerExternalReferenceCodeException(
+						"Duplicate DispatchTrigger with external reference code " +
+							dispatchTrigger.getExternalReferenceCode());
+				}
+			}
+			else {
+				if ((ercDispatchTrigger != null) &&
+					(dispatchTrigger.getDispatchTriggerId() !=
+						ercDispatchTrigger.getDispatchTriggerId())) {
+
+					throw new DuplicateDispatchTriggerExternalReferenceCodeException(
+						"Duplicate DispatchTrigger with external reference code " +
+							dispatchTrigger.getExternalReferenceCode());
+				}
+			}
 		}
 
 		ServiceContext serviceContext =
@@ -7676,15 +7700,15 @@ public class DispatchTriggerPersistenceImpl
 			new String[] {Boolean.class.getName(), Integer.class.getName()},
 			new String[] {"active_", "dispatchTaskClusterMode"}, false);
 
-		_finderPathFetchByC_ERC = new FinderPath(
-			FINDER_CLASS_NAME_ENTITY, "fetchByC_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"companyId", "externalReferenceCode"}, true);
+		_finderPathFetchByERC_C = new FinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, true);
 
-		_finderPathCountByC_ERC = new FinderPath(
-			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"companyId", "externalReferenceCode"}, false);
+		_finderPathCountByERC_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, false);
 
 		_setDispatchTriggerUtilPersistence(this);
 	}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/AccountResourceDTOConverter.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/AccountResourceDTOConverter.java
@@ -62,7 +62,7 @@ public class AccountResourceDTOConverter
 
 		AccountEntry accountEntry =
 			_accountEntryLocalService.fetchAccountEntryByExternalReferenceCode(
-				CompanyThreadLocal.getCompanyId(), externalReferenceCode);
+				externalReferenceCode, CompanyThreadLocal.getCompanyId());
 
 		if (accountEntry == null) {
 			accountEntry = _accountEntryLocalService.getAccountEntry(

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/src/main/java/com/liferay/headless/batch/engine/internal/resource/v1_0/ExportTaskResourceImpl.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/src/main/java/com/liferay/headless/batch/engine/internal/resource/v1_0/ExportTaskResourceImpl.java
@@ -66,7 +66,7 @@ public class ExportTaskResourceImpl extends BaseExportTaskResourceImpl {
 		return _toExportTask(
 			_batchEngineExportTaskLocalService.
 				getBatchEngineExportTaskByExternalReferenceCode(
-					contextCompany.getCompanyId(), externalReferenceCode));
+					externalReferenceCode, contextCompany.getCompanyId()));
 	}
 
 	@Override
@@ -77,7 +77,7 @@ public class ExportTaskResourceImpl extends BaseExportTaskResourceImpl {
 		BatchEngineExportTask batchEngineExportTask =
 			_batchEngineExportTaskLocalService.
 				getBatchEngineExportTaskByExternalReferenceCode(
-					contextCompany.getCompanyId(), externalReferenceCode);
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		return _getExportTaskContent(batchEngineExportTask);
 	}

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/src/main/java/com/liferay/headless/batch/engine/internal/resource/v1_0/ImportTaskResourceImpl.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/src/main/java/com/liferay/headless/batch/engine/internal/resource/v1_0/ImportTaskResourceImpl.java
@@ -131,7 +131,7 @@ public class ImportTaskResourceImpl extends BaseImportTaskResourceImpl {
 		return _toImportTask(
 			_batchEngineImportTaskLocalService.
 				getBatchEngineImportTaskByExternalReferenceCode(
-					contextCompany.getCompanyId(), externalReferenceCode));
+					externalReferenceCode, contextCompany.getCompanyId()));
 	}
 
 	@Override
@@ -142,7 +142,7 @@ public class ImportTaskResourceImpl extends BaseImportTaskResourceImpl {
 		return _getImportTaskContent(
 			_batchEngineImportTaskLocalService.
 				getBatchEngineImportTaskByExternalReferenceCode(
-					contextCompany.getCompanyId(), externalReferenceCode));
+					externalReferenceCode, contextCompany.getCompanyId()));
 	}
 
 	@Override
@@ -153,7 +153,7 @@ public class ImportTaskResourceImpl extends BaseImportTaskResourceImpl {
 		BatchEngineImportTask batchEngineImportTask =
 			_batchEngineImportTaskLocalService.
 				getBatchEngineImportTaskByExternalReferenceCode(
-					contextCompany.getCompanyId(), externalReferenceCode);
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		return _getImportTaskFailedItemReport(
 			batchEngineImportTask.getBatchEngineImportTaskId());

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BlogPostingResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BlogPostingResourceImpl.java
@@ -102,7 +102,7 @@ public class BlogPostingResourceImpl extends BaseBlogPostingResourceImpl {
 
 		BlogsEntry blogsEntry =
 			_blogsEntryLocalService.getBlogsEntryByExternalReferenceCode(
-				siteId, externalReferenceCode);
+				externalReferenceCode, siteId);
 
 		_blogsEntryService.deleteEntry(blogsEntry.getEntryId());
 	}
@@ -256,7 +256,7 @@ public class BlogPostingResourceImpl extends BaseBlogPostingResourceImpl {
 
 		BlogsEntry blogsEntry =
 			_blogsEntryLocalService.fetchBlogsEntryByExternalReferenceCode(
-				siteId, externalReferenceCode);
+				externalReferenceCode, siteId);
 
 		if (blogsEntry != null) {
 			return _updateBlogPosting(blogsEntry, blogPosting);

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/KnowledgeBaseFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/KnowledgeBaseFolderResourceImpl.java
@@ -67,7 +67,7 @@ public class KnowledgeBaseFolderResourceImpl
 
 		KBFolder kbFolder =
 			_kbFolderLocalService.getKBFolderByExternalReferenceCode(
-				siteId, externalReferenceCode);
+				externalReferenceCode, siteId);
 
 		_kbFolderService.deleteKBFolder(kbFolder.getKbFolderId());
 	}
@@ -210,7 +210,7 @@ public class KnowledgeBaseFolderResourceImpl
 
 		KBFolder kbFolder =
 			_kbFolderLocalService.fetchKBFolderByExternalReferenceCode(
-				siteId, externalReferenceCode);
+				externalReferenceCode, siteId);
 
 		if (kbFolder != null) {
 			return _updateKnowledgeBaseFolder(kbFolder, knowledgeBaseFolder);

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardMessageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardMessageResourceImpl.java
@@ -123,7 +123,7 @@ public class MessageBoardMessageResourceImpl
 
 		MBMessage mbMessage =
 			_mbMessageLocalService.getMBMessageByExternalReferenceCode(
-				siteId, externalReferenceCode);
+				externalReferenceCode, siteId);
 
 		_mbMessageService.deleteMessage(mbMessage.getMessageId());
 	}
@@ -307,7 +307,7 @@ public class MessageBoardMessageResourceImpl
 
 		return _toMessageBoardMessage(
 			_mbMessageLocalService.getMBMessageByExternalReferenceCode(
-				siteId, externalReferenceCode));
+				externalReferenceCode, siteId));
 	}
 
 	@Override
@@ -439,7 +439,7 @@ public class MessageBoardMessageResourceImpl
 
 		MBMessage mbMessage =
 			_mbMessageLocalService.fetchMBMessageByExternalReferenceCode(
-				siteId, externalReferenceCode);
+				externalReferenceCode, siteId);
 
 		if (mbMessage != null) {
 			return _updateMessageBoardMessage(mbMessage, messageBoardMessage);

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentFolderResourceImpl.java
@@ -327,7 +327,7 @@ public class StructuredContentFolderResourceImpl
 		JournalFolder journalFolder =
 			_journalFolderLocalService.
 				fetchJournalFolderByExternalReferenceCode(
-					assetLibraryId, externalReferenceCode);
+					externalReferenceCode, assetLibraryId);
 
 		if (journalFolder != null) {
 			return _updateStructuredContentFolder(
@@ -351,7 +351,7 @@ public class StructuredContentFolderResourceImpl
 		JournalFolder journalFolder =
 			_journalFolderLocalService.
 				fetchJournalFolderByExternalReferenceCode(
-					siteId, externalReferenceCode);
+					externalReferenceCode, siteId);
 
 		if (journalFolder != null) {
 			return _updateStructuredContentFolder(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/WikiNodeResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/WikiNodeResourceImpl.java
@@ -61,7 +61,7 @@ public class WikiNodeResourceImpl extends BaseWikiNodeResourceImpl {
 
 		com.liferay.wiki.model.WikiNode wikiNode =
 			_wikiNodeLocalService.getWikiNodeByExternalReferenceCode(
-				siteId, externalReferenceCode);
+				externalReferenceCode, siteId);
 
 		_wikiNodeService.deleteNode(wikiNode.getNodeId());
 	}
@@ -156,7 +156,7 @@ public class WikiNodeResourceImpl extends BaseWikiNodeResourceImpl {
 
 		com.liferay.wiki.model.WikiNode serviceBuilderWikiNode =
 			_wikiNodeLocalService.fetchWikiNodeByExternalReferenceCode(
-				siteId, externalReferenceCode);
+				externalReferenceCode, siteId);
 
 		if (serviceBuilderWikiNode != null) {
 			return _updateWikiNode(serviceBuilderWikiNode, wikiNode);

--- a/modules/apps/journal/journal-api/bnd.bnd
+++ b/modules/apps/journal/journal-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Journal API
 Bundle-SymbolicName: com.liferay.journal.api
-Bundle-Version: 19.0.1
+Bundle-Version: 20.0.0
 Export-Package:\
 	com.liferay.journal.configuration,\
 	com.liferay.journal.constants,\

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/exception/DuplicateArticleExternalReferenceCodeException.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/exception/DuplicateArticleExternalReferenceCodeException.java
@@ -14,13 +14,13 @@
 
 package com.liferay.journal.exception;
 
-import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.SystemException;
 
 /**
  * @author Brian Wing Shun Chan
  */
 public class DuplicateArticleExternalReferenceCodeException
-	extends PortalException {
+	extends SystemException {
 
 	public DuplicateArticleExternalReferenceCodeException() {
 	}

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/exception/DuplicateFolderExternalReferenceCodeException.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/exception/DuplicateFolderExternalReferenceCodeException.java
@@ -14,13 +14,13 @@
 
 package com.liferay.journal.exception;
 
-import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.SystemException;
 
 /**
  * @author Brian Wing Shun Chan
  */
 public class DuplicateFolderExternalReferenceCodeException
-	extends PortalException {
+	extends SystemException {
 
 	public DuplicateFolderExternalReferenceCodeException() {
 	}

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/exception/DuplicateJournalFolderExternalReferenceCodeException.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/exception/DuplicateJournalFolderExternalReferenceCodeException.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.journal.exception;
+
+import com.liferay.portal.kernel.exception.SystemException;
+
+/**
+ * @author Brian Wing Shun Chan
+ */
+public class DuplicateJournalFolderExternalReferenceCodeException
+	extends SystemException {
+
+	public DuplicateJournalFolderExternalReferenceCodeException() {
+	}
+
+	public DuplicateJournalFolderExternalReferenceCodeException(String msg) {
+		super(msg);
+	}
+
+	public DuplicateJournalFolderExternalReferenceCodeException(
+		String msg, Throwable throwable) {
+
+		super(msg, throwable);
+	}
+
+	public DuplicateJournalFolderExternalReferenceCodeException(
+		Throwable throwable) {
+
+		super(throwable);
+	}
+
+}

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalFolderLocalService.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalFolderLocalService.java
@@ -255,24 +255,9 @@ public interface JournalFolderLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public JournalFolder fetchJournalFolder(long folderId);
 
-	/**
-	 * Returns the journal folder with the matching external reference code and group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the journal folder's external reference code
-	 * @return the matching journal folder, or <code>null</code> if a matching journal folder could not be found
-	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public JournalFolder fetchJournalFolderByExternalReferenceCode(
-		long groupId, String externalReferenceCode);
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchJournalFolderByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public JournalFolder fetchJournalFolderByReferenceCode(
-		long groupId, String externalReferenceCode);
+		String externalReferenceCode, long groupId);
 
 	/**
 	 * Returns the journal folder matching the UUID and group.
@@ -382,17 +367,9 @@ public interface JournalFolderLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public JournalFolder getJournalFolder(long folderId) throws PortalException;
 
-	/**
-	 * Returns the journal folder with the matching external reference code and group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the journal folder's external reference code
-	 * @return the matching journal folder
-	 * @throws PortalException if a matching journal folder could not be found
-	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public JournalFolder getJournalFolderByExternalReferenceCode(
-			long groupId, String externalReferenceCode)
+			String externalReferenceCode, long groupId)
 		throws PortalException;
 
 	/**

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalFolderLocalServiceUtil.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalFolderLocalServiceUtil.java
@@ -265,29 +265,11 @@ public class JournalFolderLocalServiceUtil {
 		return getService().fetchJournalFolder(folderId);
 	}
 
-	/**
-	 * Returns the journal folder with the matching external reference code and group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the journal folder's external reference code
-	 * @return the matching journal folder, or <code>null</code> if a matching journal folder could not be found
-	 */
 	public static JournalFolder fetchJournalFolderByExternalReferenceCode(
-		long groupId, String externalReferenceCode) {
+		String externalReferenceCode, long groupId) {
 
 		return getService().fetchJournalFolderByExternalReferenceCode(
-			groupId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchJournalFolderByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	public static JournalFolder fetchJournalFolderByReferenceCode(
-		long groupId, String externalReferenceCode) {
-
-		return getService().fetchJournalFolderByReferenceCode(
-			groupId, externalReferenceCode);
+			externalReferenceCode, groupId);
 	}
 
 	/**
@@ -465,20 +447,12 @@ public class JournalFolderLocalServiceUtil {
 		return getService().getJournalFolder(folderId);
 	}
 
-	/**
-	 * Returns the journal folder with the matching external reference code and group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the journal folder's external reference code
-	 * @return the matching journal folder
-	 * @throws PortalException if a matching journal folder could not be found
-	 */
 	public static JournalFolder getJournalFolderByExternalReferenceCode(
-			long groupId, String externalReferenceCode)
+			String externalReferenceCode, long groupId)
 		throws PortalException {
 
 		return getService().getJournalFolderByExternalReferenceCode(
-			groupId, externalReferenceCode);
+			externalReferenceCode, groupId);
 	}
 
 	/**

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalFolderLocalServiceWrapper.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalFolderLocalServiceWrapper.java
@@ -298,32 +298,13 @@ public class JournalFolderLocalServiceWrapper
 		return _journalFolderLocalService.fetchJournalFolder(folderId);
 	}
 
-	/**
-	 * Returns the journal folder with the matching external reference code and group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the journal folder's external reference code
-	 * @return the matching journal folder, or <code>null</code> if a matching journal folder could not be found
-	 */
 	@Override
 	public JournalFolder fetchJournalFolderByExternalReferenceCode(
-		long groupId, String externalReferenceCode) {
+		String externalReferenceCode, long groupId) {
 
 		return _journalFolderLocalService.
 			fetchJournalFolderByExternalReferenceCode(
-				groupId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchJournalFolderByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public JournalFolder fetchJournalFolderByReferenceCode(
-		long groupId, String externalReferenceCode) {
-
-		return _journalFolderLocalService.fetchJournalFolderByReferenceCode(
-			groupId, externalReferenceCode);
+				externalReferenceCode, groupId);
 	}
 
 	/**
@@ -534,22 +515,14 @@ public class JournalFolderLocalServiceWrapper
 		return _journalFolderLocalService.getJournalFolder(folderId);
 	}
 
-	/**
-	 * Returns the journal folder with the matching external reference code and group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the journal folder's external reference code
-	 * @return the matching journal folder
-	 * @throws PortalException if a matching journal folder could not be found
-	 */
 	@Override
 	public JournalFolder getJournalFolderByExternalReferenceCode(
-			long groupId, String externalReferenceCode)
+			String externalReferenceCode, long groupId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _journalFolderLocalService.
 			getJournalFolderByExternalReferenceCode(
-				groupId, externalReferenceCode);
+				externalReferenceCode, groupId);
 	}
 
 	/**

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/persistence/JournalFolderPersistence.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/persistence/JournalFolderPersistence.java
@@ -1877,56 +1877,56 @@ public interface JournalFolderPersistence
 		long folderId, long companyId, long parentFolderId, int status);
 
 	/**
-	 * Returns the journal folder where groupId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchFolderException</code> if it could not be found.
+	 * Returns the journal folder where externalReferenceCode = &#63; and groupId = &#63; or throws a <code>NoSuchFolderException</code> if it could not be found.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the matching journal folder
 	 * @throws NoSuchFolderException if a matching journal folder could not be found
 	 */
-	public JournalFolder findByG_ERC(long groupId, String externalReferenceCode)
+	public JournalFolder findByERC_G(String externalReferenceCode, long groupId)
 		throws NoSuchFolderException;
 
 	/**
-	 * Returns the journal folder where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the journal folder where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the matching journal folder, or <code>null</code> if a matching journal folder could not be found
 	 */
-	public JournalFolder fetchByG_ERC(
-		long groupId, String externalReferenceCode);
+	public JournalFolder fetchByERC_G(
+		String externalReferenceCode, long groupId);
 
 	/**
-	 * Returns the journal folder where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the journal folder where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching journal folder, or <code>null</code> if a matching journal folder could not be found
 	 */
-	public JournalFolder fetchByG_ERC(
-		long groupId, String externalReferenceCode, boolean useFinderCache);
+	public JournalFolder fetchByERC_G(
+		String externalReferenceCode, long groupId, boolean useFinderCache);
 
 	/**
-	 * Removes the journal folder where groupId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the journal folder where externalReferenceCode = &#63; and groupId = &#63; from the database.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the journal folder that was removed
 	 */
-	public JournalFolder removeByG_ERC(
-			long groupId, String externalReferenceCode)
+	public JournalFolder removeByERC_G(
+			String externalReferenceCode, long groupId)
 		throws NoSuchFolderException;
 
 	/**
-	 * Returns the number of journal folders where groupId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of journal folders where externalReferenceCode = &#63; and groupId = &#63;.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the number of matching journal folders
 	 */
-	public int countByG_ERC(long groupId, String externalReferenceCode);
+	public int countByERC_G(String externalReferenceCode, long groupId);
 
 	/**
 	 * Caches the journal folder in the entity cache if it is enabled.

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/persistence/JournalFolderUtil.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/persistence/JournalFolderUtil.java
@@ -2334,71 +2334,71 @@ public class JournalFolderUtil {
 	}
 
 	/**
-	 * Returns the journal folder where groupId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchFolderException</code> if it could not be found.
+	 * Returns the journal folder where externalReferenceCode = &#63; and groupId = &#63; or throws a <code>NoSuchFolderException</code> if it could not be found.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the matching journal folder
 	 * @throws NoSuchFolderException if a matching journal folder could not be found
 	 */
-	public static JournalFolder findByG_ERC(
-			long groupId, String externalReferenceCode)
+	public static JournalFolder findByERC_G(
+			String externalReferenceCode, long groupId)
 		throws com.liferay.journal.exception.NoSuchFolderException {
 
-		return getPersistence().findByG_ERC(groupId, externalReferenceCode);
+		return getPersistence().findByERC_G(externalReferenceCode, groupId);
 	}
 
 	/**
-	 * Returns the journal folder where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the journal folder where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the matching journal folder, or <code>null</code> if a matching journal folder could not be found
 	 */
-	public static JournalFolder fetchByG_ERC(
-		long groupId, String externalReferenceCode) {
+	public static JournalFolder fetchByERC_G(
+		String externalReferenceCode, long groupId) {
 
-		return getPersistence().fetchByG_ERC(groupId, externalReferenceCode);
+		return getPersistence().fetchByERC_G(externalReferenceCode, groupId);
 	}
 
 	/**
-	 * Returns the journal folder where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the journal folder where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching journal folder, or <code>null</code> if a matching journal folder could not be found
 	 */
-	public static JournalFolder fetchByG_ERC(
-		long groupId, String externalReferenceCode, boolean useFinderCache) {
+	public static JournalFolder fetchByERC_G(
+		String externalReferenceCode, long groupId, boolean useFinderCache) {
 
-		return getPersistence().fetchByG_ERC(
-			groupId, externalReferenceCode, useFinderCache);
+		return getPersistence().fetchByERC_G(
+			externalReferenceCode, groupId, useFinderCache);
 	}
 
 	/**
-	 * Removes the journal folder where groupId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the journal folder where externalReferenceCode = &#63; and groupId = &#63; from the database.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the journal folder that was removed
 	 */
-	public static JournalFolder removeByG_ERC(
-			long groupId, String externalReferenceCode)
+	public static JournalFolder removeByERC_G(
+			String externalReferenceCode, long groupId)
 		throws com.liferay.journal.exception.NoSuchFolderException {
 
-		return getPersistence().removeByG_ERC(groupId, externalReferenceCode);
+		return getPersistence().removeByERC_G(externalReferenceCode, groupId);
 	}
 
 	/**
-	 * Returns the number of journal folders where groupId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of journal folders where externalReferenceCode = &#63; and groupId = &#63;.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the number of matching journal folders
 	 */
-	public static int countByG_ERC(long groupId, String externalReferenceCode) {
-		return getPersistence().countByG_ERC(groupId, externalReferenceCode);
+	public static int countByERC_G(String externalReferenceCode, long groupId) {
+		return getPersistence().countByERC_G(externalReferenceCode, groupId);
 	}
 
 	/**

--- a/modules/apps/journal/journal-api/src/main/resources/com/liferay/journal/exception/packageinfo
+++ b/modules/apps/journal/journal-api/src/main/resources/com/liferay/journal/exception/packageinfo
@@ -1,1 +1,1 @@
-version 2.4.0
+version 3.0.0

--- a/modules/apps/journal/journal-api/src/main/resources/com/liferay/journal/service/packageinfo
+++ b/modules/apps/journal/journal-api/src/main/resources/com/liferay/journal/service/packageinfo
@@ -1,1 +1,1 @@
-version 7.1.0
+version 8.0.0

--- a/modules/apps/journal/journal-api/src/main/resources/com/liferay/journal/service/persistence/packageinfo
+++ b/modules/apps/journal/journal-api/src/main/resources/com/liferay/journal/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 7.1.0
+version 8.0.0

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/base/JournalFolderLocalServiceBaseImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/base/JournalFolderLocalServiceBaseImpl.java
@@ -279,48 +279,21 @@ public abstract class JournalFolderLocalServiceBaseImpl
 		return journalFolderPersistence.fetchByUUID_G(uuid, groupId);
 	}
 
-	/**
-	 * Returns the journal folder with the matching external reference code and group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the journal folder's external reference code
-	 * @return the matching journal folder, or <code>null</code> if a matching journal folder could not be found
-	 */
 	@Override
 	public JournalFolder fetchJournalFolderByExternalReferenceCode(
-		long groupId, String externalReferenceCode) {
+		String externalReferenceCode, long groupId) {
 
-		return journalFolderPersistence.fetchByG_ERC(
-			groupId, externalReferenceCode);
+		return journalFolderPersistence.fetchByERC_G(
+			externalReferenceCode, groupId);
 	}
 
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchJournalFolderByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public JournalFolder fetchJournalFolderByReferenceCode(
-		long groupId, String externalReferenceCode) {
-
-		return fetchJournalFolderByExternalReferenceCode(
-			groupId, externalReferenceCode);
-	}
-
-	/**
-	 * Returns the journal folder with the matching external reference code and group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the journal folder's external reference code
-	 * @return the matching journal folder
-	 * @throws PortalException if a matching journal folder could not be found
-	 */
 	@Override
 	public JournalFolder getJournalFolderByExternalReferenceCode(
-			long groupId, String externalReferenceCode)
+			String externalReferenceCode, long groupId)
 		throws PortalException {
 
-		return journalFolderPersistence.findByG_ERC(
-			groupId, externalReferenceCode);
+		return journalFolderPersistence.findByERC_G(
+			externalReferenceCode, groupId);
 	}
 
 	/**

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalFolderLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalFolderLocalServiceImpl.java
@@ -1522,8 +1522,8 @@ public class JournalFolderLocalServiceImpl
 			return;
 		}
 
-		JournalFolder journalFolder = journalFolderPersistence.fetchByG_ERC(
-			groupId, externalReferenceCode);
+		JournalFolder journalFolder = journalFolderPersistence.fetchByERC_G(
+			externalReferenceCode, groupId);
 
 		if (journalFolder != null) {
 			throw new DuplicateFolderExternalReferenceCodeException(

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalFolderServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalFolderServiceImpl.java
@@ -137,7 +137,7 @@ public class JournalFolderServiceImpl extends JournalFolderServiceBaseImpl {
 
 		JournalFolder folder =
 			journalFolderLocalService.getJournalFolderByExternalReferenceCode(
-				groupId, externalReferenceCode);
+				externalReferenceCode, groupId);
 
 		_journalFolderModelResourcePermission.check(
 			getPermissionChecker(), folder, ActionKeys.VIEW);

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/persistence/impl/JournalFolderPersistenceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/persistence/impl/JournalFolderPersistenceImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.journal.service.persistence.impl;
 
+import com.liferay.journal.exception.DuplicateJournalFolderExternalReferenceCodeException;
 import com.liferay.journal.exception.NoSuchFolderException;
 import com.liferay.journal.model.JournalFolder;
 import com.liferay.journal.model.JournalFolderTable;
@@ -7466,34 +7467,34 @@ public class JournalFolderPersistenceImpl
 	private static final String _FINDER_COLUMN_GTF_C_P_NOTS_STATUS_2 =
 		"journalFolder.status != ?";
 
-	private FinderPath _finderPathFetchByG_ERC;
-	private FinderPath _finderPathCountByG_ERC;
+	private FinderPath _finderPathFetchByERC_G;
+	private FinderPath _finderPathCountByERC_G;
 
 	/**
-	 * Returns the journal folder where groupId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchFolderException</code> if it could not be found.
+	 * Returns the journal folder where externalReferenceCode = &#63; and groupId = &#63; or throws a <code>NoSuchFolderException</code> if it could not be found.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the matching journal folder
 	 * @throws NoSuchFolderException if a matching journal folder could not be found
 	 */
 	@Override
-	public JournalFolder findByG_ERC(long groupId, String externalReferenceCode)
+	public JournalFolder findByERC_G(String externalReferenceCode, long groupId)
 		throws NoSuchFolderException {
 
-		JournalFolder journalFolder = fetchByG_ERC(
-			groupId, externalReferenceCode);
+		JournalFolder journalFolder = fetchByERC_G(
+			externalReferenceCode, groupId);
 
 		if (journalFolder == null) {
 			StringBundler sb = new StringBundler(6);
 
 			sb.append(_NO_SUCH_ENTITY_WITH_KEY);
 
-			sb.append("groupId=");
-			sb.append(groupId);
-
-			sb.append(", externalReferenceCode=");
+			sb.append("externalReferenceCode=");
 			sb.append(externalReferenceCode);
+
+			sb.append(", groupId=");
+			sb.append(groupId);
 
 			sb.append("}");
 
@@ -7508,30 +7509,30 @@ public class JournalFolderPersistenceImpl
 	}
 
 	/**
-	 * Returns the journal folder where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the journal folder where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the matching journal folder, or <code>null</code> if a matching journal folder could not be found
 	 */
 	@Override
-	public JournalFolder fetchByG_ERC(
-		long groupId, String externalReferenceCode) {
+	public JournalFolder fetchByERC_G(
+		String externalReferenceCode, long groupId) {
 
-		return fetchByG_ERC(groupId, externalReferenceCode, true);
+		return fetchByERC_G(externalReferenceCode, groupId, true);
 	}
 
 	/**
-	 * Returns the journal folder where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the journal folder where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching journal folder, or <code>null</code> if a matching journal folder could not be found
 	 */
 	@Override
-	public JournalFolder fetchByG_ERC(
-		long groupId, String externalReferenceCode, boolean useFinderCache) {
+	public JournalFolder fetchByERC_G(
+		String externalReferenceCode, long groupId, boolean useFinderCache) {
 
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
@@ -7541,23 +7542,23 @@ public class JournalFolderPersistenceImpl
 		Object[] finderArgs = null;
 
 		if (useFinderCache && productionMode) {
-			finderArgs = new Object[] {groupId, externalReferenceCode};
+			finderArgs = new Object[] {externalReferenceCode, groupId};
 		}
 
 		Object result = null;
 
 		if (useFinderCache && productionMode) {
 			result = finderCache.getResult(
-				_finderPathFetchByG_ERC, finderArgs, this);
+				_finderPathFetchByERC_G, finderArgs, this);
 		}
 
 		if (result instanceof JournalFolder) {
 			JournalFolder journalFolder = (JournalFolder)result;
 
-			if ((groupId != journalFolder.getGroupId()) ||
-				!Objects.equals(
+			if (!Objects.equals(
 					externalReferenceCode,
-					journalFolder.getExternalReferenceCode())) {
+					journalFolder.getExternalReferenceCode()) ||
+				(groupId != journalFolder.getGroupId())) {
 
 				result = null;
 			}
@@ -7568,18 +7569,18 @@ public class JournalFolderPersistenceImpl
 
 			sb.append(_SQL_SELECT_JOURNALFOLDER_WHERE);
 
-			sb.append(_FINDER_COLUMN_G_ERC_GROUPID_2);
-
 			boolean bindExternalReferenceCode = false;
 
 			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_3);
+				sb.append(_FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_3);
 			}
 			else {
 				bindExternalReferenceCode = true;
 
-				sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_2);
+				sb.append(_FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_2);
 			}
+
+			sb.append(_FINDER_COLUMN_ERC_G_GROUPID_2);
 
 			String sql = sb.toString();
 
@@ -7592,18 +7593,18 @@ public class JournalFolderPersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
-				queryPos.add(groupId);
-
 				if (bindExternalReferenceCode) {
 					queryPos.add(externalReferenceCode);
 				}
+
+				queryPos.add(groupId);
 
 				List<JournalFolder> list = query.list();
 
 				if (list.isEmpty()) {
 					if (useFinderCache && productionMode) {
 						finderCache.putResult(
-							_finderPathFetchByG_ERC, finderArgs, list);
+							_finderPathFetchByERC_G, finderArgs, list);
 					}
 				}
 				else {
@@ -7631,32 +7632,32 @@ public class JournalFolderPersistenceImpl
 	}
 
 	/**
-	 * Removes the journal folder where groupId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the journal folder where externalReferenceCode = &#63; and groupId = &#63; from the database.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the journal folder that was removed
 	 */
 	@Override
-	public JournalFolder removeByG_ERC(
-			long groupId, String externalReferenceCode)
+	public JournalFolder removeByERC_G(
+			String externalReferenceCode, long groupId)
 		throws NoSuchFolderException {
 
-		JournalFolder journalFolder = findByG_ERC(
-			groupId, externalReferenceCode);
+		JournalFolder journalFolder = findByERC_G(
+			externalReferenceCode, groupId);
 
 		return remove(journalFolder);
 	}
 
 	/**
-	 * Returns the number of journal folders where groupId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of journal folders where externalReferenceCode = &#63; and groupId = &#63;.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the number of matching journal folders
 	 */
 	@Override
-	public int countByG_ERC(long groupId, String externalReferenceCode) {
+	public int countByERC_G(String externalReferenceCode, long groupId) {
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
 		boolean productionMode = ctPersistenceHelper.isProductionMode(
@@ -7668,9 +7669,9 @@ public class JournalFolderPersistenceImpl
 		Long count = null;
 
 		if (productionMode) {
-			finderPath = _finderPathCountByG_ERC;
+			finderPath = _finderPathCountByERC_G;
 
-			finderArgs = new Object[] {groupId, externalReferenceCode};
+			finderArgs = new Object[] {externalReferenceCode, groupId};
 
 			count = (Long)finderCache.getResult(finderPath, finderArgs, this);
 		}
@@ -7680,18 +7681,18 @@ public class JournalFolderPersistenceImpl
 
 			sb.append(_SQL_COUNT_JOURNALFOLDER_WHERE);
 
-			sb.append(_FINDER_COLUMN_G_ERC_GROUPID_2);
-
 			boolean bindExternalReferenceCode = false;
 
 			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_3);
+				sb.append(_FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_3);
 			}
 			else {
 				bindExternalReferenceCode = true;
 
-				sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_2);
+				sb.append(_FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_2);
 			}
+
+			sb.append(_FINDER_COLUMN_ERC_G_GROUPID_2);
 
 			String sql = sb.toString();
 
@@ -7704,11 +7705,11 @@ public class JournalFolderPersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
-				queryPos.add(groupId);
-
 				if (bindExternalReferenceCode) {
 					queryPos.add(externalReferenceCode);
 				}
+
+				queryPos.add(groupId);
 
 				count = (Long)query.uniqueResult();
 
@@ -7727,14 +7728,14 @@ public class JournalFolderPersistenceImpl
 		return count.intValue();
 	}
 
-	private static final String _FINDER_COLUMN_G_ERC_GROUPID_2 =
-		"journalFolder.groupId = ? AND ";
+	private static final String _FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_2 =
+		"journalFolder.externalReferenceCode = ? AND ";
 
-	private static final String _FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_2 =
-		"journalFolder.externalReferenceCode = ?";
+	private static final String _FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_3 =
+		"(journalFolder.externalReferenceCode IS NULL OR journalFolder.externalReferenceCode = '') AND ";
 
-	private static final String _FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_3 =
-		"(journalFolder.externalReferenceCode IS NULL OR journalFolder.externalReferenceCode = '')";
+	private static final String _FINDER_COLUMN_ERC_G_GROUPID_2 =
+		"journalFolder.groupId = ?";
 
 	public JournalFolderPersistenceImpl() {
 		Map<String, String> dbColumnNames = new HashMap<String, String>();
@@ -7785,10 +7786,10 @@ public class JournalFolderPersistenceImpl
 			journalFolder);
 
 		finderCache.putResult(
-			_finderPathFetchByG_ERC,
+			_finderPathFetchByERC_G,
 			new Object[] {
-				journalFolder.getGroupId(),
-				journalFolder.getExternalReferenceCode()
+				journalFolder.getExternalReferenceCode(),
+				journalFolder.getGroupId()
 			},
 			journalFolder);
 	}
@@ -7897,13 +7898,13 @@ public class JournalFolderPersistenceImpl
 			_finderPathFetchByG_P_N, args, journalFolderModelImpl);
 
 		args = new Object[] {
-			journalFolderModelImpl.getGroupId(),
-			journalFolderModelImpl.getExternalReferenceCode()
+			journalFolderModelImpl.getExternalReferenceCode(),
+			journalFolderModelImpl.getGroupId()
 		};
 
-		finderCache.putResult(_finderPathCountByG_ERC, args, Long.valueOf(1));
+		finderCache.putResult(_finderPathCountByERC_G, args, Long.valueOf(1));
 		finderCache.putResult(
-			_finderPathFetchByG_ERC, args, journalFolderModelImpl);
+			_finderPathFetchByERC_G, args, journalFolderModelImpl);
 	}
 
 	/**
@@ -8045,6 +8046,29 @@ public class JournalFolderPersistenceImpl
 
 		if (Validator.isNull(journalFolder.getExternalReferenceCode())) {
 			journalFolder.setExternalReferenceCode(journalFolder.getUuid());
+		}
+		else {
+			JournalFolder ercJournalFolder = fetchByERC_G(
+				journalFolder.getExternalReferenceCode(),
+				journalFolder.getGroupId());
+
+			if (isNew) {
+				if (ercJournalFolder != null) {
+					throw new DuplicateJournalFolderExternalReferenceCodeException(
+						"Duplicate JournalFolder with external reference code " +
+							journalFolder.getExternalReferenceCode());
+				}
+			}
+			else {
+				if ((ercJournalFolder != null) &&
+					(journalFolder.getFolderId() !=
+						ercJournalFolder.getFolderId())) {
+
+					throw new DuplicateJournalFolderExternalReferenceCodeException(
+						"Duplicate JournalFolder with external reference code " +
+							journalFolder.getExternalReferenceCode());
+				}
+			}
 		}
 
 		ServiceContext serviceContext =
@@ -8590,7 +8614,7 @@ public class JournalFolderPersistenceImpl
 			new String[] {"groupId", "parentFolderId", "name"});
 
 		_uniqueIndexColumnNames.add(
-			new String[] {"groupId", "externalReferenceCode"});
+			new String[] {"externalReferenceCode", "groupId"});
 	}
 
 	/**
@@ -8817,15 +8841,15 @@ public class JournalFolderPersistenceImpl
 			new String[] {"folderId", "companyId", "parentFolderId", "status"},
 			false);
 
-		_finderPathFetchByG_ERC = new FinderPath(
-			FINDER_CLASS_NAME_ENTITY, "fetchByG_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"groupId", "externalReferenceCode"}, true);
+		_finderPathFetchByERC_G = new FinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByERC_G",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "groupId"}, true);
 
-		_finderPathCountByG_ERC = new FinderPath(
-			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"groupId", "externalReferenceCode"}, false);
+		_finderPathCountByERC_G = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByERC_G",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "groupId"}, false);
 
 		_setJournalFolderUtilPersistence(this);
 	}

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalFolderServiceTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalFolderServiceTest.java
@@ -195,7 +195,7 @@ public class JournalFolderServiceTest {
 
 		JournalFolder folder2 =
 			_journalFolderLocalService.getJournalFolderByExternalReferenceCode(
-				_group.getGroupId(), externalReferenceCode);
+				externalReferenceCode, _group.getGroupId());
 
 		Assert.assertEquals(folder1, folder2);
 	}
@@ -322,7 +322,7 @@ public class JournalFolderServiceTest {
 		JournalFolder folder2 =
 			JournalFolderLocalServiceUtil.
 				getJournalFolderByExternalReferenceCode(
-					_group.getGroupId(), externalReferenceCode);
+					externalReferenceCode, _group.getGroupId());
 
 		Assert.assertEquals(
 			folder2.getExternalReferenceCode(), externalReferenceCode);

--- a/modules/apps/knowledge-base/knowledge-base-api/bnd.bnd
+++ b/modules/apps/knowledge-base/knowledge-base-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Knowledge Base API
 Bundle-SymbolicName: com.liferay.knowledge.base.api
-Bundle-Version: 14.2.0
+Bundle-Version: 15.0.0
 Export-Package:\
 	com.liferay.knowledge.base.configuration,\
 	com.liferay.knowledge.base.constants,\

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/exception/DuplicateKBArticleExternalReferenceCodeException.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/exception/DuplicateKBArticleExternalReferenceCodeException.java
@@ -14,13 +14,13 @@
 
 package com.liferay.knowledge.base.exception;
 
-import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.SystemException;
 
 /**
  * @author Brian Wing Shun Chan
  */
 public class DuplicateKBArticleExternalReferenceCodeException
-	extends PortalException {
+	extends SystemException {
 
 	public DuplicateKBArticleExternalReferenceCodeException() {
 	}

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/exception/DuplicateKBFolderExternalReferenceCodeException.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/exception/DuplicateKBFolderExternalReferenceCodeException.java
@@ -14,13 +14,13 @@
 
 package com.liferay.knowledge.base.exception;
 
-import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.SystemException;
 
 /**
  * @author Brian Wing Shun Chan
  */
 public class DuplicateKBFolderExternalReferenceCodeException
-	extends PortalException {
+	extends SystemException {
 
 	public DuplicateKBFolderExternalReferenceCodeException() {
 	}

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBFolderLocalService.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBFolderLocalService.java
@@ -223,24 +223,9 @@ public interface KBFolderLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public KBFolder fetchKBFolder(String uuid, long groupId);
 
-	/**
-	 * Returns the kb folder with the matching external reference code and group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the kb folder's external reference code
-	 * @return the matching kb folder, or <code>null</code> if a matching kb folder could not be found
-	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public KBFolder fetchKBFolderByExternalReferenceCode(
-		long groupId, String externalReferenceCode);
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchKBFolderByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public KBFolder fetchKBFolderByReferenceCode(
-		long groupId, String externalReferenceCode);
+		String externalReferenceCode, long groupId);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public KBFolder fetchKBFolderByUrlTitle(
@@ -277,17 +262,9 @@ public interface KBFolderLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public KBFolder getKBFolder(long kbFolderId) throws PortalException;
 
-	/**
-	 * Returns the kb folder with the matching external reference code and group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the kb folder's external reference code
-	 * @return the matching kb folder
-	 * @throws PortalException if a matching kb folder could not be found
-	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public KBFolder getKBFolderByExternalReferenceCode(
-			long groupId, String externalReferenceCode)
+			String externalReferenceCode, long groupId)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBFolderLocalServiceUtil.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBFolderLocalServiceUtil.java
@@ -245,29 +245,11 @@ public class KBFolderLocalServiceUtil {
 		return getService().fetchKBFolder(uuid, groupId);
 	}
 
-	/**
-	 * Returns the kb folder with the matching external reference code and group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the kb folder's external reference code
-	 * @return the matching kb folder, or <code>null</code> if a matching kb folder could not be found
-	 */
 	public static KBFolder fetchKBFolderByExternalReferenceCode(
-		long groupId, String externalReferenceCode) {
+		String externalReferenceCode, long groupId) {
 
 		return getService().fetchKBFolderByExternalReferenceCode(
-			groupId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchKBFolderByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	public static KBFolder fetchKBFolderByReferenceCode(
-		long groupId, String externalReferenceCode) {
-
-		return getService().fetchKBFolderByReferenceCode(
-			groupId, externalReferenceCode);
+			externalReferenceCode, groupId);
 	}
 
 	public static KBFolder fetchKBFolderByUrlTitle(
@@ -323,20 +305,12 @@ public class KBFolderLocalServiceUtil {
 		return getService().getKBFolder(kbFolderId);
 	}
 
-	/**
-	 * Returns the kb folder with the matching external reference code and group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the kb folder's external reference code
-	 * @return the matching kb folder
-	 * @throws PortalException if a matching kb folder could not be found
-	 */
 	public static KBFolder getKBFolderByExternalReferenceCode(
-			long groupId, String externalReferenceCode)
+			String externalReferenceCode, long groupId)
 		throws PortalException {
 
 		return getService().getKBFolderByExternalReferenceCode(
-			groupId, externalReferenceCode);
+			externalReferenceCode, groupId);
 	}
 
 	public static KBFolder getKBFolderByUrlTitle(

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBFolderLocalServiceWrapper.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBFolderLocalServiceWrapper.java
@@ -280,33 +280,13 @@ public class KBFolderLocalServiceWrapper
 		return _kbFolderLocalService.fetchKBFolder(uuid, groupId);
 	}
 
-	/**
-	 * Returns the kb folder with the matching external reference code and group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the kb folder's external reference code
-	 * @return the matching kb folder, or <code>null</code> if a matching kb folder could not be found
-	 */
 	@Override
 	public com.liferay.knowledge.base.model.KBFolder
 		fetchKBFolderByExternalReferenceCode(
-			long groupId, String externalReferenceCode) {
+			String externalReferenceCode, long groupId) {
 
 		return _kbFolderLocalService.fetchKBFolderByExternalReferenceCode(
-			groupId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchKBFolderByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public com.liferay.knowledge.base.model.KBFolder
-		fetchKBFolderByReferenceCode(
-			long groupId, String externalReferenceCode) {
-
-		return _kbFolderLocalService.fetchKBFolderByReferenceCode(
-			groupId, externalReferenceCode);
+			externalReferenceCode, groupId);
 	}
 
 	@Override
@@ -372,22 +352,14 @@ public class KBFolderLocalServiceWrapper
 		return _kbFolderLocalService.getKBFolder(kbFolderId);
 	}
 
-	/**
-	 * Returns the kb folder with the matching external reference code and group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the kb folder's external reference code
-	 * @return the matching kb folder
-	 * @throws PortalException if a matching kb folder could not be found
-	 */
 	@Override
 	public com.liferay.knowledge.base.model.KBFolder
 			getKBFolderByExternalReferenceCode(
-				long groupId, String externalReferenceCode)
+				String externalReferenceCode, long groupId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _kbFolderLocalService.getKBFolderByExternalReferenceCode(
-			groupId, externalReferenceCode);
+			externalReferenceCode, groupId);
 	}
 
 	@Override

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/persistence/KBFolderPersistence.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/persistence/KBFolderPersistence.java
@@ -874,54 +874,54 @@ public interface KBFolderPersistence extends BasePersistence<KBFolder> {
 		long groupId, long parentKBFolderId, String urlTitle);
 
 	/**
-	 * Returns the kb folder where groupId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchFolderException</code> if it could not be found.
+	 * Returns the kb folder where externalReferenceCode = &#63; and groupId = &#63; or throws a <code>NoSuchFolderException</code> if it could not be found.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the matching kb folder
 	 * @throws NoSuchFolderException if a matching kb folder could not be found
 	 */
-	public KBFolder findByG_ERC(long groupId, String externalReferenceCode)
+	public KBFolder findByERC_G(String externalReferenceCode, long groupId)
 		throws NoSuchFolderException;
 
 	/**
-	 * Returns the kb folder where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the kb folder where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the matching kb folder, or <code>null</code> if a matching kb folder could not be found
 	 */
-	public KBFolder fetchByG_ERC(long groupId, String externalReferenceCode);
+	public KBFolder fetchByERC_G(String externalReferenceCode, long groupId);
 
 	/**
-	 * Returns the kb folder where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the kb folder where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching kb folder, or <code>null</code> if a matching kb folder could not be found
 	 */
-	public KBFolder fetchByG_ERC(
-		long groupId, String externalReferenceCode, boolean useFinderCache);
+	public KBFolder fetchByERC_G(
+		String externalReferenceCode, long groupId, boolean useFinderCache);
 
 	/**
-	 * Removes the kb folder where groupId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the kb folder where externalReferenceCode = &#63; and groupId = &#63; from the database.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the kb folder that was removed
 	 */
-	public KBFolder removeByG_ERC(long groupId, String externalReferenceCode)
+	public KBFolder removeByERC_G(String externalReferenceCode, long groupId)
 		throws NoSuchFolderException;
 
 	/**
-	 * Returns the number of kb folders where groupId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of kb folders where externalReferenceCode = &#63; and groupId = &#63;.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the number of matching kb folders
 	 */
-	public int countByG_ERC(long groupId, String externalReferenceCode);
+	public int countByERC_G(String externalReferenceCode, long groupId);
 
 	/**
 	 * Caches the kb folder in the entity cache if it is enabled.

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/persistence/KBFolderUtil.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/persistence/KBFolderUtil.java
@@ -1123,71 +1123,71 @@ public class KBFolderUtil {
 	}
 
 	/**
-	 * Returns the kb folder where groupId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchFolderException</code> if it could not be found.
+	 * Returns the kb folder where externalReferenceCode = &#63; and groupId = &#63; or throws a <code>NoSuchFolderException</code> if it could not be found.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the matching kb folder
 	 * @throws NoSuchFolderException if a matching kb folder could not be found
 	 */
-	public static KBFolder findByG_ERC(
-			long groupId, String externalReferenceCode)
+	public static KBFolder findByERC_G(
+			String externalReferenceCode, long groupId)
 		throws com.liferay.knowledge.base.exception.NoSuchFolderException {
 
-		return getPersistence().findByG_ERC(groupId, externalReferenceCode);
+		return getPersistence().findByERC_G(externalReferenceCode, groupId);
 	}
 
 	/**
-	 * Returns the kb folder where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the kb folder where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the matching kb folder, or <code>null</code> if a matching kb folder could not be found
 	 */
-	public static KBFolder fetchByG_ERC(
-		long groupId, String externalReferenceCode) {
+	public static KBFolder fetchByERC_G(
+		String externalReferenceCode, long groupId) {
 
-		return getPersistence().fetchByG_ERC(groupId, externalReferenceCode);
+		return getPersistence().fetchByERC_G(externalReferenceCode, groupId);
 	}
 
 	/**
-	 * Returns the kb folder where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the kb folder where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching kb folder, or <code>null</code> if a matching kb folder could not be found
 	 */
-	public static KBFolder fetchByG_ERC(
-		long groupId, String externalReferenceCode, boolean useFinderCache) {
+	public static KBFolder fetchByERC_G(
+		String externalReferenceCode, long groupId, boolean useFinderCache) {
 
-		return getPersistence().fetchByG_ERC(
-			groupId, externalReferenceCode, useFinderCache);
+		return getPersistence().fetchByERC_G(
+			externalReferenceCode, groupId, useFinderCache);
 	}
 
 	/**
-	 * Removes the kb folder where groupId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the kb folder where externalReferenceCode = &#63; and groupId = &#63; from the database.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the kb folder that was removed
 	 */
-	public static KBFolder removeByG_ERC(
-			long groupId, String externalReferenceCode)
+	public static KBFolder removeByERC_G(
+			String externalReferenceCode, long groupId)
 		throws com.liferay.knowledge.base.exception.NoSuchFolderException {
 
-		return getPersistence().removeByG_ERC(groupId, externalReferenceCode);
+		return getPersistence().removeByERC_G(externalReferenceCode, groupId);
 	}
 
 	/**
-	 * Returns the number of kb folders where groupId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of kb folders where externalReferenceCode = &#63; and groupId = &#63;.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the number of matching kb folders
 	 */
-	public static int countByG_ERC(long groupId, String externalReferenceCode) {
-		return getPersistence().countByG_ERC(groupId, externalReferenceCode);
+	public static int countByERC_G(String externalReferenceCode, long groupId) {
+		return getPersistence().countByERC_G(externalReferenceCode, groupId);
 	}
 
 	/**

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/resources/com/liferay/knowledge/base/exception/packageinfo
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/resources/com/liferay/knowledge/base/exception/packageinfo
@@ -1,1 +1,1 @@
-version 1.5.0
+version 2.0.0

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/resources/com/liferay/knowledge/base/service/packageinfo
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/resources/com/liferay/knowledge/base/service/packageinfo
@@ -1,1 +1,1 @@
-version 6.1.0
+version 7.0.0

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/resources/com/liferay/knowledge/base/service/persistence/packageinfo
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/resources/com/liferay/knowledge/base/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 3.0.0
+version 4.0.0

--- a/modules/apps/knowledge-base/knowledge-base-service/service.xml
+++ b/modules/apps/knowledge-base/knowledge-base-service/service.xml
@@ -345,8 +345,6 @@
 		</finder>
 	</entity>
 	<exceptions>
-		<exception>DuplicateKBArticleExternalReferenceCode</exception>
-		<exception>DuplicateKBFolderExternalReferenceCode</exception>
 		<exception>DuplicateKBFolderName</exception>
 		<exception>InvalidKBFolderName</exception>
 		<exception>KBArticleContent</exception>

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/base/KBFolderLocalServiceBaseImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/base/KBFolderLocalServiceBaseImpl.java
@@ -263,46 +263,19 @@ public abstract class KBFolderLocalServiceBaseImpl
 		return kbFolderPersistence.fetchByUUID_G(uuid, groupId);
 	}
 
-	/**
-	 * Returns the kb folder with the matching external reference code and group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the kb folder's external reference code
-	 * @return the matching kb folder, or <code>null</code> if a matching kb folder could not be found
-	 */
 	@Override
 	public KBFolder fetchKBFolderByExternalReferenceCode(
-		long groupId, String externalReferenceCode) {
+		String externalReferenceCode, long groupId) {
 
-		return kbFolderPersistence.fetchByG_ERC(groupId, externalReferenceCode);
+		return kbFolderPersistence.fetchByERC_G(externalReferenceCode, groupId);
 	}
 
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchKBFolderByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public KBFolder fetchKBFolderByReferenceCode(
-		long groupId, String externalReferenceCode) {
-
-		return fetchKBFolderByExternalReferenceCode(
-			groupId, externalReferenceCode);
-	}
-
-	/**
-	 * Returns the kb folder with the matching external reference code and group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the kb folder's external reference code
-	 * @return the matching kb folder
-	 * @throws PortalException if a matching kb folder could not be found
-	 */
 	@Override
 	public KBFolder getKBFolderByExternalReferenceCode(
-			long groupId, String externalReferenceCode)
+			String externalReferenceCode, long groupId)
 		throws PortalException {
 
-		return kbFolderPersistence.findByG_ERC(groupId, externalReferenceCode);
+		return kbFolderPersistence.findByERC_G(externalReferenceCode, groupId);
 	}
 
 	/**

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
@@ -29,7 +29,6 @@ import com.liferay.knowledge.base.constants.KBArticleConstants;
 import com.liferay.knowledge.base.constants.KBConstants;
 import com.liferay.knowledge.base.constants.KBFolderConstants;
 import com.liferay.knowledge.base.constants.KBPortletKeys;
-import com.liferay.knowledge.base.exception.DuplicateKBArticleExternalReferenceCodeException;
 import com.liferay.knowledge.base.exception.KBArticleContentException;
 import com.liferay.knowledge.base.exception.KBArticleExpirationDateException;
 import com.liferay.knowledge.base.exception.KBArticleParentException;
@@ -188,8 +187,6 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 		double priority = _getPriority(groupId, parentResourcePrimKey);
 
 		long kbArticleId = counterLocalService.increment();
-
-		_validateExternalReferenceCode(externalReferenceCode, groupId);
 
 		_validate(expirationDate, content, reviewDate, sourceURL, title);
 		_validateParent(parentResourceClassNameId, parentResourcePrimKey);
@@ -2090,25 +2087,6 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 		if ((reviewDate != null) && reviewDate.before(now)) {
 			throw new KBArticleReviewDateException(
 				"Review date is " + reviewDate + " in the past");
-		}
-	}
-
-	private void _validateExternalReferenceCode(
-			String externalReferenceCode, long groupId)
-		throws PortalException {
-
-		if (Validator.isNull(externalReferenceCode)) {
-			return;
-		}
-
-		KBArticle kbArticle = fetchLatestKBArticleByExternalReferenceCode(
-			groupId, externalReferenceCode);
-
-		if (kbArticle != null) {
-			throw new DuplicateKBArticleExternalReferenceCodeException(
-				StringBundler.concat(
-					"Duplicate knowledge base article external reference code ",
-					externalReferenceCode, " in group ", groupId));
 		}
 	}
 

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBFolderLocalServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBFolderLocalServiceImpl.java
@@ -16,7 +16,6 @@ package com.liferay.knowledge.base.service.impl;
 
 import com.liferay.expando.kernel.service.ExpandoRowLocalService;
 import com.liferay.knowledge.base.constants.KBFolderConstants;
-import com.liferay.knowledge.base.exception.DuplicateKBFolderExternalReferenceCodeException;
 import com.liferay.knowledge.base.exception.DuplicateKBFolderNameException;
 import com.liferay.knowledge.base.exception.InvalidKBFolderNameException;
 import com.liferay.knowledge.base.exception.KBFolderParentException;
@@ -26,7 +25,6 @@ import com.liferay.knowledge.base.model.KBFolder;
 import com.liferay.knowledge.base.service.KBArticleLocalService;
 import com.liferay.knowledge.base.service.base.KBFolderLocalServiceBaseImpl;
 import com.liferay.knowledge.base.util.KnowledgeBaseUtil;
-import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.dao.orm.QueryDefinition;
@@ -76,8 +74,6 @@ public class KBFolderLocalServiceImpl extends KBFolderLocalServiceBaseImpl {
 		_validateParent(parentResourceClassNameId, parentResourcePrimKey);
 
 		long kbFolderId = counterLocalService.increment();
-
-		_validateExternalReferenceCode(externalReferenceCode, groupId);
 
 		KBFolder kbFolder = kbFolderPersistence.create(kbFolderId);
 
@@ -343,25 +339,6 @@ public class KBFolderLocalServiceImpl extends KBFolderLocalServiceBaseImpl {
 		}
 
 		return uniqueUrlTitle;
-	}
-
-	private void _validateExternalReferenceCode(
-			String externalReferenceCode, long groupId)
-		throws PortalException {
-
-		if (Validator.isNull(externalReferenceCode)) {
-			return;
-		}
-
-		KBFolder kbFolder = kbFolderPersistence.fetchByG_ERC(
-			groupId, externalReferenceCode);
-
-		if (kbFolder != null) {
-			throw new DuplicateKBFolderExternalReferenceCodeException(
-				StringBundler.concat(
-					"Duplicate knowledge base folder external reference code ",
-					externalReferenceCode, " in group ", groupId));
-		}
 	}
 
 	private void _validateName(long groupId, long parentKBFolderId, String name)

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBFolderServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBFolderServiceImpl.java
@@ -135,7 +135,7 @@ public class KBFolderServiceImpl extends KBFolderServiceBaseImpl {
 
 		KBFolder kbFolder =
 			kbFolderLocalService.getKBFolderByExternalReferenceCode(
-				groupId, externalReferenceCode);
+				externalReferenceCode, groupId);
 
 		_kbFolderModelResourcePermission.check(
 			getPermissionChecker(), kbFolder, KBActionKeys.VIEW);

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/persistence/impl/KBFolderPersistenceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/persistence/impl/KBFolderPersistenceImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.knowledge.base.service.persistence.impl;
 
+import com.liferay.knowledge.base.exception.DuplicateKBFolderExternalReferenceCodeException;
 import com.liferay.knowledge.base.exception.NoSuchFolderException;
 import com.liferay.knowledge.base.model.KBFolder;
 import com.liferay.knowledge.base.model.KBFolderTable;
@@ -3461,33 +3462,33 @@ public class KBFolderPersistenceImpl
 	private static final String _FINDER_COLUMN_G_P_UT_URLTITLE_3 =
 		"(kbFolder.urlTitle IS NULL OR kbFolder.urlTitle = '')";
 
-	private FinderPath _finderPathFetchByG_ERC;
-	private FinderPath _finderPathCountByG_ERC;
+	private FinderPath _finderPathFetchByERC_G;
+	private FinderPath _finderPathCountByERC_G;
 
 	/**
-	 * Returns the kb folder where groupId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchFolderException</code> if it could not be found.
+	 * Returns the kb folder where externalReferenceCode = &#63; and groupId = &#63; or throws a <code>NoSuchFolderException</code> if it could not be found.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the matching kb folder
 	 * @throws NoSuchFolderException if a matching kb folder could not be found
 	 */
 	@Override
-	public KBFolder findByG_ERC(long groupId, String externalReferenceCode)
+	public KBFolder findByERC_G(String externalReferenceCode, long groupId)
 		throws NoSuchFolderException {
 
-		KBFolder kbFolder = fetchByG_ERC(groupId, externalReferenceCode);
+		KBFolder kbFolder = fetchByERC_G(externalReferenceCode, groupId);
 
 		if (kbFolder == null) {
 			StringBundler sb = new StringBundler(6);
 
 			sb.append(_NO_SUCH_ENTITY_WITH_KEY);
 
-			sb.append("groupId=");
-			sb.append(groupId);
-
-			sb.append(", externalReferenceCode=");
+			sb.append("externalReferenceCode=");
 			sb.append(externalReferenceCode);
+
+			sb.append(", groupId=");
+			sb.append(groupId);
 
 			sb.append("}");
 
@@ -3502,51 +3503,51 @@ public class KBFolderPersistenceImpl
 	}
 
 	/**
-	 * Returns the kb folder where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the kb folder where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the matching kb folder, or <code>null</code> if a matching kb folder could not be found
 	 */
 	@Override
-	public KBFolder fetchByG_ERC(long groupId, String externalReferenceCode) {
-		return fetchByG_ERC(groupId, externalReferenceCode, true);
+	public KBFolder fetchByERC_G(String externalReferenceCode, long groupId) {
+		return fetchByERC_G(externalReferenceCode, groupId, true);
 	}
 
 	/**
-	 * Returns the kb folder where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the kb folder where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching kb folder, or <code>null</code> if a matching kb folder could not be found
 	 */
 	@Override
-	public KBFolder fetchByG_ERC(
-		long groupId, String externalReferenceCode, boolean useFinderCache) {
+	public KBFolder fetchByERC_G(
+		String externalReferenceCode, long groupId, boolean useFinderCache) {
 
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
 		Object[] finderArgs = null;
 
 		if (useFinderCache) {
-			finderArgs = new Object[] {groupId, externalReferenceCode};
+			finderArgs = new Object[] {externalReferenceCode, groupId};
 		}
 
 		Object result = null;
 
 		if (useFinderCache) {
 			result = finderCache.getResult(
-				_finderPathFetchByG_ERC, finderArgs, this);
+				_finderPathFetchByERC_G, finderArgs, this);
 		}
 
 		if (result instanceof KBFolder) {
 			KBFolder kbFolder = (KBFolder)result;
 
-			if ((groupId != kbFolder.getGroupId()) ||
-				!Objects.equals(
+			if (!Objects.equals(
 					externalReferenceCode,
-					kbFolder.getExternalReferenceCode())) {
+					kbFolder.getExternalReferenceCode()) ||
+				(groupId != kbFolder.getGroupId())) {
 
 				result = null;
 			}
@@ -3557,18 +3558,18 @@ public class KBFolderPersistenceImpl
 
 			sb.append(_SQL_SELECT_KBFOLDER_WHERE);
 
-			sb.append(_FINDER_COLUMN_G_ERC_GROUPID_2);
-
 			boolean bindExternalReferenceCode = false;
 
 			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_3);
+				sb.append(_FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_3);
 			}
 			else {
 				bindExternalReferenceCode = true;
 
-				sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_2);
+				sb.append(_FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_2);
 			}
+
+			sb.append(_FINDER_COLUMN_ERC_G_GROUPID_2);
 
 			String sql = sb.toString();
 
@@ -3581,18 +3582,18 @@ public class KBFolderPersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
-				queryPos.add(groupId);
-
 				if (bindExternalReferenceCode) {
 					queryPos.add(externalReferenceCode);
 				}
+
+				queryPos.add(groupId);
 
 				List<KBFolder> list = query.list();
 
 				if (list.isEmpty()) {
 					if (useFinderCache) {
 						finderCache.putResult(
-							_finderPathFetchByG_ERC, finderArgs, list);
+							_finderPathFetchByERC_G, finderArgs, list);
 					}
 				}
 				else {
@@ -3620,35 +3621,35 @@ public class KBFolderPersistenceImpl
 	}
 
 	/**
-	 * Removes the kb folder where groupId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the kb folder where externalReferenceCode = &#63; and groupId = &#63; from the database.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the kb folder that was removed
 	 */
 	@Override
-	public KBFolder removeByG_ERC(long groupId, String externalReferenceCode)
+	public KBFolder removeByERC_G(String externalReferenceCode, long groupId)
 		throws NoSuchFolderException {
 
-		KBFolder kbFolder = findByG_ERC(groupId, externalReferenceCode);
+		KBFolder kbFolder = findByERC_G(externalReferenceCode, groupId);
 
 		return remove(kbFolder);
 	}
 
 	/**
-	 * Returns the number of kb folders where groupId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of kb folders where externalReferenceCode = &#63; and groupId = &#63;.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the number of matching kb folders
 	 */
 	@Override
-	public int countByG_ERC(long groupId, String externalReferenceCode) {
+	public int countByERC_G(String externalReferenceCode, long groupId) {
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
-		FinderPath finderPath = _finderPathCountByG_ERC;
+		FinderPath finderPath = _finderPathCountByERC_G;
 
-		Object[] finderArgs = new Object[] {groupId, externalReferenceCode};
+		Object[] finderArgs = new Object[] {externalReferenceCode, groupId};
 
 		Long count = (Long)finderCache.getResult(finderPath, finderArgs, this);
 
@@ -3657,18 +3658,18 @@ public class KBFolderPersistenceImpl
 
 			sb.append(_SQL_COUNT_KBFOLDER_WHERE);
 
-			sb.append(_FINDER_COLUMN_G_ERC_GROUPID_2);
-
 			boolean bindExternalReferenceCode = false;
 
 			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_3);
+				sb.append(_FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_3);
 			}
 			else {
 				bindExternalReferenceCode = true;
 
-				sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_2);
+				sb.append(_FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_2);
 			}
+
+			sb.append(_FINDER_COLUMN_ERC_G_GROUPID_2);
 
 			String sql = sb.toString();
 
@@ -3681,11 +3682,11 @@ public class KBFolderPersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
-				queryPos.add(groupId);
-
 				if (bindExternalReferenceCode) {
 					queryPos.add(externalReferenceCode);
 				}
+
+				queryPos.add(groupId);
 
 				count = (Long)query.uniqueResult();
 
@@ -3702,14 +3703,14 @@ public class KBFolderPersistenceImpl
 		return count.intValue();
 	}
 
-	private static final String _FINDER_COLUMN_G_ERC_GROUPID_2 =
-		"kbFolder.groupId = ? AND ";
+	private static final String _FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_2 =
+		"kbFolder.externalReferenceCode = ? AND ";
 
-	private static final String _FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_2 =
-		"kbFolder.externalReferenceCode = ?";
+	private static final String _FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_3 =
+		"(kbFolder.externalReferenceCode IS NULL OR kbFolder.externalReferenceCode = '') AND ";
 
-	private static final String _FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_3 =
-		"(kbFolder.externalReferenceCode IS NULL OR kbFolder.externalReferenceCode = '')";
+	private static final String _FINDER_COLUMN_ERC_G_GROUPID_2 =
+		"kbFolder.groupId = ?";
 
 	public KBFolderPersistenceImpl() {
 		Map<String, String> dbColumnNames = new HashMap<String, String>();
@@ -3757,9 +3758,9 @@ public class KBFolderPersistenceImpl
 			kbFolder);
 
 		finderCache.putResult(
-			_finderPathFetchByG_ERC,
+			_finderPathFetchByERC_G,
 			new Object[] {
-				kbFolder.getGroupId(), kbFolder.getExternalReferenceCode()
+				kbFolder.getExternalReferenceCode(), kbFolder.getGroupId()
 			},
 			kbFolder);
 	}
@@ -3861,12 +3862,12 @@ public class KBFolderPersistenceImpl
 			_finderPathFetchByG_P_UT, args, kbFolderModelImpl);
 
 		args = new Object[] {
-			kbFolderModelImpl.getGroupId(),
-			kbFolderModelImpl.getExternalReferenceCode()
+			kbFolderModelImpl.getExternalReferenceCode(),
+			kbFolderModelImpl.getGroupId()
 		};
 
-		finderCache.putResult(_finderPathCountByG_ERC, args, Long.valueOf(1));
-		finderCache.putResult(_finderPathFetchByG_ERC, args, kbFolderModelImpl);
+		finderCache.putResult(_finderPathCountByERC_G, args, Long.valueOf(1));
+		finderCache.putResult(_finderPathFetchByERC_G, args, kbFolderModelImpl);
 	}
 
 	/**
@@ -4004,6 +4005,27 @@ public class KBFolderPersistenceImpl
 
 		if (Validator.isNull(kbFolder.getExternalReferenceCode())) {
 			kbFolder.setExternalReferenceCode(kbFolder.getUuid());
+		}
+		else {
+			KBFolder ercKBFolder = fetchByERC_G(
+				kbFolder.getExternalReferenceCode(), kbFolder.getGroupId());
+
+			if (isNew) {
+				if (ercKBFolder != null) {
+					throw new DuplicateKBFolderExternalReferenceCodeException(
+						"Duplicate KBFolder with external reference code " +
+							kbFolder.getExternalReferenceCode());
+				}
+			}
+			else {
+				if ((ercKBFolder != null) &&
+					(kbFolder.getKbFolderId() != ercKBFolder.getKbFolderId())) {
+
+					throw new DuplicateKBFolderExternalReferenceCodeException(
+						"Duplicate KBFolder with external reference code " +
+							kbFolder.getExternalReferenceCode());
+				}
+			}
 		}
 
 		ServiceContext serviceContext =
@@ -4452,15 +4474,15 @@ public class KBFolderPersistenceImpl
 			},
 			new String[] {"groupId", "parentKBFolderId", "urlTitle"}, false);
 
-		_finderPathFetchByG_ERC = new FinderPath(
-			FINDER_CLASS_NAME_ENTITY, "fetchByG_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"groupId", "externalReferenceCode"}, true);
+		_finderPathFetchByERC_G = new FinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByERC_G",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "groupId"}, true);
 
-		_finderPathCountByG_ERC = new FinderPath(
-			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"groupId", "externalReferenceCode"}, false);
+		_finderPathCountByERC_G = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByERC_G",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "groupId"}, false);
 
 		_setKBFolderUtilPersistence(this);
 	}

--- a/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/persistence/test/KBFolderPersistenceTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/persistence/test/KBFolderPersistenceTest.java
@@ -15,6 +15,7 @@
 package com.liferay.knowledge.base.service.persistence.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.knowledge.base.exception.DuplicateKBFolderExternalReferenceCodeException;
 import com.liferay.knowledge.base.exception.NoSuchFolderException;
 import com.liferay.knowledge.base.model.KBFolder;
 import com.liferay.knowledge.base.service.KBFolderLocalServiceUtil;
@@ -192,6 +193,26 @@ public class KBFolderPersistenceTest {
 			Time.getShortTimestamp(newKBFolder.getLastPublishDate()));
 	}
 
+	@Test(expected = DuplicateKBFolderExternalReferenceCodeException.class)
+	public void testUpdateWithExistingExternalReferenceCode() throws Exception {
+		KBFolder kbFolder = addKBFolder();
+
+		KBFolder newKBFolder = addKBFolder();
+
+		newKBFolder.setGroupId(kbFolder.getGroupId());
+
+		newKBFolder = _persistence.update(newKBFolder);
+
+		Session session = _persistence.getCurrentSession();
+
+		session.evict(newKBFolder);
+
+		newKBFolder.setExternalReferenceCode(
+			kbFolder.getExternalReferenceCode());
+
+		_persistence.update(newKBFolder);
+	}
+
 	@Test
 	public void testCountByUuid() throws Exception {
 		_persistence.countByUuid("");
@@ -255,12 +276,12 @@ public class KBFolderPersistenceTest {
 	}
 
 	@Test
-	public void testCountByG_ERC() throws Exception {
-		_persistence.countByG_ERC(RandomTestUtil.nextLong(), "");
+	public void testCountByERC_G() throws Exception {
+		_persistence.countByERC_G("", RandomTestUtil.nextLong());
 
-		_persistence.countByG_ERC(0L, "null");
+		_persistence.countByERC_G("null", 0L);
 
-		_persistence.countByG_ERC(0L, (String)null);
+		_persistence.countByERC_G((String)null, 0L);
 	}
 
 	@Test
@@ -596,15 +617,15 @@ public class KBFolderPersistenceTest {
 				new Class<?>[] {String.class}, "urlTitle"));
 
 		Assert.assertEquals(
-			Long.valueOf(kbFolder.getGroupId()),
-			ReflectionTestUtil.<Long>invoke(
-				kbFolder, "getColumnOriginalValue",
-				new Class<?>[] {String.class}, "groupId"));
-		Assert.assertEquals(
 			kbFolder.getExternalReferenceCode(),
 			ReflectionTestUtil.invoke(
 				kbFolder, "getColumnOriginalValue",
 				new Class<?>[] {String.class}, "externalReferenceCode"));
+		Assert.assertEquals(
+			Long.valueOf(kbFolder.getGroupId()),
+			ReflectionTestUtil.<Long>invoke(
+				kbFolder, "getColumnOriginalValue",
+				new Class<?>[] {String.class}, "groupId"));
 	}
 
 	protected KBFolder addKBFolder() throws Exception {

--- a/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/test/KBFolderLocalServiceTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/test/KBFolderLocalServiceTest.java
@@ -125,7 +125,7 @@ public class KBFolderLocalServiceTest {
 
 		KBFolder kbFolder2 =
 			_kbFolderLocalService.getKBFolderByExternalReferenceCode(
-				_group.getGroupId(), externalReferenceCode);
+				externalReferenceCode, _group.getGroupId());
 
 		Assert.assertEquals(kbFolder1, kbFolder2);
 	}

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/EditLayoutMVCActionCommand.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/EditLayoutMVCActionCommand.java
@@ -291,7 +291,7 @@ public class EditLayoutMVCActionCommand extends BaseMVCActionCommand {
 			ClientExtensionEntryRel clientExtensionEntryRel =
 				_clientExtensionEntryRelLocalService.
 					fetchClientExtensionEntryRelByExternalReferenceCode(
-						layout.getCompanyId(), cetExternalReferenceCode);
+						cetExternalReferenceCode, layout.getCompanyId());
 
 			if (clientExtensionEntryRel == null) {
 				_clientExtensionEntryRelLocalService.

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/EditLayoutSetMVCActionCommand.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/EditLayoutSetMVCActionCommand.java
@@ -131,7 +131,7 @@ public class EditLayoutSetMVCActionCommand extends BaseMVCActionCommand {
 			ClientExtensionEntryRel clientExtensionEntryRel =
 				_clientExtensionEntryRelLocalService.
 					fetchClientExtensionEntryRelByExternalReferenceCode(
-						layoutSet.getCompanyId(), cetExternalReferenceCode);
+						cetExternalReferenceCode, layoutSet.getCompanyId());
 
 			if (clientExtensionEntryRel == null) {
 				_clientExtensionEntryRelLocalService.

--- a/modules/apps/layout/layout-utility-page-api/bnd.bnd
+++ b/modules/apps/layout/layout-utility-page-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Layout Utility Page API
 Bundle-SymbolicName: com.liferay.layout.utility.page.api
-Bundle-Version: 2.5.1
+Bundle-Version: 3.0.0
 Export-Package:\
 	com.liferay.layout.utility.page.constants,\
 	com.liferay.layout.utility.page.exception,\

--- a/modules/apps/layout/layout-utility-page-api/src/main/java/com/liferay/layout/utility/page/exception/DuplicateLayoutUtilityPageEntryExternalReferenceCodeException.java
+++ b/modules/apps/layout/layout-utility-page-api/src/main/java/com/liferay/layout/utility/page/exception/DuplicateLayoutUtilityPageEntryExternalReferenceCodeException.java
@@ -14,13 +14,13 @@
 
 package com.liferay.layout.utility.page.exception;
 
-import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.SystemException;
 
 /**
  * @author Brian Wing Shun Chan
  */
 public class DuplicateLayoutUtilityPageEntryExternalReferenceCodeException
-	extends PortalException {
+	extends SystemException {
 
 	public DuplicateLayoutUtilityPageEntryExternalReferenceCodeException() {
 	}

--- a/modules/apps/layout/layout-utility-page-api/src/main/java/com/liferay/layout/utility/page/service/LayoutUtilityPageEntryLocalService.java
+++ b/modules/apps/layout/layout-utility-page-api/src/main/java/com/liferay/layout/utility/page/service/LayoutUtilityPageEntryLocalService.java
@@ -233,25 +233,10 @@ public interface LayoutUtilityPageEntryLocalService
 	public LayoutUtilityPageEntry fetchLayoutUtilityPageEntry(
 		long LayoutUtilityPageEntryId);
 
-	/**
-	 * Returns the layout utility page entry with the matching external reference code and group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the layout utility page entry's external reference code
-	 * @return the matching layout utility page entry, or <code>null</code> if a matching layout utility page entry could not be found
-	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public LayoutUtilityPageEntry
 		fetchLayoutUtilityPageEntryByExternalReferenceCode(
-			long groupId, String externalReferenceCode);
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchLayoutUtilityPageEntryByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public LayoutUtilityPageEntry fetchLayoutUtilityPageEntryByReferenceCode(
-		long groupId, String externalReferenceCode);
+			String externalReferenceCode, long groupId);
 
 	/**
 	 * Returns the layout utility page entry matching the UUID and group.
@@ -359,18 +344,10 @@ public interface LayoutUtilityPageEntryLocalService
 			long LayoutUtilityPageEntryId)
 		throws PortalException;
 
-	/**
-	 * Returns the layout utility page entry with the matching external reference code and group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the layout utility page entry's external reference code
-	 * @return the matching layout utility page entry
-	 * @throws PortalException if a matching layout utility page entry could not be found
-	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public LayoutUtilityPageEntry
 			getLayoutUtilityPageEntryByExternalReferenceCode(
-				long groupId, String externalReferenceCode)
+				String externalReferenceCode, long groupId)
 		throws PortalException;
 
 	/**

--- a/modules/apps/layout/layout-utility-page-api/src/main/java/com/liferay/layout/utility/page/service/LayoutUtilityPageEntryLocalServiceUtil.java
+++ b/modules/apps/layout/layout-utility-page-api/src/main/java/com/liferay/layout/utility/page/service/LayoutUtilityPageEntryLocalServiceUtil.java
@@ -249,31 +249,12 @@ public class LayoutUtilityPageEntryLocalServiceUtil {
 			LayoutUtilityPageEntryId);
 	}
 
-	/**
-	 * Returns the layout utility page entry with the matching external reference code and group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the layout utility page entry's external reference code
-	 * @return the matching layout utility page entry, or <code>null</code> if a matching layout utility page entry could not be found
-	 */
 	public static LayoutUtilityPageEntry
 		fetchLayoutUtilityPageEntryByExternalReferenceCode(
-			long groupId, String externalReferenceCode) {
+			String externalReferenceCode, long groupId) {
 
 		return getService().fetchLayoutUtilityPageEntryByExternalReferenceCode(
-			groupId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchLayoutUtilityPageEntryByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	public static LayoutUtilityPageEntry
-		fetchLayoutUtilityPageEntryByReferenceCode(
-			long groupId, String externalReferenceCode) {
-
-		return getService().fetchLayoutUtilityPageEntryByReferenceCode(
-			groupId, externalReferenceCode);
+			externalReferenceCode, groupId);
 	}
 
 	/**
@@ -418,21 +399,13 @@ public class LayoutUtilityPageEntryLocalServiceUtil {
 		return getService().getLayoutUtilityPageEntry(LayoutUtilityPageEntryId);
 	}
 
-	/**
-	 * Returns the layout utility page entry with the matching external reference code and group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the layout utility page entry's external reference code
-	 * @return the matching layout utility page entry
-	 * @throws PortalException if a matching layout utility page entry could not be found
-	 */
 	public static LayoutUtilityPageEntry
 			getLayoutUtilityPageEntryByExternalReferenceCode(
-				long groupId, String externalReferenceCode)
+				String externalReferenceCode, long groupId)
 		throws PortalException {
 
 		return getService().getLayoutUtilityPageEntryByExternalReferenceCode(
-			groupId, externalReferenceCode);
+			externalReferenceCode, groupId);
 	}
 
 	/**

--- a/modules/apps/layout/layout-utility-page-api/src/main/java/com/liferay/layout/utility/page/service/LayoutUtilityPageEntryLocalServiceWrapper.java
+++ b/modules/apps/layout/layout-utility-page-api/src/main/java/com/liferay/layout/utility/page/service/LayoutUtilityPageEntryLocalServiceWrapper.java
@@ -278,34 +278,14 @@ public class LayoutUtilityPageEntryLocalServiceWrapper
 			LayoutUtilityPageEntryId);
 	}
 
-	/**
-	 * Returns the layout utility page entry with the matching external reference code and group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the layout utility page entry's external reference code
-	 * @return the matching layout utility page entry, or <code>null</code> if a matching layout utility page entry could not be found
-	 */
 	@Override
 	public LayoutUtilityPageEntry
 		fetchLayoutUtilityPageEntryByExternalReferenceCode(
-			long groupId, String externalReferenceCode) {
+			String externalReferenceCode, long groupId) {
 
 		return _layoutUtilityPageEntryLocalService.
 			fetchLayoutUtilityPageEntryByExternalReferenceCode(
-				groupId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchLayoutUtilityPageEntryByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public LayoutUtilityPageEntry fetchLayoutUtilityPageEntryByReferenceCode(
-		long groupId, String externalReferenceCode) {
-
-		return _layoutUtilityPageEntryLocalService.
-			fetchLayoutUtilityPageEntryByReferenceCode(
-				groupId, externalReferenceCode);
+				externalReferenceCode, groupId);
 	}
 
 	/**
@@ -475,23 +455,15 @@ public class LayoutUtilityPageEntryLocalServiceWrapper
 			LayoutUtilityPageEntryId);
 	}
 
-	/**
-	 * Returns the layout utility page entry with the matching external reference code and group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the layout utility page entry's external reference code
-	 * @return the matching layout utility page entry
-	 * @throws PortalException if a matching layout utility page entry could not be found
-	 */
 	@Override
 	public LayoutUtilityPageEntry
 			getLayoutUtilityPageEntryByExternalReferenceCode(
-				long groupId, String externalReferenceCode)
+				String externalReferenceCode, long groupId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _layoutUtilityPageEntryLocalService.
 			getLayoutUtilityPageEntryByExternalReferenceCode(
-				groupId, externalReferenceCode);
+				externalReferenceCode, groupId);
 	}
 
 	/**

--- a/modules/apps/layout/layout-utility-page-api/src/main/java/com/liferay/layout/utility/page/service/persistence/LayoutUtilityPageEntryPersistence.java
+++ b/modules/apps/layout/layout-utility-page-api/src/main/java/com/liferay/layout/utility/page/service/persistence/LayoutUtilityPageEntryPersistence.java
@@ -1134,57 +1134,57 @@ public interface LayoutUtilityPageEntryPersistence
 	public int countByG_N_T(long groupId, String name, int type);
 
 	/**
-	 * Returns the layout utility page entry where groupId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchLayoutUtilityPageEntryException</code> if it could not be found.
+	 * Returns the layout utility page entry where externalReferenceCode = &#63; and groupId = &#63; or throws a <code>NoSuchLayoutUtilityPageEntryException</code> if it could not be found.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the matching layout utility page entry
 	 * @throws NoSuchLayoutUtilityPageEntryException if a matching layout utility page entry could not be found
 	 */
-	public LayoutUtilityPageEntry findByG_ERC(
-			long groupId, String externalReferenceCode)
+	public LayoutUtilityPageEntry findByERC_G(
+			String externalReferenceCode, long groupId)
 		throws NoSuchLayoutUtilityPageEntryException;
 
 	/**
-	 * Returns the layout utility page entry where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the layout utility page entry where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the matching layout utility page entry, or <code>null</code> if a matching layout utility page entry could not be found
 	 */
-	public LayoutUtilityPageEntry fetchByG_ERC(
-		long groupId, String externalReferenceCode);
+	public LayoutUtilityPageEntry fetchByERC_G(
+		String externalReferenceCode, long groupId);
 
 	/**
-	 * Returns the layout utility page entry where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the layout utility page entry where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching layout utility page entry, or <code>null</code> if a matching layout utility page entry could not be found
 	 */
-	public LayoutUtilityPageEntry fetchByG_ERC(
-		long groupId, String externalReferenceCode, boolean useFinderCache);
+	public LayoutUtilityPageEntry fetchByERC_G(
+		String externalReferenceCode, long groupId, boolean useFinderCache);
 
 	/**
-	 * Removes the layout utility page entry where groupId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the layout utility page entry where externalReferenceCode = &#63; and groupId = &#63; from the database.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the layout utility page entry that was removed
 	 */
-	public LayoutUtilityPageEntry removeByG_ERC(
-			long groupId, String externalReferenceCode)
+	public LayoutUtilityPageEntry removeByERC_G(
+			String externalReferenceCode, long groupId)
 		throws NoSuchLayoutUtilityPageEntryException;
 
 	/**
-	 * Returns the number of layout utility page entries where groupId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of layout utility page entries where externalReferenceCode = &#63; and groupId = &#63;.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the number of matching layout utility page entries
 	 */
-	public int countByG_ERC(long groupId, String externalReferenceCode);
+	public int countByERC_G(String externalReferenceCode, long groupId);
 
 	/**
 	 * Caches the layout utility page entry in the entity cache if it is enabled.

--- a/modules/apps/layout/layout-utility-page-api/src/main/java/com/liferay/layout/utility/page/service/persistence/LayoutUtilityPageEntryUtil.java
+++ b/modules/apps/layout/layout-utility-page-api/src/main/java/com/liferay/layout/utility/page/service/persistence/LayoutUtilityPageEntryUtil.java
@@ -1470,73 +1470,73 @@ public class LayoutUtilityPageEntryUtil {
 	}
 
 	/**
-	 * Returns the layout utility page entry where groupId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchLayoutUtilityPageEntryException</code> if it could not be found.
+	 * Returns the layout utility page entry where externalReferenceCode = &#63; and groupId = &#63; or throws a <code>NoSuchLayoutUtilityPageEntryException</code> if it could not be found.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the matching layout utility page entry
 	 * @throws NoSuchLayoutUtilityPageEntryException if a matching layout utility page entry could not be found
 	 */
-	public static LayoutUtilityPageEntry findByG_ERC(
-			long groupId, String externalReferenceCode)
+	public static LayoutUtilityPageEntry findByERC_G(
+			String externalReferenceCode, long groupId)
 		throws com.liferay.layout.utility.page.exception.
 			NoSuchLayoutUtilityPageEntryException {
 
-		return getPersistence().findByG_ERC(groupId, externalReferenceCode);
+		return getPersistence().findByERC_G(externalReferenceCode, groupId);
 	}
 
 	/**
-	 * Returns the layout utility page entry where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the layout utility page entry where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the matching layout utility page entry, or <code>null</code> if a matching layout utility page entry could not be found
 	 */
-	public static LayoutUtilityPageEntry fetchByG_ERC(
-		long groupId, String externalReferenceCode) {
+	public static LayoutUtilityPageEntry fetchByERC_G(
+		String externalReferenceCode, long groupId) {
 
-		return getPersistence().fetchByG_ERC(groupId, externalReferenceCode);
+		return getPersistence().fetchByERC_G(externalReferenceCode, groupId);
 	}
 
 	/**
-	 * Returns the layout utility page entry where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the layout utility page entry where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching layout utility page entry, or <code>null</code> if a matching layout utility page entry could not be found
 	 */
-	public static LayoutUtilityPageEntry fetchByG_ERC(
-		long groupId, String externalReferenceCode, boolean useFinderCache) {
+	public static LayoutUtilityPageEntry fetchByERC_G(
+		String externalReferenceCode, long groupId, boolean useFinderCache) {
 
-		return getPersistence().fetchByG_ERC(
-			groupId, externalReferenceCode, useFinderCache);
+		return getPersistence().fetchByERC_G(
+			externalReferenceCode, groupId, useFinderCache);
 	}
 
 	/**
-	 * Removes the layout utility page entry where groupId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the layout utility page entry where externalReferenceCode = &#63; and groupId = &#63; from the database.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the layout utility page entry that was removed
 	 */
-	public static LayoutUtilityPageEntry removeByG_ERC(
-			long groupId, String externalReferenceCode)
+	public static LayoutUtilityPageEntry removeByERC_G(
+			String externalReferenceCode, long groupId)
 		throws com.liferay.layout.utility.page.exception.
 			NoSuchLayoutUtilityPageEntryException {
 
-		return getPersistence().removeByG_ERC(groupId, externalReferenceCode);
+		return getPersistence().removeByERC_G(externalReferenceCode, groupId);
 	}
 
 	/**
-	 * Returns the number of layout utility page entries where groupId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of layout utility page entries where externalReferenceCode = &#63; and groupId = &#63;.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the number of matching layout utility page entries
 	 */
-	public static int countByG_ERC(long groupId, String externalReferenceCode) {
-		return getPersistence().countByG_ERC(groupId, externalReferenceCode);
+	public static int countByERC_G(String externalReferenceCode, long groupId) {
+		return getPersistence().countByERC_G(externalReferenceCode, groupId);
 	}
 
 	/**

--- a/modules/apps/layout/layout-utility-page-api/src/main/resources/com/liferay/layout/utility/page/exception/packageinfo
+++ b/modules/apps/layout/layout-utility-page-api/src/main/resources/com/liferay/layout/utility/page/exception/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 3.0.0

--- a/modules/apps/layout/layout-utility-page-api/src/main/resources/com/liferay/layout/utility/page/service/packageinfo
+++ b/modules/apps/layout/layout-utility-page-api/src/main/resources/com/liferay/layout/utility/page/service/packageinfo
@@ -1,1 +1,1 @@
-version 2.3.0
+version 3.0.0

--- a/modules/apps/layout/layout-utility-page-api/src/main/resources/com/liferay/layout/utility/page/service/persistence/packageinfo
+++ b/modules/apps/layout/layout-utility-page-api/src/main/resources/com/liferay/layout/utility/page/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 2.0.0

--- a/modules/apps/layout/layout-utility-page-service/service.xml
+++ b/modules/apps/layout/layout-utility-page-service/service.xml
@@ -57,7 +57,6 @@
 		</finder>
 	</entity>
 	<exceptions>
-		<exception>DuplicateLayoutUtilityPageEntryExternalReferenceCode</exception>
 		<exception>LayoutUtilityPageEntryName</exception>
 	</exceptions>
 </service-builder>

--- a/modules/apps/layout/layout-utility-page-service/src/main/java/com/liferay/layout/utility/page/service/base/LayoutUtilityPageEntryLocalServiceBaseImpl.java
+++ b/modules/apps/layout/layout-utility-page-service/src/main/java/com/liferay/layout/utility/page/service/base/LayoutUtilityPageEntryLocalServiceBaseImpl.java
@@ -286,50 +286,23 @@ public abstract class LayoutUtilityPageEntryLocalServiceBaseImpl
 		return layoutUtilityPageEntryPersistence.fetchByUUID_G(uuid, groupId);
 	}
 
-	/**
-	 * Returns the layout utility page entry with the matching external reference code and group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the layout utility page entry's external reference code
-	 * @return the matching layout utility page entry, or <code>null</code> if a matching layout utility page entry could not be found
-	 */
 	@Override
 	public LayoutUtilityPageEntry
 		fetchLayoutUtilityPageEntryByExternalReferenceCode(
-			long groupId, String externalReferenceCode) {
+			String externalReferenceCode, long groupId) {
 
-		return layoutUtilityPageEntryPersistence.fetchByG_ERC(
-			groupId, externalReferenceCode);
+		return layoutUtilityPageEntryPersistence.fetchByERC_G(
+			externalReferenceCode, groupId);
 	}
 
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchLayoutUtilityPageEntryByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public LayoutUtilityPageEntry fetchLayoutUtilityPageEntryByReferenceCode(
-		long groupId, String externalReferenceCode) {
-
-		return fetchLayoutUtilityPageEntryByExternalReferenceCode(
-			groupId, externalReferenceCode);
-	}
-
-	/**
-	 * Returns the layout utility page entry with the matching external reference code and group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the layout utility page entry's external reference code
-	 * @return the matching layout utility page entry
-	 * @throws PortalException if a matching layout utility page entry could not be found
-	 */
 	@Override
 	public LayoutUtilityPageEntry
 			getLayoutUtilityPageEntryByExternalReferenceCode(
-				long groupId, String externalReferenceCode)
+				String externalReferenceCode, long groupId)
 		throws PortalException {
 
-		return layoutUtilityPageEntryPersistence.findByG_ERC(
-			groupId, externalReferenceCode);
+		return layoutUtilityPageEntryPersistence.findByERC_G(
+			externalReferenceCode, groupId);
 	}
 
 	/**

--- a/modules/apps/layout/layout-utility-page-service/src/main/java/com/liferay/layout/utility/page/service/impl/LayoutUtilityPageEntryLocalServiceImpl.java
+++ b/modules/apps/layout/layout-utility-page-service/src/main/java/com/liferay/layout/utility/page/service/impl/LayoutUtilityPageEntryLocalServiceImpl.java
@@ -14,11 +14,9 @@
 
 package com.liferay.layout.utility.page.service.impl;
 
-import com.liferay.layout.utility.page.exception.DuplicateLayoutUtilityPageEntryExternalReferenceCodeException;
 import com.liferay.layout.utility.page.exception.LayoutUtilityPageEntryNameException;
 import com.liferay.layout.utility.page.model.LayoutUtilityPageEntry;
 import com.liferay.layout.utility.page.service.base.LayoutUtilityPageEntryLocalServiceBaseImpl;
-import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -73,7 +71,6 @@ public class LayoutUtilityPageEntryLocalServiceImpl
 			String name, int type, long masterLayoutPlid)
 		throws PortalException {
 
-		_validateExternalReferenceCode(externalReferenceCode, groupId);
 		_validateName(groupId, name);
 
 		LayoutUtilityPageEntry layoutUtilityPageEntry =
@@ -381,26 +378,6 @@ public class LayoutUtilityPageEntryLocalServiceImpl
 		}
 
 		return name;
-	}
-
-	private void _validateExternalReferenceCode(
-			String externalReferenceCode, long groupId)
-		throws PortalException {
-
-		if (Validator.isNull(externalReferenceCode)) {
-			return;
-		}
-
-		LayoutUtilityPageEntry layoutUtilityPageEntry =
-			layoutUtilityPageEntryPersistence.fetchByG_ERC(
-				groupId, externalReferenceCode);
-
-		if (layoutUtilityPageEntry != null) {
-			throw new DuplicateLayoutUtilityPageEntryExternalReferenceCodeException(
-				StringBundler.concat(
-					"Duplicate layout utility page entry external reference ",
-					"code ", externalReferenceCode, " in group ", groupId));
-		}
 	}
 
 	private void _validateName(long groupId, String name)

--- a/modules/apps/layout/layout-utility-page-service/src/main/java/com/liferay/layout/utility/page/service/persistence/impl/LayoutUtilityPageEntryPersistenceImpl.java
+++ b/modules/apps/layout/layout-utility-page-service/src/main/java/com/liferay/layout/utility/page/service/persistence/impl/LayoutUtilityPageEntryPersistenceImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.layout.utility.page.service.persistence.impl;
 
+import com.liferay.layout.utility.page.exception.DuplicateLayoutUtilityPageEntryExternalReferenceCodeException;
 import com.liferay.layout.utility.page.exception.NoSuchLayoutUtilityPageEntryException;
 import com.liferay.layout.utility.page.model.LayoutUtilityPageEntry;
 import com.liferay.layout.utility.page.model.LayoutUtilityPageEntryTable;
@@ -4739,35 +4740,35 @@ public class LayoutUtilityPageEntryPersistenceImpl
 	private static final String _FINDER_COLUMN_G_N_T_TYPE_2 =
 		"layoutUtilityPageEntry.type = ?";
 
-	private FinderPath _finderPathFetchByG_ERC;
-	private FinderPath _finderPathCountByG_ERC;
+	private FinderPath _finderPathFetchByERC_G;
+	private FinderPath _finderPathCountByERC_G;
 
 	/**
-	 * Returns the layout utility page entry where groupId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchLayoutUtilityPageEntryException</code> if it could not be found.
+	 * Returns the layout utility page entry where externalReferenceCode = &#63; and groupId = &#63; or throws a <code>NoSuchLayoutUtilityPageEntryException</code> if it could not be found.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the matching layout utility page entry
 	 * @throws NoSuchLayoutUtilityPageEntryException if a matching layout utility page entry could not be found
 	 */
 	@Override
-	public LayoutUtilityPageEntry findByG_ERC(
-			long groupId, String externalReferenceCode)
+	public LayoutUtilityPageEntry findByERC_G(
+			String externalReferenceCode, long groupId)
 		throws NoSuchLayoutUtilityPageEntryException {
 
-		LayoutUtilityPageEntry layoutUtilityPageEntry = fetchByG_ERC(
-			groupId, externalReferenceCode);
+		LayoutUtilityPageEntry layoutUtilityPageEntry = fetchByERC_G(
+			externalReferenceCode, groupId);
 
 		if (layoutUtilityPageEntry == null) {
 			StringBundler sb = new StringBundler(6);
 
 			sb.append(_NO_SUCH_ENTITY_WITH_KEY);
 
-			sb.append("groupId=");
-			sb.append(groupId);
-
-			sb.append(", externalReferenceCode=");
+			sb.append("externalReferenceCode=");
 			sb.append(externalReferenceCode);
+
+			sb.append(", groupId=");
+			sb.append(groupId);
 
 			sb.append("}");
 
@@ -4782,30 +4783,30 @@ public class LayoutUtilityPageEntryPersistenceImpl
 	}
 
 	/**
-	 * Returns the layout utility page entry where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the layout utility page entry where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the matching layout utility page entry, or <code>null</code> if a matching layout utility page entry could not be found
 	 */
 	@Override
-	public LayoutUtilityPageEntry fetchByG_ERC(
-		long groupId, String externalReferenceCode) {
+	public LayoutUtilityPageEntry fetchByERC_G(
+		String externalReferenceCode, long groupId) {
 
-		return fetchByG_ERC(groupId, externalReferenceCode, true);
+		return fetchByERC_G(externalReferenceCode, groupId, true);
 	}
 
 	/**
-	 * Returns the layout utility page entry where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the layout utility page entry where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching layout utility page entry, or <code>null</code> if a matching layout utility page entry could not be found
 	 */
 	@Override
-	public LayoutUtilityPageEntry fetchByG_ERC(
-		long groupId, String externalReferenceCode, boolean useFinderCache) {
+	public LayoutUtilityPageEntry fetchByERC_G(
+		String externalReferenceCode, long groupId, boolean useFinderCache) {
 
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
@@ -4815,24 +4816,24 @@ public class LayoutUtilityPageEntryPersistenceImpl
 		Object[] finderArgs = null;
 
 		if (useFinderCache && productionMode) {
-			finderArgs = new Object[] {groupId, externalReferenceCode};
+			finderArgs = new Object[] {externalReferenceCode, groupId};
 		}
 
 		Object result = null;
 
 		if (useFinderCache && productionMode) {
 			result = finderCache.getResult(
-				_finderPathFetchByG_ERC, finderArgs, this);
+				_finderPathFetchByERC_G, finderArgs, this);
 		}
 
 		if (result instanceof LayoutUtilityPageEntry) {
 			LayoutUtilityPageEntry layoutUtilityPageEntry =
 				(LayoutUtilityPageEntry)result;
 
-			if ((groupId != layoutUtilityPageEntry.getGroupId()) ||
-				!Objects.equals(
+			if (!Objects.equals(
 					externalReferenceCode,
-					layoutUtilityPageEntry.getExternalReferenceCode())) {
+					layoutUtilityPageEntry.getExternalReferenceCode()) ||
+				(groupId != layoutUtilityPageEntry.getGroupId())) {
 
 				result = null;
 			}
@@ -4843,18 +4844,18 @@ public class LayoutUtilityPageEntryPersistenceImpl
 
 			sb.append(_SQL_SELECT_LAYOUTUTILITYPAGEENTRY_WHERE);
 
-			sb.append(_FINDER_COLUMN_G_ERC_GROUPID_2);
-
 			boolean bindExternalReferenceCode = false;
 
 			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_3);
+				sb.append(_FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_3);
 			}
 			else {
 				bindExternalReferenceCode = true;
 
-				sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_2);
+				sb.append(_FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_2);
 			}
+
+			sb.append(_FINDER_COLUMN_ERC_G_GROUPID_2);
 
 			String sql = sb.toString();
 
@@ -4867,18 +4868,18 @@ public class LayoutUtilityPageEntryPersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
-				queryPos.add(groupId);
-
 				if (bindExternalReferenceCode) {
 					queryPos.add(externalReferenceCode);
 				}
+
+				queryPos.add(groupId);
 
 				List<LayoutUtilityPageEntry> list = query.list();
 
 				if (list.isEmpty()) {
 					if (useFinderCache && productionMode) {
 						finderCache.putResult(
-							_finderPathFetchByG_ERC, finderArgs, list);
+							_finderPathFetchByERC_G, finderArgs, list);
 					}
 				}
 				else {
@@ -4906,32 +4907,32 @@ public class LayoutUtilityPageEntryPersistenceImpl
 	}
 
 	/**
-	 * Removes the layout utility page entry where groupId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the layout utility page entry where externalReferenceCode = &#63; and groupId = &#63; from the database.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the layout utility page entry that was removed
 	 */
 	@Override
-	public LayoutUtilityPageEntry removeByG_ERC(
-			long groupId, String externalReferenceCode)
+	public LayoutUtilityPageEntry removeByERC_G(
+			String externalReferenceCode, long groupId)
 		throws NoSuchLayoutUtilityPageEntryException {
 
-		LayoutUtilityPageEntry layoutUtilityPageEntry = findByG_ERC(
-			groupId, externalReferenceCode);
+		LayoutUtilityPageEntry layoutUtilityPageEntry = findByERC_G(
+			externalReferenceCode, groupId);
 
 		return remove(layoutUtilityPageEntry);
 	}
 
 	/**
-	 * Returns the number of layout utility page entries where groupId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of layout utility page entries where externalReferenceCode = &#63; and groupId = &#63;.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the number of matching layout utility page entries
 	 */
 	@Override
-	public int countByG_ERC(long groupId, String externalReferenceCode) {
+	public int countByERC_G(String externalReferenceCode, long groupId) {
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
 		boolean productionMode = ctPersistenceHelper.isProductionMode(
@@ -4943,9 +4944,9 @@ public class LayoutUtilityPageEntryPersistenceImpl
 		Long count = null;
 
 		if (productionMode) {
-			finderPath = _finderPathCountByG_ERC;
+			finderPath = _finderPathCountByERC_G;
 
-			finderArgs = new Object[] {groupId, externalReferenceCode};
+			finderArgs = new Object[] {externalReferenceCode, groupId};
 
 			count = (Long)finderCache.getResult(finderPath, finderArgs, this);
 		}
@@ -4955,18 +4956,18 @@ public class LayoutUtilityPageEntryPersistenceImpl
 
 			sb.append(_SQL_COUNT_LAYOUTUTILITYPAGEENTRY_WHERE);
 
-			sb.append(_FINDER_COLUMN_G_ERC_GROUPID_2);
-
 			boolean bindExternalReferenceCode = false;
 
 			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_3);
+				sb.append(_FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_3);
 			}
 			else {
 				bindExternalReferenceCode = true;
 
-				sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_2);
+				sb.append(_FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_2);
 			}
+
+			sb.append(_FINDER_COLUMN_ERC_G_GROUPID_2);
 
 			String sql = sb.toString();
 
@@ -4979,11 +4980,11 @@ public class LayoutUtilityPageEntryPersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
-				queryPos.add(groupId);
-
 				if (bindExternalReferenceCode) {
 					queryPos.add(externalReferenceCode);
 				}
+
+				queryPos.add(groupId);
 
 				count = (Long)query.uniqueResult();
 
@@ -5002,14 +5003,14 @@ public class LayoutUtilityPageEntryPersistenceImpl
 		return count.intValue();
 	}
 
-	private static final String _FINDER_COLUMN_G_ERC_GROUPID_2 =
-		"layoutUtilityPageEntry.groupId = ? AND ";
+	private static final String _FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_2 =
+		"layoutUtilityPageEntry.externalReferenceCode = ? AND ";
 
-	private static final String _FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_2 =
-		"layoutUtilityPageEntry.externalReferenceCode = ?";
+	private static final String _FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_3 =
+		"(layoutUtilityPageEntry.externalReferenceCode IS NULL OR layoutUtilityPageEntry.externalReferenceCode = '') AND ";
 
-	private static final String _FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_3 =
-		"(layoutUtilityPageEntry.externalReferenceCode IS NULL OR layoutUtilityPageEntry.externalReferenceCode = '')";
+	private static final String _FINDER_COLUMN_ERC_G_GROUPID_2 =
+		"layoutUtilityPageEntry.groupId = ?";
 
 	public LayoutUtilityPageEntryPersistenceImpl() {
 		Map<String, String> dbColumnNames = new HashMap<String, String>();
@@ -5060,10 +5061,10 @@ public class LayoutUtilityPageEntryPersistenceImpl
 			layoutUtilityPageEntry);
 
 		finderCache.putResult(
-			_finderPathFetchByG_ERC,
+			_finderPathFetchByERC_G,
 			new Object[] {
-				layoutUtilityPageEntry.getGroupId(),
-				layoutUtilityPageEntry.getExternalReferenceCode()
+				layoutUtilityPageEntry.getExternalReferenceCode(),
+				layoutUtilityPageEntry.getGroupId()
 			},
 			layoutUtilityPageEntry);
 	}
@@ -5175,13 +5176,13 @@ public class LayoutUtilityPageEntryPersistenceImpl
 			_finderPathFetchByG_N_T, args, layoutUtilityPageEntryModelImpl);
 
 		args = new Object[] {
-			layoutUtilityPageEntryModelImpl.getGroupId(),
-			layoutUtilityPageEntryModelImpl.getExternalReferenceCode()
+			layoutUtilityPageEntryModelImpl.getExternalReferenceCode(),
+			layoutUtilityPageEntryModelImpl.getGroupId()
 		};
 
-		finderCache.putResult(_finderPathCountByG_ERC, args, Long.valueOf(1));
+		finderCache.putResult(_finderPathCountByERC_G, args, Long.valueOf(1));
 		finderCache.putResult(
-			_finderPathFetchByG_ERC, args, layoutUtilityPageEntryModelImpl);
+			_finderPathFetchByERC_G, args, layoutUtilityPageEntryModelImpl);
 	}
 
 	/**
@@ -5337,6 +5338,30 @@ public class LayoutUtilityPageEntryPersistenceImpl
 
 			layoutUtilityPageEntry.setExternalReferenceCode(
 				layoutUtilityPageEntry.getUuid());
+		}
+		else {
+			LayoutUtilityPageEntry ercLayoutUtilityPageEntry = fetchByERC_G(
+				layoutUtilityPageEntry.getExternalReferenceCode(),
+				layoutUtilityPageEntry.getGroupId());
+
+			if (isNew) {
+				if (ercLayoutUtilityPageEntry != null) {
+					throw new DuplicateLayoutUtilityPageEntryExternalReferenceCodeException(
+						"Duplicate LayoutUtilityPageEntry with external reference code " +
+							layoutUtilityPageEntry.getExternalReferenceCode());
+				}
+			}
+			else {
+				if ((ercLayoutUtilityPageEntry != null) &&
+					(layoutUtilityPageEntry.getLayoutUtilityPageEntryId() !=
+						ercLayoutUtilityPageEntry.
+							getLayoutUtilityPageEntryId())) {
+
+					throw new DuplicateLayoutUtilityPageEntryExternalReferenceCodeException(
+						"Duplicate LayoutUtilityPageEntry with external reference code " +
+							layoutUtilityPageEntry.getExternalReferenceCode());
+				}
+			}
 		}
 
 		ServiceContext serviceContext =
@@ -5892,7 +5917,7 @@ public class LayoutUtilityPageEntryPersistenceImpl
 		_uniqueIndexColumnNames.add(new String[] {"groupId", "name", "type_"});
 
 		_uniqueIndexColumnNames.add(
-			new String[] {"groupId", "externalReferenceCode"});
+			new String[] {"externalReferenceCode", "groupId"});
 	}
 
 	/**
@@ -6043,15 +6068,15 @@ public class LayoutUtilityPageEntryPersistenceImpl
 			},
 			new String[] {"groupId", "name", "type_"}, false);
 
-		_finderPathFetchByG_ERC = new FinderPath(
-			FINDER_CLASS_NAME_ENTITY, "fetchByG_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"groupId", "externalReferenceCode"}, true);
+		_finderPathFetchByERC_G = new FinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByERC_G",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "groupId"}, true);
 
-		_finderPathCountByG_ERC = new FinderPath(
-			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"groupId", "externalReferenceCode"}, false);
+		_finderPathCountByERC_G = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByERC_G",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "groupId"}, false);
 
 		_setLayoutUtilityPageEntryUtilPersistence(this);
 	}

--- a/modules/apps/layout/layout-utility-page-test/src/testIntegration/java/com/liferay/layout/utility/page/service/persistence/test/LayoutUtilityPageEntryPersistenceTest.java
+++ b/modules/apps/layout/layout-utility-page-test/src/testIntegration/java/com/liferay/layout/utility/page/service/persistence/test/LayoutUtilityPageEntryPersistenceTest.java
@@ -15,6 +15,7 @@
 package com.liferay.layout.utility.page.service.persistence.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.layout.utility.page.exception.DuplicateLayoutUtilityPageEntryExternalReferenceCodeException;
 import com.liferay.layout.utility.page.exception.NoSuchLayoutUtilityPageEntryException;
 import com.liferay.layout.utility.page.model.LayoutUtilityPageEntry;
 import com.liferay.layout.utility.page.service.LayoutUtilityPageEntryLocalServiceUtil;
@@ -229,6 +230,32 @@ public class LayoutUtilityPageEntryPersistenceTest {
 				newLayoutUtilityPageEntry.getLastPublishDate()));
 	}
 
+	@Test(
+		expected = DuplicateLayoutUtilityPageEntryExternalReferenceCodeException.class
+	)
+	public void testUpdateWithExistingExternalReferenceCode() throws Exception {
+		LayoutUtilityPageEntry layoutUtilityPageEntry =
+			addLayoutUtilityPageEntry();
+
+		LayoutUtilityPageEntry newLayoutUtilityPageEntry =
+			addLayoutUtilityPageEntry();
+
+		newLayoutUtilityPageEntry.setGroupId(
+			layoutUtilityPageEntry.getGroupId());
+
+		newLayoutUtilityPageEntry = _persistence.update(
+			newLayoutUtilityPageEntry);
+
+		Session session = _persistence.getCurrentSession();
+
+		session.evict(newLayoutUtilityPageEntry);
+
+		newLayoutUtilityPageEntry.setExternalReferenceCode(
+			layoutUtilityPageEntry.getExternalReferenceCode());
+
+		_persistence.update(newLayoutUtilityPageEntry);
+	}
+
 	@Test
 	public void testCountByUuid() throws Exception {
 		_persistence.countByUuid("");
@@ -291,12 +318,12 @@ public class LayoutUtilityPageEntryPersistenceTest {
 	}
 
 	@Test
-	public void testCountByG_ERC() throws Exception {
-		_persistence.countByG_ERC(RandomTestUtil.nextLong(), "");
+	public void testCountByERC_G() throws Exception {
+		_persistence.countByERC_G("", RandomTestUtil.nextLong());
 
-		_persistence.countByG_ERC(0L, "null");
+		_persistence.countByERC_G("null", 0L);
 
-		_persistence.countByG_ERC(0L, (String)null);
+		_persistence.countByERC_G((String)null, 0L);
 	}
 
 	@Test
@@ -663,15 +690,15 @@ public class LayoutUtilityPageEntryPersistenceTest {
 				new Class<?>[] {String.class}, "type_"));
 
 		Assert.assertEquals(
-			Long.valueOf(layoutUtilityPageEntry.getGroupId()),
-			ReflectionTestUtil.<Long>invoke(
-				layoutUtilityPageEntry, "getColumnOriginalValue",
-				new Class<?>[] {String.class}, "groupId"));
-		Assert.assertEquals(
 			layoutUtilityPageEntry.getExternalReferenceCode(),
 			ReflectionTestUtil.invoke(
 				layoutUtilityPageEntry, "getColumnOriginalValue",
 				new Class<?>[] {String.class}, "externalReferenceCode"));
+		Assert.assertEquals(
+			Long.valueOf(layoutUtilityPageEntry.getGroupId()),
+			ReflectionTestUtil.<Long>invoke(
+				layoutUtilityPageEntry, "getColumnOriginalValue",
+				new Class<?>[] {String.class}, "groupId"));
 	}
 
 	protected LayoutUtilityPageEntry addLayoutUtilityPageEntry()

--- a/modules/apps/list-type/list-type-api/bnd.bnd
+++ b/modules/apps/list-type/list-type-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay List Type API
 Bundle-SymbolicName: com.liferay.list.type.api
-Bundle-Version: 4.1.1
+Bundle-Version: 5.0.0
 Export-Package:\
 	com.liferay.list.type.constants,\
 	com.liferay.list.type.exception,\

--- a/modules/apps/list-type/list-type-api/src/main/java/com/liferay/list/type/exception/DuplicateListTypeDefinitionExternalReferenceCodeException.java
+++ b/modules/apps/list-type/list-type-api/src/main/java/com/liferay/list/type/exception/DuplicateListTypeDefinitionExternalReferenceCodeException.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.list.type.exception;
+
+import com.liferay.portal.kernel.exception.SystemException;
+
+/**
+ * @author Gabriel Albuquerque
+ */
+public class DuplicateListTypeDefinitionExternalReferenceCodeException
+	extends SystemException {
+
+	public DuplicateListTypeDefinitionExternalReferenceCodeException() {
+	}
+
+	public DuplicateListTypeDefinitionExternalReferenceCodeException(
+		String msg) {
+
+		super(msg);
+	}
+
+	public DuplicateListTypeDefinitionExternalReferenceCodeException(
+		String msg, Throwable throwable) {
+
+		super(msg, throwable);
+	}
+
+	public DuplicateListTypeDefinitionExternalReferenceCodeException(
+		Throwable throwable) {
+
+		super(throwable);
+	}
+
+}

--- a/modules/apps/list-type/list-type-api/src/main/java/com/liferay/list/type/service/ListTypeDefinitionLocalService.java
+++ b/modules/apps/list-type/list-type-api/src/main/java/com/liferay/list/type/service/ListTypeDefinitionLocalService.java
@@ -225,24 +225,9 @@ public interface ListTypeDefinitionLocalService
 	public ListTypeDefinition fetchListTypeDefinition(
 		long listTypeDefinitionId);
 
-	/**
-	 * Returns the list type definition with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the list type definition's external reference code
-	 * @return the matching list type definition, or <code>null</code> if a matching list type definition could not be found
-	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public ListTypeDefinition fetchListTypeDefinitionByExternalReferenceCode(
-		long companyId, String externalReferenceCode);
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchListTypeDefinitionByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public ListTypeDefinition fetchListTypeDefinitionByReferenceCode(
-		long companyId, String externalReferenceCode);
+		String externalReferenceCode, long companyId);
 
 	/**
 	 * Returns the list type definition with the matching UUID and company.
@@ -276,17 +261,9 @@ public interface ListTypeDefinitionLocalService
 	public ListTypeDefinition getListTypeDefinition(long listTypeDefinitionId)
 		throws PortalException;
 
-	/**
-	 * Returns the list type definition with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the list type definition's external reference code
-	 * @return the matching list type definition
-	 * @throws PortalException if a matching list type definition could not be found
-	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public ListTypeDefinition getListTypeDefinitionByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
+			String externalReferenceCode, long companyId)
 		throws PortalException;
 
 	/**

--- a/modules/apps/list-type/list-type-api/src/main/java/com/liferay/list/type/service/ListTypeDefinitionLocalServiceUtil.java
+++ b/modules/apps/list-type/list-type-api/src/main/java/com/liferay/list/type/service/ListTypeDefinitionLocalServiceUtil.java
@@ -238,30 +238,12 @@ public class ListTypeDefinitionLocalServiceUtil {
 		return getService().fetchListTypeDefinition(listTypeDefinitionId);
 	}
 
-	/**
-	 * Returns the list type definition with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the list type definition's external reference code
-	 * @return the matching list type definition, or <code>null</code> if a matching list type definition could not be found
-	 */
 	public static ListTypeDefinition
 		fetchListTypeDefinitionByExternalReferenceCode(
-			long companyId, String externalReferenceCode) {
+			String externalReferenceCode, long companyId) {
 
 		return getService().fetchListTypeDefinitionByExternalReferenceCode(
-			companyId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchListTypeDefinitionByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	public static ListTypeDefinition fetchListTypeDefinitionByReferenceCode(
-		long companyId, String externalReferenceCode) {
-
-		return getService().fetchListTypeDefinitionByReferenceCode(
-			companyId, externalReferenceCode);
+			externalReferenceCode, companyId);
 	}
 
 	/**
@@ -313,21 +295,13 @@ public class ListTypeDefinitionLocalServiceUtil {
 		return getService().getListTypeDefinition(listTypeDefinitionId);
 	}
 
-	/**
-	 * Returns the list type definition with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the list type definition's external reference code
-	 * @return the matching list type definition
-	 * @throws PortalException if a matching list type definition could not be found
-	 */
 	public static ListTypeDefinition
 			getListTypeDefinitionByExternalReferenceCode(
-				long companyId, String externalReferenceCode)
+				String externalReferenceCode, long companyId)
 		throws PortalException {
 
 		return getService().getListTypeDefinitionByExternalReferenceCode(
-			companyId, externalReferenceCode);
+			externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/list-type/list-type-api/src/main/java/com/liferay/list/type/service/ListTypeDefinitionLocalServiceWrapper.java
+++ b/modules/apps/list-type/list-type-api/src/main/java/com/liferay/list/type/service/ListTypeDefinitionLocalServiceWrapper.java
@@ -265,35 +265,14 @@ public class ListTypeDefinitionLocalServiceWrapper
 			listTypeDefinitionId);
 	}
 
-	/**
-	 * Returns the list type definition with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the list type definition's external reference code
-	 * @return the matching list type definition, or <code>null</code> if a matching list type definition could not be found
-	 */
 	@Override
 	public com.liferay.list.type.model.ListTypeDefinition
 		fetchListTypeDefinitionByExternalReferenceCode(
-			long companyId, String externalReferenceCode) {
+			String externalReferenceCode, long companyId) {
 
 		return _listTypeDefinitionLocalService.
 			fetchListTypeDefinitionByExternalReferenceCode(
-				companyId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchListTypeDefinitionByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public com.liferay.list.type.model.ListTypeDefinition
-		fetchListTypeDefinitionByReferenceCode(
-			long companyId, String externalReferenceCode) {
-
-		return _listTypeDefinitionLocalService.
-			fetchListTypeDefinitionByReferenceCode(
-				companyId, externalReferenceCode);
+				externalReferenceCode, companyId);
 	}
 
 	/**
@@ -352,23 +331,15 @@ public class ListTypeDefinitionLocalServiceWrapper
 			listTypeDefinitionId);
 	}
 
-	/**
-	 * Returns the list type definition with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the list type definition's external reference code
-	 * @return the matching list type definition
-	 * @throws PortalException if a matching list type definition could not be found
-	 */
 	@Override
 	public com.liferay.list.type.model.ListTypeDefinition
 			getListTypeDefinitionByExternalReferenceCode(
-				long companyId, String externalReferenceCode)
+				String externalReferenceCode, long companyId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _listTypeDefinitionLocalService.
 			getListTypeDefinitionByExternalReferenceCode(
-				companyId, externalReferenceCode);
+				externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/list-type/list-type-api/src/main/java/com/liferay/list/type/service/persistence/ListTypeDefinitionPersistence.java
+++ b/modules/apps/list-type/list-type-api/src/main/java/com/liferay/list/type/service/persistence/ListTypeDefinitionPersistence.java
@@ -474,57 +474,57 @@ public interface ListTypeDefinitionPersistence
 	public int filterCountByUuid_C(String uuid, long companyId);
 
 	/**
-	 * Returns the list type definition where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchListTypeDefinitionException</code> if it could not be found.
+	 * Returns the list type definition where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchListTypeDefinitionException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching list type definition
 	 * @throws NoSuchListTypeDefinitionException if a matching list type definition could not be found
 	 */
-	public ListTypeDefinition findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public ListTypeDefinition findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchListTypeDefinitionException;
 
 	/**
-	 * Returns the list type definition where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the list type definition where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching list type definition, or <code>null</code> if a matching list type definition could not be found
 	 */
-	public ListTypeDefinition fetchByC_ERC(
-		long companyId, String externalReferenceCode);
+	public ListTypeDefinition fetchByERC_C(
+		String externalReferenceCode, long companyId);
 
 	/**
-	 * Returns the list type definition where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the list type definition where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching list type definition, or <code>null</code> if a matching list type definition could not be found
 	 */
-	public ListTypeDefinition fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache);
+	public ListTypeDefinition fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache);
 
 	/**
-	 * Removes the list type definition where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the list type definition where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the list type definition that was removed
 	 */
-	public ListTypeDefinition removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public ListTypeDefinition removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchListTypeDefinitionException;
 
 	/**
-	 * Returns the number of list type definitions where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of list type definitions where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching list type definitions
 	 */
-	public int countByC_ERC(long companyId, String externalReferenceCode);
+	public int countByERC_C(String externalReferenceCode, long companyId);
 
 	/**
 	 * Caches the list type definition in the entity cache if it is enabled.

--- a/modules/apps/list-type/list-type-api/src/main/java/com/liferay/list/type/service/persistence/ListTypeDefinitionUtil.java
+++ b/modules/apps/list-type/list-type-api/src/main/java/com/liferay/list/type/service/persistence/ListTypeDefinitionUtil.java
@@ -643,75 +643,75 @@ public class ListTypeDefinitionUtil {
 	}
 
 	/**
-	 * Returns the list type definition where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchListTypeDefinitionException</code> if it could not be found.
+	 * Returns the list type definition where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchListTypeDefinitionException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching list type definition
 	 * @throws NoSuchListTypeDefinitionException if a matching list type definition could not be found
 	 */
-	public static ListTypeDefinition findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public static ListTypeDefinition findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws com.liferay.list.type.exception.
 			NoSuchListTypeDefinitionException {
 
-		return getPersistence().findByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().findByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the list type definition where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the list type definition where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching list type definition, or <code>null</code> if a matching list type definition could not be found
 	 */
-	public static ListTypeDefinition fetchByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public static ListTypeDefinition fetchByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return getPersistence().fetchByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().fetchByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the list type definition where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the list type definition where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching list type definition, or <code>null</code> if a matching list type definition could not be found
 	 */
-	public static ListTypeDefinition fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache) {
+	public static ListTypeDefinition fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache) {
 
-		return getPersistence().fetchByC_ERC(
-			companyId, externalReferenceCode, useFinderCache);
+		return getPersistence().fetchByERC_C(
+			externalReferenceCode, companyId, useFinderCache);
 	}
 
 	/**
-	 * Removes the list type definition where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the list type definition where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the list type definition that was removed
 	 */
-	public static ListTypeDefinition removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public static ListTypeDefinition removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws com.liferay.list.type.exception.
 			NoSuchListTypeDefinitionException {
 
-		return getPersistence().removeByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().removeByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the number of list type definitions where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of list type definitions where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching list type definitions
 	 */
-	public static int countByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public static int countByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return getPersistence().countByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().countByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/list-type/list-type-api/src/main/resources/com/liferay/list/type/exception/packageinfo
+++ b/modules/apps/list-type/list-type-api/src/main/resources/com/liferay/list/type/exception/packageinfo
@@ -1,1 +1,1 @@
-version 1.2.0
+version 1.3.0

--- a/modules/apps/list-type/list-type-api/src/main/resources/com/liferay/list/type/service/packageinfo
+++ b/modules/apps/list-type/list-type-api/src/main/resources/com/liferay/list/type/service/packageinfo
@@ -1,1 +1,1 @@
-version 3.0.0
+version 4.0.0

--- a/modules/apps/list-type/list-type-api/src/main/resources/com/liferay/list/type/service/persistence/packageinfo
+++ b/modules/apps/list-type/list-type-api/src/main/resources/com/liferay/list/type/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 1.2.0
+version 2.0.0

--- a/modules/apps/list-type/list-type-service/service.xml
+++ b/modules/apps/list-type/list-type-service/service.xml
@@ -58,7 +58,6 @@
 	</entity>
 	<exceptions>
 		<exception>DuplicateListTypeEntry</exception>
-		<exception>DuplicateListTypeExternalReferenceCode</exception>
 		<exception>ListTypeDefinitionName</exception>
 		<exception>ListTypeEntryKey</exception>
 		<exception>ListTypeEntryName</exception>

--- a/modules/apps/list-type/list-type-service/src/main/java/com/liferay/list/type/service/base/ListTypeDefinitionLocalServiceBaseImpl.java
+++ b/modules/apps/list-type/list-type-service/src/main/java/com/liferay/list/type/service/base/ListTypeDefinitionLocalServiceBaseImpl.java
@@ -281,48 +281,21 @@ public abstract class ListTypeDefinitionLocalServiceBaseImpl
 			uuid, companyId, null);
 	}
 
-	/**
-	 * Returns the list type definition with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the list type definition's external reference code
-	 * @return the matching list type definition, or <code>null</code> if a matching list type definition could not be found
-	 */
 	@Override
 	public ListTypeDefinition fetchListTypeDefinitionByExternalReferenceCode(
-		long companyId, String externalReferenceCode) {
+		String externalReferenceCode, long companyId) {
 
-		return listTypeDefinitionPersistence.fetchByC_ERC(
-			companyId, externalReferenceCode);
+		return listTypeDefinitionPersistence.fetchByERC_C(
+			externalReferenceCode, companyId);
 	}
 
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchListTypeDefinitionByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public ListTypeDefinition fetchListTypeDefinitionByReferenceCode(
-		long companyId, String externalReferenceCode) {
-
-		return fetchListTypeDefinitionByExternalReferenceCode(
-			companyId, externalReferenceCode);
-	}
-
-	/**
-	 * Returns the list type definition with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the list type definition's external reference code
-	 * @return the matching list type definition
-	 * @throws PortalException if a matching list type definition could not be found
-	 */
 	@Override
 	public ListTypeDefinition getListTypeDefinitionByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
+			String externalReferenceCode, long companyId)
 		throws PortalException {
 
-		return listTypeDefinitionPersistence.findByC_ERC(
-			companyId, externalReferenceCode);
+		return listTypeDefinitionPersistence.findByERC_C(
+			externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/list-type/list-type-service/src/main/java/com/liferay/list/type/service/impl/ListTypeDefinitionLocalServiceImpl.java
+++ b/modules/apps/list-type/list-type-service/src/main/java/com/liferay/list/type/service/impl/ListTypeDefinitionLocalServiceImpl.java
@@ -64,8 +64,8 @@ public class ListTypeDefinitionLocalServiceImpl
 				counterLocalService.increment());
 
 		if (GetterUtil.getBoolean(PropsUtil.get("feature.flag.LPS-164278"))) {
-			int count = listTypeDefinitionPersistence.countByC_ERC(
-				listTypeDefinition.getCompanyId(), externalReferenceCode);
+			int count = listTypeDefinitionPersistence.countByERC_C(
+				externalReferenceCode, listTypeDefinition.getCompanyId());
 
 			if (count != 0) {
 				throw new DuplicateListTypeExternalReferenceCodeException(

--- a/modules/apps/list-type/list-type-service/src/main/java/com/liferay/list/type/service/persistence/impl/ListTypeDefinitionPersistenceImpl.java
+++ b/modules/apps/list-type/list-type-service/src/main/java/com/liferay/list/type/service/persistence/impl/ListTypeDefinitionPersistenceImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.list.type.service.persistence.impl;
 
+import com.liferay.list.type.exception.DuplicateListTypeDefinitionExternalReferenceCodeException;
 import com.liferay.list.type.exception.NoSuchListTypeDefinitionException;
 import com.liferay.list.type.model.ListTypeDefinition;
 import com.liferay.list.type.model.ListTypeDefinitionTable;
@@ -2099,35 +2100,35 @@ public class ListTypeDefinitionPersistenceImpl
 	private static final String _FINDER_COLUMN_UUID_C_COMPANYID_2 =
 		"listTypeDefinition.companyId = ?";
 
-	private FinderPath _finderPathFetchByC_ERC;
-	private FinderPath _finderPathCountByC_ERC;
+	private FinderPath _finderPathFetchByERC_C;
+	private FinderPath _finderPathCountByERC_C;
 
 	/**
-	 * Returns the list type definition where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchListTypeDefinitionException</code> if it could not be found.
+	 * Returns the list type definition where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchListTypeDefinitionException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching list type definition
 	 * @throws NoSuchListTypeDefinitionException if a matching list type definition could not be found
 	 */
 	@Override
-	public ListTypeDefinition findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public ListTypeDefinition findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchListTypeDefinitionException {
 
-		ListTypeDefinition listTypeDefinition = fetchByC_ERC(
-			companyId, externalReferenceCode);
+		ListTypeDefinition listTypeDefinition = fetchByERC_C(
+			externalReferenceCode, companyId);
 
 		if (listTypeDefinition == null) {
 			StringBundler sb = new StringBundler(6);
 
 			sb.append(_NO_SUCH_ENTITY_WITH_KEY);
 
-			sb.append("companyId=");
-			sb.append(companyId);
-
-			sb.append(", externalReferenceCode=");
+			sb.append("externalReferenceCode=");
 			sb.append(externalReferenceCode);
+
+			sb.append(", companyId=");
+			sb.append(companyId);
 
 			sb.append("}");
 
@@ -2142,53 +2143,53 @@ public class ListTypeDefinitionPersistenceImpl
 	}
 
 	/**
-	 * Returns the list type definition where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the list type definition where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching list type definition, or <code>null</code> if a matching list type definition could not be found
 	 */
 	@Override
-	public ListTypeDefinition fetchByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public ListTypeDefinition fetchByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return fetchByC_ERC(companyId, externalReferenceCode, true);
+		return fetchByERC_C(externalReferenceCode, companyId, true);
 	}
 
 	/**
-	 * Returns the list type definition where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the list type definition where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching list type definition, or <code>null</code> if a matching list type definition could not be found
 	 */
 	@Override
-	public ListTypeDefinition fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache) {
+	public ListTypeDefinition fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache) {
 
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
 		Object[] finderArgs = null;
 
 		if (useFinderCache) {
-			finderArgs = new Object[] {companyId, externalReferenceCode};
+			finderArgs = new Object[] {externalReferenceCode, companyId};
 		}
 
 		Object result = null;
 
 		if (useFinderCache) {
 			result = finderCache.getResult(
-				_finderPathFetchByC_ERC, finderArgs, this);
+				_finderPathFetchByERC_C, finderArgs, this);
 		}
 
 		if (result instanceof ListTypeDefinition) {
 			ListTypeDefinition listTypeDefinition = (ListTypeDefinition)result;
 
-			if ((companyId != listTypeDefinition.getCompanyId()) ||
-				!Objects.equals(
+			if (!Objects.equals(
 					externalReferenceCode,
-					listTypeDefinition.getExternalReferenceCode())) {
+					listTypeDefinition.getExternalReferenceCode()) ||
+				(companyId != listTypeDefinition.getCompanyId())) {
 
 				result = null;
 			}
@@ -2199,18 +2200,18 @@ public class ListTypeDefinitionPersistenceImpl
 
 			sb.append(_SQL_SELECT_LISTTYPEDEFINITION_WHERE);
 
-			sb.append(_FINDER_COLUMN_C_ERC_COMPANYID_2);
-
 			boolean bindExternalReferenceCode = false;
 
 			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3);
 			}
 			else {
 				bindExternalReferenceCode = true;
 
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2);
 			}
+
+			sb.append(_FINDER_COLUMN_ERC_C_COMPANYID_2);
 
 			String sql = sb.toString();
 
@@ -2223,18 +2224,18 @@ public class ListTypeDefinitionPersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
-				queryPos.add(companyId);
-
 				if (bindExternalReferenceCode) {
 					queryPos.add(externalReferenceCode);
 				}
+
+				queryPos.add(companyId);
 
 				List<ListTypeDefinition> list = query.list();
 
 				if (list.isEmpty()) {
 					if (useFinderCache) {
 						finderCache.putResult(
-							_finderPathFetchByC_ERC, finderArgs, list);
+							_finderPathFetchByERC_C, finderArgs, list);
 					}
 				}
 				else {
@@ -2262,37 +2263,37 @@ public class ListTypeDefinitionPersistenceImpl
 	}
 
 	/**
-	 * Removes the list type definition where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the list type definition where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the list type definition that was removed
 	 */
 	@Override
-	public ListTypeDefinition removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public ListTypeDefinition removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchListTypeDefinitionException {
 
-		ListTypeDefinition listTypeDefinition = findByC_ERC(
-			companyId, externalReferenceCode);
+		ListTypeDefinition listTypeDefinition = findByERC_C(
+			externalReferenceCode, companyId);
 
 		return remove(listTypeDefinition);
 	}
 
 	/**
-	 * Returns the number of list type definitions where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of list type definitions where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching list type definitions
 	 */
 	@Override
-	public int countByC_ERC(long companyId, String externalReferenceCode) {
+	public int countByERC_C(String externalReferenceCode, long companyId) {
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
-		FinderPath finderPath = _finderPathCountByC_ERC;
+		FinderPath finderPath = _finderPathCountByERC_C;
 
-		Object[] finderArgs = new Object[] {companyId, externalReferenceCode};
+		Object[] finderArgs = new Object[] {externalReferenceCode, companyId};
 
 		Long count = (Long)finderCache.getResult(finderPath, finderArgs, this);
 
@@ -2301,18 +2302,18 @@ public class ListTypeDefinitionPersistenceImpl
 
 			sb.append(_SQL_COUNT_LISTTYPEDEFINITION_WHERE);
 
-			sb.append(_FINDER_COLUMN_C_ERC_COMPANYID_2);
-
 			boolean bindExternalReferenceCode = false;
 
 			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3);
 			}
 			else {
 				bindExternalReferenceCode = true;
 
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2);
 			}
+
+			sb.append(_FINDER_COLUMN_ERC_C_COMPANYID_2);
 
 			String sql = sb.toString();
 
@@ -2325,11 +2326,11 @@ public class ListTypeDefinitionPersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
-				queryPos.add(companyId);
-
 				if (bindExternalReferenceCode) {
 					queryPos.add(externalReferenceCode);
 				}
+
+				queryPos.add(companyId);
 
 				count = (Long)query.uniqueResult();
 
@@ -2346,14 +2347,14 @@ public class ListTypeDefinitionPersistenceImpl
 		return count.intValue();
 	}
 
-	private static final String _FINDER_COLUMN_C_ERC_COMPANYID_2 =
-		"listTypeDefinition.companyId = ? AND ";
+	private static final String _FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2 =
+		"listTypeDefinition.externalReferenceCode = ? AND ";
 
-	private static final String _FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2 =
-		"listTypeDefinition.externalReferenceCode = ?";
+	private static final String _FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3 =
+		"(listTypeDefinition.externalReferenceCode IS NULL OR listTypeDefinition.externalReferenceCode = '') AND ";
 
-	private static final String _FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3 =
-		"(listTypeDefinition.externalReferenceCode IS NULL OR listTypeDefinition.externalReferenceCode = '')";
+	private static final String _FINDER_COLUMN_ERC_C_COMPANYID_2 =
+		"listTypeDefinition.companyId = ?";
 
 	public ListTypeDefinitionPersistenceImpl() {
 		Map<String, String> dbColumnNames = new HashMap<String, String>();
@@ -2382,10 +2383,10 @@ public class ListTypeDefinitionPersistenceImpl
 			listTypeDefinition);
 
 		finderCache.putResult(
-			_finderPathFetchByC_ERC,
+			_finderPathFetchByERC_C,
 			new Object[] {
-				listTypeDefinition.getCompanyId(),
-				listTypeDefinition.getExternalReferenceCode()
+				listTypeDefinition.getExternalReferenceCode(),
+				listTypeDefinition.getCompanyId()
 			},
 			listTypeDefinition);
 	}
@@ -2465,13 +2466,13 @@ public class ListTypeDefinitionPersistenceImpl
 		ListTypeDefinitionModelImpl listTypeDefinitionModelImpl) {
 
 		Object[] args = new Object[] {
-			listTypeDefinitionModelImpl.getCompanyId(),
-			listTypeDefinitionModelImpl.getExternalReferenceCode()
+			listTypeDefinitionModelImpl.getExternalReferenceCode(),
+			listTypeDefinitionModelImpl.getCompanyId()
 		};
 
-		finderCache.putResult(_finderPathCountByC_ERC, args, Long.valueOf(1));
+		finderCache.putResult(_finderPathCountByERC_C, args, Long.valueOf(1));
 		finderCache.putResult(
-			_finderPathFetchByC_ERC, args, listTypeDefinitionModelImpl);
+			_finderPathFetchByERC_C, args, listTypeDefinitionModelImpl);
 	}
 
 	/**
@@ -2620,6 +2621,29 @@ public class ListTypeDefinitionPersistenceImpl
 		if (Validator.isNull(listTypeDefinition.getExternalReferenceCode())) {
 			listTypeDefinition.setExternalReferenceCode(
 				listTypeDefinition.getUuid());
+		}
+		else {
+			ListTypeDefinition ercListTypeDefinition = fetchByERC_C(
+				listTypeDefinition.getExternalReferenceCode(),
+				listTypeDefinition.getCompanyId());
+
+			if (isNew) {
+				if (ercListTypeDefinition != null) {
+					throw new DuplicateListTypeDefinitionExternalReferenceCodeException(
+						"Duplicate ListTypeDefinition with external reference code " +
+							listTypeDefinition.getExternalReferenceCode());
+				}
+			}
+			else {
+				if ((ercListTypeDefinition != null) &&
+					(listTypeDefinition.getListTypeDefinitionId() !=
+						ercListTypeDefinition.getListTypeDefinitionId())) {
+
+					throw new DuplicateListTypeDefinitionExternalReferenceCodeException(
+						"Duplicate ListTypeDefinition with external reference code " +
+							listTypeDefinition.getExternalReferenceCode());
+				}
+			}
 		}
 
 		ServiceContext serviceContext =
@@ -2996,15 +3020,15 @@ public class ListTypeDefinitionPersistenceImpl
 			new String[] {String.class.getName(), Long.class.getName()},
 			new String[] {"uuid_", "companyId"}, false);
 
-		_finderPathFetchByC_ERC = new FinderPath(
-			FINDER_CLASS_NAME_ENTITY, "fetchByC_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"companyId", "externalReferenceCode"}, true);
+		_finderPathFetchByERC_C = new FinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, true);
 
-		_finderPathCountByC_ERC = new FinderPath(
-			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"companyId", "externalReferenceCode"}, false);
+		_finderPathCountByERC_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, false);
 
 		_setListTypeDefinitionUtilPersistence(this);
 	}

--- a/modules/apps/list-type/list-type-test/src/testIntegration/java/com/liferay/list/type/service/persistence/test/ListTypeDefinitionPersistenceTest.java
+++ b/modules/apps/list-type/list-type-test/src/testIntegration/java/com/liferay/list/type/service/persistence/test/ListTypeDefinitionPersistenceTest.java
@@ -15,6 +15,7 @@
 package com.liferay.list.type.service.persistence.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.list.type.exception.DuplicateListTypeDefinitionExternalReferenceCodeException;
 import com.liferay.list.type.exception.NoSuchListTypeDefinitionException;
 import com.liferay.list.type.model.ListTypeDefinition;
 import com.liferay.list.type.service.ListTypeDefinitionLocalServiceUtil;
@@ -183,6 +184,28 @@ public class ListTypeDefinitionPersistenceTest {
 			newListTypeDefinition.getName());
 	}
 
+	@Test(
+		expected = DuplicateListTypeDefinitionExternalReferenceCodeException.class
+	)
+	public void testUpdateWithExistingExternalReferenceCode() throws Exception {
+		ListTypeDefinition listTypeDefinition = addListTypeDefinition();
+
+		ListTypeDefinition newListTypeDefinition = addListTypeDefinition();
+
+		newListTypeDefinition.setCompanyId(listTypeDefinition.getCompanyId());
+
+		newListTypeDefinition = _persistence.update(newListTypeDefinition);
+
+		Session session = _persistence.getCurrentSession();
+
+		session.evict(newListTypeDefinition);
+
+		newListTypeDefinition.setExternalReferenceCode(
+			listTypeDefinition.getExternalReferenceCode());
+
+		_persistence.update(newListTypeDefinition);
+	}
+
 	@Test
 	public void testCountByUuid() throws Exception {
 		_persistence.countByUuid("");
@@ -202,12 +225,12 @@ public class ListTypeDefinitionPersistenceTest {
 	}
 
 	@Test
-	public void testCountByC_ERC() throws Exception {
-		_persistence.countByC_ERC(RandomTestUtil.nextLong(), "");
+	public void testCountByERC_C() throws Exception {
+		_persistence.countByERC_C("", RandomTestUtil.nextLong());
 
-		_persistence.countByC_ERC(0L, "null");
+		_persistence.countByERC_C("null", 0L);
 
-		_persistence.countByC_ERC(0L, (String)null);
+		_persistence.countByERC_C((String)null, 0L);
 	}
 
 	@Test
@@ -519,15 +542,15 @@ public class ListTypeDefinitionPersistenceTest {
 
 	private void _assertOriginalValues(ListTypeDefinition listTypeDefinition) {
 		Assert.assertEquals(
-			Long.valueOf(listTypeDefinition.getCompanyId()),
-			ReflectionTestUtil.<Long>invoke(
-				listTypeDefinition, "getColumnOriginalValue",
-				new Class<?>[] {String.class}, "companyId"));
-		Assert.assertEquals(
 			listTypeDefinition.getExternalReferenceCode(),
 			ReflectionTestUtil.invoke(
 				listTypeDefinition, "getColumnOriginalValue",
 				new Class<?>[] {String.class}, "externalReferenceCode"));
+		Assert.assertEquals(
+			Long.valueOf(listTypeDefinition.getCompanyId()),
+			ReflectionTestUtil.<Long>invoke(
+				listTypeDefinition, "getColumnOriginalValue",
+				new Class<?>[] {String.class}, "companyId"));
 	}
 
 	protected ListTypeDefinition addListTypeDefinition() throws Exception {

--- a/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/exception/DuplicateMBMessageExternalReferenceCodeException.java
+++ b/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/exception/DuplicateMBMessageExternalReferenceCodeException.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.message.boards.exception;
+
+import com.liferay.portal.kernel.exception.SystemException;
+
+/**
+ * @author Brian Wing Shun Chan
+ */
+public class DuplicateMBMessageExternalReferenceCodeException
+	extends SystemException {
+
+	public DuplicateMBMessageExternalReferenceCodeException() {
+	}
+
+	public DuplicateMBMessageExternalReferenceCodeException(String msg) {
+		super(msg);
+	}
+
+	public DuplicateMBMessageExternalReferenceCodeException(
+		String msg, Throwable throwable) {
+
+		super(msg, throwable);
+	}
+
+	public DuplicateMBMessageExternalReferenceCodeException(
+		Throwable throwable) {
+
+		super(throwable);
+	}
+
+}

--- a/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/exception/DuplicateMessageExternalReferenceCodeException.java
+++ b/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/exception/DuplicateMessageExternalReferenceCodeException.java
@@ -14,13 +14,13 @@
 
 package com.liferay.message.boards.exception;
 
-import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.SystemException;
 
 /**
  * @author Brian Wing Shun Chan
  */
 public class DuplicateMessageExternalReferenceCodeException
-	extends PortalException {
+	extends SystemException {
 
 	public DuplicateMessageExternalReferenceCodeException() {
 	}

--- a/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/MBMessageLocalService.java
+++ b/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/MBMessageLocalService.java
@@ -357,24 +357,9 @@ public interface MBMessageLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public MBMessage fetchMBMessage(long messageId);
 
-	/**
-	 * Returns the message-boards message with the matching external reference code and group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the message-boards message's external reference code
-	 * @return the matching message-boards message, or <code>null</code> if a matching message-boards message could not be found
-	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public MBMessage fetchMBMessageByExternalReferenceCode(
-		long groupId, String externalReferenceCode);
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchMBMessageByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public MBMessage fetchMBMessageByReferenceCode(
-		long groupId, String externalReferenceCode);
+		String externalReferenceCode, long groupId);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public MBMessage fetchMBMessageByUrlSubject(
@@ -508,17 +493,9 @@ public interface MBMessageLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public MBMessage getMBMessage(long messageId) throws PortalException;
 
-	/**
-	 * Returns the message-boards message with the matching external reference code and group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the message-boards message's external reference code
-	 * @return the matching message-boards message
-	 * @throws PortalException if a matching message-boards message could not be found
-	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public MBMessage getMBMessageByExternalReferenceCode(
-			long groupId, String externalReferenceCode)
+			String externalReferenceCode, long groupId)
 		throws PortalException;
 
 	/**

--- a/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/MBMessageLocalServiceUtil.java
+++ b/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/MBMessageLocalServiceUtil.java
@@ -452,29 +452,11 @@ public class MBMessageLocalServiceUtil {
 		return getService().fetchMBMessage(messageId);
 	}
 
-	/**
-	 * Returns the message-boards message with the matching external reference code and group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the message-boards message's external reference code
-	 * @return the matching message-boards message, or <code>null</code> if a matching message-boards message could not be found
-	 */
 	public static MBMessage fetchMBMessageByExternalReferenceCode(
-		long groupId, String externalReferenceCode) {
+		String externalReferenceCode, long groupId) {
 
 		return getService().fetchMBMessageByExternalReferenceCode(
-			groupId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchMBMessageByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	public static MBMessage fetchMBMessageByReferenceCode(
-		long groupId, String externalReferenceCode) {
-
-		return getService().fetchMBMessageByReferenceCode(
-			groupId, externalReferenceCode);
+			externalReferenceCode, groupId);
 	}
 
 	public static MBMessage fetchMBMessageByUrlSubject(
@@ -690,20 +672,12 @@ public class MBMessageLocalServiceUtil {
 		return getService().getMBMessage(messageId);
 	}
 
-	/**
-	 * Returns the message-boards message with the matching external reference code and group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the message-boards message's external reference code
-	 * @return the matching message-boards message
-	 * @throws PortalException if a matching message-boards message could not be found
-	 */
 	public static MBMessage getMBMessageByExternalReferenceCode(
-			long groupId, String externalReferenceCode)
+			String externalReferenceCode, long groupId)
 		throws PortalException {
 
 		return getService().getMBMessageByExternalReferenceCode(
-			groupId, externalReferenceCode);
+			externalReferenceCode, groupId);
 	}
 
 	/**

--- a/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/MBMessageLocalServiceWrapper.java
+++ b/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/MBMessageLocalServiceWrapper.java
@@ -493,31 +493,12 @@ public class MBMessageLocalServiceWrapper
 		return _mbMessageLocalService.fetchMBMessage(messageId);
 	}
 
-	/**
-	 * Returns the message-boards message with the matching external reference code and group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the message-boards message's external reference code
-	 * @return the matching message-boards message, or <code>null</code> if a matching message-boards message could not be found
-	 */
 	@Override
 	public MBMessage fetchMBMessageByExternalReferenceCode(
-		long groupId, String externalReferenceCode) {
+		String externalReferenceCode, long groupId) {
 
 		return _mbMessageLocalService.fetchMBMessageByExternalReferenceCode(
-			groupId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchMBMessageByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public MBMessage fetchMBMessageByReferenceCode(
-		long groupId, String externalReferenceCode) {
-
-		return _mbMessageLocalService.fetchMBMessageByReferenceCode(
-			groupId, externalReferenceCode);
+			externalReferenceCode, groupId);
 	}
 
 	@Override
@@ -772,21 +753,13 @@ public class MBMessageLocalServiceWrapper
 		return _mbMessageLocalService.getMBMessage(messageId);
 	}
 
-	/**
-	 * Returns the message-boards message with the matching external reference code and group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the message-boards message's external reference code
-	 * @return the matching message-boards message
-	 * @throws PortalException if a matching message-boards message could not be found
-	 */
 	@Override
 	public MBMessage getMBMessageByExternalReferenceCode(
-			long groupId, String externalReferenceCode)
+			String externalReferenceCode, long groupId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _mbMessageLocalService.getMBMessageByExternalReferenceCode(
-			groupId, externalReferenceCode);
+			externalReferenceCode, groupId);
 	}
 
 	/**

--- a/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/persistence/MBMessagePersistence.java
+++ b/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/persistence/MBMessagePersistence.java
@@ -5522,54 +5522,54 @@ public interface MBMessagePersistence
 		long userId, long classNameId, long classPK, int status);
 
 	/**
-	 * Returns the message-boards message where groupId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchMessageException</code> if it could not be found.
+	 * Returns the message-boards message where externalReferenceCode = &#63; and groupId = &#63; or throws a <code>NoSuchMessageException</code> if it could not be found.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the matching message-boards message
 	 * @throws NoSuchMessageException if a matching message-boards message could not be found
 	 */
-	public MBMessage findByG_ERC(long groupId, String externalReferenceCode)
+	public MBMessage findByERC_G(String externalReferenceCode, long groupId)
 		throws NoSuchMessageException;
 
 	/**
-	 * Returns the message-boards message where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the message-boards message where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the matching message-boards message, or <code>null</code> if a matching message-boards message could not be found
 	 */
-	public MBMessage fetchByG_ERC(long groupId, String externalReferenceCode);
+	public MBMessage fetchByERC_G(String externalReferenceCode, long groupId);
 
 	/**
-	 * Returns the message-boards message where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the message-boards message where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching message-boards message, or <code>null</code> if a matching message-boards message could not be found
 	 */
-	public MBMessage fetchByG_ERC(
-		long groupId, String externalReferenceCode, boolean useFinderCache);
+	public MBMessage fetchByERC_G(
+		String externalReferenceCode, long groupId, boolean useFinderCache);
 
 	/**
-	 * Removes the message-boards message where groupId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the message-boards message where externalReferenceCode = &#63; and groupId = &#63; from the database.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the message-boards message that was removed
 	 */
-	public MBMessage removeByG_ERC(long groupId, String externalReferenceCode)
+	public MBMessage removeByERC_G(String externalReferenceCode, long groupId)
 		throws NoSuchMessageException;
 
 	/**
-	 * Returns the number of message-boards messages where groupId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of message-boards messages where externalReferenceCode = &#63; and groupId = &#63;.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the number of matching message-boards messages
 	 */
-	public int countByG_ERC(long groupId, String externalReferenceCode);
+	public int countByERC_G(String externalReferenceCode, long groupId);
 
 	/**
 	 * Caches the message-boards message in the entity cache if it is enabled.

--- a/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/persistence/MBMessageUtil.java
+++ b/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/persistence/MBMessageUtil.java
@@ -6683,71 +6683,71 @@ public class MBMessageUtil {
 	}
 
 	/**
-	 * Returns the message-boards message where groupId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchMessageException</code> if it could not be found.
+	 * Returns the message-boards message where externalReferenceCode = &#63; and groupId = &#63; or throws a <code>NoSuchMessageException</code> if it could not be found.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the matching message-boards message
 	 * @throws NoSuchMessageException if a matching message-boards message could not be found
 	 */
-	public static MBMessage findByG_ERC(
-			long groupId, String externalReferenceCode)
+	public static MBMessage findByERC_G(
+			String externalReferenceCode, long groupId)
 		throws com.liferay.message.boards.exception.NoSuchMessageException {
 
-		return getPersistence().findByG_ERC(groupId, externalReferenceCode);
+		return getPersistence().findByERC_G(externalReferenceCode, groupId);
 	}
 
 	/**
-	 * Returns the message-boards message where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the message-boards message where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the matching message-boards message, or <code>null</code> if a matching message-boards message could not be found
 	 */
-	public static MBMessage fetchByG_ERC(
-		long groupId, String externalReferenceCode) {
+	public static MBMessage fetchByERC_G(
+		String externalReferenceCode, long groupId) {
 
-		return getPersistence().fetchByG_ERC(groupId, externalReferenceCode);
+		return getPersistence().fetchByERC_G(externalReferenceCode, groupId);
 	}
 
 	/**
-	 * Returns the message-boards message where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the message-boards message where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching message-boards message, or <code>null</code> if a matching message-boards message could not be found
 	 */
-	public static MBMessage fetchByG_ERC(
-		long groupId, String externalReferenceCode, boolean useFinderCache) {
+	public static MBMessage fetchByERC_G(
+		String externalReferenceCode, long groupId, boolean useFinderCache) {
 
-		return getPersistence().fetchByG_ERC(
-			groupId, externalReferenceCode, useFinderCache);
+		return getPersistence().fetchByERC_G(
+			externalReferenceCode, groupId, useFinderCache);
 	}
 
 	/**
-	 * Removes the message-boards message where groupId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the message-boards message where externalReferenceCode = &#63; and groupId = &#63; from the database.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the message-boards message that was removed
 	 */
-	public static MBMessage removeByG_ERC(
-			long groupId, String externalReferenceCode)
+	public static MBMessage removeByERC_G(
+			String externalReferenceCode, long groupId)
 		throws com.liferay.message.boards.exception.NoSuchMessageException {
 
-		return getPersistence().removeByG_ERC(groupId, externalReferenceCode);
+		return getPersistence().removeByERC_G(externalReferenceCode, groupId);
 	}
 
 	/**
-	 * Returns the number of message-boards messages where groupId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of message-boards messages where externalReferenceCode = &#63; and groupId = &#63;.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the number of matching message-boards messages
 	 */
-	public static int countByG_ERC(long groupId, String externalReferenceCode) {
-		return getPersistence().countByG_ERC(groupId, externalReferenceCode);
+	public static int countByERC_G(String externalReferenceCode, long groupId) {
+		return getPersistence().countByERC_G(externalReferenceCode, groupId);
 	}
 
 	/**

--- a/modules/apps/message-boards/message-boards-api/src/main/resources/com/liferay/message/boards/exception/packageinfo
+++ b/modules/apps/message-boards/message-boards-api/src/main/resources/com/liferay/message/boards/exception/packageinfo
@@ -1,1 +1,1 @@
-version 1.2.0
+version 2.0.0

--- a/modules/apps/message-boards/message-boards-api/src/main/resources/com/liferay/message/boards/service/packageinfo
+++ b/modules/apps/message-boards/message-boards-api/src/main/resources/com/liferay/message/boards/service/packageinfo
@@ -1,1 +1,1 @@
-version 8.0.0
+version 9.0.0

--- a/modules/apps/message-boards/message-boards-api/src/main/resources/com/liferay/message/boards/service/persistence/packageinfo
+++ b/modules/apps/message-boards/message-boards-api/src/main/resources/com/liferay/message/boards/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 6.3.0
+version 7.0.0

--- a/modules/apps/message-boards/message-boards-comment/src/main/java/com/liferay/message/boards/comment/internal/MBCommentManagerImpl.java
+++ b/modules/apps/message-boards/message-boards-comment/src/main/java/com/liferay/message/boards/comment/internal/MBCommentManagerImpl.java
@@ -236,7 +236,7 @@ public class MBCommentManagerImpl implements CommentManager {
 	public Comment fetchComment(long groupId, String externalReferenceCode) {
 		MBMessage mbMessage =
 			_mbMessageLocalService.fetchMBMessageByExternalReferenceCode(
-				groupId, externalReferenceCode);
+				externalReferenceCode, groupId);
 
 		if (mbMessage == null) {
 			return null;
@@ -292,7 +292,7 @@ public class MBCommentManagerImpl implements CommentManager {
 
 		return new MBCommentImpl(
 			_mbMessageLocalService.getMBMessageByExternalReferenceCode(
-				groupId, externalReferenceCode));
+				externalReferenceCode, groupId));
 	}
 
 	@Override

--- a/modules/apps/message-boards/message-boards-comment/src/test/java/com/liferay/message/boards/comment/internal/MBCommentManagerImplTest.java
+++ b/modules/apps/message-boards/message-boards-comment/src/test/java/com/liferay/message/boards/comment/internal/MBCommentManagerImplTest.java
@@ -290,7 +290,7 @@ public class MBCommentManagerImplTest extends Mockito {
 
 		Mockito.when(
 			_mbMessageLocalService.fetchMBMessageByExternalReferenceCode(
-				anyLong(), anyString())
+				anyString(), anyLong())
 		).thenReturn(
 			_mbMessage
 		);
@@ -307,7 +307,7 @@ public class MBCommentManagerImplTest extends Mockito {
 		Mockito.verify(
 			_mbMessageLocalService
 		).fetchMBMessageByExternalReferenceCode(
-			groupId, externalReferenceCode
+			externalReferenceCode, groupId
 		);
 	}
 
@@ -318,7 +318,7 @@ public class MBCommentManagerImplTest extends Mockito {
 
 		Mockito.when(
 			_mbMessageLocalService.fetchMBMessageByExternalReferenceCode(
-				anyLong(), anyString())
+				anyString(), anyLong())
 		).thenReturn(
 			null
 		);
@@ -331,7 +331,7 @@ public class MBCommentManagerImplTest extends Mockito {
 		Mockito.verify(
 			_mbMessageLocalService
 		).fetchMBMessageByExternalReferenceCode(
-			groupId, externalReferenceCode
+			externalReferenceCode, groupId
 		);
 	}
 
@@ -344,7 +344,7 @@ public class MBCommentManagerImplTest extends Mockito {
 
 		Mockito.when(
 			_mbMessageLocalService.getMBMessageByExternalReferenceCode(
-				anyLong(), anyString())
+				anyString(), anyLong())
 		).thenReturn(
 			_mbMessage
 		);
@@ -361,7 +361,7 @@ public class MBCommentManagerImplTest extends Mockito {
 		Mockito.verify(
 			_mbMessageLocalService
 		).getMBMessageByExternalReferenceCode(
-			groupId, externalReferenceCode
+			externalReferenceCode, groupId
 		);
 	}
 

--- a/modules/apps/message-boards/message-boards-service/service.xml
+++ b/modules/apps/message-boards/message-boards-service/service.xml
@@ -553,7 +553,6 @@
 		<exception>BannedUser</exception>
 		<exception>CategoryName</exception>
 		<exception>DiscussionMaxComments</exception>
-		<exception>DuplicateMessageExternalReferenceCode</exception>
 		<exception>LockedThread</exception>
 		<exception>MailingListEmailAddress</exception>
 		<exception>MailingListInServerName</exception>

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/base/MBMessageLocalServiceBaseImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/base/MBMessageLocalServiceBaseImpl.java
@@ -275,47 +275,20 @@ public abstract class MBMessageLocalServiceBaseImpl
 		return mbMessagePersistence.fetchByUUID_G(uuid, groupId);
 	}
 
-	/**
-	 * Returns the message-boards message with the matching external reference code and group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the message-boards message's external reference code
-	 * @return the matching message-boards message, or <code>null</code> if a matching message-boards message could not be found
-	 */
 	@Override
 	public MBMessage fetchMBMessageByExternalReferenceCode(
-		long groupId, String externalReferenceCode) {
+		String externalReferenceCode, long groupId) {
 
-		return mbMessagePersistence.fetchByG_ERC(
-			groupId, externalReferenceCode);
+		return mbMessagePersistence.fetchByERC_G(
+			externalReferenceCode, groupId);
 	}
 
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchMBMessageByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public MBMessage fetchMBMessageByReferenceCode(
-		long groupId, String externalReferenceCode) {
-
-		return fetchMBMessageByExternalReferenceCode(
-			groupId, externalReferenceCode);
-	}
-
-	/**
-	 * Returns the message-boards message with the matching external reference code and group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the message-boards message's external reference code
-	 * @return the matching message-boards message
-	 * @throws PortalException if a matching message-boards message could not be found
-	 */
 	@Override
 	public MBMessage getMBMessageByExternalReferenceCode(
-			long groupId, String externalReferenceCode)
+			String externalReferenceCode, long groupId)
 		throws PortalException {
 
-		return mbMessagePersistence.findByG_ERC(groupId, externalReferenceCode);
+		return mbMessagePersistence.findByERC_G(externalReferenceCode, groupId);
 	}
 
 	/**

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMessageLocalServiceImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMessageLocalServiceImpl.java
@@ -2902,8 +2902,8 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 			return;
 		}
 
-		MBMessage message = mbMessagePersistence.fetchByG_ERC(
-			groupId, externalReferenceCode);
+		MBMessage message = mbMessagePersistence.fetchByERC_G(
+			externalReferenceCode, groupId);
 
 		if (message != null) {
 			throw new DuplicateMessageExternalReferenceCodeException(

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMessageLocalServiceImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMessageLocalServiceImpl.java
@@ -31,7 +31,6 @@ import com.liferay.message.boards.constants.MBConstants;
 import com.liferay.message.boards.constants.MBMessageConstants;
 import com.liferay.message.boards.constants.MBThreadConstants;
 import com.liferay.message.boards.exception.DiscussionMaxCommentsException;
-import com.liferay.message.boards.exception.DuplicateMessageExternalReferenceCodeException;
 import com.liferay.message.boards.exception.MessageBodyException;
 import com.liferay.message.boards.exception.MessageSubjectException;
 import com.liferay.message.boards.exception.NoSuchThreadException;
@@ -433,8 +432,6 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 		Date modifiedDate = serviceContext.getModifiedDate(date);
 
 		long messageId = counterLocalService.increment();
-
-		_validateExternalReferenceCode(externalReferenceCode, groupId);
 
 		subject = _getSubject(subject, body);
 
@@ -2891,25 +2888,6 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 			int max = PropsValues.DISCUSSION_MAX_COMMENTS - 1;
 
 			throw new DiscussionMaxCommentsException(count + " exceeds " + max);
-		}
-	}
-
-	private void _validateExternalReferenceCode(
-			String externalReferenceCode, long groupId)
-		throws PortalException {
-
-		if (Validator.isNull(externalReferenceCode)) {
-			return;
-		}
-
-		MBMessage message = mbMessagePersistence.fetchByERC_G(
-			externalReferenceCode, groupId);
-
-		if (message != null) {
-			throw new DuplicateMessageExternalReferenceCodeException(
-				StringBundler.concat(
-					"Duplicate message external reference code ",
-					externalReferenceCode, " in group ", groupId));
 		}
 	}
 

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/persistence/impl/MBMessagePersistenceImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/persistence/impl/MBMessagePersistenceImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.message.boards.service.persistence.impl;
 
+import com.liferay.message.boards.exception.DuplicateMBMessageExternalReferenceCodeException;
 import com.liferay.message.boards.exception.NoSuchMessageException;
 import com.liferay.message.boards.model.MBMessage;
 import com.liferay.message.boards.model.MBMessageTable;
@@ -21126,33 +21127,33 @@ public class MBMessagePersistenceImpl
 	private static final String _FINDER_COLUMN_U_C_C_S_STATUS_2 =
 		"mbMessage.status = ?";
 
-	private FinderPath _finderPathFetchByG_ERC;
-	private FinderPath _finderPathCountByG_ERC;
+	private FinderPath _finderPathFetchByERC_G;
+	private FinderPath _finderPathCountByERC_G;
 
 	/**
-	 * Returns the message-boards message where groupId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchMessageException</code> if it could not be found.
+	 * Returns the message-boards message where externalReferenceCode = &#63; and groupId = &#63; or throws a <code>NoSuchMessageException</code> if it could not be found.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the matching message-boards message
 	 * @throws NoSuchMessageException if a matching message-boards message could not be found
 	 */
 	@Override
-	public MBMessage findByG_ERC(long groupId, String externalReferenceCode)
+	public MBMessage findByERC_G(String externalReferenceCode, long groupId)
 		throws NoSuchMessageException {
 
-		MBMessage mbMessage = fetchByG_ERC(groupId, externalReferenceCode);
+		MBMessage mbMessage = fetchByERC_G(externalReferenceCode, groupId);
 
 		if (mbMessage == null) {
 			StringBundler sb = new StringBundler(6);
 
 			sb.append(_NO_SUCH_ENTITY_WITH_KEY);
 
-			sb.append("groupId=");
-			sb.append(groupId);
-
-			sb.append(", externalReferenceCode=");
+			sb.append("externalReferenceCode=");
 			sb.append(externalReferenceCode);
+
+			sb.append(", groupId=");
+			sb.append(groupId);
 
 			sb.append("}");
 
@@ -21167,28 +21168,28 @@ public class MBMessagePersistenceImpl
 	}
 
 	/**
-	 * Returns the message-boards message where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the message-boards message where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the matching message-boards message, or <code>null</code> if a matching message-boards message could not be found
 	 */
 	@Override
-	public MBMessage fetchByG_ERC(long groupId, String externalReferenceCode) {
-		return fetchByG_ERC(groupId, externalReferenceCode, true);
+	public MBMessage fetchByERC_G(String externalReferenceCode, long groupId) {
+		return fetchByERC_G(externalReferenceCode, groupId, true);
 	}
 
 	/**
-	 * Returns the message-boards message where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the message-boards message where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching message-boards message, or <code>null</code> if a matching message-boards message could not be found
 	 */
 	@Override
-	public MBMessage fetchByG_ERC(
-		long groupId, String externalReferenceCode, boolean useFinderCache) {
+	public MBMessage fetchByERC_G(
+		String externalReferenceCode, long groupId, boolean useFinderCache) {
 
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
@@ -21198,23 +21199,23 @@ public class MBMessagePersistenceImpl
 		Object[] finderArgs = null;
 
 		if (useFinderCache && productionMode) {
-			finderArgs = new Object[] {groupId, externalReferenceCode};
+			finderArgs = new Object[] {externalReferenceCode, groupId};
 		}
 
 		Object result = null;
 
 		if (useFinderCache && productionMode) {
 			result = finderCache.getResult(
-				_finderPathFetchByG_ERC, finderArgs, this);
+				_finderPathFetchByERC_G, finderArgs, this);
 		}
 
 		if (result instanceof MBMessage) {
 			MBMessage mbMessage = (MBMessage)result;
 
-			if ((groupId != mbMessage.getGroupId()) ||
-				!Objects.equals(
+			if (!Objects.equals(
 					externalReferenceCode,
-					mbMessage.getExternalReferenceCode())) {
+					mbMessage.getExternalReferenceCode()) ||
+				(groupId != mbMessage.getGroupId())) {
 
 				result = null;
 			}
@@ -21225,18 +21226,18 @@ public class MBMessagePersistenceImpl
 
 			sb.append(_SQL_SELECT_MBMESSAGE_WHERE);
 
-			sb.append(_FINDER_COLUMN_G_ERC_GROUPID_2);
-
 			boolean bindExternalReferenceCode = false;
 
 			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_3);
+				sb.append(_FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_3);
 			}
 			else {
 				bindExternalReferenceCode = true;
 
-				sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_2);
+				sb.append(_FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_2);
 			}
+
+			sb.append(_FINDER_COLUMN_ERC_G_GROUPID_2);
 
 			String sql = sb.toString();
 
@@ -21249,18 +21250,18 @@ public class MBMessagePersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
-				queryPos.add(groupId);
-
 				if (bindExternalReferenceCode) {
 					queryPos.add(externalReferenceCode);
 				}
+
+				queryPos.add(groupId);
 
 				List<MBMessage> list = query.list();
 
 				if (list.isEmpty()) {
 					if (useFinderCache && productionMode) {
 						finderCache.putResult(
-							_finderPathFetchByG_ERC, finderArgs, list);
+							_finderPathFetchByERC_G, finderArgs, list);
 					}
 				}
 				else {
@@ -21288,30 +21289,30 @@ public class MBMessagePersistenceImpl
 	}
 
 	/**
-	 * Removes the message-boards message where groupId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the message-boards message where externalReferenceCode = &#63; and groupId = &#63; from the database.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the message-boards message that was removed
 	 */
 	@Override
-	public MBMessage removeByG_ERC(long groupId, String externalReferenceCode)
+	public MBMessage removeByERC_G(String externalReferenceCode, long groupId)
 		throws NoSuchMessageException {
 
-		MBMessage mbMessage = findByG_ERC(groupId, externalReferenceCode);
+		MBMessage mbMessage = findByERC_G(externalReferenceCode, groupId);
 
 		return remove(mbMessage);
 	}
 
 	/**
-	 * Returns the number of message-boards messages where groupId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of message-boards messages where externalReferenceCode = &#63; and groupId = &#63;.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the number of matching message-boards messages
 	 */
 	@Override
-	public int countByG_ERC(long groupId, String externalReferenceCode) {
+	public int countByERC_G(String externalReferenceCode, long groupId) {
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
 		boolean productionMode = ctPersistenceHelper.isProductionMode(
@@ -21323,9 +21324,9 @@ public class MBMessagePersistenceImpl
 		Long count = null;
 
 		if (productionMode) {
-			finderPath = _finderPathCountByG_ERC;
+			finderPath = _finderPathCountByERC_G;
 
-			finderArgs = new Object[] {groupId, externalReferenceCode};
+			finderArgs = new Object[] {externalReferenceCode, groupId};
 
 			count = (Long)finderCache.getResult(finderPath, finderArgs, this);
 		}
@@ -21335,18 +21336,18 @@ public class MBMessagePersistenceImpl
 
 			sb.append(_SQL_COUNT_MBMESSAGE_WHERE);
 
-			sb.append(_FINDER_COLUMN_G_ERC_GROUPID_2);
-
 			boolean bindExternalReferenceCode = false;
 
 			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_3);
+				sb.append(_FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_3);
 			}
 			else {
 				bindExternalReferenceCode = true;
 
-				sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_2);
+				sb.append(_FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_2);
 			}
+
+			sb.append(_FINDER_COLUMN_ERC_G_GROUPID_2);
 
 			String sql = sb.toString();
 
@@ -21359,11 +21360,11 @@ public class MBMessagePersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
-				queryPos.add(groupId);
-
 				if (bindExternalReferenceCode) {
 					queryPos.add(externalReferenceCode);
 				}
+
+				queryPos.add(groupId);
 
 				count = (Long)query.uniqueResult();
 
@@ -21382,14 +21383,14 @@ public class MBMessagePersistenceImpl
 		return count.intValue();
 	}
 
-	private static final String _FINDER_COLUMN_G_ERC_GROUPID_2 =
-		"mbMessage.groupId = ? AND ";
+	private static final String _FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_2 =
+		"mbMessage.externalReferenceCode = ? AND ";
 
-	private static final String _FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_2 =
-		"mbMessage.externalReferenceCode = ?";
+	private static final String _FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_3 =
+		"(mbMessage.externalReferenceCode IS NULL OR mbMessage.externalReferenceCode = '') AND ";
 
-	private static final String _FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_3 =
-		"(mbMessage.externalReferenceCode IS NULL OR mbMessage.externalReferenceCode = '')";
+	private static final String _FINDER_COLUMN_ERC_G_GROUPID_2 =
+		"mbMessage.groupId = ?";
 
 	public MBMessagePersistenceImpl() {
 		Map<String, String> dbColumnNames = new HashMap<String, String>();
@@ -21431,9 +21432,9 @@ public class MBMessagePersistenceImpl
 			mbMessage);
 
 		finderCache.putResult(
-			_finderPathFetchByG_ERC,
+			_finderPathFetchByERC_G,
 			new Object[] {
-				mbMessage.getGroupId(), mbMessage.getExternalReferenceCode()
+				mbMessage.getExternalReferenceCode(), mbMessage.getGroupId()
 			},
 			mbMessage);
 	}
@@ -21528,13 +21529,13 @@ public class MBMessagePersistenceImpl
 		finderCache.putResult(_finderPathFetchByG_US, args, mbMessageModelImpl);
 
 		args = new Object[] {
-			mbMessageModelImpl.getGroupId(),
-			mbMessageModelImpl.getExternalReferenceCode()
+			mbMessageModelImpl.getExternalReferenceCode(),
+			mbMessageModelImpl.getGroupId()
 		};
 
-		finderCache.putResult(_finderPathCountByG_ERC, args, Long.valueOf(1));
+		finderCache.putResult(_finderPathCountByERC_G, args, Long.valueOf(1));
 		finderCache.putResult(
-			_finderPathFetchByG_ERC, args, mbMessageModelImpl);
+			_finderPathFetchByERC_G, args, mbMessageModelImpl);
 	}
 
 	/**
@@ -21674,6 +21675,27 @@ public class MBMessagePersistenceImpl
 
 		if (Validator.isNull(mbMessage.getExternalReferenceCode())) {
 			mbMessage.setExternalReferenceCode(mbMessage.getUuid());
+		}
+		else {
+			MBMessage ercMBMessage = fetchByERC_G(
+				mbMessage.getExternalReferenceCode(), mbMessage.getGroupId());
+
+			if (isNew) {
+				if (ercMBMessage != null) {
+					throw new DuplicateMBMessageExternalReferenceCodeException(
+						"Duplicate MBMessage with external reference code " +
+							mbMessage.getExternalReferenceCode());
+				}
+			}
+			else {
+				if ((ercMBMessage != null) &&
+					(mbMessage.getMessageId() != ercMBMessage.getMessageId())) {
+
+					throw new DuplicateMBMessageExternalReferenceCodeException(
+						"Duplicate MBMessage with external reference code " +
+							mbMessage.getExternalReferenceCode());
+				}
+			}
 		}
 
 		ServiceContext serviceContext =
@@ -22245,7 +22267,7 @@ public class MBMessagePersistenceImpl
 		_uniqueIndexColumnNames.add(new String[] {"groupId", "urlSubject"});
 
 		_uniqueIndexColumnNames.add(
-			new String[] {"groupId", "externalReferenceCode"});
+			new String[] {"externalReferenceCode", "groupId"});
 	}
 
 	/**
@@ -22894,15 +22916,15 @@ public class MBMessagePersistenceImpl
 			},
 			new String[] {"userId", "classNameId", "classPK", "status"}, false);
 
-		_finderPathFetchByG_ERC = new FinderPath(
-			FINDER_CLASS_NAME_ENTITY, "fetchByG_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"groupId", "externalReferenceCode"}, true);
+		_finderPathFetchByERC_G = new FinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByERC_G",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "groupId"}, true);
 
-		_finderPathCountByG_ERC = new FinderPath(
-			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"groupId", "externalReferenceCode"}, false);
+		_finderPathCountByERC_G = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByERC_G",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "groupId"}, false);
 
 		_setMBMessageUtilPersistence(this);
 	}

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/test/MBMessageLocalServiceTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/test/MBMessageLocalServiceTest.java
@@ -239,7 +239,7 @@ public class MBMessageLocalServiceTest {
 
 		MBMessage mbMessage2 =
 			MBMessageLocalServiceUtil.getMBMessageByExternalReferenceCode(
-				_group.getGroupId(), externalReferenceCode);
+				externalReferenceCode, _group.getGroupId());
 
 		Assert.assertEquals(mbMessage1, mbMessage2);
 	}

--- a/modules/apps/oauth2-provider/oauth2-provider-api/bnd.bnd
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay OAuth2 Provider API
 Bundle-SymbolicName: com.liferay.oauth2.provider.api
-Bundle-Version: 8.2.1
+Bundle-Version: 9.0.0
 Export-Package:\
 	com.liferay.oauth2.provider.configuration,\
 	com.liferay.oauth2.provider.constants,\

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/exception/DuplicateOAuth2ApplicationExternalReferenceCodeException.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/exception/DuplicateOAuth2ApplicationExternalReferenceCodeException.java
@@ -14,13 +14,13 @@
 
 package com.liferay.oauth2.provider.exception;
 
-import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.SystemException;
 
 /**
  * @author Brian Wing Shun Chan
  */
 public class DuplicateOAuth2ApplicationExternalReferenceCodeException
-	extends PortalException {
+	extends SystemException {
 
 	public DuplicateOAuth2ApplicationExternalReferenceCodeException() {
 	}

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalService.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalService.java
@@ -267,24 +267,9 @@ public interface OAuth2ApplicationLocalService
 	public OAuth2Application fetchOAuth2Application(
 		long companyId, String clientId);
 
-	/**
-	 * Returns the o auth2 application with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the o auth2 application's external reference code
-	 * @return the matching o auth2 application, or <code>null</code> if a matching o auth2 application could not be found
-	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public OAuth2Application fetchOAuth2ApplicationByExternalReferenceCode(
-		long companyId, String externalReferenceCode);
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchOAuth2ApplicationByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public OAuth2Application fetchOAuth2ApplicationByReferenceCode(
-		long companyId, String externalReferenceCode);
+		String externalReferenceCode, long companyId);
 
 	/**
 	 * Returns the o auth2 application with the matching UUID and company.
@@ -323,17 +308,9 @@ public interface OAuth2ApplicationLocalService
 			long companyId, String clientId)
 		throws NoSuchOAuth2ApplicationException;
 
-	/**
-	 * Returns the o auth2 application with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the o auth2 application's external reference code
-	 * @return the matching o auth2 application
-	 * @throws PortalException if a matching o auth2 application could not be found
-	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public OAuth2Application getOAuth2ApplicationByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
+			String externalReferenceCode, long companyId)
 		throws PortalException;
 
 	/**

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalServiceUtil.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalServiceUtil.java
@@ -328,30 +328,12 @@ public class OAuth2ApplicationLocalServiceUtil {
 		return getService().fetchOAuth2Application(companyId, clientId);
 	}
 
-	/**
-	 * Returns the o auth2 application with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the o auth2 application's external reference code
-	 * @return the matching o auth2 application, or <code>null</code> if a matching o auth2 application could not be found
-	 */
 	public static OAuth2Application
 		fetchOAuth2ApplicationByExternalReferenceCode(
-			long companyId, String externalReferenceCode) {
+			String externalReferenceCode, long companyId) {
 
 		return getService().fetchOAuth2ApplicationByExternalReferenceCode(
-			companyId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchOAuth2ApplicationByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	public static OAuth2Application fetchOAuth2ApplicationByReferenceCode(
-		long companyId, String externalReferenceCode) {
-
-		return getService().fetchOAuth2ApplicationByReferenceCode(
-			companyId, externalReferenceCode);
+			externalReferenceCode, companyId);
 	}
 
 	/**
@@ -411,20 +393,12 @@ public class OAuth2ApplicationLocalServiceUtil {
 		return getService().getOAuth2Application(companyId, clientId);
 	}
 
-	/**
-	 * Returns the o auth2 application with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the o auth2 application's external reference code
-	 * @return the matching o auth2 application
-	 * @throws PortalException if a matching o auth2 application could not be found
-	 */
 	public static OAuth2Application getOAuth2ApplicationByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
+			String externalReferenceCode, long companyId)
 		throws PortalException {
 
 		return getService().getOAuth2ApplicationByExternalReferenceCode(
-			companyId, externalReferenceCode);
+			externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalServiceWrapper.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalServiceWrapper.java
@@ -371,35 +371,14 @@ public class OAuth2ApplicationLocalServiceWrapper
 			companyId, clientId);
 	}
 
-	/**
-	 * Returns the o auth2 application with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the o auth2 application's external reference code
-	 * @return the matching o auth2 application, or <code>null</code> if a matching o auth2 application could not be found
-	 */
 	@Override
 	public com.liferay.oauth2.provider.model.OAuth2Application
 		fetchOAuth2ApplicationByExternalReferenceCode(
-			long companyId, String externalReferenceCode) {
+			String externalReferenceCode, long companyId) {
 
 		return _oAuth2ApplicationLocalService.
 			fetchOAuth2ApplicationByExternalReferenceCode(
-				companyId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchOAuth2ApplicationByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public com.liferay.oauth2.provider.model.OAuth2Application
-		fetchOAuth2ApplicationByReferenceCode(
-			long companyId, String externalReferenceCode) {
-
-		return _oAuth2ApplicationLocalService.
-			fetchOAuth2ApplicationByReferenceCode(
-				companyId, externalReferenceCode);
+				externalReferenceCode, companyId);
 	}
 
 	/**
@@ -468,23 +447,15 @@ public class OAuth2ApplicationLocalServiceWrapper
 			companyId, clientId);
 	}
 
-	/**
-	 * Returns the o auth2 application with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the o auth2 application's external reference code
-	 * @return the matching o auth2 application
-	 * @throws PortalException if a matching o auth2 application could not be found
-	 */
 	@Override
 	public com.liferay.oauth2.provider.model.OAuth2Application
 			getOAuth2ApplicationByExternalReferenceCode(
-				long companyId, String externalReferenceCode)
+				String externalReferenceCode, long companyId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _oAuth2ApplicationLocalService.
 			getOAuth2ApplicationByExternalReferenceCode(
-				companyId, externalReferenceCode);
+				externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/persistence/OAuth2ApplicationPersistence.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/persistence/OAuth2ApplicationPersistence.java
@@ -957,57 +957,57 @@ public interface OAuth2ApplicationPersistence
 	public int filterCountByC_CP(long companyId, int clientProfile);
 
 	/**
-	 * Returns the o auth2 application where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchOAuth2ApplicationException</code> if it could not be found.
+	 * Returns the o auth2 application where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchOAuth2ApplicationException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching o auth2 application
 	 * @throws NoSuchOAuth2ApplicationException if a matching o auth2 application could not be found
 	 */
-	public OAuth2Application findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public OAuth2Application findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchOAuth2ApplicationException;
 
 	/**
-	 * Returns the o auth2 application where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the o auth2 application where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching o auth2 application, or <code>null</code> if a matching o auth2 application could not be found
 	 */
-	public OAuth2Application fetchByC_ERC(
-		long companyId, String externalReferenceCode);
+	public OAuth2Application fetchByERC_C(
+		String externalReferenceCode, long companyId);
 
 	/**
-	 * Returns the o auth2 application where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the o auth2 application where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching o auth2 application, or <code>null</code> if a matching o auth2 application could not be found
 	 */
-	public OAuth2Application fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache);
+	public OAuth2Application fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache);
 
 	/**
-	 * Removes the o auth2 application where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the o auth2 application where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the o auth2 application that was removed
 	 */
-	public OAuth2Application removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public OAuth2Application removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchOAuth2ApplicationException;
 
 	/**
-	 * Returns the number of o auth2 applications where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of o auth2 applications where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching o auth2 applications
 	 */
-	public int countByC_ERC(long companyId, String externalReferenceCode);
+	public int countByERC_C(String externalReferenceCode, long companyId);
 
 	/**
 	 * Caches the o auth2 application in the entity cache if it is enabled.

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/persistence/OAuth2ApplicationUtil.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/persistence/OAuth2ApplicationUtil.java
@@ -1241,75 +1241,75 @@ public class OAuth2ApplicationUtil {
 	}
 
 	/**
-	 * Returns the o auth2 application where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchOAuth2ApplicationException</code> if it could not be found.
+	 * Returns the o auth2 application where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchOAuth2ApplicationException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching o auth2 application
 	 * @throws NoSuchOAuth2ApplicationException if a matching o auth2 application could not be found
 	 */
-	public static OAuth2Application findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public static OAuth2Application findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws com.liferay.oauth2.provider.exception.
 			NoSuchOAuth2ApplicationException {
 
-		return getPersistence().findByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().findByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the o auth2 application where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the o auth2 application where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching o auth2 application, or <code>null</code> if a matching o auth2 application could not be found
 	 */
-	public static OAuth2Application fetchByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public static OAuth2Application fetchByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return getPersistence().fetchByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().fetchByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the o auth2 application where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the o auth2 application where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching o auth2 application, or <code>null</code> if a matching o auth2 application could not be found
 	 */
-	public static OAuth2Application fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache) {
+	public static OAuth2Application fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache) {
 
-		return getPersistence().fetchByC_ERC(
-			companyId, externalReferenceCode, useFinderCache);
+		return getPersistence().fetchByERC_C(
+			externalReferenceCode, companyId, useFinderCache);
 	}
 
 	/**
-	 * Removes the o auth2 application where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the o auth2 application where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the o auth2 application that was removed
 	 */
-	public static OAuth2Application removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public static OAuth2Application removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws com.liferay.oauth2.provider.exception.
 			NoSuchOAuth2ApplicationException {
 
-		return getPersistence().removeByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().removeByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the number of o auth2 applications where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of o auth2 applications where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching o auth2 applications
 	 */
-	public static int countByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public static int countByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return getPersistence().countByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().countByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/resources/com/liferay/oauth2/provider/exception/packageinfo
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/resources/com/liferay/oauth2/provider/exception/packageinfo
@@ -1,1 +1,1 @@
-version 1.3.0
+version 2.0.0

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/resources/com/liferay/oauth2/provider/service/packageinfo
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/resources/com/liferay/oauth2/provider/service/packageinfo
@@ -1,1 +1,1 @@
-version 2.2.0
+version 3.0.0

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/resources/com/liferay/oauth2/provider/service/persistence/packageinfo
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/resources/com/liferay/oauth2/provider/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 4.2.0
+version 5.0.0

--- a/modules/apps/oauth2-provider/oauth2-provider-service/service.xml
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/service.xml
@@ -170,7 +170,6 @@
 	</entity>
 	<exceptions>
 		<exception>DuplicateOAuth2ApplicationClientId</exception>
-		<exception>DuplicateOAuth2ApplicationExternalReferenceCode</exception>
 		<exception>DuplicateOAuth2ScopeGrant</exception>
 		<exception>OAuth2ApplicationClientCredentialUserId</exception>
 		<exception>OAuth2ApplicationClientGrantType</exception>

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/base/OAuth2ApplicationLocalServiceBaseImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/base/OAuth2ApplicationLocalServiceBaseImpl.java
@@ -275,48 +275,21 @@ public abstract class OAuth2ApplicationLocalServiceBaseImpl
 			uuid, companyId, null);
 	}
 
-	/**
-	 * Returns the o auth2 application with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the o auth2 application's external reference code
-	 * @return the matching o auth2 application, or <code>null</code> if a matching o auth2 application could not be found
-	 */
 	@Override
 	public OAuth2Application fetchOAuth2ApplicationByExternalReferenceCode(
-		long companyId, String externalReferenceCode) {
+		String externalReferenceCode, long companyId) {
 
-		return oAuth2ApplicationPersistence.fetchByC_ERC(
-			companyId, externalReferenceCode);
+		return oAuth2ApplicationPersistence.fetchByERC_C(
+			externalReferenceCode, companyId);
 	}
 
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchOAuth2ApplicationByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public OAuth2Application fetchOAuth2ApplicationByReferenceCode(
-		long companyId, String externalReferenceCode) {
-
-		return fetchOAuth2ApplicationByExternalReferenceCode(
-			companyId, externalReferenceCode);
-	}
-
-	/**
-	 * Returns the o auth2 application with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the o auth2 application's external reference code
-	 * @return the matching o auth2 application
-	 * @throws PortalException if a matching o auth2 application could not be found
-	 */
 	@Override
 	public OAuth2Application getOAuth2ApplicationByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
+			String externalReferenceCode, long companyId)
 		throws PortalException {
 
-		return oAuth2ApplicationPersistence.findByC_ERC(
-			companyId, externalReferenceCode);
+		return oAuth2ApplicationPersistence.findByERC_C(
+			externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationLocalServiceImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationLocalServiceImpl.java
@@ -19,7 +19,6 @@ import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.oauth2.provider.constants.GrantType;
 import com.liferay.oauth2.provider.constants.OAuth2ProviderConstants;
 import com.liferay.oauth2.provider.exception.DuplicateOAuth2ApplicationClientIdException;
-import com.liferay.oauth2.provider.exception.DuplicateOAuth2ApplicationExternalReferenceCodeException;
 import com.liferay.oauth2.provider.exception.NoSuchOAuth2ApplicationException;
 import com.liferay.oauth2.provider.exception.OAuth2ApplicationClientGrantTypeException;
 import com.liferay.oauth2.provider.exception.OAuth2ApplicationHomePageURLException;
@@ -519,9 +518,6 @@ public class OAuth2ApplicationLocalServiceImpl
 			return oAuth2Application;
 		}
 
-		_validateExternalReferenceCode(
-			oAuth2Application.getOAuth2ApplicationId(), externalReferenceCode);
-
 		oAuth2Application.setExternalReferenceCode(externalReferenceCode);
 
 		return updateOAuth2Application(oAuth2Application);
@@ -909,29 +905,6 @@ public class OAuth2ApplicationLocalServiceImpl
 				throw new OAuth2ApplicationRedirectURIException(
 					redirectURI, uriSyntaxException);
 			}
-		}
-	}
-
-	private void _validateExternalReferenceCode(
-			long oAuthApplicationId, String externalReferenceCode)
-		throws PortalException {
-
-		if (Validator.isNull(externalReferenceCode)) {
-			return;
-		}
-
-		OAuth2Application oAuth2Application = getOAuth2Application(
-			oAuthApplicationId);
-
-		oAuth2Application = fetchOAuth2ApplicationByExternalReferenceCode(
-			externalReferenceCode, oAuth2Application.getCompanyId());
-
-		if (oAuth2Application == null) {
-			return;
-		}
-
-		if (oAuth2Application.getOAuth2ApplicationId() != oAuthApplicationId) {
-			throw new DuplicateOAuth2ApplicationExternalReferenceCodeException();
 		}
 	}
 

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationLocalServiceImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationLocalServiceImpl.java
@@ -315,7 +315,7 @@ public class OAuth2ApplicationLocalServiceImpl
 
 		OAuth2Application oAuth2Application =
 			fetchOAuth2ApplicationByExternalReferenceCode(
-				user.getCompanyId(), externalReferenceCode);
+				externalReferenceCode, user.getCompanyId());
 
 		if (oAuth2Application != null) {
 			long oAuth2ApplicationScopeAliasesId =
@@ -372,7 +372,7 @@ public class OAuth2ApplicationLocalServiceImpl
 
 		OAuth2Application oAuth2Application =
 			fetchOAuth2ApplicationByExternalReferenceCode(
-				user.getCompanyId(), externalReferenceCode);
+				externalReferenceCode, user.getCompanyId());
 
 		if (oAuth2Application != null) {
 			long oAuth2ApplicationScopeAliasesId =
@@ -924,7 +924,7 @@ public class OAuth2ApplicationLocalServiceImpl
 			oAuthApplicationId);
 
 		oAuth2Application = fetchOAuth2ApplicationByExternalReferenceCode(
-			oAuth2Application.getCompanyId(), externalReferenceCode);
+			externalReferenceCode, oAuth2Application.getCompanyId());
 
 		if (oAuth2Application == null) {
 			return;

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/persistence/impl/OAuth2ApplicationPersistenceImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/persistence/impl/OAuth2ApplicationPersistenceImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.oauth2.provider.service.persistence.impl;
 
+import com.liferay.oauth2.provider.exception.DuplicateOAuth2ApplicationExternalReferenceCodeException;
 import com.liferay.oauth2.provider.exception.NoSuchOAuth2ApplicationException;
 import com.liferay.oauth2.provider.model.OAuth2Application;
 import com.liferay.oauth2.provider.model.OAuth2ApplicationTable;
@@ -4202,35 +4203,35 @@ public class OAuth2ApplicationPersistenceImpl
 	private static final String _FINDER_COLUMN_C_CP_CLIENTPROFILE_2 =
 		"oAuth2Application.clientProfile = ?";
 
-	private FinderPath _finderPathFetchByC_ERC;
-	private FinderPath _finderPathCountByC_ERC;
+	private FinderPath _finderPathFetchByERC_C;
+	private FinderPath _finderPathCountByERC_C;
 
 	/**
-	 * Returns the o auth2 application where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchOAuth2ApplicationException</code> if it could not be found.
+	 * Returns the o auth2 application where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchOAuth2ApplicationException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching o auth2 application
 	 * @throws NoSuchOAuth2ApplicationException if a matching o auth2 application could not be found
 	 */
 	@Override
-	public OAuth2Application findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public OAuth2Application findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchOAuth2ApplicationException {
 
-		OAuth2Application oAuth2Application = fetchByC_ERC(
-			companyId, externalReferenceCode);
+		OAuth2Application oAuth2Application = fetchByERC_C(
+			externalReferenceCode, companyId);
 
 		if (oAuth2Application == null) {
 			StringBundler sb = new StringBundler(6);
 
 			sb.append(_NO_SUCH_ENTITY_WITH_KEY);
 
-			sb.append("companyId=");
-			sb.append(companyId);
-
-			sb.append(", externalReferenceCode=");
+			sb.append("externalReferenceCode=");
 			sb.append(externalReferenceCode);
+
+			sb.append(", companyId=");
+			sb.append(companyId);
 
 			sb.append("}");
 
@@ -4245,53 +4246,53 @@ public class OAuth2ApplicationPersistenceImpl
 	}
 
 	/**
-	 * Returns the o auth2 application where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the o auth2 application where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching o auth2 application, or <code>null</code> if a matching o auth2 application could not be found
 	 */
 	@Override
-	public OAuth2Application fetchByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public OAuth2Application fetchByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return fetchByC_ERC(companyId, externalReferenceCode, true);
+		return fetchByERC_C(externalReferenceCode, companyId, true);
 	}
 
 	/**
-	 * Returns the o auth2 application where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the o auth2 application where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching o auth2 application, or <code>null</code> if a matching o auth2 application could not be found
 	 */
 	@Override
-	public OAuth2Application fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache) {
+	public OAuth2Application fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache) {
 
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
 		Object[] finderArgs = null;
 
 		if (useFinderCache) {
-			finderArgs = new Object[] {companyId, externalReferenceCode};
+			finderArgs = new Object[] {externalReferenceCode, companyId};
 		}
 
 		Object result = null;
 
 		if (useFinderCache) {
 			result = finderCache.getResult(
-				_finderPathFetchByC_ERC, finderArgs, this);
+				_finderPathFetchByERC_C, finderArgs, this);
 		}
 
 		if (result instanceof OAuth2Application) {
 			OAuth2Application oAuth2Application = (OAuth2Application)result;
 
-			if ((companyId != oAuth2Application.getCompanyId()) ||
-				!Objects.equals(
+			if (!Objects.equals(
 					externalReferenceCode,
-					oAuth2Application.getExternalReferenceCode())) {
+					oAuth2Application.getExternalReferenceCode()) ||
+				(companyId != oAuth2Application.getCompanyId())) {
 
 				result = null;
 			}
@@ -4302,18 +4303,18 @@ public class OAuth2ApplicationPersistenceImpl
 
 			sb.append(_SQL_SELECT_OAUTH2APPLICATION_WHERE);
 
-			sb.append(_FINDER_COLUMN_C_ERC_COMPANYID_2);
-
 			boolean bindExternalReferenceCode = false;
 
 			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3);
 			}
 			else {
 				bindExternalReferenceCode = true;
 
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2);
 			}
+
+			sb.append(_FINDER_COLUMN_ERC_C_COMPANYID_2);
 
 			String sql = sb.toString();
 
@@ -4326,18 +4327,18 @@ public class OAuth2ApplicationPersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
-				queryPos.add(companyId);
-
 				if (bindExternalReferenceCode) {
 					queryPos.add(externalReferenceCode);
 				}
+
+				queryPos.add(companyId);
 
 				List<OAuth2Application> list = query.list();
 
 				if (list.isEmpty()) {
 					if (useFinderCache) {
 						finderCache.putResult(
-							_finderPathFetchByC_ERC, finderArgs, list);
+							_finderPathFetchByERC_C, finderArgs, list);
 					}
 				}
 				else {
@@ -4365,37 +4366,37 @@ public class OAuth2ApplicationPersistenceImpl
 	}
 
 	/**
-	 * Removes the o auth2 application where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the o auth2 application where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the o auth2 application that was removed
 	 */
 	@Override
-	public OAuth2Application removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public OAuth2Application removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchOAuth2ApplicationException {
 
-		OAuth2Application oAuth2Application = findByC_ERC(
-			companyId, externalReferenceCode);
+		OAuth2Application oAuth2Application = findByERC_C(
+			externalReferenceCode, companyId);
 
 		return remove(oAuth2Application);
 	}
 
 	/**
-	 * Returns the number of o auth2 applications where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of o auth2 applications where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching o auth2 applications
 	 */
 	@Override
-	public int countByC_ERC(long companyId, String externalReferenceCode) {
+	public int countByERC_C(String externalReferenceCode, long companyId) {
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
-		FinderPath finderPath = _finderPathCountByC_ERC;
+		FinderPath finderPath = _finderPathCountByERC_C;
 
-		Object[] finderArgs = new Object[] {companyId, externalReferenceCode};
+		Object[] finderArgs = new Object[] {externalReferenceCode, companyId};
 
 		Long count = (Long)finderCache.getResult(finderPath, finderArgs, this);
 
@@ -4404,18 +4405,18 @@ public class OAuth2ApplicationPersistenceImpl
 
 			sb.append(_SQL_COUNT_OAUTH2APPLICATION_WHERE);
 
-			sb.append(_FINDER_COLUMN_C_ERC_COMPANYID_2);
-
 			boolean bindExternalReferenceCode = false;
 
 			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3);
 			}
 			else {
 				bindExternalReferenceCode = true;
 
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2);
 			}
+
+			sb.append(_FINDER_COLUMN_ERC_C_COMPANYID_2);
 
 			String sql = sb.toString();
 
@@ -4428,11 +4429,11 @@ public class OAuth2ApplicationPersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
-				queryPos.add(companyId);
-
 				if (bindExternalReferenceCode) {
 					queryPos.add(externalReferenceCode);
 				}
+
+				queryPos.add(companyId);
 
 				count = (Long)query.uniqueResult();
 
@@ -4449,14 +4450,14 @@ public class OAuth2ApplicationPersistenceImpl
 		return count.intValue();
 	}
 
-	private static final String _FINDER_COLUMN_C_ERC_COMPANYID_2 =
-		"oAuth2Application.companyId = ? AND ";
+	private static final String _FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2 =
+		"oAuth2Application.externalReferenceCode = ? AND ";
 
-	private static final String _FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2 =
-		"oAuth2Application.externalReferenceCode = ?";
+	private static final String _FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3 =
+		"(oAuth2Application.externalReferenceCode IS NULL OR oAuth2Application.externalReferenceCode = '') AND ";
 
-	private static final String _FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3 =
-		"(oAuth2Application.externalReferenceCode IS NULL OR oAuth2Application.externalReferenceCode = '')";
+	private static final String _FINDER_COLUMN_ERC_C_COMPANYID_2 =
+		"oAuth2Application.companyId = ?";
 
 	public OAuth2ApplicationPersistenceImpl() {
 		Map<String, String> dbColumnNames = new HashMap<String, String>();
@@ -4495,10 +4496,10 @@ public class OAuth2ApplicationPersistenceImpl
 			oAuth2Application);
 
 		finderCache.putResult(
-			_finderPathFetchByC_ERC,
+			_finderPathFetchByERC_C,
 			new Object[] {
-				oAuth2Application.getCompanyId(),
-				oAuth2Application.getExternalReferenceCode()
+				oAuth2Application.getExternalReferenceCode(),
+				oAuth2Application.getCompanyId()
 			},
 			oAuth2Application);
 	}
@@ -4587,13 +4588,13 @@ public class OAuth2ApplicationPersistenceImpl
 			_finderPathFetchByC_C, args, oAuth2ApplicationModelImpl);
 
 		args = new Object[] {
-			oAuth2ApplicationModelImpl.getCompanyId(),
-			oAuth2ApplicationModelImpl.getExternalReferenceCode()
+			oAuth2ApplicationModelImpl.getExternalReferenceCode(),
+			oAuth2ApplicationModelImpl.getCompanyId()
 		};
 
-		finderCache.putResult(_finderPathCountByC_ERC, args, Long.valueOf(1));
+		finderCache.putResult(_finderPathCountByERC_C, args, Long.valueOf(1));
 		finderCache.putResult(
-			_finderPathFetchByC_ERC, args, oAuth2ApplicationModelImpl);
+			_finderPathFetchByERC_C, args, oAuth2ApplicationModelImpl);
 	}
 
 	/**
@@ -4740,6 +4741,29 @@ public class OAuth2ApplicationPersistenceImpl
 		if (Validator.isNull(oAuth2Application.getExternalReferenceCode())) {
 			oAuth2Application.setExternalReferenceCode(
 				oAuth2Application.getUuid());
+		}
+		else {
+			OAuth2Application ercOAuth2Application = fetchByERC_C(
+				oAuth2Application.getExternalReferenceCode(),
+				oAuth2Application.getCompanyId());
+
+			if (isNew) {
+				if (ercOAuth2Application != null) {
+					throw new DuplicateOAuth2ApplicationExternalReferenceCodeException(
+						"Duplicate OAuth2Application with external reference code " +
+							oAuth2Application.getExternalReferenceCode());
+				}
+			}
+			else {
+				if ((ercOAuth2Application != null) &&
+					(oAuth2Application.getOAuth2ApplicationId() !=
+						ercOAuth2Application.getOAuth2ApplicationId())) {
+
+					throw new DuplicateOAuth2ApplicationExternalReferenceCodeException(
+						"Duplicate OAuth2Application with external reference code " +
+							oAuth2Application.getExternalReferenceCode());
+				}
+			}
 		}
 
 		ServiceContext serviceContext =
@@ -5162,15 +5186,15 @@ public class OAuth2ApplicationPersistenceImpl
 			new String[] {Long.class.getName(), Integer.class.getName()},
 			new String[] {"companyId", "clientProfile"}, false);
 
-		_finderPathFetchByC_ERC = new FinderPath(
-			FINDER_CLASS_NAME_ENTITY, "fetchByC_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"companyId", "externalReferenceCode"}, true);
+		_finderPathFetchByERC_C = new FinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, true);
 
-		_finderPathCountByC_ERC = new FinderPath(
-			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"companyId", "externalReferenceCode"}, false);
+		_finderPathCountByERC_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, false);
 
 		_setOAuth2ApplicationUtilPersistence(this);
 	}

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/configuration/test/BaseConfigurationFactoryTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/configuration/test/BaseConfigurationFactoryTest.java
@@ -72,8 +72,8 @@ public class BaseConfigurationFactoryTest {
 				oAuth2Application =
 					_oAuth2ApplicationLocalService.
 						getOAuth2ApplicationByExternalReferenceCode(
-							TestPropsValues.getCompanyId(),
-							externalReferenceCode);
+							externalReferenceCode,
+							TestPropsValues.getCompanyId());
 			}
 			catch (Exception exception) {
 

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/dto/v1_0/util/ObjectFieldUtil.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/dto/v1_0/util/ObjectFieldUtil.java
@@ -63,8 +63,8 @@ public class ObjectFieldUtil {
 		ListTypeDefinition listTypeDefinition =
 			listTypeDefinitionLocalService.
 				fetchListTypeDefinitionByExternalReferenceCode(
-					companyId,
-					objectField.getListTypeDefinitionExternalReferenceCode());
+					objectField.getListTypeDefinitionExternalReferenceCode(),
+					companyId);
 
 		if (listTypeDefinition == null) {
 			listTypeDefinition =
@@ -125,8 +125,8 @@ public class ObjectFieldUtil {
 		ListTypeDefinition listTypeDefinition =
 			listTypeDefinitionLocalService.
 				fetchListTypeDefinitionByExternalReferenceCode(
-					companyId,
-					objectField.getListTypeDefinitionExternalReferenceCode());
+					objectField.getListTypeDefinitionExternalReferenceCode(),
+					companyId);
 
 		if (listTypeDefinition == null) {
 			return 0;

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectRelationshipResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectRelationshipResourceImpl.java
@@ -138,9 +138,9 @@ public class ObjectRelationshipResourceImpl
 			com.liferay.object.model.ObjectDefinition objectDefinition =
 				_objectDefinitionLocalService.
 					fetchObjectDefinitionByExternalReferenceCode(
-						contextCompany.getCompanyId(),
 						objectRelationship.
-							getObjectDefinitionExternalReferenceCode2());
+							getObjectDefinitionExternalReferenceCode2(),
+						contextCompany.getCompanyId());
 
 			if (objectDefinition == null) {
 				objectDefinition =

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/exception/DuplicateObjectDefinitionExternalReferenceCodeException.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/exception/DuplicateObjectDefinitionExternalReferenceCodeException.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.exception;
+
+import com.liferay.portal.kernel.exception.SystemException;
+
+/**
+ * @author Marco Leo
+ */
+public class DuplicateObjectDefinitionExternalReferenceCodeException
+	extends SystemException {
+
+	public DuplicateObjectDefinitionExternalReferenceCodeException() {
+	}
+
+	public DuplicateObjectDefinitionExternalReferenceCodeException(String msg) {
+		super(msg);
+	}
+
+	public DuplicateObjectDefinitionExternalReferenceCodeException(
+		String msg, Throwable throwable) {
+
+		super(msg, throwable);
+	}
+
+	public DuplicateObjectDefinitionExternalReferenceCodeException(
+		Throwable throwable) {
+
+		super(throwable);
+	}
+
+}

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/exception/DuplicateObjectFieldExternalReferenceCodeException.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/exception/DuplicateObjectFieldExternalReferenceCodeException.java
@@ -14,13 +14,13 @@
 
 package com.liferay.object.exception;
 
-import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.SystemException;
 
 /**
  * @author Marco Leo
  */
 public class DuplicateObjectFieldExternalReferenceCodeException
-	extends PortalException {
+	extends SystemException {
 
 	public DuplicateObjectFieldExternalReferenceCodeException() {
 	}

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionLocalService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionLocalService.java
@@ -252,24 +252,9 @@ public interface ObjectDefinitionLocalService
 	public ObjectDefinition fetchObjectDefinitionByClassName(
 		long companyId, String className);
 
-	/**
-	 * Returns the object definition with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the object definition's external reference code
-	 * @return the matching object definition, or <code>null</code> if a matching object definition could not be found
-	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public ObjectDefinition fetchObjectDefinitionByExternalReferenceCode(
-		long companyId, String externalReferenceCode);
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchObjectDefinitionByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public ObjectDefinition fetchObjectDefinitionByReferenceCode(
-		long companyId, String externalReferenceCode);
+		String externalReferenceCode, long companyId);
 
 	/**
 	 * Returns the object definition with the matching UUID and company.
@@ -309,17 +294,9 @@ public interface ObjectDefinitionLocalService
 	public ObjectDefinition getObjectDefinition(long objectDefinitionId)
 		throws PortalException;
 
-	/**
-	 * Returns the object definition with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the object definition's external reference code
-	 * @return the matching object definition
-	 * @throws PortalException if a matching object definition could not be found
-	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public ObjectDefinition getObjectDefinitionByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
+			String externalReferenceCode, long companyId)
 		throws PortalException;
 
 	/**

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionLocalServiceUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionLocalServiceUtil.java
@@ -290,29 +290,11 @@ public class ObjectDefinitionLocalServiceUtil {
 			companyId, className);
 	}
 
-	/**
-	 * Returns the object definition with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the object definition's external reference code
-	 * @return the matching object definition, or <code>null</code> if a matching object definition could not be found
-	 */
 	public static ObjectDefinition fetchObjectDefinitionByExternalReferenceCode(
-		long companyId, String externalReferenceCode) {
+		String externalReferenceCode, long companyId) {
 
 		return getService().fetchObjectDefinitionByExternalReferenceCode(
-			companyId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchObjectDefinitionByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	public static ObjectDefinition fetchObjectDefinitionByReferenceCode(
-		long companyId, String externalReferenceCode) {
-
-		return getService().fetchObjectDefinitionByReferenceCode(
-			companyId, externalReferenceCode);
+			externalReferenceCode, companyId);
 	}
 
 	/**
@@ -373,20 +355,12 @@ public class ObjectDefinitionLocalServiceUtil {
 		return getService().getObjectDefinition(objectDefinitionId);
 	}
 
-	/**
-	 * Returns the object definition with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the object definition's external reference code
-	 * @return the matching object definition
-	 * @throws PortalException if a matching object definition could not be found
-	 */
 	public static ObjectDefinition getObjectDefinitionByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
+			String externalReferenceCode, long companyId)
 		throws PortalException {
 
 		return getService().getObjectDefinitionByExternalReferenceCode(
-			companyId, externalReferenceCode);
+			externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionLocalServiceWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionLocalServiceWrapper.java
@@ -325,35 +325,14 @@ public class ObjectDefinitionLocalServiceWrapper
 			companyId, className);
 	}
 
-	/**
-	 * Returns the object definition with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the object definition's external reference code
-	 * @return the matching object definition, or <code>null</code> if a matching object definition could not be found
-	 */
 	@Override
 	public com.liferay.object.model.ObjectDefinition
 		fetchObjectDefinitionByExternalReferenceCode(
-			long companyId, String externalReferenceCode) {
+			String externalReferenceCode, long companyId) {
 
 		return _objectDefinitionLocalService.
 			fetchObjectDefinitionByExternalReferenceCode(
-				companyId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchObjectDefinitionByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public com.liferay.object.model.ObjectDefinition
-		fetchObjectDefinitionByReferenceCode(
-			long companyId, String externalReferenceCode) {
-
-		return _objectDefinitionLocalService.
-			fetchObjectDefinitionByReferenceCode(
-				companyId, externalReferenceCode);
+				externalReferenceCode, companyId);
 	}
 
 	/**
@@ -426,23 +405,15 @@ public class ObjectDefinitionLocalServiceWrapper
 			objectDefinitionId);
 	}
 
-	/**
-	 * Returns the object definition with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the object definition's external reference code
-	 * @return the matching object definition
-	 * @throws PortalException if a matching object definition could not be found
-	 */
 	@Override
 	public com.liferay.object.model.ObjectDefinition
 			getObjectDefinitionByExternalReferenceCode(
-				long companyId, String externalReferenceCode)
+				String externalReferenceCode, long companyId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _objectDefinitionLocalService.
 			getObjectDefinitionByExternalReferenceCode(
-				companyId, externalReferenceCode);
+				externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/persistence/ObjectDefinitionPersistence.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/persistence/ObjectDefinitionPersistence.java
@@ -1722,57 +1722,57 @@ public interface ObjectDefinitionPersistence
 		long companyId, boolean active, boolean system, int status);
 
 	/**
-	 * Returns the object definition where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchObjectDefinitionException</code> if it could not be found.
+	 * Returns the object definition where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchObjectDefinitionException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching object definition
 	 * @throws NoSuchObjectDefinitionException if a matching object definition could not be found
 	 */
-	public ObjectDefinition findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public ObjectDefinition findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchObjectDefinitionException;
 
 	/**
-	 * Returns the object definition where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the object definition where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching object definition, or <code>null</code> if a matching object definition could not be found
 	 */
-	public ObjectDefinition fetchByC_ERC(
-		long companyId, String externalReferenceCode);
+	public ObjectDefinition fetchByERC_C(
+		String externalReferenceCode, long companyId);
 
 	/**
-	 * Returns the object definition where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the object definition where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching object definition, or <code>null</code> if a matching object definition could not be found
 	 */
-	public ObjectDefinition fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache);
+	public ObjectDefinition fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache);
 
 	/**
-	 * Removes the object definition where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the object definition where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the object definition that was removed
 	 */
-	public ObjectDefinition removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public ObjectDefinition removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchObjectDefinitionException;
 
 	/**
-	 * Returns the number of object definitions where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of object definitions where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching object definitions
 	 */
-	public int countByC_ERC(long companyId, String externalReferenceCode);
+	public int countByERC_C(String externalReferenceCode, long companyId);
 
 	/**
 	 * Caches the object definition in the entity cache if it is enabled.

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/persistence/ObjectDefinitionUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/persistence/ObjectDefinitionUtil.java
@@ -2134,73 +2134,73 @@ public class ObjectDefinitionUtil {
 	}
 
 	/**
-	 * Returns the object definition where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchObjectDefinitionException</code> if it could not be found.
+	 * Returns the object definition where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchObjectDefinitionException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching object definition
 	 * @throws NoSuchObjectDefinitionException if a matching object definition could not be found
 	 */
-	public static ObjectDefinition findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public static ObjectDefinition findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws com.liferay.object.exception.NoSuchObjectDefinitionException {
 
-		return getPersistence().findByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().findByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the object definition where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the object definition where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching object definition, or <code>null</code> if a matching object definition could not be found
 	 */
-	public static ObjectDefinition fetchByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public static ObjectDefinition fetchByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return getPersistence().fetchByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().fetchByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the object definition where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the object definition where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching object definition, or <code>null</code> if a matching object definition could not be found
 	 */
-	public static ObjectDefinition fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache) {
+	public static ObjectDefinition fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache) {
 
-		return getPersistence().fetchByC_ERC(
-			companyId, externalReferenceCode, useFinderCache);
+		return getPersistence().fetchByERC_C(
+			externalReferenceCode, companyId, useFinderCache);
 	}
 
 	/**
-	 * Removes the object definition where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the object definition where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the object definition that was removed
 	 */
-	public static ObjectDefinition removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public static ObjectDefinition removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws com.liferay.object.exception.NoSuchObjectDefinitionException {
 
-		return getPersistence().removeByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().removeByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**
-	 * Returns the number of object definitions where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of object definitions where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching object definitions
 	 */
-	public static int countByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public static int countByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return getPersistence().countByC_ERC(companyId, externalReferenceCode);
+		return getPersistence().countByERC_C(externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/exception/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/exception/packageinfo
@@ -1,1 +1,1 @@
-version 12.0.0
+version 13.0.0

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/service/persistence/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 5.1.0
+version 6.0.0

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/base/ObjectDefinitionLocalServiceBaseImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/base/ObjectDefinitionLocalServiceBaseImpl.java
@@ -275,48 +275,21 @@ public abstract class ObjectDefinitionLocalServiceBaseImpl
 			uuid, companyId, null);
 	}
 
-	/**
-	 * Returns the object definition with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the object definition's external reference code
-	 * @return the matching object definition, or <code>null</code> if a matching object definition could not be found
-	 */
 	@Override
 	public ObjectDefinition fetchObjectDefinitionByExternalReferenceCode(
-		long companyId, String externalReferenceCode) {
+		String externalReferenceCode, long companyId) {
 
-		return objectDefinitionPersistence.fetchByC_ERC(
-			companyId, externalReferenceCode);
+		return objectDefinitionPersistence.fetchByERC_C(
+			externalReferenceCode, companyId);
 	}
 
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchObjectDefinitionByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public ObjectDefinition fetchObjectDefinitionByReferenceCode(
-		long companyId, String externalReferenceCode) {
-
-		return fetchObjectDefinitionByExternalReferenceCode(
-			companyId, externalReferenceCode);
-	}
-
-	/**
-	 * Returns the object definition with the matching external reference code and company.
-	 *
-	 * @param companyId the primary key of the company
-	 * @param externalReferenceCode the object definition's external reference code
-	 * @return the matching object definition
-	 * @throws PortalException if a matching object definition could not be found
-	 */
 	@Override
 	public ObjectDefinition getObjectDefinitionByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
+			String externalReferenceCode, long companyId)
 		throws PortalException {
 
-		return objectDefinitionPersistence.findByC_ERC(
-			companyId, externalReferenceCode);
+		return objectDefinitionPersistence.findByERC_C(
+			externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionServiceImpl.java
@@ -93,7 +93,7 @@ public class ObjectDefinitionServiceImpl
 		ObjectDefinition objectDefinition =
 			objectDefinitionLocalService.
 				fetchObjectDefinitionByExternalReferenceCode(
-					companyId, externalReferenceCode);
+					externalReferenceCode, companyId);
 
 		if (objectDefinition != null) {
 			_objectDefinitionModelResourcePermission.check(
@@ -122,7 +122,7 @@ public class ObjectDefinitionServiceImpl
 		ObjectDefinition objectDefinition =
 			objectDefinitionLocalService.
 				getObjectDefinitionByExternalReferenceCode(
-					companyId, externalReferenceCode);
+					externalReferenceCode, companyId);
 
 		_objectDefinitionModelResourcePermission.check(
 			getPermissionChecker(), objectDefinition, ActionKeys.VIEW);

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/persistence/impl/ObjectDefinitionPersistenceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/persistence/impl/ObjectDefinitionPersistenceImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.object.service.persistence.impl;
 
+import com.liferay.object.exception.DuplicateObjectDefinitionExternalReferenceCodeException;
 import com.liferay.object.exception.NoSuchObjectDefinitionException;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectDefinitionTable;
@@ -7417,35 +7418,35 @@ public class ObjectDefinitionPersistenceImpl
 	private static final String _FINDER_COLUMN_C_A_S_S_STATUS_2 =
 		"objectDefinition.status = ?";
 
-	private FinderPath _finderPathFetchByC_ERC;
-	private FinderPath _finderPathCountByC_ERC;
+	private FinderPath _finderPathFetchByERC_C;
+	private FinderPath _finderPathCountByERC_C;
 
 	/**
-	 * Returns the object definition where companyId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchObjectDefinitionException</code> if it could not be found.
+	 * Returns the object definition where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchObjectDefinitionException</code> if it could not be found.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching object definition
 	 * @throws NoSuchObjectDefinitionException if a matching object definition could not be found
 	 */
 	@Override
-	public ObjectDefinition findByC_ERC(
-			long companyId, String externalReferenceCode)
+	public ObjectDefinition findByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchObjectDefinitionException {
 
-		ObjectDefinition objectDefinition = fetchByC_ERC(
-			companyId, externalReferenceCode);
+		ObjectDefinition objectDefinition = fetchByERC_C(
+			externalReferenceCode, companyId);
 
 		if (objectDefinition == null) {
 			StringBundler sb = new StringBundler(6);
 
 			sb.append(_NO_SUCH_ENTITY_WITH_KEY);
 
-			sb.append("companyId=");
-			sb.append(companyId);
-
-			sb.append(", externalReferenceCode=");
+			sb.append("externalReferenceCode=");
 			sb.append(externalReferenceCode);
+
+			sb.append(", companyId=");
+			sb.append(companyId);
 
 			sb.append("}");
 
@@ -7460,53 +7461,53 @@ public class ObjectDefinitionPersistenceImpl
 	}
 
 	/**
-	 * Returns the object definition where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the object definition where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the matching object definition, or <code>null</code> if a matching object definition could not be found
 	 */
 	@Override
-	public ObjectDefinition fetchByC_ERC(
-		long companyId, String externalReferenceCode) {
+	public ObjectDefinition fetchByERC_C(
+		String externalReferenceCode, long companyId) {
 
-		return fetchByC_ERC(companyId, externalReferenceCode, true);
+		return fetchByERC_C(externalReferenceCode, companyId, true);
 	}
 
 	/**
-	 * Returns the object definition where companyId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the object definition where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching object definition, or <code>null</code> if a matching object definition could not be found
 	 */
 	@Override
-	public ObjectDefinition fetchByC_ERC(
-		long companyId, String externalReferenceCode, boolean useFinderCache) {
+	public ObjectDefinition fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache) {
 
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
 		Object[] finderArgs = null;
 
 		if (useFinderCache) {
-			finderArgs = new Object[] {companyId, externalReferenceCode};
+			finderArgs = new Object[] {externalReferenceCode, companyId};
 		}
 
 		Object result = null;
 
 		if (useFinderCache) {
 			result = finderCache.getResult(
-				_finderPathFetchByC_ERC, finderArgs, this);
+				_finderPathFetchByERC_C, finderArgs, this);
 		}
 
 		if (result instanceof ObjectDefinition) {
 			ObjectDefinition objectDefinition = (ObjectDefinition)result;
 
-			if ((companyId != objectDefinition.getCompanyId()) ||
-				!Objects.equals(
+			if (!Objects.equals(
 					externalReferenceCode,
-					objectDefinition.getExternalReferenceCode())) {
+					objectDefinition.getExternalReferenceCode()) ||
+				(companyId != objectDefinition.getCompanyId())) {
 
 				result = null;
 			}
@@ -7517,18 +7518,18 @@ public class ObjectDefinitionPersistenceImpl
 
 			sb.append(_SQL_SELECT_OBJECTDEFINITION_WHERE);
 
-			sb.append(_FINDER_COLUMN_C_ERC_COMPANYID_2);
-
 			boolean bindExternalReferenceCode = false;
 
 			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3);
 			}
 			else {
 				bindExternalReferenceCode = true;
 
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2);
 			}
+
+			sb.append(_FINDER_COLUMN_ERC_C_COMPANYID_2);
 
 			String sql = sb.toString();
 
@@ -7541,18 +7542,18 @@ public class ObjectDefinitionPersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
-				queryPos.add(companyId);
-
 				if (bindExternalReferenceCode) {
 					queryPos.add(externalReferenceCode);
 				}
+
+				queryPos.add(companyId);
 
 				List<ObjectDefinition> list = query.list();
 
 				if (list.isEmpty()) {
 					if (useFinderCache) {
 						finderCache.putResult(
-							_finderPathFetchByC_ERC, finderArgs, list);
+							_finderPathFetchByERC_C, finderArgs, list);
 					}
 				}
 				else {
@@ -7580,37 +7581,37 @@ public class ObjectDefinitionPersistenceImpl
 	}
 
 	/**
-	 * Removes the object definition where companyId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the object definition where externalReferenceCode = &#63; and companyId = &#63; from the database.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the object definition that was removed
 	 */
 	@Override
-	public ObjectDefinition removeByC_ERC(
-			long companyId, String externalReferenceCode)
+	public ObjectDefinition removeByERC_C(
+			String externalReferenceCode, long companyId)
 		throws NoSuchObjectDefinitionException {
 
-		ObjectDefinition objectDefinition = findByC_ERC(
-			companyId, externalReferenceCode);
+		ObjectDefinition objectDefinition = findByERC_C(
+			externalReferenceCode, companyId);
 
 		return remove(objectDefinition);
 	}
 
 	/**
-	 * Returns the number of object definitions where companyId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of object definitions where externalReferenceCode = &#63; and companyId = &#63;.
 	 *
-	 * @param companyId the company ID
 	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
 	 * @return the number of matching object definitions
 	 */
 	@Override
-	public int countByC_ERC(long companyId, String externalReferenceCode) {
+	public int countByERC_C(String externalReferenceCode, long companyId) {
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
-		FinderPath finderPath = _finderPathCountByC_ERC;
+		FinderPath finderPath = _finderPathCountByERC_C;
 
-		Object[] finderArgs = new Object[] {companyId, externalReferenceCode};
+		Object[] finderArgs = new Object[] {externalReferenceCode, companyId};
 
 		Long count = (Long)finderCache.getResult(finderPath, finderArgs, this);
 
@@ -7619,18 +7620,18 @@ public class ObjectDefinitionPersistenceImpl
 
 			sb.append(_SQL_COUNT_OBJECTDEFINITION_WHERE);
 
-			sb.append(_FINDER_COLUMN_C_ERC_COMPANYID_2);
-
 			boolean bindExternalReferenceCode = false;
 
 			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3);
 			}
 			else {
 				bindExternalReferenceCode = true;
 
-				sb.append(_FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2);
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2);
 			}
+
+			sb.append(_FINDER_COLUMN_ERC_C_COMPANYID_2);
 
 			String sql = sb.toString();
 
@@ -7643,11 +7644,11 @@ public class ObjectDefinitionPersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
-				queryPos.add(companyId);
-
 				if (bindExternalReferenceCode) {
 					queryPos.add(externalReferenceCode);
 				}
+
+				queryPos.add(companyId);
 
 				count = (Long)query.uniqueResult();
 
@@ -7664,14 +7665,14 @@ public class ObjectDefinitionPersistenceImpl
 		return count.intValue();
 	}
 
-	private static final String _FINDER_COLUMN_C_ERC_COMPANYID_2 =
-		"objectDefinition.companyId = ? AND ";
+	private static final String _FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2 =
+		"objectDefinition.externalReferenceCode = ? AND ";
 
-	private static final String _FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_2 =
-		"objectDefinition.externalReferenceCode = ?";
+	private static final String _FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3 =
+		"(objectDefinition.externalReferenceCode IS NULL OR objectDefinition.externalReferenceCode = '') AND ";
 
-	private static final String _FINDER_COLUMN_C_ERC_EXTERNALREFERENCECODE_3 =
-		"(objectDefinition.externalReferenceCode IS NULL OR objectDefinition.externalReferenceCode = '')";
+	private static final String _FINDER_COLUMN_ERC_C_COMPANYID_2 =
+		"objectDefinition.companyId = ?";
 
 	public ObjectDefinitionPersistenceImpl() {
 		Map<String, String> dbColumnNames = new HashMap<String, String>();
@@ -7718,10 +7719,10 @@ public class ObjectDefinitionPersistenceImpl
 			objectDefinition);
 
 		finderCache.putResult(
-			_finderPathFetchByC_ERC,
+			_finderPathFetchByERC_C,
 			new Object[] {
-				objectDefinition.getCompanyId(),
-				objectDefinition.getExternalReferenceCode()
+				objectDefinition.getExternalReferenceCode(),
+				objectDefinition.getCompanyId()
 			},
 			objectDefinition);
 	}
@@ -7818,13 +7819,13 @@ public class ObjectDefinitionPersistenceImpl
 			_finderPathFetchByC_N, args, objectDefinitionModelImpl);
 
 		args = new Object[] {
-			objectDefinitionModelImpl.getCompanyId(),
-			objectDefinitionModelImpl.getExternalReferenceCode()
+			objectDefinitionModelImpl.getExternalReferenceCode(),
+			objectDefinitionModelImpl.getCompanyId()
 		};
 
-		finderCache.putResult(_finderPathCountByC_ERC, args, Long.valueOf(1));
+		finderCache.putResult(_finderPathCountByERC_C, args, Long.valueOf(1));
 		finderCache.putResult(
-			_finderPathFetchByC_ERC, args, objectDefinitionModelImpl);
+			_finderPathFetchByERC_C, args, objectDefinitionModelImpl);
 	}
 
 	/**
@@ -7968,6 +7969,29 @@ public class ObjectDefinitionPersistenceImpl
 		if (Validator.isNull(objectDefinition.getExternalReferenceCode())) {
 			objectDefinition.setExternalReferenceCode(
 				objectDefinition.getUuid());
+		}
+		else {
+			ObjectDefinition ercObjectDefinition = fetchByERC_C(
+				objectDefinition.getExternalReferenceCode(),
+				objectDefinition.getCompanyId());
+
+			if (isNew) {
+				if (ercObjectDefinition != null) {
+					throw new DuplicateObjectDefinitionExternalReferenceCodeException(
+						"Duplicate ObjectDefinition with external reference code " +
+							objectDefinition.getExternalReferenceCode());
+				}
+			}
+			else {
+				if ((ercObjectDefinition != null) &&
+					(objectDefinition.getObjectDefinitionId() !=
+						ercObjectDefinition.getObjectDefinitionId())) {
+
+					throw new DuplicateObjectDefinitionExternalReferenceCodeException(
+						"Duplicate ObjectDefinition with external reference code " +
+							objectDefinition.getExternalReferenceCode());
+				}
+			}
 		}
 
 		ServiceContext serviceContext =
@@ -8468,15 +8492,15 @@ public class ObjectDefinitionPersistenceImpl
 			},
 			new String[] {"companyId", "active_", "system_", "status"}, false);
 
-		_finderPathFetchByC_ERC = new FinderPath(
-			FINDER_CLASS_NAME_ENTITY, "fetchByC_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"companyId", "externalReferenceCode"}, true);
+		_finderPathFetchByERC_C = new FinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, true);
 
-		_finderPathCountByC_ERC = new FinderPath(
-			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"companyId", "externalReferenceCode"}, false);
+		_finderPathCountByERC_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, false);
 
 		_setObjectDefinitionUtilPersistence(this);
 	}

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectDefinitionPersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectDefinitionPersistenceTest.java
@@ -15,6 +15,7 @@
 package com.liferay.object.service.persistence.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.object.exception.DuplicateObjectDefinitionExternalReferenceCodeException;
 import com.liferay.object.exception.NoSuchObjectDefinitionException;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
@@ -294,6 +295,28 @@ public class ObjectDefinitionPersistenceTest {
 			newObjectDefinition.getStatus());
 	}
 
+	@Test(
+		expected = DuplicateObjectDefinitionExternalReferenceCodeException.class
+	)
+	public void testUpdateWithExistingExternalReferenceCode() throws Exception {
+		ObjectDefinition objectDefinition = addObjectDefinition();
+
+		ObjectDefinition newObjectDefinition = addObjectDefinition();
+
+		newObjectDefinition.setCompanyId(objectDefinition.getCompanyId());
+
+		newObjectDefinition = _persistence.update(newObjectDefinition);
+
+		Session session = _persistence.getCurrentSession();
+
+		session.evict(newObjectDefinition);
+
+		newObjectDefinition.setExternalReferenceCode(
+			objectDefinition.getExternalReferenceCode());
+
+		_persistence.update(newObjectDefinition);
+	}
+
 	@Test
 	public void testCountByUuid() throws Exception {
 		_persistence.countByUuid("");
@@ -373,12 +396,12 @@ public class ObjectDefinitionPersistenceTest {
 	}
 
 	@Test
-	public void testCountByC_ERC() throws Exception {
-		_persistence.countByC_ERC(RandomTestUtil.nextLong(), "");
+	public void testCountByERC_C() throws Exception {
+		_persistence.countByERC_C("", RandomTestUtil.nextLong());
 
-		_persistence.countByC_ERC(0L, "null");
+		_persistence.countByERC_C("null", 0L);
 
-		_persistence.countByC_ERC(0L, (String)null);
+		_persistence.countByERC_C((String)null, 0L);
 	}
 
 	@Test
@@ -712,15 +735,15 @@ public class ObjectDefinitionPersistenceTest {
 				new Class<?>[] {String.class}, "name"));
 
 		Assert.assertEquals(
-			Long.valueOf(objectDefinition.getCompanyId()),
-			ReflectionTestUtil.<Long>invoke(
-				objectDefinition, "getColumnOriginalValue",
-				new Class<?>[] {String.class}, "companyId"));
-		Assert.assertEquals(
 			objectDefinition.getExternalReferenceCode(),
 			ReflectionTestUtil.invoke(
 				objectDefinition, "getColumnOriginalValue",
 				new Class<?>[] {String.class}, "externalReferenceCode"));
+		Assert.assertEquals(
+			Long.valueOf(objectDefinition.getCompanyId()),
+			ReflectionTestUtil.<Long>invoke(
+				objectDefinition, "getColumnOriginalValue",
+				new Class<?>[] {String.class}, "companyId"));
 	}
 
 	protected ObjectDefinition addObjectDefinition() throws Exception {

--- a/modules/apps/portal/portal-catapult-impl/src/main/java/com/liferay/portal/catapult/internal/PortalCatapultImpl.java
+++ b/modules/apps/portal/portal-catapult-impl/src/main/java/com/liferay/portal/catapult/internal/PortalCatapultImpl.java
@@ -55,7 +55,7 @@ public class PortalCatapultImpl implements PortalCatapult {
 		OAuth2Application oAuth2Application =
 			_oAuth2ApplicationLocalService.
 				getOAuth2ApplicationByExternalReferenceCode(
-					companyId, oAuth2ApplicationExternalReferenceCode);
+					oAuth2ApplicationExternalReferenceCode, companyId);
 
 		options.setLocation(_getLocation(oAuth2Application, resourcePath));
 

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test/src/testIntegration/java/com/liferay/site/initializer/extender/internal/test/BundleSiteInitializerTest.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test/src/testIntegration/java/com/liferay/site/initializer/extender/internal/test/BundleSiteInitializerTest.java
@@ -394,7 +394,7 @@ public class BundleSiteInitializerTest {
 		ClientExtensionEntry clientExtensionEntry =
 			_clientExtensionEntryLocalService.
 				fetchClientExtensionEntryByExternalReferenceCode(
-					group.getCompanyId(), "ERC001");
+					"ERC001", group.getCompanyId());
 
 		Assert.assertNotNull(clientExtensionEntry);
 

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/exception/DuplicateNodeExternalReferenceCodeException.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/exception/DuplicateNodeExternalReferenceCodeException.java
@@ -14,13 +14,13 @@
 
 package com.liferay.wiki.exception;
 
-import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.SystemException;
 
 /**
  * @author Brian Wing Shun Chan
  */
 public class DuplicateNodeExternalReferenceCodeException
-	extends PortalException {
+	extends SystemException {
 
 	public DuplicateNodeExternalReferenceCodeException() {
 	}

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/exception/DuplicatePageExternalReferenceCodeException.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/exception/DuplicatePageExternalReferenceCodeException.java
@@ -14,13 +14,13 @@
 
 package com.liferay.wiki.exception;
 
-import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.SystemException;
 
 /**
  * @author Brian Wing Shun Chan
  */
 public class DuplicatePageExternalReferenceCodeException
-	extends PortalException {
+	extends SystemException {
 
 	public DuplicatePageExternalReferenceCodeException() {
 	}

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/exception/DuplicateWikiNodeExternalReferenceCodeException.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/exception/DuplicateWikiNodeExternalReferenceCodeException.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.wiki.exception;
+
+import com.liferay.portal.kernel.exception.SystemException;
+
+/**
+ * @author Brian Wing Shun Chan
+ */
+public class DuplicateWikiNodeExternalReferenceCodeException
+	extends SystemException {
+
+	public DuplicateWikiNodeExternalReferenceCodeException() {
+	}
+
+	public DuplicateWikiNodeExternalReferenceCodeException(String msg) {
+		super(msg);
+	}
+
+	public DuplicateWikiNodeExternalReferenceCodeException(
+		String msg, Throwable throwable) {
+
+		super(msg, throwable);
+	}
+
+	public DuplicateWikiNodeExternalReferenceCodeException(
+		Throwable throwable) {
+
+		super(throwable);
+	}
+
+}

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiNodeLocalService.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiNodeLocalService.java
@@ -256,24 +256,9 @@ public interface WikiNodeLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public WikiNode fetchWikiNode(long nodeId);
 
-	/**
-	 * Returns the wiki node with the matching external reference code and group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the wiki node's external reference code
-	 * @return the matching wiki node, or <code>null</code> if a matching wiki node could not be found
-	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public WikiNode fetchWikiNodeByExternalReferenceCode(
-		long groupId, String externalReferenceCode);
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchWikiNodeByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public WikiNode fetchWikiNodeByReferenceCode(
-		long groupId, String externalReferenceCode);
+		String externalReferenceCode, long groupId);
 
 	/**
 	 * Returns the wiki node matching the UUID and group.
@@ -361,17 +346,9 @@ public interface WikiNodeLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public WikiNode getWikiNode(long nodeId) throws PortalException;
 
-	/**
-	 * Returns the wiki node with the matching external reference code and group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the wiki node's external reference code
-	 * @return the matching wiki node
-	 * @throws PortalException if a matching wiki node could not be found
-	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public WikiNode getWikiNodeByExternalReferenceCode(
-			long groupId, String externalReferenceCode)
+			String externalReferenceCode, long groupId)
 		throws PortalException;
 
 	/**

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiNodeLocalServiceUtil.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiNodeLocalServiceUtil.java
@@ -288,29 +288,11 @@ public class WikiNodeLocalServiceUtil {
 		return getService().fetchWikiNode(nodeId);
 	}
 
-	/**
-	 * Returns the wiki node with the matching external reference code and group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the wiki node's external reference code
-	 * @return the matching wiki node, or <code>null</code> if a matching wiki node could not be found
-	 */
 	public static WikiNode fetchWikiNodeByExternalReferenceCode(
-		long groupId, String externalReferenceCode) {
+		String externalReferenceCode, long groupId) {
 
 		return getService().fetchWikiNodeByExternalReferenceCode(
-			groupId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchWikiNodeByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	public static WikiNode fetchWikiNodeByReferenceCode(
-		long groupId, String externalReferenceCode) {
-
-		return getService().fetchWikiNodeByReferenceCode(
-			groupId, externalReferenceCode);
+			externalReferenceCode, groupId);
 	}
 
 	/**
@@ -437,20 +419,12 @@ public class WikiNodeLocalServiceUtil {
 		return getService().getWikiNode(nodeId);
 	}
 
-	/**
-	 * Returns the wiki node with the matching external reference code and group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the wiki node's external reference code
-	 * @return the matching wiki node
-	 * @throws PortalException if a matching wiki node could not be found
-	 */
 	public static WikiNode getWikiNodeByExternalReferenceCode(
-			long groupId, String externalReferenceCode)
+			String externalReferenceCode, long groupId)
 		throws PortalException {
 
 		return getService().getWikiNodeByExternalReferenceCode(
-			groupId, externalReferenceCode);
+			externalReferenceCode, groupId);
 	}
 
 	/**

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiNodeLocalServiceWrapper.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiNodeLocalServiceWrapper.java
@@ -328,31 +328,12 @@ public class WikiNodeLocalServiceWrapper
 		return _wikiNodeLocalService.fetchWikiNode(nodeId);
 	}
 
-	/**
-	 * Returns the wiki node with the matching external reference code and group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the wiki node's external reference code
-	 * @return the matching wiki node, or <code>null</code> if a matching wiki node could not be found
-	 */
 	@Override
 	public com.liferay.wiki.model.WikiNode fetchWikiNodeByExternalReferenceCode(
-		long groupId, String externalReferenceCode) {
+		String externalReferenceCode, long groupId) {
 
 		return _wikiNodeLocalService.fetchWikiNodeByExternalReferenceCode(
-			groupId, externalReferenceCode);
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchWikiNodeByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public com.liferay.wiki.model.WikiNode fetchWikiNodeByReferenceCode(
-		long groupId, String externalReferenceCode) {
-
-		return _wikiNodeLocalService.fetchWikiNodeByReferenceCode(
-			groupId, externalReferenceCode);
+			externalReferenceCode, groupId);
 	}
 
 	/**
@@ -511,21 +492,13 @@ public class WikiNodeLocalServiceWrapper
 		return _wikiNodeLocalService.getWikiNode(nodeId);
 	}
 
-	/**
-	 * Returns the wiki node with the matching external reference code and group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the wiki node's external reference code
-	 * @return the matching wiki node
-	 * @throws PortalException if a matching wiki node could not be found
-	 */
 	@Override
 	public com.liferay.wiki.model.WikiNode getWikiNodeByExternalReferenceCode(
-			long groupId, String externalReferenceCode)
+			String externalReferenceCode, long groupId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _wikiNodeLocalService.getWikiNodeByExternalReferenceCode(
-			groupId, externalReferenceCode);
+			externalReferenceCode, groupId);
 	}
 
 	/**

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/persistence/WikiNodePersistence.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/persistence/WikiNodePersistence.java
@@ -1164,54 +1164,54 @@ public interface WikiNodePersistence extends BasePersistence<WikiNode> {
 	public int countByC_S(long companyId, int status);
 
 	/**
-	 * Returns the wiki node where groupId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchNodeException</code> if it could not be found.
+	 * Returns the wiki node where externalReferenceCode = &#63; and groupId = &#63; or throws a <code>NoSuchNodeException</code> if it could not be found.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the matching wiki node
 	 * @throws NoSuchNodeException if a matching wiki node could not be found
 	 */
-	public WikiNode findByG_ERC(long groupId, String externalReferenceCode)
+	public WikiNode findByERC_G(String externalReferenceCode, long groupId)
 		throws NoSuchNodeException;
 
 	/**
-	 * Returns the wiki node where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the wiki node where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the matching wiki node, or <code>null</code> if a matching wiki node could not be found
 	 */
-	public WikiNode fetchByG_ERC(long groupId, String externalReferenceCode);
+	public WikiNode fetchByERC_G(String externalReferenceCode, long groupId);
 
 	/**
-	 * Returns the wiki node where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the wiki node where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching wiki node, or <code>null</code> if a matching wiki node could not be found
 	 */
-	public WikiNode fetchByG_ERC(
-		long groupId, String externalReferenceCode, boolean useFinderCache);
+	public WikiNode fetchByERC_G(
+		String externalReferenceCode, long groupId, boolean useFinderCache);
 
 	/**
-	 * Removes the wiki node where groupId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the wiki node where externalReferenceCode = &#63; and groupId = &#63; from the database.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the wiki node that was removed
 	 */
-	public WikiNode removeByG_ERC(long groupId, String externalReferenceCode)
+	public WikiNode removeByERC_G(String externalReferenceCode, long groupId)
 		throws NoSuchNodeException;
 
 	/**
-	 * Returns the number of wiki nodes where groupId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of wiki nodes where externalReferenceCode = &#63; and groupId = &#63;.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the number of matching wiki nodes
 	 */
-	public int countByG_ERC(long groupId, String externalReferenceCode);
+	public int countByERC_G(String externalReferenceCode, long groupId);
 
 	/**
 	 * Caches the wiki node in the entity cache if it is enabled.

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/persistence/WikiNodeUtil.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/persistence/WikiNodeUtil.java
@@ -1448,71 +1448,71 @@ public class WikiNodeUtil {
 	}
 
 	/**
-	 * Returns the wiki node where groupId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchNodeException</code> if it could not be found.
+	 * Returns the wiki node where externalReferenceCode = &#63; and groupId = &#63; or throws a <code>NoSuchNodeException</code> if it could not be found.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the matching wiki node
 	 * @throws NoSuchNodeException if a matching wiki node could not be found
 	 */
-	public static WikiNode findByG_ERC(
-			long groupId, String externalReferenceCode)
+	public static WikiNode findByERC_G(
+			String externalReferenceCode, long groupId)
 		throws com.liferay.wiki.exception.NoSuchNodeException {
 
-		return getPersistence().findByG_ERC(groupId, externalReferenceCode);
+		return getPersistence().findByERC_G(externalReferenceCode, groupId);
 	}
 
 	/**
-	 * Returns the wiki node where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the wiki node where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the matching wiki node, or <code>null</code> if a matching wiki node could not be found
 	 */
-	public static WikiNode fetchByG_ERC(
-		long groupId, String externalReferenceCode) {
+	public static WikiNode fetchByERC_G(
+		String externalReferenceCode, long groupId) {
 
-		return getPersistence().fetchByG_ERC(groupId, externalReferenceCode);
+		return getPersistence().fetchByERC_G(externalReferenceCode, groupId);
 	}
 
 	/**
-	 * Returns the wiki node where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the wiki node where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching wiki node, or <code>null</code> if a matching wiki node could not be found
 	 */
-	public static WikiNode fetchByG_ERC(
-		long groupId, String externalReferenceCode, boolean useFinderCache) {
+	public static WikiNode fetchByERC_G(
+		String externalReferenceCode, long groupId, boolean useFinderCache) {
 
-		return getPersistence().fetchByG_ERC(
-			groupId, externalReferenceCode, useFinderCache);
+		return getPersistence().fetchByERC_G(
+			externalReferenceCode, groupId, useFinderCache);
 	}
 
 	/**
-	 * Removes the wiki node where groupId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the wiki node where externalReferenceCode = &#63; and groupId = &#63; from the database.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the wiki node that was removed
 	 */
-	public static WikiNode removeByG_ERC(
-			long groupId, String externalReferenceCode)
+	public static WikiNode removeByERC_G(
+			String externalReferenceCode, long groupId)
 		throws com.liferay.wiki.exception.NoSuchNodeException {
 
-		return getPersistence().removeByG_ERC(groupId, externalReferenceCode);
+		return getPersistence().removeByERC_G(externalReferenceCode, groupId);
 	}
 
 	/**
-	 * Returns the number of wiki nodes where groupId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of wiki nodes where externalReferenceCode = &#63; and groupId = &#63;.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the number of matching wiki nodes
 	 */
-	public static int countByG_ERC(long groupId, String externalReferenceCode) {
-		return getPersistence().countByG_ERC(groupId, externalReferenceCode);
+	public static int countByERC_G(String externalReferenceCode, long groupId) {
+		return getPersistence().countByERC_G(externalReferenceCode, groupId);
 	}
 
 	/**

--- a/modules/apps/wiki/wiki-api/src/main/resources/com/liferay/wiki/exception/packageinfo
+++ b/modules/apps/wiki/wiki-api/src/main/resources/com/liferay/wiki/exception/packageinfo
@@ -1,1 +1,1 @@
-version 1.4.0
+version 2.0.0

--- a/modules/apps/wiki/wiki-api/src/main/resources/com/liferay/wiki/service/packageinfo
+++ b/modules/apps/wiki/wiki-api/src/main/resources/com/liferay/wiki/service/packageinfo
@@ -1,1 +1,1 @@
-version 2.5.0
+version 3.0.0

--- a/modules/apps/wiki/wiki-api/src/main/resources/com/liferay/wiki/service/persistence/packageinfo
+++ b/modules/apps/wiki/wiki-api/src/main/resources/com/liferay/wiki/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 3.2.0
+version 4.0.0

--- a/modules/apps/wiki/wiki-service/service.xml
+++ b/modules/apps/wiki/wiki-service/service.xml
@@ -298,10 +298,8 @@
 		</finder>
 	</entity>
 	<exceptions>
-		<exception>DuplicateNodeExternalReferenceCode</exception>
 		<exception>DuplicateNodeName</exception>
 		<exception>DuplicatePage</exception>
-		<exception>DuplicatePageExternalReferenceCode</exception>
 		<exception>ImportFiles</exception>
 		<exception>NodeName</exception>
 		<exception>PageAttachment</exception>

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/base/WikiNodeLocalServiceBaseImpl.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/base/WikiNodeLocalServiceBaseImpl.java
@@ -271,46 +271,19 @@ public abstract class WikiNodeLocalServiceBaseImpl
 		return wikiNodePersistence.fetchByUUID_G(uuid, groupId);
 	}
 
-	/**
-	 * Returns the wiki node with the matching external reference code and group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the wiki node's external reference code
-	 * @return the matching wiki node, or <code>null</code> if a matching wiki node could not be found
-	 */
 	@Override
 	public WikiNode fetchWikiNodeByExternalReferenceCode(
-		long groupId, String externalReferenceCode) {
+		String externalReferenceCode, long groupId) {
 
-		return wikiNodePersistence.fetchByG_ERC(groupId, externalReferenceCode);
+		return wikiNodePersistence.fetchByERC_G(externalReferenceCode, groupId);
 	}
 
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetchWikiNodeByExternalReferenceCode(long, String)}
-	 */
-	@Deprecated
-	@Override
-	public WikiNode fetchWikiNodeByReferenceCode(
-		long groupId, String externalReferenceCode) {
-
-		return fetchWikiNodeByExternalReferenceCode(
-			groupId, externalReferenceCode);
-	}
-
-	/**
-	 * Returns the wiki node with the matching external reference code and group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the wiki node's external reference code
-	 * @return the matching wiki node
-	 * @throws PortalException if a matching wiki node could not be found
-	 */
 	@Override
 	public WikiNode getWikiNodeByExternalReferenceCode(
-			long groupId, String externalReferenceCode)
+			String externalReferenceCode, long groupId)
 		throws PortalException {
 
-		return wikiNodePersistence.findByG_ERC(groupId, externalReferenceCode);
+		return wikiNodePersistence.findByERC_G(externalReferenceCode, groupId);
 	}
 
 	/**

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiNodeLocalServiceImpl.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiNodeLocalServiceImpl.java
@@ -55,7 +55,6 @@ import com.liferay.trash.model.TrashEntry;
 import com.liferay.trash.service.TrashEntryLocalService;
 import com.liferay.wiki.configuration.WikiGroupServiceConfiguration;
 import com.liferay.wiki.constants.WikiConstants;
-import com.liferay.wiki.exception.DuplicateNodeExternalReferenceCodeException;
 import com.liferay.wiki.exception.DuplicateNodeNameException;
 import com.liferay.wiki.exception.NodeNameException;
 import com.liferay.wiki.importer.WikiImporter;
@@ -132,8 +131,6 @@ public class WikiNodeLocalServiceImpl extends WikiNodeLocalServiceBaseImpl {
 		_validate(groupId, name);
 
 		long nodeId = counterLocalService.increment();
-
-		_validateExternalReferenceCode(externalReferenceCode, groupId);
 
 		WikiNode node = wikiNodePersistence.create(nodeId);
 
@@ -648,25 +645,6 @@ public class WikiNodeLocalServiceImpl extends WikiNodeLocalServiceBaseImpl {
 
 	private void _validate(long groupId, String name) throws PortalException {
 		_validate(0, groupId, name);
-	}
-
-	private void _validateExternalReferenceCode(
-			String externalReferenceCode, long groupId)
-		throws PortalException {
-
-		if (Validator.isNull(externalReferenceCode)) {
-			return;
-		}
-
-		WikiNode wikiNode = wikiNodePersistence.fetchByERC_G(
-			externalReferenceCode, groupId);
-
-		if (wikiNode != null) {
-			throw new DuplicateNodeExternalReferenceCodeException(
-				StringBundler.concat(
-					"Duplicate node external reference code ",
-					externalReferenceCode, " in group ", groupId));
-		}
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiNodeLocalServiceImpl.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiNodeLocalServiceImpl.java
@@ -658,8 +658,8 @@ public class WikiNodeLocalServiceImpl extends WikiNodeLocalServiceBaseImpl {
 			return;
 		}
 
-		WikiNode wikiNode = wikiNodePersistence.fetchByG_ERC(
-			groupId, externalReferenceCode);
+		WikiNode wikiNode = wikiNodePersistence.fetchByERC_G(
+			externalReferenceCode, groupId);
 
 		if (wikiNode != null) {
 			throw new DuplicateNodeExternalReferenceCodeException(

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiNodeServiceImpl.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiNodeServiceImpl.java
@@ -182,7 +182,7 @@ public class WikiNodeServiceImpl extends WikiNodeServiceBaseImpl {
 		throws PortalException {
 
 		WikiNode node = wikiNodeLocalService.getWikiNodeByExternalReferenceCode(
-			groupId, externalReferenceCode);
+			externalReferenceCode, groupId);
 
 		_wikiNodeModelResourcePermission.check(
 			getPermissionChecker(), node, ActionKeys.VIEW);

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageLocalServiceImpl.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageLocalServiceImpl.java
@@ -114,7 +114,6 @@ import com.liferay.wiki.engine.WikiEngine;
 import com.liferay.wiki.engine.WikiEngineRenderer;
 import com.liferay.wiki.escape.WikiEscapeUtil;
 import com.liferay.wiki.exception.DuplicatePageException;
-import com.liferay.wiki.exception.DuplicatePageExternalReferenceCodeException;
 import com.liferay.wiki.exception.NoSuchPageException;
 import com.liferay.wiki.exception.PageContentException;
 import com.liferay.wiki.exception.PageTitleException;
@@ -255,9 +254,6 @@ public class WikiPageLocalServiceImpl extends WikiPageLocalServiceBaseImpl {
 		Date date = new Date();
 
 		long pageId = counterLocalService.increment();
-
-		_validateExternalReferenceCode(
-			externalReferenceCode, node.getGroupId());
 
 		content = SanitizerUtil.sanitize(
 			user.getCompanyId(), node.getGroupId(), userId,
@@ -3430,25 +3426,6 @@ public class WikiPageLocalServiceImpl extends WikiPageLocalServiceBaseImpl {
 		_wikiPageTitleValidator.validate(title);
 
 		_validate(nodeId, content, format);
-	}
-
-	private void _validateExternalReferenceCode(
-			String externalReferenceCode, long groupId)
-		throws PortalException {
-
-		if (Validator.isNull(externalReferenceCode)) {
-			return;
-		}
-
-		WikiPage wikiPage = fetchLatestPageByExternalReferenceCode(
-			groupId, externalReferenceCode);
-
-		if (wikiPage != null) {
-			throw new DuplicatePageExternalReferenceCodeException(
-				StringBundler.concat(
-					"Duplicate page external reference code ",
-					externalReferenceCode, " in group ", groupId));
-		}
 	}
 
 	private static final String _OUTGOING_LINKS = "OUTGOING_LINKS";

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/persistence/impl/WikiNodePersistenceImpl.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/persistence/impl/WikiNodePersistenceImpl.java
@@ -40,6 +40,7 @@ import com.liferay.portal.kernel.util.ProxyUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.uuid.PortalUUID;
+import com.liferay.wiki.exception.DuplicateWikiNodeExternalReferenceCodeException;
 import com.liferay.wiki.exception.NoSuchNodeException;
 import com.liferay.wiki.model.WikiNode;
 import com.liferay.wiki.model.WikiNodeTable;
@@ -4508,33 +4509,33 @@ public class WikiNodePersistenceImpl
 	private static final String _FINDER_COLUMN_C_S_STATUS_2 =
 		"wikiNode.status = ?";
 
-	private FinderPath _finderPathFetchByG_ERC;
-	private FinderPath _finderPathCountByG_ERC;
+	private FinderPath _finderPathFetchByERC_G;
+	private FinderPath _finderPathCountByERC_G;
 
 	/**
-	 * Returns the wiki node where groupId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchNodeException</code> if it could not be found.
+	 * Returns the wiki node where externalReferenceCode = &#63; and groupId = &#63; or throws a <code>NoSuchNodeException</code> if it could not be found.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the matching wiki node
 	 * @throws NoSuchNodeException if a matching wiki node could not be found
 	 */
 	@Override
-	public WikiNode findByG_ERC(long groupId, String externalReferenceCode)
+	public WikiNode findByERC_G(String externalReferenceCode, long groupId)
 		throws NoSuchNodeException {
 
-		WikiNode wikiNode = fetchByG_ERC(groupId, externalReferenceCode);
+		WikiNode wikiNode = fetchByERC_G(externalReferenceCode, groupId);
 
 		if (wikiNode == null) {
 			StringBundler sb = new StringBundler(6);
 
 			sb.append(_NO_SUCH_ENTITY_WITH_KEY);
 
-			sb.append("groupId=");
-			sb.append(groupId);
-
-			sb.append(", externalReferenceCode=");
+			sb.append("externalReferenceCode=");
 			sb.append(externalReferenceCode);
+
+			sb.append(", groupId=");
+			sb.append(groupId);
 
 			sb.append("}");
 
@@ -4549,51 +4550,51 @@ public class WikiNodePersistenceImpl
 	}
 
 	/**
-	 * Returns the wiki node where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the wiki node where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the matching wiki node, or <code>null</code> if a matching wiki node could not be found
 	 */
 	@Override
-	public WikiNode fetchByG_ERC(long groupId, String externalReferenceCode) {
-		return fetchByG_ERC(groupId, externalReferenceCode, true);
+	public WikiNode fetchByERC_G(String externalReferenceCode, long groupId) {
+		return fetchByERC_G(externalReferenceCode, groupId, true);
 	}
 
 	/**
-	 * Returns the wiki node where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the wiki node where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching wiki node, or <code>null</code> if a matching wiki node could not be found
 	 */
 	@Override
-	public WikiNode fetchByG_ERC(
-		long groupId, String externalReferenceCode, boolean useFinderCache) {
+	public WikiNode fetchByERC_G(
+		String externalReferenceCode, long groupId, boolean useFinderCache) {
 
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
 		Object[] finderArgs = null;
 
 		if (useFinderCache) {
-			finderArgs = new Object[] {groupId, externalReferenceCode};
+			finderArgs = new Object[] {externalReferenceCode, groupId};
 		}
 
 		Object result = null;
 
 		if (useFinderCache) {
 			result = finderCache.getResult(
-				_finderPathFetchByG_ERC, finderArgs, this);
+				_finderPathFetchByERC_G, finderArgs, this);
 		}
 
 		if (result instanceof WikiNode) {
 			WikiNode wikiNode = (WikiNode)result;
 
-			if ((groupId != wikiNode.getGroupId()) ||
-				!Objects.equals(
+			if (!Objects.equals(
 					externalReferenceCode,
-					wikiNode.getExternalReferenceCode())) {
+					wikiNode.getExternalReferenceCode()) ||
+				(groupId != wikiNode.getGroupId())) {
 
 				result = null;
 			}
@@ -4604,18 +4605,18 @@ public class WikiNodePersistenceImpl
 
 			sb.append(_SQL_SELECT_WIKINODE_WHERE);
 
-			sb.append(_FINDER_COLUMN_G_ERC_GROUPID_2);
-
 			boolean bindExternalReferenceCode = false;
 
 			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_3);
+				sb.append(_FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_3);
 			}
 			else {
 				bindExternalReferenceCode = true;
 
-				sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_2);
+				sb.append(_FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_2);
 			}
+
+			sb.append(_FINDER_COLUMN_ERC_G_GROUPID_2);
 
 			String sql = sb.toString();
 
@@ -4628,18 +4629,18 @@ public class WikiNodePersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
-				queryPos.add(groupId);
-
 				if (bindExternalReferenceCode) {
 					queryPos.add(externalReferenceCode);
 				}
+
+				queryPos.add(groupId);
 
 				List<WikiNode> list = query.list();
 
 				if (list.isEmpty()) {
 					if (useFinderCache) {
 						finderCache.putResult(
-							_finderPathFetchByG_ERC, finderArgs, list);
+							_finderPathFetchByERC_G, finderArgs, list);
 					}
 				}
 				else {
@@ -4667,35 +4668,35 @@ public class WikiNodePersistenceImpl
 	}
 
 	/**
-	 * Removes the wiki node where groupId = &#63; and externalReferenceCode = &#63; from the database.
+	 * Removes the wiki node where externalReferenceCode = &#63; and groupId = &#63; from the database.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the wiki node that was removed
 	 */
 	@Override
-	public WikiNode removeByG_ERC(long groupId, String externalReferenceCode)
+	public WikiNode removeByERC_G(String externalReferenceCode, long groupId)
 		throws NoSuchNodeException {
 
-		WikiNode wikiNode = findByG_ERC(groupId, externalReferenceCode);
+		WikiNode wikiNode = findByERC_G(externalReferenceCode, groupId);
 
 		return remove(wikiNode);
 	}
 
 	/**
-	 * Returns the number of wiki nodes where groupId = &#63; and externalReferenceCode = &#63;.
+	 * Returns the number of wiki nodes where externalReferenceCode = &#63; and groupId = &#63;.
 	 *
-	 * @param groupId the group ID
 	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
 	 * @return the number of matching wiki nodes
 	 */
 	@Override
-	public int countByG_ERC(long groupId, String externalReferenceCode) {
+	public int countByERC_G(String externalReferenceCode, long groupId) {
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
-		FinderPath finderPath = _finderPathCountByG_ERC;
+		FinderPath finderPath = _finderPathCountByERC_G;
 
-		Object[] finderArgs = new Object[] {groupId, externalReferenceCode};
+		Object[] finderArgs = new Object[] {externalReferenceCode, groupId};
 
 		Long count = (Long)finderCache.getResult(finderPath, finderArgs, this);
 
@@ -4704,18 +4705,18 @@ public class WikiNodePersistenceImpl
 
 			sb.append(_SQL_COUNT_WIKINODE_WHERE);
 
-			sb.append(_FINDER_COLUMN_G_ERC_GROUPID_2);
-
 			boolean bindExternalReferenceCode = false;
 
 			if (externalReferenceCode.isEmpty()) {
-				sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_3);
+				sb.append(_FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_3);
 			}
 			else {
 				bindExternalReferenceCode = true;
 
-				sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_2);
+				sb.append(_FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_2);
 			}
+
+			sb.append(_FINDER_COLUMN_ERC_G_GROUPID_2);
 
 			String sql = sb.toString();
 
@@ -4728,11 +4729,11 @@ public class WikiNodePersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
-				queryPos.add(groupId);
-
 				if (bindExternalReferenceCode) {
 					queryPos.add(externalReferenceCode);
 				}
+
+				queryPos.add(groupId);
 
 				count = (Long)query.uniqueResult();
 
@@ -4749,14 +4750,14 @@ public class WikiNodePersistenceImpl
 		return count.intValue();
 	}
 
-	private static final String _FINDER_COLUMN_G_ERC_GROUPID_2 =
-		"wikiNode.groupId = ? AND ";
+	private static final String _FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_2 =
+		"wikiNode.externalReferenceCode = ? AND ";
 
-	private static final String _FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_2 =
-		"wikiNode.externalReferenceCode = ?";
+	private static final String _FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_3 =
+		"(wikiNode.externalReferenceCode IS NULL OR wikiNode.externalReferenceCode = '') AND ";
 
-	private static final String _FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_3 =
-		"(wikiNode.externalReferenceCode IS NULL OR wikiNode.externalReferenceCode = '')";
+	private static final String _FINDER_COLUMN_ERC_G_GROUPID_2 =
+		"wikiNode.groupId = ?";
 
 	public WikiNodePersistenceImpl() {
 		Map<String, String> dbColumnNames = new HashMap<String, String>();
@@ -4792,9 +4793,9 @@ public class WikiNodePersistenceImpl
 			new Object[] {wikiNode.getGroupId(), wikiNode.getName()}, wikiNode);
 
 		finderCache.putResult(
-			_finderPathFetchByG_ERC,
+			_finderPathFetchByERC_G,
 			new Object[] {
-				wikiNode.getGroupId(), wikiNode.getExternalReferenceCode()
+				wikiNode.getExternalReferenceCode(), wikiNode.getGroupId()
 			},
 			wikiNode);
 	}
@@ -4885,12 +4886,12 @@ public class WikiNodePersistenceImpl
 		finderCache.putResult(_finderPathFetchByG_N, args, wikiNodeModelImpl);
 
 		args = new Object[] {
-			wikiNodeModelImpl.getGroupId(),
-			wikiNodeModelImpl.getExternalReferenceCode()
+			wikiNodeModelImpl.getExternalReferenceCode(),
+			wikiNodeModelImpl.getGroupId()
 		};
 
-		finderCache.putResult(_finderPathCountByG_ERC, args, Long.valueOf(1));
-		finderCache.putResult(_finderPathFetchByG_ERC, args, wikiNodeModelImpl);
+		finderCache.putResult(_finderPathCountByERC_G, args, Long.valueOf(1));
+		finderCache.putResult(_finderPathFetchByERC_G, args, wikiNodeModelImpl);
 	}
 
 	/**
@@ -5026,6 +5027,27 @@ public class WikiNodePersistenceImpl
 
 		if (Validator.isNull(wikiNode.getExternalReferenceCode())) {
 			wikiNode.setExternalReferenceCode(wikiNode.getUuid());
+		}
+		else {
+			WikiNode ercWikiNode = fetchByERC_G(
+				wikiNode.getExternalReferenceCode(), wikiNode.getGroupId());
+
+			if (isNew) {
+				if (ercWikiNode != null) {
+					throw new DuplicateWikiNodeExternalReferenceCodeException(
+						"Duplicate WikiNode with external reference code " +
+							wikiNode.getExternalReferenceCode());
+				}
+			}
+			else {
+				if ((ercWikiNode != null) &&
+					(wikiNode.getNodeId() != ercWikiNode.getNodeId())) {
+
+					throw new DuplicateWikiNodeExternalReferenceCodeException(
+						"Duplicate WikiNode with external reference code " +
+							wikiNode.getExternalReferenceCode());
+				}
+			}
 		}
 
 		ServiceContext serviceContext =
@@ -5487,15 +5509,15 @@ public class WikiNodePersistenceImpl
 			new String[] {Long.class.getName(), Integer.class.getName()},
 			new String[] {"companyId", "status"}, false);
 
-		_finderPathFetchByG_ERC = new FinderPath(
-			FINDER_CLASS_NAME_ENTITY, "fetchByG_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"groupId", "externalReferenceCode"}, true);
+		_finderPathFetchByERC_G = new FinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByERC_G",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "groupId"}, true);
 
-		_finderPathCountByG_ERC = new FinderPath(
-			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_ERC",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"groupId", "externalReferenceCode"}, false);
+		_finderPathCountByERC_G = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByERC_G",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "groupId"}, false);
 
 		_setWikiNodeUtilPersistence(this);
 	}

--- a/modules/apps/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/service/test/WikiNodeLocalServiceTest.java
+++ b/modules/apps/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/service/test/WikiNodeLocalServiceTest.java
@@ -111,7 +111,7 @@ public class WikiNodeLocalServiceTest {
 
 		WikiNode wikiNode2 =
 			WikiNodeLocalServiceUtil.getWikiNodeByExternalReferenceCode(
-				TestPropsValues.getGroupId(), externalReferenceCode);
+				externalReferenceCode, TestPropsValues.getGroupId());
 
 		Assert.assertEquals(wikiNode1, wikiNode2);
 	}

--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_impl.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_impl.ftl
@@ -825,14 +825,13 @@ public class ${entity.name}PersistenceImpl extends BasePersistenceImpl<${entity.
 
 					if (isNew) {
 						if (erc${entity.name} != null) {
-							throw new ${duplicateEntityExternalReferenceCode}Exception();
+								throw new ${duplicateEntityExternalReferenceCode}Exception("Duplicate ${entity.name} with external reference code " + ${entity.variableName}.getExternalReferenceCode());
 						}
 					}
 					else {
 						if ((erc${entity.name} != null) &&
 							(${entity.variableName}.get${entity.PKMethodName}() != erc${entity.name}.get${entity.PKMethodName}())) {
-
-							throw new ${duplicateEntityExternalReferenceCode}Exception();
+								throw new ${duplicateEntityExternalReferenceCode}Exception("Duplicate ${entity.name} with external reference code " + ${entity.variableName}.getExternalReferenceCode());
 						}
 					}
 				}

--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_test.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_test.ftl
@@ -16,8 +16,12 @@
 
 package ${packagePath}.service.persistence.test;
 
-<#assign noSuchEntity = serviceBuilder.getNoSuchEntityException(entity) />
+<#assign
+	duplicateEntityExternalReferenceCode = serviceBuilder.getDuplicateEntityExternalReferenceCodeException(entity)
+	noSuchEntity = serviceBuilder.getNoSuchEntityException(entity)
+/>
 
+import ${apiPackagePath}.exception.${duplicateEntityExternalReferenceCode}Exception;
 import ${apiPackagePath}.exception.${noSuchEntity}Exception;
 import ${apiPackagePath}.model.${entity.name};
 import ${apiPackagePath}.service.${entity.name}LocalServiceUtil;
@@ -324,6 +328,27 @@ public class ${entity.name}PersistenceTest {
 			</#if>
 		</#list>
 	}
+
+	<#if entity.hasExternalReferenceCode()>
+		@Test(expected = ${duplicateEntityExternalReferenceCode}Exception.class)
+		public void testUpdateWithExistingExternalReferenceCode() throws Exception {
+			${entity.name} ${entity.variableName} = add${entity.name}();
+
+			${entity.name} new${entity.name} = add${entity.name}();
+
+			new${entity.name}.set${entity.externalReferenceCode?cap_first}Id(${entity.variableName}.get${entity.externalReferenceCode?cap_first}Id());
+
+			new${entity.name} = _persistence.update(new${entity.name});
+
+			Session session = _persistence.getCurrentSession();
+
+			session.evict(new${entity.name});
+
+			new${entity.name}.setExternalReferenceCode(${entity.variableName}.getExternalReferenceCode());
+
+			_persistence.update(new${entity.name});
+		}
+	</#if>
 
 	<#list entity.entityFinders as entityFinder>
 		@Test

--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/service_base_impl.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/service_base_impl.ftl
@@ -508,42 +508,35 @@ import org.osgi.service.component.annotations.Reference;
 		</#if>
 
 		<#if entity.hasExternalReferenceCode() && !entity.versionEntity??>
-			/**
-			 * Returns the ${entity.humanName} with the matching external reference code and ${entity.externalReferenceCode}.
-			 *
-			 * @param ${entity.externalReferenceCode}Id the primary key of the ${entity.externalReferenceCode}
-			 * @param externalReferenceCode the ${entity.humanName}'s external reference code
-			 * @return the matching ${entity.humanName}, or <code>null</code> if a matching ${entity.humanName} could not be found
-			<#list serviceBaseExceptions as exception>
-			 * @throws ${exception}
-			</#list>
-			 */
-			@Override
-			public ${entity.name} fetch${entity.name}ByExternalReferenceCode(long ${entity.externalReferenceCode}Id, String externalReferenceCode) <#if (serviceBaseExceptions?size gt 0)>throws ${stringUtil.merge(serviceBaseExceptions)} </#if>{
-				return ${entity.variableName}Persistence.fetchBy${entity.externalReferenceCode?cap_first[0..0]}_ERC(${entity.externalReferenceCode}Id, externalReferenceCode);
-			}
+			<#if serviceBuilder.isVersionGTE_7_4_0()>
+				@Override
+				public ${entity.name} fetch${entity.name}ByExternalReferenceCode(String externalReferenceCode, long ${entity.externalReferenceCode}Id) <#if (serviceBaseExceptions?size gt 0)>throws ${stringUtil.merge(serviceBaseExceptions)} </#if>{
+					return ${entity.variableName}Persistence.fetchByERC_${entity.externalReferenceCode?cap_first[0..0]}(externalReferenceCode, ${entity.externalReferenceCode}Id);
+				}
 
-			/**
-			 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #fetch${entity.name}ByExternalReferenceCode(long, String)}
-			 */
-			@Deprecated
-			@Override
-			public ${entity.name} fetch${entity.name}ByReferenceCode(long ${entity.externalReferenceCode}Id, String externalReferenceCode) <#if (serviceBaseExceptions?size gt 0)>throws ${stringUtil.merge(serviceBaseExceptions)} </#if>{
-				return fetch${entity.name}ByExternalReferenceCode(${entity.externalReferenceCode}Id, externalReferenceCode);
-			}
+				@Override
+				public ${entity.name} get${entity.name}ByExternalReferenceCode(String externalReferenceCode, long ${entity.externalReferenceCode}Id) throws PortalException {
+					return ${entity.variableName}Persistence.findByERC_${entity.externalReferenceCode?cap_first[0..0]}(externalReferenceCode, ${entity.externalReferenceCode}Id);
+				}
+			<#else>
+				@Deprecated
+				@Override
+				public ${entity.name} fetch${entity.name}ByExternalReferenceCode(long ${entity.externalReferenceCode}Id, String externalReferenceCode) <#if (serviceBaseExceptions?size gt 0)>throws ${stringUtil.merge(serviceBaseExceptions)} </#if>{
+					return ${entity.variableName}Persistence.fetchBy${entity.externalReferenceCode?cap_first[0..0]}_ERC(${entity.externalReferenceCode}Id, externalReferenceCode);
+				}
 
-			/**
-			 * Returns the ${entity.humanName} with the matching external reference code and ${entity.externalReferenceCode}.
-			 *
-			 * @param ${entity.externalReferenceCode}Id the primary key of the ${entity.externalReferenceCode}
-			 * @param externalReferenceCode the ${entity.humanName}'s external reference code
-			 * @return the matching ${entity.humanName}
-			 * @throws PortalException if a matching ${entity.humanName} could not be found
-			 */
-			@Override
-			public ${entity.name} get${entity.name}ByExternalReferenceCode(long ${entity.externalReferenceCode}Id, String externalReferenceCode) throws PortalException {
-				return ${entity.variableName}Persistence.findBy${entity.externalReferenceCode?cap_first[0..0]}_ERC(${entity.externalReferenceCode}Id, externalReferenceCode);
-			}
+				@Deprecated
+				@Override
+				public ${entity.name} fetch${entity.name}ByReferenceCode(long ${entity.externalReferenceCode}Id, String externalReferenceCode) <#if (serviceBaseExceptions?size gt 0)>throws ${stringUtil.merge(serviceBaseExceptions)} </#if>{
+					return fetch${entity.name}ByExternalReferenceCode(${entity.externalReferenceCode}Id, externalReferenceCode);
+				}
+
+				@Deprecated
+				@Override
+				public ${entity.name} get${entity.name}ByExternalReferenceCode(long ${entity.externalReferenceCode}Id, String externalReferenceCode) throws PortalException {
+					return ${entity.variableName}Persistence.findBy${entity.externalReferenceCode?cap_first[0..0]}_ERC(${entity.externalReferenceCode}Id, externalReferenceCode);
+				}
+			</#if>
 		</#if>
 
 		<#assign serviceBaseExceptions = serviceBuilder.getServiceBaseExceptions(methods, "get" + entity.name, [entity.PKClassName], ["PortalException"]) />

--- a/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 49.0.0
+version 49.0.1

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForComments.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForComments.testcase
@@ -242,7 +242,7 @@ definition {
 		task ("Then I receive an error code response about duplicate erc") {
 			TestUtils.assertPartialEquals(
 				actual = "${response}",
-				expected = "Duplicate message external reference code");
+				expected = "Duplicate MBMessage with external reference code ercComment");
 		}
 
 		task ("And Then another comment with the same external reference code is not being created") {


### PR DESCRIPTION
**What is new?**
- This is a continuation of https://github.com/sergiojimcos/liferay-portal/pull/3.
- Update some templates in Service Builder tool to validate ERC.
- Creates `Duplicate<Entity>ExternalReferenceCodeExceptions` just executing the Service Builder. It doesn't need to indicate in the `service.xml`
- Update naming from `findByG_ERC` to `findByERC_G`.
- Execute `buildService` in:
- [x] Account Entry
- [x] Batch-Engine
- [x] Blogs
- [x] ClientExtensions
- [x] Commerce
- [x] Commerce Account
- [x] Commerce Disccount
- [x] Commerce Order Rule
- [x] Commerce Pricing
- [x] Commerce Term
- [x] Dispatch
- [x] Journal
- [x] KnowledgeBase
- [x] Layout Util Page
- [x] List Type
- [x] MessageBoard
- [x] OAuth2
- [x] Objects
- [x] Wiki
- Manual changes in other modules that are related to the previous. 

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-163008