### PR TITLE
LPS-170501 New endpoint to look up public OAuth2Application info

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/info/OAuth2ProviderApplicationInfo.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/info/OAuth2ProviderApplicationInfo.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.oauth2.provider.rest.internal.endpoint.info;
+
+import com.liferay.oauth2.provider.model.OAuth2Application;
+import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.util.Validator;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Stian Sigvartsen
+ */
+@Component(
+	property = {
+		"osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.OAuth2.Application)",
+		"osgi.jaxrs.name=Liferay.Authorization.Application.Info",
+		"osgi.jaxrs.resource=true"
+	},
+	service = OAuth2ProviderApplicationInfo.class
+)
+@Path("/application-info")
+public class OAuth2ProviderApplicationInfo {
+
+	@GET
+	@Produces(MediaType.APPLICATION_JSON)
+	public Response info(
+		@QueryParam("externalReferenceCode") String externalReferenceCode) {
+
+		OAuth2Application oAuth2Application = null;
+
+		if (!Validator.isBlank(externalReferenceCode)) {
+			oAuth2Application =
+				_oAuth2ApplicationLocalService.
+					fetchOAuth2ApplicationByExternalReferenceCode(
+						externalReferenceCode,
+						CompanyThreadLocal.getCompanyId());
+		}
+
+		if (oAuth2Application == null) {
+			return Response.status(
+				Response.Status.BAD_REQUEST
+			).entity(
+				"Invalid externalReferenceCode"
+			).type(
+				MediaType.TEXT_PLAIN
+			).build();
+		}
+
+		return Response.ok(
+			JSONUtil.put(
+				"client_id", oAuth2Application.getClientId()
+			).toString()
+		).build();
+	}
+
+	@Reference
+	private OAuth2ApplicationLocalService _oAuth2ApplicationLocalService;
+
+}


### PR DESCRIPTION
Hi Brian. As discussed, hopefully this will be sufficient for the Sprint Boot client?

I return a JSON structure so we can add additional public information if/when the need arrises.

To invoke with cURL:
`curl -G -v -d 'externalReferenceCode=X' http://localhost:8080/o/oauth2/application-info`

Returns HTTP 400 Invalid request or 200.
`{"client_id":"ABC"}`