### PR TITLE
LPS-169931 MimeTypesUtil getContentType can return a null so we have to check if the mimetype is null or not and return an empty string if it is

### DIFF
--- a/modules/apps/document-library/document-library-repository-cmis-impl/src/main/java/com/liferay/document/library/repository/cmis/internal/model/CMISFileVersion.java
+++ b/modules/apps/document-library/document-library-repository-cmis-impl/src/main/java/com/liferay/document/library/repository/cmis/internal/model/CMISFileVersion.java
@@ -225,11 +225,15 @@ public class CMISFileVersion extends BaseCMISModel implements FileVersion {
 	public String getMimeType() {
 		String mimeType = _document.getContentStreamMimeType();
 
+		if (Validator.isNull(mimeType)) {
+			mimeType = MimeTypesUtil.getContentType(getTitle());
+		}
+
 		if (Validator.isNotNull(mimeType)) {
 			return mimeType;
 		}
 
-		return MimeTypesUtil.getContentType(getTitle());
+		return StringPool.BLANK;
 	}
 
 	@Override

--- a/modules/apps/document-library/document-library-repository-external-api/src/main/java/com/liferay/document/library/repository/external/model/ExtRepositoryFileVersionAdapter.java
+++ b/modules/apps/document-library/document-library-repository-external-api/src/main/java/com/liferay/document/library/repository/external/model/ExtRepositoryFileVersionAdapter.java
@@ -18,6 +18,7 @@ import com.liferay.document.library.kernel.util.DLUtil;
 import com.liferay.document.library.repository.external.ExtRepositoryAdapter;
 import com.liferay.document.library.repository.external.ExtRepositoryFileVersion;
 import com.liferay.exportimport.kernel.lar.StagedModelType;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileVersion;
@@ -126,7 +127,11 @@ public class ExtRepositoryFileVersionAdapter
 			mimeType = MimeTypesUtil.getContentType(getTitle());
 		}
 
-		return mimeType;
+		if (Validator.isNotNull(mimeType)) {
+			return mimeType;
+		}
+
+		return StringPool.BLANK;
 	}
 
 	@Override


### PR DESCRIPTION
The original PR comment:

> MimeTypesUtil getContentType can return a null so we have to check if the mimeType is null or not and return an empty string if it is 

@brianchandotcom resending this pull directly to you since after a few retries we confirmed this pull is not related to any of the failing tests in https://github.com/liferay-lima/liferay-portal/pull/3788.