### PR TITLE
LPS-170788 Filter object applications

### DIFF
--- a/modules/apps/headless/headless-discovery/headless-discovery-impl/build.gradle
+++ b/modules/apps/headless/headless-discovery/headless-discovery-impl/build.gradle
@@ -14,5 +14,6 @@ dependencies {
 	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-persistence-api")
+	compileOnly project(":core:osgi-service-tracker-collections")
 	compileOnly project(":core:petra:petra-string")
 }

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -72,6 +72,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.ws.rs.NotFoundException;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.ext.ExceptionMapper;
@@ -150,11 +151,17 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 		Map<Long, ObjectDefinition> objectDefinitions =
 			_objectDefinitionsMap.get(restContextPath);
 
+		ObjectDefinition objectDefinition = null;
+
 		if (objectDefinitions != null) {
-			return objectDefinitions.get(companyId);
+			objectDefinition = objectDefinitions.get(companyId);
 		}
 
-		return null;
+		if (objectDefinition == null) {
+			throw new NotFoundException();
+		}
+
+		return objectDefinition;
 	}
 
 	@Override


### PR DESCRIPTION
Manually forwarding from https://github.com/liferay-headless/liferay-portal/pull/914

Original PR description:


## Purpose of the PR
Filtering the Object REST Applications created dynamically in the Liferay API Explorer.

When we have more than one instances, the objects created can be visible (only the name) among the different Liferay instances. This PR solves that.

### Before the PR
Instance 1: 
![image](https://user-images.githubusercontent.com/17163902/206300776-45b8e56d-e2f1-4d31-8981-672b885ad53b.png)

Instance 2:
![image](https://user-images.githubusercontent.com/17163902/206300841-076dbf41-07af-4f4c-828f-ff610403a1de.png)

### After the PR
Instance 1: ![image](https://user-images.githubusercontent.com/17163902/206300326-28f940ac-8421-41d1-bf5a-189ed0753d91.png)
Instance 2: 
![image](https://user-images.githubusercontent.com/17163902/206300430-4f768596-7921-4d4b-8542-4cc1f1a63f13.png)
