### PR TITLE
LPS-167597 Update portletId following to CETDeployer

### DIFF
--- a/modules/apps/client-extension/client-extension-test/build.gradle
+++ b/modules/apps/client-extension/client-extension-test/build.gradle
@@ -4,6 +4,7 @@ dependencies {
 	testIntegrationCompile project(":apps:layout:layout-test-util")
 	testIntegrationCompile project(":apps:portal-configuration:portal-configuration-test-util")
 	testIntegrationCompile project(":apps:portal:portal-props-test-util")
+	testIntegrationCompile project(":apps:static:portal:portal-upgrade-api")
 	testIntegrationCompile project(":core:osgi-service-tracker-collections")
 	testIntegrationCompile project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/upgrade/v3_0_1/test/UpgradePortletIdTest.java
+++ b/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/upgrade/v3_0_1/test/UpgradePortletIdTest.java
@@ -1,0 +1,235 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.client.extension.upgrade.v3_0_1.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.client.extension.constants.ClientExtensionEntryConstants;
+import com.liferay.client.extension.service.ClientExtensionEntryLocalService;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.PortletPreferences;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
+import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
+import com.liferay.portal.kernel.service.persistence.PortletPreferencesPersistence;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.upgrade.UpgradeStep;
+import com.liferay.portal.kernel.upgrade.util.UpgradeProcessUtil;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortletKeys;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Objects;
+
+import javax.portlet.Portlet;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceRegistration;
+
+/**
+ * @author Binh Tran
+ */
+@RunWith(Arquillian.class)
+public class UpgradePortletIdTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testDoUpgrade() throws Exception {
+		UserTestUtil.setUser(TestPropsValues.getUser());
+
+		Group group = GroupTestUtil.addGroup();
+
+		Layout layout = LayoutTestUtil.addTypePortletLayout(group.getGroupId());
+
+		long companyId = layout.getCompanyId();
+
+		long plid = layout.getPlid();
+
+		_addClientExtensionEntry(
+			"3b2b53fb-f264-f234-49d8-8d434d048e75-TEST", companyId);
+
+		UpgradeProcess upgradeProcess = _getUpgradeProcess();
+
+		String externalReferenceCodeForPortletIdNormalized =
+			"3b2b53fb_f264_f234_49d8_8d434d048e75_TEST";
+
+		String portletIdWithoutCompanyId =
+			_PORTLET_ID_PREFIX + "3b2b53fb_f264_f234_49d8_8d434d048e75_TEST";
+
+		ServiceRegistration<Portlet> serviceRegistration = _registerTestPortlet(
+			portletIdWithoutCompanyId);
+
+		try {
+			LayoutTestUtil.addPortletToLayout(
+				TestPropsValues.getUserId(), layout, portletIdWithoutCompanyId,
+				"column-1", new HashMap<>());
+
+			PortletPreferences portletPreferencesBeforeUpgrade =
+				_portletPreferencesLocalService.fetchPortletPreferences(
+					PortletKeys.PREFS_OWNER_ID_DEFAULT,
+					PortletKeys.PREFS_OWNER_TYPE_LAYOUT, plid,
+					portletIdWithoutCompanyId);
+
+			Assert.assertNotNull(portletPreferencesBeforeUpgrade);
+
+			Assert.assertEquals(
+				"Assert the portletPreferences portletId before upgrade",
+				portletIdWithoutCompanyId,
+				portletPreferencesBeforeUpgrade.getPortletId());
+
+			upgradeProcess.upgrade();
+
+			String newPortletIdWithCompanyId = StringBundler.concat(
+				_PORTLET_ID_PREFIX, companyId, StringPool.UNDERLINE,
+				externalReferenceCodeForPortletIdNormalized);
+
+			_portletPreferencesPersistence.clearCache();
+
+			PortletPreferences portletPreferencesWithOldId =
+				_portletPreferencesLocalService.fetchPortletPreferences(
+					PortletKeys.PREFS_OWNER_ID_DEFAULT,
+					PortletKeys.PREFS_OWNER_TYPE_LAYOUT, plid,
+					portletIdWithoutCompanyId);
+
+			PortletPreferences portletPreferencesWithNewId =
+				_portletPreferencesLocalService.fetchPortletPreferences(
+					PortletKeys.PREFS_OWNER_ID_DEFAULT,
+					PortletKeys.PREFS_OWNER_TYPE_LAYOUT, plid,
+					newPortletIdWithCompanyId);
+
+			Assert.assertNull(portletPreferencesWithOldId);
+
+			Assert.assertNotNull(portletPreferencesWithNewId);
+
+			Assert.assertEquals(
+				"Assert the portletPreferences portletId after upgrade",
+				newPortletIdWithCompanyId,
+				portletPreferencesWithNewId.getPortletId());
+		}
+		finally {
+			serviceRegistration.unregister();
+		}
+	}
+
+	private void _addClientExtensionEntry(
+			String clientExtensionEntryErc, long companyId)
+		throws Exception {
+
+		_clientExtensionEntryLocalService.addClientExtensionEntry(
+			clientExtensionEntryErc, TestPropsValues.getUserId(),
+			StringPool.BLANK,
+			Collections.singletonMap(
+				LocaleUtil.fromLanguageId(
+					UpgradeProcessUtil.getDefaultLanguageId(companyId)),
+				RandomTestUtil.randomString()),
+			StringPool.BLANK, StringPool.BLANK,
+			ClientExtensionEntryConstants.TYPE_CUSTOM_ELEMENT,
+			UnicodePropertiesBuilder.create(
+				true
+			).put(
+				"htmlElementName", "valid-html-element-name"
+			).put(
+				"instanceable", false
+			).put(
+				"urls", "http://" + RandomTestUtil.randomString() + ".com"
+			).buildString());
+	}
+
+	private UpgradeProcess _getUpgradeProcess() {
+		UpgradeProcess[] upgradeProcesses = new UpgradeProcess[1];
+
+		_upgradeStepRegistrator.register(
+			(fromSchemaVersionString, toSchemaVersionString, upgradeSteps) -> {
+				for (UpgradeStep upgradeStep : upgradeSteps) {
+					Class<? extends UpgradeStep> clazz = upgradeStep.getClass();
+
+					if (Objects.equals(
+							clazz.getName(),
+							"com.liferay.client.extension.web.internal." +
+								"upgrade.v3_0_1.UpgradePortletId")) {
+
+						upgradeProcesses[0] = (UpgradeProcess)upgradeStep;
+
+						break;
+					}
+				}
+			});
+
+		return upgradeProcesses[0];
+	}
+
+	private ServiceRegistration<Portlet> _registerTestPortlet(
+		String portletIdWithoutCompanyId) {
+
+		Bundle bundle = FrameworkUtil.getBundle(UpgradePortletIdTest.class);
+
+		BundleContext bundleContext = bundle.getBundleContext();
+
+		return bundleContext.registerService(
+			Portlet.class, new MVCPortlet(),
+			HashMapDictionaryBuilder.<String, Object>put(
+				"com.liferay.portlet.preferences-company-wide", "false"
+			).put(
+				"com.liferay.portlet.preferences-owned-by-group", false
+			).put(
+				"com.liferay.portlet.preferences-unique-per-layout", true
+			).put(
+				"javax.portlet.name", portletIdWithoutCompanyId
+			).build());
+	}
+
+	private static final String _PORTLET_ID_PREFIX =
+		"com_liferay_client_extension_web_internal_portlet_" +
+			"ClientExtensionEntryPortlet_";
+
+	@Inject
+	private ClientExtensionEntryLocalService _clientExtensionEntryLocalService;
+
+	@Inject
+	private PortletPreferencesLocalService _portletPreferencesLocalService;
+
+	@Inject
+	private PortletPreferencesPersistence _portletPreferencesPersistence;
+
+	@Inject(
+		filter = "component.name=com.liferay.client.extension.web.internal.upgrade.registry.ClientExtensionWebUpgradeStepRegistrator"
+	)
+	private UpgradeStepRegistrator _upgradeStepRegistrator;
+
+}

