### PR TITLE
LPS 167597 Fix the test

### DIFF
--- a/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/upgrade/v3_0_1/test/UpgradePortletIdTest.java
+++ b/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/upgrade/v3_0_1/test/UpgradePortletIdTest.java
@@ -49,7 +49,6 @@ import javax.portlet.Portlet;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -70,7 +69,6 @@ public class UpgradePortletIdTest {
 	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
 		new LiferayIntegrationTestRule();
 
-	@Ignore
 	@Test
 	public void testDoUpgrade() throws Exception {
 		//UserTestUtil.setUser(TestPropsValues.getUser());

--- a/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/upgrade/v3_0_1/test/UpgradePortletIdTest.java
+++ b/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/upgrade/v3_0_1/test/UpgradePortletIdTest.java
@@ -71,7 +71,7 @@ public class UpgradePortletIdTest {
 
 	@Test
 	public void testDoUpgrade() throws Exception {
-		//UserTestUtil.setUser(TestPropsValues.getUser());
+		UserTestUtil.setUser(TestPropsValues.getUser());
 
 		Group group = GroupTestUtil.addGroup();
 
@@ -176,9 +176,7 @@ public class UpgradePortletIdTest {
 		return upgradeProcesses[0];
 	}
 
-	private ServiceRegistration<Portlet> _register(
-		String oldPortletId) {
-
+	private ServiceRegistration<Portlet> _register(String oldPortletId) {
 		Bundle bundle = FrameworkUtil.getBundle(UpgradePortletIdTest.class);
 
 		BundleContext bundleContext = bundle.getBundleContext();


### PR DESCRIPTION
Hi Brian,
`UserTestUtil.setUser(TestPropsValues.getUser()); ` is needed for initializing the permission checker that is required when adding the portlet to the layout.