### PR TITLE
LPS-160420 Display style lost after re-navigating to DM within Publications

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminDisplayContext.java
@@ -915,16 +915,22 @@ public class DLAdminDisplayContext {
 
 	private void _setPortletPreference(String name, String value) {
 		if (_themeDisplay.isSignedIn()) {
-			PortletPreferences portletPreferences = _getPortletPreferences();
+			try (SafeCloseable safeCloseable =
+					CTCollectionThreadLocal.
+						setProductionModeWithSafeCloseable()) {
 
-			try {
-				portletPreferences.setValue(name, value);
+				PortletPreferences portletPreferences =
+					_getPortletPreferences();
 
-				portletPreferences.store();
-			}
-			catch (Exception exception) {
-				if (_log.isWarnEnabled()) {
-					_log.warn(exception);
+				try {
+					portletPreferences.setValue(name, value);
+
+					portletPreferences.store();
+				}
+				catch (Exception exception) {
+					if (_log.isWarnEnabled()) {
+						_log.warn(exception);
+					}
 				}
 			}
 		}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/publications/PublicationsDM.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/publications/PublicationsDM.testcase
@@ -60,10 +60,6 @@ definition {
 			key_dmDocumentTitle = "Check in as major version",
 			locator1 = "DocumentsAndMedia#ICON_DOCUMENT_ICON_LOCKED");
 
-		// Workaround LPS-160420
-
-		LexiconEntry.changeDisplayStyle(displayStyle = "list");
-
 		DMDocument.checkDocumentCheckboxCP(dmDocumentTitle = "DM Document Title");
 
 		DMDocument.viewDocumentVersionNumberCmdPG(dmDocumentVersionNumber = "2.0");
@@ -73,10 +69,6 @@ definition {
 		Publications.viewPublicationPublished(publicationName = "Publication Name");
 
 		DMNavigator.openDocumentsAndMediaAdmin(siteURLKey = "site-name");
-
-		// Workaround LPS-160420
-
-		LexiconEntry.changeDisplayStyle(displayStyle = "list");
 
 		DMDocument.checkDocumentCheckboxCP(dmDocumentTitle = "DM Document Title");
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-160420
https://issues.liferay.com/browse/LPS-164060

Manually forwarding since `relevant` failed due to unrelated errors. Ran `publications`, `document`, `relevant`, and `sf` in https://github.com/liferay-publications/liferay-portal/pull/334 and didn't find any related errors.