--- a/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/type/deployer/CETDeployerImpl.java
+++ b/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/type/deployer/CETDeployerImpl.java
@@ -22,6 +22,7 @@ import com.liferay.client.extension.type.deployer.CETDeployer;
 import com.liferay.client.extension.web.internal.portlet.ClientExtensionEntryFriendlyURLMapper;
 import com.liferay.client.extension.web.internal.portlet.ClientExtensionEntryPortlet;
 import com.liferay.client.extension.web.internal.portlet.action.ClientExtensionEntryConfigurationAction;
+import com.liferay.client.extension.web.internal.util.CETUtil;
 import com.liferay.frontend.js.loader.modules.extender.npm.NPMResolver;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -116,14 +117,12 @@ public class CETDeployerImpl implements CETDeployer {
 	}
 
 	private String _getPortletId(CET cet) {
-		String externalReferenceCode = cet.getExternalReferenceCode();
-
 		return StringBundler.concat(
 			"com_liferay_client_extension_web_internal_portlet_",
 			"ClientExtensionEntryPortlet_", cet.getCompanyId(),
 			StringPool.UNDERLINE,
-			externalReferenceCode.replaceAll(
-				"[^a-zA-Z0-9_]", StringPool.UNDERLINE));
+			CETUtil.normalizeExternalReferenceCodeForPortletId(
+				cet.getExternalReferenceCode()));
 	}
 
 	private ServiceRegistration<ConfigurationAction>

