### PR TITLE
LPS-163975 Adding support for batch statements on processConcurrently

### DIFF
--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/BaseDBProcessTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/BaseDBProcessTest.java
@@ -539,13 +539,11 @@ public class BaseDBProcessTest extends BaseDBProcess {
 					_PROCESS_CONCURRENTLY_EXECUTIONS, " and typeInteger = id"));
 			ResultSet resultSet = preparedStatement.executeQuery()) {
 
-			if (resultSet.next()) {
-				Assert.assertEquals(
-					_PROCESS_CONCURRENTLY_EXECUTIONS, resultSet.getInt(1));
-			}
-		}
+			resultSet.next();
 
-		throw new Exception("Table does not exist");
+			Assert.assertEquals(
+				_PROCESS_CONCURRENTLY_EXECUTIONS, resultSet.getInt(1));
+		}
 	}
 
 	private static final String _INDEX_NAME = "IX_TEMP";

--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/BaseDBProcessTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/BaseDBProcessTest.java
@@ -433,7 +433,7 @@ public class BaseDBProcessTest extends BaseDBProcess {
 	@Test
 	public void testProcessConcurrentlyWithList() throws Exception {
 		Integer[] values = IntStream.rangeClosed(
-			1, _RANGE_MAX
+			1, _PROCESS_CONCURRENTLY_EXECUTIONS
 		).boxed(
 		).toArray(
 			Integer[]::new
@@ -486,7 +486,7 @@ public class BaseDBProcessTest extends BaseDBProcess {
 	}
 
 	private void _populateTable() throws Exception {
-		for (int i = 1; i <= _RANGE_MAX; i++) {
+		for (int i = 1; i <= _PROCESS_CONCURRENTLY_EXECUTIONS; i++) {
 			runSQL(
 				StringBundler.concat(
 					"insert into ", _TABLE_NAME, " (id, notNilColumn) values (",
@@ -535,12 +535,13 @@ public class BaseDBProcessTest extends BaseDBProcess {
 		try (PreparedStatement preparedStatement = connection.prepareStatement(
 				StringBundler.concat(
 					"select count(1) from ", _TABLE_NAME,
-					" where id >= 1 and id <= ", _RANGE_MAX,
-					" and typeInteger = id"));
+					" where id >= 1 and id <= ",
+					_PROCESS_CONCURRENTLY_EXECUTIONS, " and typeInteger = id"));
 			ResultSet resultSet = preparedStatement.executeQuery()) {
 
 			if (resultSet.next()) {
-				Assert.assertEquals(_RANGE_MAX, resultSet.getInt(1));
+				Assert.assertEquals(
+					_PROCESS_CONCURRENTLY_EXECUTIONS, resultSet.getInt(1));
 			}
 		}
 
@@ -549,7 +550,7 @@ public class BaseDBProcessTest extends BaseDBProcess {
 
 	private static final String _INDEX_NAME = "IX_TEMP";
 
-	private static final int _RANGE_MAX = 2000;
+	private static final int _PROCESS_CONCURRENTLY_EXECUTIONS = 100;
 
 	private static final String _TABLE_NAME = "BasedDBProcessTest";
 

--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/BaseDBProcessTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/BaseDBProcessTest.java
@@ -409,6 +409,27 @@ public class BaseDBProcessTest extends BaseDBProcess {
 	}
 
 	@Test
+	public void testProcessConcurrently() throws Exception {
+		_validateProcessConcurrently(
+			threadIds -> processConcurrently(
+				"select id from " + _TABLE_NAME,
+				resultSet -> new Object[] {resultSet.getInt("id")},
+				values -> {
+					Thread currentThread = Thread.currentThread();
+
+					threadIds.add(currentThread.getId());
+
+					int value = (int)values[0];
+
+					runSQL(
+						StringBundler.concat(
+							"update ", _TABLE_NAME, " set typeInteger = ",
+							value, " where id = ", value));
+				},
+				null));
+	}
+
+	@Test
 	public void testProcessConcurrentlyWithBatch() throws Exception {
 		_validateProcessConcurrently(
 			threadIds -> processConcurrently(
@@ -446,27 +467,6 @@ public class BaseDBProcessTest extends BaseDBProcess {
 					Thread currentThread = Thread.currentThread();
 
 					threadIds.add(currentThread.getId());
-
-					runSQL(
-						StringBundler.concat(
-							"update ", _TABLE_NAME, " set typeInteger = ",
-							value, " where id = ", value));
-				},
-				null));
-	}
-
-	@Test
-	public void testProcessConcurrentlyWithSelect() throws Exception {
-		_validateProcessConcurrently(
-			threadIds -> processConcurrently(
-				"select id from " + _TABLE_NAME,
-				resultSet -> new Object[] {resultSet.getInt("id")},
-				values -> {
-					Thread currentThread = Thread.currentThread();
-
-					threadIds.add(currentThread.getId());
-
-					int value = (int)values[0];
 
 					runSQL(
 						StringBundler.concat(

--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/BaseDBProcessTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/BaseDBProcessTest.java
@@ -35,6 +35,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -522,7 +523,7 @@ public class BaseDBProcessTest extends BaseDBProcess {
 
 		_populateTable();
 
-		Set<Long> threadIds = new HashSet<>();
+		Set<Long> threadIds = Collections.synchronizedSet(new HashSet<>());
 
 		unsafeConsumer.accept(threadIds);
 

--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/BaseDBProcessTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/BaseDBProcessTest.java
@@ -428,6 +428,8 @@ public class BaseDBProcessTest extends BaseDBProcess {
 
 	@Test
 	public void testProcessConcurrentlyWithList() throws Exception {
+		_populateTable();
+
 		Integer[] values = IntStream.rangeClosed(
 			1, _RANGE_MAX
 		).boxed(
@@ -439,9 +441,8 @@ public class BaseDBProcessTest extends BaseDBProcess {
 			values,
 			value -> runSQL(
 				StringBundler.concat(
-					"insert into ", _TABLE_NAME,
-					" (id, notNilColumn, typeInteger) values (", value,
-					", '1', ", value, ")")),
+					"update ", _TABLE_NAME, " set typeInteger = ", value,
+					" where id = ", value)),
 			null);
 
 		_verifyTableContent();

--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/BaseDBProcessTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/BaseDBProcessTest.java
@@ -476,38 +476,6 @@ public class BaseDBProcessTest extends BaseDBProcess {
 			_connection, indexMetadatas);
 	}
 
-	private boolean _checkValue(int key) throws Exception {
-		try (PreparedStatement preparedStatement = connection.prepareStatement(
-				StringBundler.concat(
-					"select typeInteger from ", _TABLE_NAME, " where id = ",
-					key));
-			ResultSet resultSet = preparedStatement.executeQuery()) {
-
-			if (resultSet.next()) {
-				if (resultSet.getInt("typeInteger") == key) {
-					return true;
-				}
-
-				return false;
-			}
-		}
-
-		return false;
-	}
-
-	private int _getCount(String tableName) throws Exception {
-		try (PreparedStatement preparedStatement = connection.prepareStatement(
-				"select count(1) from " + tableName);
-			ResultSet resultSet = preparedStatement.executeQuery()) {
-
-			if (resultSet.next()) {
-				return resultSet.getInt(1);
-			}
-		}
-
-		throw new Exception("Table does not exist");
-	}
-
 	private void _populateTable() throws Exception {
 		for (int i = 1; i <= _RANGE_MAX; i++) {
 			runSQL(
@@ -540,12 +508,19 @@ public class BaseDBProcessTest extends BaseDBProcess {
 	}
 
 	private void _verifyTableContent() throws Exception {
-		Assert.assertEquals(_RANGE_MAX, _getCount(_TABLE_NAME));
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				StringBundler.concat(
+					"select count(1) from ", _TABLE_NAME,
+					" where id >= 1 and id <= ", _RANGE_MAX,
+					" and typeInteger = id"));
+			ResultSet resultSet = preparedStatement.executeQuery()) {
 
-		for (int i = 1; i <= _RANGE_MAX; i++) {
-			Assert.assertTrue(
-				"Key " + i + " does not have the right value", _checkValue(i));
+			if (resultSet.next()) {
+				Assert.assertEquals(_RANGE_MAX, resultSet.getInt(1));
+			}
 		}
+
+		throw new Exception("Table does not exist");
 	}
 
 	private static final String _INDEX_NAME = "IX_TEMP";

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/UpgradePortletPreferences.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/UpgradePortletPreferences.java
@@ -16,7 +16,6 @@ package com.liferay.portal.upgrade.v7_4_x;
 
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.dao.orm.common.SQLTransformer;
-import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.model.PortletConstants;
 import com.liferay.portal.kernel.model.PortletPreferenceValue;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
@@ -54,13 +53,18 @@ public class UpgradePortletPreferences extends UpgradeProcess {
 					"preferences from PortletPreferences where preferences ",
 					"not like '", PortletConstants.DEFAULT_PREFERENCES,
 					"%' and preferences is not null")),
+			StringBundler.concat(
+				"insert into PortletPreferenceValue (mvccVersion, ",
+				"ctCollectionId, portletPreferenceValueId, companyId, ",
+				"portletPreferencesId, index_, largeValue, name, readOnly, ",
+				"smallValue) values (0, ?, ?, ?, ?, ?, ?, ?, ?, ?)"),
 			resultSet -> new Object[] {
 				resultSet.getLong("ctCollectionId"),
 				resultSet.getLong("portletPreferencesId"),
 				resultSet.getLong("companyId"),
 				resultSet.getString("preferences")
 			},
-			values -> {
+			(values, preparedStatement) -> {
 				long ctCollectionId = (Long)values[0];
 				long portletPreferencesId = (Long)values[1];
 				long companyId = (Long)values[2];
@@ -68,7 +72,7 @@ public class UpgradePortletPreferences extends UpgradeProcess {
 
 				_upgradePortletPreferences(
 					ctCollectionId, portletPreferencesId, companyId,
-					preferences);
+					preferences, preparedStatement);
 			},
 			null);
 	}
@@ -83,7 +87,7 @@ public class UpgradePortletPreferences extends UpgradeProcess {
 
 	private void _upgradePortletPreferences(
 			long ctCollectionId, long portletPreferencesId, long companyId,
-			String preferences)
+			String preferences, PreparedStatement preparedStatement)
 		throws Exception {
 
 		if (preferences.isEmpty()) {
@@ -97,50 +101,37 @@ public class UpgradePortletPreferences extends UpgradeProcess {
 			return;
 		}
 
-		try (PreparedStatement preparedStatement =
-				AutoBatchPreparedStatementUtil.autoBatch(
-					connection,
-					StringBundler.concat(
-						"insert into PortletPreferenceValue (mvccVersion, ",
-						"ctCollectionId, portletPreferenceValueId, companyId, ",
-						"portletPreferencesId, index_, largeValue, name, ",
-						"readOnly, smallValue) values (0, ?, ?, ?, ?, ?, ?, ",
-						"?, ?, ?)"))) {
+		for (Preference preference : preferenceMap.values()) {
+			String[] values = preference.getValues();
 
-			for (Preference preference : preferenceMap.values()) {
-				String[] values = preference.getValues();
+			for (int i = 0; i < values.length; i++) {
+				String value = values[i];
 
-				for (int i = 0; i < values.length; i++) {
-					String value = values[i];
+				String largeValue = null;
+				String smallValue = null;
 
-					String largeValue = null;
-					String smallValue = null;
+				if (value.length() >
+						PortletPreferenceValueImpl.SMALL_VALUE_MAX_LENGTH) {
 
-					if (value.length() >
-							PortletPreferenceValueImpl.SMALL_VALUE_MAX_LENGTH) {
-
-						largeValue = value;
-					}
-					else {
-						smallValue = value;
-					}
-
-					preparedStatement.setLong(1, ctCollectionId);
-					preparedStatement.setLong(
-						2, increment(PortletPreferenceValue.class.getName()));
-					preparedStatement.setLong(3, companyId);
-					preparedStatement.setLong(4, portletPreferencesId);
-					preparedStatement.setInt(5, i);
-					preparedStatement.setString(6, largeValue);
-					preparedStatement.setString(7, preference.getName());
-					preparedStatement.setBoolean(8, preference.isReadOnly());
-					preparedStatement.setString(9, smallValue);
-
-					preparedStatement.addBatch();
+					largeValue = value;
 				}
-			}
+				else {
+					smallValue = value;
+				}
 
-			preparedStatement.executeBatch();
+				preparedStatement.setLong(1, ctCollectionId);
+				preparedStatement.setLong(
+					2, increment(PortletPreferenceValue.class.getName()));
+				preparedStatement.setLong(3, companyId);
+				preparedStatement.setLong(4, portletPreferencesId);
+				preparedStatement.setInt(5, i);
+				preparedStatement.setString(6, largeValue);
+				preparedStatement.setString(7, preference.getName());
+				preparedStatement.setBoolean(8, preference.isReadOnly());
+				preparedStatement.setString(9, smallValue);
+
+				preparedStatement.addBatch();
+			}
 		}
 	}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
@@ -53,7 +53,6 @@ import java.sql.Statement;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -473,7 +472,7 @@ public abstract class BaseDBProcess implements DBProcess {
 
 	private PreparedStatement _getConcurrentPreparedStatement(
 		String updateSqlQuery,
-		HashMap<Thread, PreparedStatement> preparedStatementHashMap) {
+		Map<Thread, PreparedStatement> preparedStatementHashMap) {
 
 		return preparedStatementHashMap.computeIfAbsent(
 			Thread.currentThread(),
@@ -552,8 +551,8 @@ public abstract class BaseDBProcess implements DBProcess {
 
 		List<Future<Void>> futures = new ArrayList<>();
 
-		HashMap<Thread, PreparedStatement> preparedStatementHashMap =
-			new HashMap<>();
+		Map<Thread, PreparedStatement> preparedStatementHashMap =
+			new ConcurrentHashMap<>();
 
 		try {
 			boolean notificationEnabled = NotificationThreadLocal.isEnabled();

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/packageinfo
@@ -1,1 +1,1 @@
-version 10.1.0
+version 10.2.0

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/packageinfo
@@ -1,1 +1,1 @@
-version 19.0.0
+version 19.1.0

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/util/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/util/packageinfo
@@ -1,1 +1,1 @@
-version 10.2.0
+version 10.3.0


### PR DESCRIPTION
- LPS-163975 Adding proper AutoBatch support to processConcurrenly method
- LPS-163975 Making each thread to have its own prepared statement and renaming some methods for more clarity
- LPS-163975 Reuse code having one single private _processConcurrently method
- LPS-163975 Applying change to an existing upgrade process
- LPS-163975 Baseline
- LPS-163975 Applying to more cases in the portal
- LPS-163975 Adding integration tests for processConcurrently methods
- LPS-163975 Changing HashMap for ConcurrentHashMap to avoid error due to concurrency
- LPS-163975 Verify in simpler way
- LPS-163975 Same logic that in the rest of the cases
- LPS-163975 Populate and validate in one single method
- LPS-163975 We do not need so many executions
- LPS-163975 Fix test
- LPS-163975 Rename because this method does not have any particularity
- LPS-163975 Changing naming to better fit the portal
- LPS-163975 Synchronizing hashSet to avoid concurrency issues
