### PR TITLE
LPS-169194 Research caching for JS modules resolution servlet

### DIFF
--- a/modules/apps/frontend-js/frontend-js-loader-modules-extender-api/src/main/java/com/liferay/frontend/js/loader/modules/extender/npm/NPMRegistryUpdatesListener.java
+++ b/modules/apps/frontend-js/frontend-js-loader-modules-extender-api/src/main/java/com/liferay/frontend/js/loader/modules/extender/npm/NPMRegistryUpdatesListener.java
@@ -18,6 +18,23 @@ package com.liferay.frontend.js.loader.modules.extender.npm;
  * Can be implemented by any service needing to be notified when the
  * {@link NPMRegistry} is updated.
  *
+ * Note that implementers of this interface must not depend on
+ * {@link NPMRegistry}, since that would create circular references.
+ *
+ * If, for some reason, you need to invoke {@link NPMRegistry} from your
+ * listener, the best way to obtain a reference to it is by using a
+ * {@link org.osgi.util.tracker.ServiceTracker} and assuming that any data you
+ * compute that depends on {@link NPMRegistry} is optional, since it is possible
+ * that, by the time you need to access it, the {@link NPMRegistry} is not
+ * available.
+ *
+ * Another caveat: the {@link NPMRegistry} invokes listeners whenever it goes
+ * up and down, so you don't need to worry about that in your listener
+ * implementation. However, if your listener goes down, then up, the
+ * {@link NPMRegistry} won't invoke it, so it's your responsibility to handle
+ * that situation, whether by simulating an update or doing anything you need to
+ * make your data depending on {@link NPMRegistry} available.
+ *
  * @author Iván Zaera Avellón
  * @review
  */