--- a/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/upgrade/registry/ClientExtensionWebUpgradeStepRegistrator.java
+++ b/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/upgrade/registry/ClientExtensionWebUpgradeStepRegistrator.java
@@ -15,6 +15,7 @@
 package com.liferay.client.extension.web.internal.upgrade.registry;
 
 import com.liferay.portal.kernel.model.Release;
+import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 
@@ -53,9 +54,11 @@ public class ClientExtensionWebUpgradeStepRegistrator
 			new com.liferay.client.extension.web.internal.upgrade.v2_0_0.
 				UpgradePortletId());
 
+		registry.register("2.0.0", "3.0.0", new DummyUpgradeStep());
+
 		registry.register(
-			"2.0.0", "3.0.0",
-			new com.liferay.client.extension.web.internal.upgrade.v3_0_0.
+			"3.0.0", "3.0.1",
+			new com.liferay.client.extension.web.internal.upgrade.v3_0_1.
 				UpgradePortletId());
 	}
 

--- a/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/upgrade/v3_0_1/UpgradePortletId.java
+++ b/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/upgrade/v3_0_1/UpgradePortletId.java
@@ -12,8 +12,9 @@
  * details.
  */
 
-package com.liferay.client.extension.web.internal.upgrade.v3_0_0;
+package com.liferay.client.extension.web.internal.upgrade.v3_0_1;
 
