### PR TITLE
LPS-169063 Rename parameter from relationshipNameId to relationshipNameERC and change the value from Id to ERC too.

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
@@ -540,23 +540,24 @@ public class ObjectEntryDTOConverter
 
 				map.put(objectFieldName, objectEntryId);
 
-				if (GetterUtil.getBoolean(
-						PropsUtil.get("feature.flag.LPS-161364")) &&
-					(map.get(objectRelationship.getName()) == null)) {
-
-					map.put(objectRelationship.getName() + "Id", objectEntryId);
-				}
-
 				String objectRelationshipERCFieldName =
 					ObjectFieldSettingUtil.getValue(
 						ObjectFieldSettingConstants.
 							NAME_OBJECT_RELATIONSHIP_ERC_FIELD_NAME,
 						objectField);
 
-				map.put(
-					objectRelationshipERCFieldName,
-					GetterUtil.getString(
-						values.get(objectRelationshipERCFieldName)));
+				String relatedObjectERC = GetterUtil.getString(
+					values.get(objectRelationshipERCFieldName));
+
+				if (GetterUtil.getBoolean(
+						PropsUtil.get("feature.flag.LPS-161364")) &&
+					(map.get(objectRelationship.getName()) == null)) {
+
+					map.put(
+						objectRelationship.getName() + "ERC", relatedObjectERC);
+				}
+
+				map.put(objectRelationshipERCFieldName, relatedObjectERC);
 			}
 			else {
 				map.put(objectFieldName, serializable);

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -93,15 +93,13 @@ public class ObjectEntryResourceTest {
 	public void testGetNestedFieldDetailsInOneToManyRelationship()
 		throws Exception {
 
-		ObjectRelationship objectRelationship =
-			ObjectRelationshipTestUtil.addObjectRelationship(
-				_objectDefinition1, _objectDefinition2,
-				TestPropsValues.getUserId(),
-				ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+		_objectRelationship = ObjectRelationshipTestUtil.addObjectRelationship(
+			_objectDefinition1, _objectDefinition2, TestPropsValues.getUserId(),
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
 		_objectRelationshipLocalService.addObjectRelationshipMappingTableValues(
 			TestPropsValues.getUserId(),
-			objectRelationship.getObjectRelationshipId(),
+			_objectRelationship.getObjectRelationshipId(),
 			_objectEntry1.getPrimaryKey(), _objectEntry2.getPrimaryKey(),
 			ServiceContextTestUtil.getServiceContext());
 
@@ -109,7 +107,7 @@ public class ObjectEntryResourceTest {
 			null,
 			StringBundler.concat(
 				_objectDefinition2.getRESTContextPath(), "?nestedFields=r_",
-				objectRelationship.getName(), "_",
+				_objectRelationship.getName(), "_",
 				_objectDefinition1.getPKObjectFieldName()),
 			Http.Method.GET);
 
@@ -125,21 +123,13 @@ public class ObjectEntryResourceTest {
 
 		JSONObject relatedObjectJSONObject = itemJSONObject.getJSONObject(
 			StringBundler.concat(
-				"r_", objectRelationship.getName(), "_",
+				"r_", _objectRelationship.getName(), "_",
 				StringUtil.replaceLast(
 					_objectDefinition1.getPKObjectFieldName(), "Id", "")));
 
 		Assert.assertEquals(
 			_OBJECT_FIELD_VALUE_1,
 			relatedObjectJSONObject.getString(_OBJECT_FIELD_NAME_1));
-
-		_objectRelationshipLocalService.
-			deleteObjectRelationshipMappingTableValues(
-				objectRelationship.getObjectRelationshipId(),
-				_objectEntry1.getPrimaryKey(), _objectEntry2.getPrimaryKey());
-
-		_objectRelationshipLocalService.deleteObjectRelationship(
-			objectRelationship);
 	}
 
 	@Test
@@ -233,11 +223,9 @@ public class ObjectEntryResourceTest {
 	public void testPutByExternalReferenceCodeManyToManyRelationship()
 		throws Exception {
 
-		ObjectRelationship objectRelationship =
-			ObjectRelationshipTestUtil.addObjectRelationship(
-				_objectDefinition1, _objectDefinition2,
-				TestPropsValues.getUserId(),
-				ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+		_objectRelationship = ObjectRelationshipTestUtil.addObjectRelationship(
+			_objectDefinition1, _objectDefinition2, TestPropsValues.getUserId(),
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
 		JSONObject jsonObject = HTTPTestUtil.invoke(
 			null,
@@ -245,7 +233,7 @@ public class ObjectEntryResourceTest {
 				_objectDefinition1.getRESTContextPath(),
 				"/by-external-reference-code/",
 				_objectEntry1.getExternalReferenceCode(), StringPool.SLASH,
-				objectRelationship.getName(), StringPool.SLASH,
+				_objectRelationship.getName(), StringPool.SLASH,
 				_objectEntry2.getExternalReferenceCode()),
 			Http.Method.PUT);
 
@@ -261,7 +249,7 @@ public class ObjectEntryResourceTest {
 				_objectDefinition2.getRESTContextPath(),
 				"/by-external-reference-code/",
 				_objectEntry2.getExternalReferenceCode(), StringPool.SLASH,
-				objectRelationship.getName(), StringPool.SLASH,
+				_objectRelationship.getName(), StringPool.SLASH,
 				_objectEntry1.getExternalReferenceCode()),
 			Http.Method.PUT);
 
@@ -277,16 +265,13 @@ public class ObjectEntryResourceTest {
 				_objectDefinition2.getRESTContextPath(),
 				"/by-external-reference-code/",
 				_objectEntry2.getExternalReferenceCode(), StringPool.SLASH,
-				objectRelationship.getName(), StringPool.SLASH,
+				_objectRelationship.getName(), StringPool.SLASH,
 				RandomTestUtil.randomString()),
 			Http.Method.PUT);
 
 		Assert.assertThat(
 			jsonObject.getString("title"),
 			CoreMatchers.containsString("No ObjectEntry exists with the key"));
-
-		_objectRelationshipLocalService.deleteObjectRelationship(
-			objectRelationship);
 	}
 
 	private static final String _OBJECT_FIELD_NAME_1 =


### PR DESCRIPTION
Forwarded from https://github.com/liferay-headless/liferay-portal/pull/875
Original description:


Related ticket -> [LPS-169063](https://issues.liferay.com/browse/LPS-169063)
Related story -> [LPS-161364](https://issues.liferay.com/browse/LPS-161364)
____

This PR changes the name and the value of the parameter created previously in this story.
Using the example described in the ticket:

### Before the PR
This curl request:
```## Get student
curl "http://localhost:8080/o/c/students/41421?restrictFields=actions" 
```
Gets this response:
```
...
  "universityStudentsId": 41417,
  "studentName": "Student 1",
  "r_universityStudents_c_universityId": 41417,
  "r_universityStudents_c_universityERC": "d48663a8-9402-9891-d4e6-ed5153d5655d"
}
```
Note the field `unversityStudentsId`

### After the PR
The same curl request
```## Get student
curl "http://localhost:8080/o/c/students/41421?restrictFields=actions" 
```
Gets this response:
```
...
  "universityStudentsERC": "d48663a8-9402-9891-d4e6-ed5153d5655d",
  "studentName": "Student 1",
  "r_universityStudents_c_universityId": 41417,
  "r_universityStudents_c_universityERC": "d48663a8-9402-9891-d4e6-ed5153d5655d"
}
```
Note that now the `universityStudentsId` changed to `universityStudentsERC` and its value is now the ERC of the related object.

### How to test it
Follow these steps:
* Deploy `object-rest-impl`
* Make sure that this feature flag is enabled: `feature.flag.LPS-161364`

**_NOTE: This is not a breaking change as the field `universityStudentsId` is under a feature flag, so it can be changed._**