--- a/modules/apps/frontend-js/frontend-js-loader-modules-extender/package.json
+++ b/modules/apps/frontend-js/frontend-js-loader-modules-extender/package.json
@@ -1,6 +1,6 @@
 {
 	"dependencies": {
-		"@liferay/amd-loader": "5.2.0"
+		"@liferay/amd-loader": "5.3.0"
 	},
 	"name": "frontend-js-loader-modules-extender",
 	"version": "6.0.31"

--- a/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/npm/NPMRegistryResolutionStateDigest.java
+++ b/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/npm/NPMRegistryResolutionStateDigest.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.js.loader.modules.extender.internal.npm;
+
+import com.liferay.frontend.js.loader.modules.extender.npm.JSModule;
+import com.liferay.frontend.js.loader.modules.extender.npm.JSPackage;
+import com.liferay.frontend.js.loader.modules.extender.npm.JSPackageDependency;
+import com.liferay.frontend.js.loader.modules.extender.npm.NPMRegistry;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.StringUtil;
+
+import java.io.UnsupportedEncodingException;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+/**
+ * Computes a digest (hash) with ALL values that can make module resolutions
+ * change.
+ *
+ * The data added to the digest is based on package names, versions,
+ * dependencies and any other information that, when changed, may alter the way
+ * modules are resolved.
+ *
+ * The digest is stable throughout different cluster nodes so that if two nodes
+ * share the same state, their digests are identical.
+ *
+ * @author Iván Zaera Avellón
+ * @review
+ */
+public class NPMRegistryResolutionStateDigest {
+
+	public NPMRegistryResolutionStateDigest(NPMRegistry npmRegistry) {
+		try {
+			MessageDigest messageDigest = MessageDigest.getInstance("SHA-1");
+
+			for (JSModule jsModule : npmRegistry.getResolvedJSModules()) {
+				_digest(messageDigest, jsModule);
+			}
+
+			_digest = StringUtil.bytesToHexString(messageDigest.digest());
+		}
+		catch (NoSuchAlgorithmException noSuchAlgorithmException) {
+			throw new RuntimeException(noSuchAlgorithmException);
+		}
+	}
+
+	public String getDigest() {
+		return _digest;
+	}
+
+	private void _digest(MessageDigest messageDigest, JSModule jsModule) {
+		_digest(messageDigest, jsModule.getJSPackage());
+		_digest(messageDigest, jsModule.getName());
+
+		for (String dependency : jsModule.getDependencies()) {
+			_digest(messageDigest, dependency);
+		}
+	}
+
+	private void _digest(MessageDigest messageDigest, JSPackage jsPackage) {
+		_digest(messageDigest, jsPackage.getMainModuleName());
+		_digest(messageDigest, jsPackage.getName());
+		_digest(messageDigest, jsPackage.getVersion());
+
+		for (JSPackageDependency jsPackageDependency :
+				jsPackage.getJSPackageDependencies()) {
+
+			_digestState(messageDigest, jsPackageDependency);
+		}
+	}
+
+	private void _digest(MessageDigest messageDigest, String string) {
+		try {
+			messageDigest.digest(string.getBytes(StringPool.UTF8));
+		}
+		catch (UnsupportedEncodingException unsupportedEncodingException) {
+			throw new RuntimeException(unsupportedEncodingException);
+		}
+	}
+
+	private void _digestState(
+		MessageDigest messageDigest, JSPackageDependency jsPackageDependency) {
+
+		_digest(messageDigest, jsPackageDependency.getPackageName());
+		_digest(messageDigest, jsPackageDependency.getVersionConstraints());
+	}
+
+	private final String _digest;
+
+}

--- a/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/servlet/JSResolveModulesServlet.java
+++ b/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/servlet/JSResolveModulesServlet.java
@@ -15,9 +15,12 @@
 package com.liferay.frontend.js.loader.modules.extender.internal.servlet;
 
 import com.liferay.frontend.js.loader.modules.extender.internal.configuration.Details;
+import com.liferay.frontend.js.loader.modules.extender.internal.npm.NPMRegistryResolutionStateDigest;
 import com.liferay.frontend.js.loader.modules.extender.internal.resolution.BrowserModulesResolution;
 import com.liferay.frontend.js.loader.modules.extender.internal.resolution.BrowserModulesResolver;
+import com.liferay.frontend.js.loader.modules.extender.npm.NPMRegistry;
 import com.liferay.frontend.js.loader.modules.extender.npm.NPMRegistryUpdatesListener;
+import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.util.ContentTypes;
@@ -34,7 +37,6 @@ import java.net.URLDecoder;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 
 import javax.servlet.Servlet;
@@ -42,8 +44,14 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.util.tracker.ServiceTracker;
+import org.osgi.util.tracker.ServiceTrackerCustomizer;
 
 /**
  * @author Rodolfo Roza Miranda
@@ -64,10 +72,6 @@ import org.osgi.service.component.annotations.Reference;
 public class JSResolveModulesServlet
 	extends HttpServlet implements NPMRegistryUpdatesListener {
 
-	public JSResolveModulesServlet() {
-		onAfterUpdate();
-	}
-
 	public String getURL() {
 		State state = _state.get();
 
@@ -76,7 +80,53 @@ public class JSResolveModulesServlet
 
 	@Override
 	public void onAfterUpdate() {
-		_state.set(new State());
+		_updateState(_npmRegistry.get());
+	}
+
+	@Activate
+	protected void activate(BundleContext bundleContext) {
+		_serviceTracker = ServiceTrackerFactory.open(
+			bundleContext, NPMRegistry.class,
+			new ServiceTrackerCustomizer<NPMRegistry, NPMRegistry>() {
+
+				@Override
+				public NPMRegistry addingService(
+					ServiceReference<NPMRegistry> serviceReference) {
+
+					NPMRegistry npmRegistry = bundleContext.getService(
+						serviceReference);
+
+					_npmRegistry.set(npmRegistry);
+
+					_updateState(npmRegistry);
+
+					return npmRegistry;
+				}
+
+				@Override
+				public void modifiedService(
+					ServiceReference<NPMRegistry> serviceReference,
+					NPMRegistry npmRegistry) {
+				}
+
+				@Override
+				public void removedService(
+					ServiceReference<NPMRegistry> serviceReference,
+					NPMRegistry npmRegistry) {
+
+					_npmRegistry.set(null);
+
+					_updateState(null);
+				}
+
+			});
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		_serviceTracker.close();
+
+		_serviceTracker = null;
 	}
 
 	@Override
@@ -86,6 +136,13 @@ public class JSResolveModulesServlet
 		throws IOException {
 
 		State state = _state.get();
+
+		if (state == null) {
+			httpServletResponse.sendError(
+				HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+
+			return;
+		}
 
 		if (!state.expectedPathInfo.equals(httpServletRequest.getPathInfo())) {
 			AbsolutePortalURLBuilder absolutePortalURLBuilder =
@@ -154,21 +211,35 @@ public class JSResolveModulesServlet
 		return Collections.emptyList();
 	}
 
+	private void _updateState(NPMRegistry npmRegistry) {
+		if (npmRegistry == null) {
+			_state.set(null);
+
+			return;
+		}
+
+		NPMRegistryResolutionStateDigest npmRegistryResolutionStateDigest =
+			new NPMRegistryResolutionStateDigest(npmRegistry);
+
+		_state.set(new State(npmRegistryResolutionStateDigest.getDigest()));
+	}
+
 	@Reference
 	private AbsolutePortalURLBuilderFactory _absolutePortalURLBuilderFactory;
 
 	@Reference
 	private BrowserModulesResolver _browserModulesResolver;
 
+	private final AtomicReference<NPMRegistry> _npmRegistry =
+		new AtomicReference<>();
+	private ServiceTracker<NPMRegistry, NPMRegistry> _serviceTracker;
 	private final AtomicReference<State> _state = new AtomicReference<>();
 
 	private static class State {
 
-		public State() {
-			String hash = String.valueOf(UUID.randomUUID());
-
-			expectedPathInfo = StringPool.SLASH + hash;
-			url = "/js_resolve_modules/" + hash;
+		public State(String digest) {
+			expectedPathInfo = StringPool.SLASH + digest;
+			url = "/js_resolve_modules/" + digest;
 		}
 
 		public final String expectedPathInfo;

--- a/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/servlet/JSResolveModulesServlet.java
+++ b/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/servlet/JSResolveModulesServlet.java
@@ -18,12 +18,13 @@ import com.liferay.frontend.js.loader.modules.extender.internal.configuration.De
 import com.liferay.frontend.js.loader.modules.extender.internal.resolution.BrowserModulesResolution;
 import com.liferay.frontend.js.loader.modules.extender.internal.resolution.BrowserModulesResolver;
 import com.liferay.frontend.js.loader.modules.extender.npm.NPMRegistryUpdatesListener;
-import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.url.builder.AbsolutePortalURLBuilder;
+import com.liferay.portal.url.builder.AbsolutePortalURLBuilderFactory;
 
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -51,7 +52,7 @@ import org.osgi.service.component.annotations.Reference;
 	immediate = true,
 	property = {
 		"osgi.http.whiteboard.servlet.name=com.liferay.frontend.js.loader.modules.extender.internal.servlet.JSResolveModulesServlet",
-		"osgi.http.whiteboard.servlet.pattern=/js_resolve_modules",
+		"osgi.http.whiteboard.servlet.pattern=/js_resolve_modules/*",
 		"service.ranking:Integer=" + Details.MAX_VALUE_LESS_1K
 	},
 	service = {
@@ -66,10 +67,16 @@ public class JSResolveModulesServlet
 		onAfterUpdate();
 	}
 
+	public String getURL() {
+		return _url;
+	}
+
 	@Override
 	public void onAfterUpdate() {
-		_etag = StringBundler.concat(
-			"W/\"", UUID.randomUUID(), StringPool.QUOTE);
+		String hash = String.valueOf(UUID.randomUUID());
+
+		_expectedPathInfo = StringPool.SLASH + hash;
+		_url = "/js_resolve_modules/" + hash;
 	}
 
 	@Override
@@ -78,16 +85,27 @@ public class JSResolveModulesServlet
 			HttpServletResponse httpServletResponse)
 		throws IOException {
 
-		if (_etag.equals(
-				httpServletRequest.getHeader(HttpHeaders.IF_NONE_MATCH))) {
+		if (!_expectedPathInfo.equals(httpServletRequest.getPathInfo())) {
+			AbsolutePortalURLBuilder absolutePortalURLBuilder =
+				_absolutePortalURLBuilderFactory.getAbsolutePortalURLBuilder(
+					httpServletRequest);
 
-			httpServletResponse.setStatus(HttpServletResponse.SC_NOT_MODIFIED);
+			String url = absolutePortalURLBuilder.forServlet(
+				getURL()
+			).build();
+
+			// Send a redirect so that the AMD loader knows that it must update
+			// its resolvePath to the new URL.
+
+			httpServletResponse.sendRedirect(url);
 
 			return;
 		}
 
-		httpServletResponse.addHeader(HttpHeaders.CACHE_CONTROL, "no-cache");
-		httpServletResponse.addHeader(HttpHeaders.ETAG, _etag);
+		// See https://ashton.codes/set-cache-control-max-age-1-year/
+
+		httpServletResponse.addHeader(
+			HttpHeaders.CACHE_CONTROL, "public, max-age=31536000, immutable");
 		httpServletResponse.setCharacterEncoding(StringPool.UTF8);
 		httpServletResponse.setContentType(ContentTypes.APPLICATION_JSON);
 
@@ -135,8 +153,12 @@ public class JSResolveModulesServlet
 	}
 
 	@Reference
+	private AbsolutePortalURLBuilderFactory _absolutePortalURLBuilderFactory;
+
+	@Reference
 	private BrowserModulesResolver _browserModulesResolver;
 
-	private volatile String _etag;
+	private volatile String _expectedPathInfo;
+	private volatile String _url;
 
 }

--- a/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/servlet/JSResolveModulesServlet.java
+++ b/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/servlet/JSResolveModulesServlet.java
@@ -35,6 +35,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
 
 import javax.servlet.Servlet;
 import javax.servlet.http.HttpServlet;
@@ -68,15 +69,14 @@ public class JSResolveModulesServlet
 	}
 
 	public String getURL() {
-		return _url;
+		State state = _state.get();
+
+		return state.url;
 	}
 
 	@Override
 	public void onAfterUpdate() {
-		String hash = String.valueOf(UUID.randomUUID());
-
-		_expectedPathInfo = StringPool.SLASH + hash;
-		_url = "/js_resolve_modules/" + hash;
+		_state.set(new State());
 	}
 
 	@Override
@@ -85,7 +85,9 @@ public class JSResolveModulesServlet
 			HttpServletResponse httpServletResponse)
 		throws IOException {
 
-		if (!_expectedPathInfo.equals(httpServletRequest.getPathInfo())) {
+		State state = _state.get();
+
+		if (!state.expectedPathInfo.equals(httpServletRequest.getPathInfo())) {
 			AbsolutePortalURLBuilder absolutePortalURLBuilder =
 				_absolutePortalURLBuilderFactory.getAbsolutePortalURLBuilder(
 					httpServletRequest);
@@ -158,7 +160,20 @@ public class JSResolveModulesServlet
 	@Reference
 	private BrowserModulesResolver _browserModulesResolver;
 
-	private volatile String _expectedPathInfo;
-	private volatile String _url;
+	private final AtomicReference<State> _state = new AtomicReference<>();
+
+	private static class State {
+
+		public State() {
+			String hash = String.valueOf(UUID.randomUUID());
+
+			expectedPathInfo = StringPool.SLASH + hash;
+			url = "/js_resolve_modules/" + hash;
+		}
+
+		public final String expectedPathInfo;
+		public final String url;
+
+	}
 
 }

--- a/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/servlet/taglib/JSLoaderTopHeadDynamicInclude.java
+++ b/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/servlet/taglib/JSLoaderTopHeadDynamicInclude.java
@@ -15,6 +15,7 @@
 package com.liferay.frontend.js.loader.modules.extender.internal.servlet.taglib;
 
 import com.liferay.frontend.js.loader.modules.extender.internal.configuration.Details;
+import com.liferay.frontend.js.loader.modules.extender.internal.servlet.JSResolveModulesServlet;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.frontend.esm.FrontendESMUtil;
@@ -139,7 +140,7 @@ public class JSLoaderTopHeadDynamicInclude extends BaseDynamicInclude {
 				httpServletRequest);
 
 		return absolutePortalURLBuilder.forServlet(
-			"/js_resolve_modules"
+			_jsResolveModulesServlet.getURL()
 		).build();
 	}
 
@@ -166,6 +167,10 @@ public class JSLoaderTopHeadDynamicInclude extends BaseDynamicInclude {
 
 	private volatile Bundle _bundle;
 	private volatile Details _details;
+
+	@Reference
+	private JSResolveModulesServlet _jsResolveModulesServlet;
+
 	private volatile String _lastModified;
 
 	@Reference

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -1791,10 +1791,13 @@
   dependencies:
     "@lezer/common" "^0.15.0"
 
-"@liferay/amd-loader@5.2.0":
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/@liferay/amd-loader/-/amd-loader-5.2.0.tgz#760905b2cad058048c96063329f8a178b5ce0dc7"
-  integrity sha512-6Fd036qsogJaH71KUNrPA2tk3o1c1EYBsMBPMnqsTsn4iwRxqDEs1+/bxuUg4PkyXo9hFme/wXgRLFy0x5pifw==
+"@liferay/amd-loader@5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@liferay/amd-loader/-/amd-loader-5.3.0.tgz#4c1c2c3aa2bef100a5847a55c4f1256ed871d49c"
+  integrity sha512-WDAjvCAfPefiVfDrcnFx8DkWHy9EzgsrOiU6qdemu2p5nuXCmAXoiFMrpHDVQjytk4E5Qg/lgFPLNEjsWyl/dg==
+  dependencies:
+    webpack-cli "^3.0.0"
+    webpack-dev-server "^3.0.0"
 
 "@liferay/eslint-plugin@1.4.0":
   version "1.4.0"
@@ -3001,6 +3004,11 @@ ansi-gray@^0.1.1:
   integrity sha1-KWLPVOyXksSFEKPetSRDaGHvclE=
   dependencies:
     ansi-wrap "0.1.0"
+
+ansi-html-community@0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/ansi-html-community/-/ansi-html-community-0.0.8.tgz#69fbc4d6ccbe383f9736934ae34c3f8290f1bf41"
+  integrity sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==
 
 ansi-html@0.0.7:
   version "0.0.7"
@@ -5255,7 +5263,7 @@ cross-spawn@^5.0.1:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^6.0.0:
+cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
   integrity sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==
@@ -5874,6 +5882,13 @@ debug@^3.1.0, debug@^3.1.1, debug@^3.2.5:
   dependencies:
     ms "^2.1.1"
 
+debug@^3.2.7:
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
+  integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
+  dependencies:
+    ms "^2.1.1"
+
 debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
@@ -6373,6 +6388,15 @@ enhanced-resolve@^4.0.0:
     memory-fs "^0.5.0"
     tapable "^1.0.0"
 
+enhanced-resolve@^4.1.1:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz#2f3cfd84dbe3b487f18f2db2ef1e064a571ca5ec"
+  integrity sha512-Nv9m36S/vxpsI+Hc4/ZGRs0n9mXqSWGGq49zxb/cJfPAQMbUtttJAlNPS4AQzaBdw/pKskw5bMbekT/Y7W/Wlg==
+  dependencies:
+    graceful-fs "^4.1.2"
+    memory-fs "^0.5.0"
+    tapable "^1.0.0"
+
 enhanced-resolve@^5.9.2:
   version "5.9.2"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.9.2.tgz#0224dcd6a43389ebfb2d55efee517e5466772dd9"
@@ -6774,6 +6798,11 @@ eventsource@^1.0.7:
   dependencies:
     original "^1.0.0"
 
+eventsource@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/eventsource/-/eventsource-2.0.2.tgz#76dfcc02930fb2ff339520b6d290da573a9e8508"
+  integrity sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==
+
 exec-sh@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.3.2.tgz#6738de2eb7c8e671d0366aea0b0db8c6f7d7391b"
@@ -7076,6 +7105,13 @@ faye-websocket@^0.10.0, faye-websocket@~0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/faye-websocket/-/faye-websocket-0.10.0.tgz#4e492f8d04dfb6f89003507f6edbf2d501e7c6f4"
   integrity sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=
+  dependencies:
+    websocket-driver ">=0.5.1"
+
+faye-websocket@^0.11.3, faye-websocket@^0.11.4:
+  version "0.11.4"
+  resolved "https://registry.yarnpkg.com/faye-websocket/-/faye-websocket-0.11.4.tgz#7f0d9275cfdd86a1c963dc8b65fcc451edcbb1da"
+  integrity sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==
   dependencies:
     websocket-driver ">=0.5.1"
 
@@ -8546,6 +8582,11 @@ http-parser-js@>=0.4.0:
   resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.5.0.tgz#d65edbede84349d0dc30320815a15d39cc3cbbd8"
   integrity sha512-cZdEF7r4gfRIq7ezX9J0T+kQmJNOub71dWbgAXVHDct80TKP4MCETtZQ31xyv38UwgzkWPYF/Xc0ge55dW9Z9w==
 
+http-parser-js@>=0.5.1:
+  version "0.5.8"
+  resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.5.8.tgz#af23090d9ac4e24573de6f6aecc9d84a48bf20e3"
+  integrity sha512-SGeBX54F94Wgu5RH3X5jsDtf4eHyRogWX1XGT3b4HuW3tQPM4AaBzoUji/4AAJNXCEOWZ5O0DgZmJw1947gD5Q==
+
 http-proxy-middleware@0.19.1:
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-0.19.1.tgz#183c7dc4aa1479150306498c210cdaf96080a43a"
@@ -8719,7 +8760,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -8779,6 +8820,11 @@ interpret@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.2.0.tgz#d5061a6224be58e8083985f5014d844359576296"
   integrity sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==
+
+interpret@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
+  integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
 
 interpret@^2.2.0:
   version "2.2.0"
@@ -14070,6 +14116,11 @@ safe-buffer@5.1.2, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, s
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
+safe-buffer@>=5.1.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
+  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
 safe-json-parse@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/safe-json-parse/-/safe-json-parse-1.0.1.tgz#3e76723e38dfdda13c9b1d29a1e07ffee4b30b57"
@@ -14206,6 +14257,13 @@ selfsigned@^1.10.7:
   version "1.10.8"
   resolved "https://registry.yarnpkg.com/selfsigned/-/selfsigned-1.10.8.tgz#0d17208b7d12c33f8eac85c41835f27fc3d81a30"
   integrity sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==
+  dependencies:
+    node-forge "^0.10.0"
+
+selfsigned@^1.10.8:
+  version "1.10.14"
+  resolved "https://registry.yarnpkg.com/selfsigned/-/selfsigned-1.10.14.tgz#ee51d84d9dcecc61e07e4aba34f229ab525c1574"
+  integrity sha512-lkjaiAye+wBZDCBsu5BGi0XiLRxeUlsGod5ZP924CRSEoGuZAw/f7y9RKu28rwTfiHVhdavhB0qH0INV6P1lEA==
   dependencies:
     node-forge "^0.10.0"
 
@@ -14494,6 +14552,17 @@ sockjs-client@1.4.0:
     json3 "^3.3.2"
     url-parse "^1.4.3"
 
+sockjs-client@^1.5.0:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/sockjs-client/-/sockjs-client-1.6.1.tgz#350b8eda42d6d52ddc030c39943364c11dcad806"
+  integrity sha512-2g0tjOR+fRs0amxENLi/q5TiJTqY+WXFOzb5UwXndlK6TO3U/mirZznpx6w34HVMoc3g7cY24yC/ZMIYnDlfkw==
+  dependencies:
+    debug "^3.2.7"
+    eventsource "^2.0.2"
+    faye-websocket "^0.11.4"
+    inherits "^2.0.4"
+    url-parse "^1.5.10"
+
 sockjs@0.3.20:
   version "0.3.20"
   resolved "https://registry.yarnpkg.com/sockjs/-/sockjs-0.3.20.tgz#b26a283ec562ef8b2687b44033a4eeceac75d855"
@@ -14502,6 +14571,15 @@ sockjs@0.3.20:
     faye-websocket "^0.10.0"
     uuid "^3.4.0"
     websocket-driver "0.6.5"
+
+sockjs@^0.3.21:
+  version "0.3.24"
+  resolved "https://registry.yarnpkg.com/sockjs/-/sockjs-0.3.24.tgz#c9bc8995f33a111bea0395ec30aa3206bdb5ccce"
+  integrity sha512-GJgLTZ7vYb/JtPSSZ10hsOYIvEYsjbNU+zPdIHcUaWVNUEPivzxku31865sSSud0Da0W4lEeOPlmw93zLQchuQ==
+  dependencies:
+    faye-websocket "^0.11.3"
+    uuid "^8.3.2"
+    websocket-driver "^0.7.4"
 
 sort-keys@^1.0.0:
   version "1.1.2"
@@ -16027,7 +16105,7 @@ url-parse-lax@^3.0.0:
   dependencies:
     prepend-http "^2.0.0"
 
-url-parse@^1.4.3, url-parse@^1.5.8:
+url-parse@^1.4.3, url-parse@^1.5.10, url-parse@^1.5.8:
   version "1.5.10"
   resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.10.tgz#9d3c2f736c1d75dd3bd2be507dcc111f1e2ea9c1"
   integrity sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==
@@ -16088,10 +16166,20 @@ uuid@^3.3.2, uuid@^3.4.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
+uuid@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
 v8-compile-cache@^2.0.3, v8-compile-cache@^2.1.0, v8-compile-cache@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz#9471efa3ef9128d2f7c6a7ca39c4dd6b5055b132"
   integrity sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==
+
+v8-compile-cache@^2.1.1:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
+  integrity sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==
 
 v8-to-istanbul@^4.0.1:
   version "4.1.2"
@@ -16371,6 +16459,23 @@ webidl-conversions@^4.0.2:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
   integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
 
+webpack-cli@^3.0.0:
+  version "3.3.12"
+  resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-3.3.12.tgz#94e9ada081453cd0aa609c99e500012fd3ad2d4a"
+  integrity sha512-NVWBaz9k839ZH/sinurM+HcDvJOTXwSjYp1ku+5XKeOC03z8v5QitnK/x+lAxGXFyhdayoIf/GOpv85z3/xPag==
+  dependencies:
+    chalk "^2.4.2"
+    cross-spawn "^6.0.5"
+    enhanced-resolve "^4.1.1"
+    findup-sync "^3.0.0"
+    global-modules "^2.0.0"
+    import-local "^2.0.0"
+    interpret "^1.4.0"
+    loader-utils "^1.4.0"
+    supports-color "^6.1.0"
+    v8-compile-cache "^2.1.1"
+    yargs "^13.3.2"
+
 webpack-cli@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-4.2.0.tgz#10a09030ad2bd4d8b0f78322fba6ea43ec56aaaa"
@@ -16400,6 +16505,45 @@ webpack-dev-middleware@^3.7.2:
     mkdirp "^0.5.1"
     range-parser "^1.2.1"
     webpack-log "^2.0.0"
+
+webpack-dev-server@^3.0.0:
+  version "3.11.3"
+  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-3.11.3.tgz#8c86b9d2812bf135d3c9bce6f07b718e30f7c3d3"
+  integrity sha512-3x31rjbEQWKMNzacUZRE6wXvUFuGpH7vr0lIEbYpMAG9BOxi0928QU1BBswOAP3kg3H1O4hiS+sq4YyAn6ANnA==
+  dependencies:
+    ansi-html-community "0.0.8"
+    bonjour "^3.5.0"
+    chokidar "^2.1.8"
+    compression "^1.7.4"
+    connect-history-api-fallback "^1.6.0"
+    debug "^4.1.1"
+    del "^4.1.1"
+    express "^4.17.1"
+    html-entities "^1.3.1"
+    http-proxy-middleware "0.19.1"
+    import-local "^2.0.0"
+    internal-ip "^4.3.0"
+    ip "^1.1.5"
+    is-absolute-url "^3.0.3"
+    killable "^1.0.1"
+    loglevel "^1.6.8"
+    opn "^5.5.0"
+    p-retry "^3.0.1"
+    portfinder "^1.0.26"
+    schema-utils "^1.0.0"
+    selfsigned "^1.10.8"
+    semver "^6.3.0"
+    serve-index "^1.9.1"
+    sockjs "^0.3.21"
+    sockjs-client "^1.5.0"
+    spdy "^4.0.2"
+    strip-ansi "^3.0.1"
+    supports-color "^6.1.0"
+    url "^0.11.0"
+    webpack-dev-middleware "^3.7.2"
+    webpack-log "^2.0.0"
+    ws "^6.2.1"
+    yargs "^13.3.2"
 
 webpack-dev-server@^3.11.0:
   version "3.11.0"
@@ -16511,6 +16655,15 @@ websocket-driver@>=0.5.1:
   integrity sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=
   dependencies:
     http-parser-js ">=0.4.0"
+    websocket-extensions ">=0.1.1"
+
+websocket-driver@^0.7.4:
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/websocket-driver/-/websocket-driver-0.7.4.tgz#89ad5295bbf64b480abcba31e4953aca706f5760"
+  integrity sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==
+  dependencies:
+    http-parser-js ">=0.5.1"
+    safe-buffer ">=5.1.0"
     websocket-extensions ">=0.1.1"
 
 websocket-extensions@>=0.1.1:


### PR DESCRIPTION
## Make /o/js_resolve_modules cacheable forever

Instead of using an ETag, append a random UUID suffix to /o/js_resolve_modules
URL and renew it whenever the NPMRegistry state changes.

This way, resolutions can be cached by the server, CDNs, proxies or the browser
forever because, if the server state changes, the endpoint changes and a new
resolution has to be made.

For the hot deployment case where the server state is changed while running
sessions are connected, we send a redirect to the new URL. This makes everything
work as it was working before this modification, thus, no compatibility is broken.

It is unknown if, in that situation (hot deployment), running sessions will remain
stable because they will be merging JS modules loaded with the old resolution
state with JS modules loaded with the new resolution state. However, that's the
current situation (before this change) and nobody has ever complaint, so I guess
we are safe.

In any case, if any instability should arise, it would be easily fixed by
reloading the page, so this would never be a serious problem even if it shows up.

(see this [caveat comment](https://github.com/liferay-frontend/liferay-portal/pull/2883#issuecomment-1327361465) too)

----

Sending manually as per https://github.com/liferay-frontend/liferay-portal/pull/2883#issuecomment-1329818441