+import com.liferay.client.extension.web.internal.util.CETUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.log.Log;
@@ -40,8 +41,9 @@ public class UpgradePortletId extends BasePortletIdUpgradeProcess {
 					"ClientExtensionEntry")) {
 
 			while (resultSet.next()) {
-				String externalReferenceCode = resultSet.getString(
-					"externalReferenceCode");
+				String externalReferenceCode =
+					CETUtil.normalizeExternalReferenceCodeForPortletId(
+						resultSet.getString("externalReferenceCode"));
 
 				runSQL(
 					StringBundler.concat(
@@ -84,8 +86,9 @@ public class UpgradePortletId extends BasePortletIdUpgradeProcess {
 					"ClientExtensionEntry")) {
 
 			while (resultSet.next()) {
-				String externalReferenceCode = resultSet.getString(
-					"externalReferenceCode");
+				String externalReferenceCode =
+					CETUtil.normalizeExternalReferenceCodeForPortletId(
+						resultSet.getString("externalReferenceCode"));
 
 				portletIds.add(
 					new String[] {

--- a/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/util/CETUtil.java
+++ b/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/util/CETUtil.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.client.extension.web.internal.util;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.Validator;
+
+/**
+ * @author Binh Tran
+ */
+public class CETUtil {
+
+	public static String normalizeExternalReferenceCodeForPortletId(
+		String externalReferenceCode) {
+
+		if (Validator.isNotNull(externalReferenceCode)) {
+			return externalReferenceCode.replaceAll(
+				"\\W", StringPool.UNDERLINE);
+		}
+
+		return externalReferenceCode;
+	}
+
+}


### PR DESCRIPTION
Got the QA approved for manually forwarding: https://github.com/liferay-frontend/liferay-portal/pull/2895

> ## Explanation for v3.0.0
> It first appeared in the following pull request, which is the second of three pull requests sent for LPS-159174:
> 
> #122012 [7c12ae2](https://github.com/brianchandotcom/liferay-portal/commit/7c12ae25a72890677892544c494cdc6e50dd1aba)
> 
> Asking José about why he also copied this pattern, he mentioned that he copied the code from an earlier pull request for polls.
> 
> #117555 [f740f48](https://github.com/brianchandotcom/liferay-portal/commit/f740f4854462ac7e399d1b2f0a93095eb6220981)
> 
> ## Precedent for code pattern
> Based on that response, I was able to confirm that the same code pattern currently exists in 6 different upgrade processes.
> 
> ```shell
> git ls-files -- '*.java' | grep -vF 'test/' | \
>   xargs grep -Fl 'delete from Portlet ' | \
>   xargs grep -Fl 'delete from ResourcePermission '
> ```
> 
> * client-extension-web: [v3_0_0/UpgradePortletId.java](https://github.com/liferay/liferay-portal/blob/7.4.3.52-ga52/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/upgrade/v3_0_0/UpgradePortletId.java#L46-L58)
> * dynamic-data-mapping-service: [v5_1_4/PollsPortletIdToDDMPortletIdUpgradeProcess.java](https://github.com/liferay/liferay-portal/blob/7.4.3.52-ga52/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_1_4/PollsPortletIdToDDMPortletIdUpgradeProcess.java#L33-L41)
> * license-manager-web: [v1_0_1/UpgradePortletId.java](https://github.com/liferay/liferay-portal/tree/7.4.3.52-ga52/modules/apps/license-manager/license-manager-web/src/main/java/com/liferay/license/manager/web/internal/upgrade/v1_0_1/UpgradePortletId.java#L39-L43)
> * portal-workflow-kaleo-forms-web: [v1_0_2/UpgradePortletId.java](https://github.com/liferay/liferay-portal/tree/7.4.3.52-ga52/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/java/com/liferay/portal/workflow/kaleo/forms/web/internal/upgrade/v1_0_2/UpgradePortletId.java)
> * saml-addon-keep-alive-web: [v1_0_0/PortletIdUpgradeProcess.java](https://github.com/liferay/liferay-portal/tree/7.4.3.52-ga52/modules/dxp/apps/saml/saml-addon-keep-alive-web/src/main/java/com/liferay/saml/addon/keep/alive/web/internal/upgrade/v1_0_0/PortletIdUpgradeProcess.java#L32-L52)
> * portal-impl: [v7_0_0/UpgradeDocumentLibraryPortletId.java](https://github.com/liferay/liferay-portal/tree/7.4.3.52-ga52/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeDocumentLibraryPortletId.java#L95-L100)
> 
> ## Explanation for `delete from Portlet`
> The code pattern first appears in a pull request for [LPS-62421](https://issues.liferay.com/browse/LPS-62421):
> 
> #34727 [74cfd55](https://github.com/brianchandotcom/liferay-portal/commit/74cfd5513add7c4dd2ffdf6cb3bd34f483c11a03)
> 
> The idea is that the _target_ portlet is expected to be registered as part of a normal portal startup with all the correct data, and so we don't want the _source_ portlet to be renamed into it. Instead, we just delete the _source_ portlet to prevent that rename attempt.
> 
> ## Explanation for `delete from ResourcePermission`
> The code pattern also first appears in the same pull request for [LPS-62421](https://issues.liferay.com/browse/LPS-62421):
> 
> #34727 [74cfd55](https://github.com/brianchandotcom/liferay-portal/commit/74cfd5513add7c4dd2ffdf6cb3bd34f483c11a03)
> 
> Since the primary key doesn't have any `_INSTANCE_` portlet separator, it only deletes the permissions defined either in `resource-actions/*.xml` or that were specified in the Define Permissions UI for each role.
> 
> The intent appears to have been for `resource-actions/*.xml` and my best guess is that Define Permissions values are an unintended side-effect. However, since it's revoking permissions rather than granting them, there's a slight usability downside but no security downside to the changes.
> 
> ## Explanation for v3.0.1
> Let's assume that we have an external reference code of `h5v7-remote-app`. In 2.0.0, that will result in a portlet ID of `com_liferay_client_extension_web_internal_portlet_ClientExtensionEntryPortlet_h5v7_remote_app`.
> 
> The issue with the 3.0.0 upgrade process is that it will try to delete/rename entries with portlet ID `%_h5v7-remote-app` instead of entries with portlet ID `%_h5v7_remote_app`, which won't ever match.
> 
> The fix applied in this pull request is to fix the deletion/rename attempts in the v3.0.0 upgrade so that they use `%_h5v7_remote_app`. Everything else you see is source formatting requested by the reviewers. The change from `[^a-zA-Z0-9_]` to `\W` is also just source formatting (the character class is identical to what was there originally).