### PR TITLE
LPS-169150 Google Analytics wrong dp (document path) parameter value

### DIFF
--- a/portal-web/docroot/html/common/themes/top_js.jspf
+++ b/portal-web/docroot/html/common/themes/top_js.jspf
@@ -523,7 +523,7 @@ for (String analyticsType : analyticsTypes) {
 						Liferay.on(
 							'endNavigate',
 							function(event) {
-								ga('set', 'page', event.path);
+								ga('set', 'page', Liferay.ThemeDisplay.getLayoutRelativeURL());
 								ga('send', 'pageview');
 							}
 						);


### PR DESCRIPTION
Manual forward, after :green_circle: from QA in https://github.com/liferay-frontend/liferay-portal/pull/2875#issuecomment-1329796799