### PR TITLE
[Remove immediate = true from lima Part I]  LPS-168427

### DIFF
--- a/modules/apps/sharing/sharing-web/src/main/java/com/liferay/sharing/web/internal/display/context/util/SharingMenuItemFactoryImpl.java
+++ b/modules/apps/sharing/sharing-web/src/main/java/com/liferay/sharing/web/internal/display/context/util/SharingMenuItemFactoryImpl.java
@@ -34,7 +34,6 @@ import org.osgi.service.component.annotations.Reference;
  * @author Adolfo Pérez
  */
 @Component(
-	immediate = true,
 	service = {SharingDropdownItemFactory.class, SharingMenuItemFactory.class}
 )
 public class SharingMenuItemFactoryImpl


### PR DESCRIPTION
Hi @brianchandotcom,

Based on https://github.com/brianchandotcom/liferay-portal/pull/127107#issuecomment-1333632136, the pr only removed immediate = true from SharingMenuItemFactoryImpl.

cc @dantewang, @tinatian, @shuyangzhou

Thanks,
Hai