### PR TITLE
LPS-170066 Comparable can be an integer, long or double eg instead of string

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-expression/src/main/java/com/liferay/dynamic/data/mapping/expression/internal/DDMExpressionEvaluatorVisitor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-expression/src/main/java/com/liferay/dynamic/data/mapping/expression/internal/DDMExpressionEvaluatorVisitor.java
@@ -587,11 +587,14 @@ public class DDMExpressionEvaluatorVisitor
 		if (comparable instanceof BigDecimal) {
 			return (BigDecimal)comparable;
 		}
-		else if (Validator.isNull((String)comparable)) {
+
+		String value = comparable.toString();
+
+		if (Validator.isNull(value)) {
 			return BigDecimal.ZERO;
 		}
 
-		return new BigDecimal(comparable.toString());
+		return new BigDecimal(value);
 	}
 
 	private Class<?>[] _getInterfaces(Class<?> clazz) {


### PR DESCRIPTION
Unrelated failures [here](https://github.com/liferay-forms/liferay-portal/pull/2046#issuecomment-1332668984)