### PR TITLE
Lps 166996 revert

### DIFF
--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/web/internal/asset/model/test/DepotAssetRendererFactoryTrackerTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/web/internal/asset/model/test/DepotAssetRendererFactoryTrackerTest.java
@@ -59,7 +59,7 @@ import org.springframework.mock.web.MockHttpServletRequest;
  * @author Alejandro Tardín
  */
 @RunWith(Arquillian.class)
-public class DepotAssetRendererFactoryRegistryTest {
+public class DepotAssetRendererFactoryTrackerTest {
 
 	@ClassRule
 	@Rule

--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/asset/model/DepotAssetRendererFactoryTracker.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/asset/model/DepotAssetRendererFactoryTracker.java
@@ -38,8 +38,8 @@ import org.osgi.util.tracker.ServiceTrackerCustomizer;
 /**
  * @author Alejandro Tardín
  */
-@Component(immediate = true, service = DepotAssetRendererFactoryRegistry.class)
-public class DepotAssetRendererFactoryRegistry {
+@Component(immediate = true, service = DepotAssetRendererFactoryTracker.class)
+public class DepotAssetRendererFactoryTracker {
 
 	@Activate
 	protected void activate(BundleContext bundleContext) {


### PR DESCRIPTION
The *Registry should be applied to classes that track and collect services, and provide API for others to obtain the services. This class doesn't provide API so it should not be renamed. FYI @shuyangzhou @tinatian