### PR TITLE
LPS-171065 Append t=<timestamp> parameter to custom element URLs

### DIFF
--- a/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/type/deployer/CETDeployerImpl.java
+++ b/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/type/deployer/CETDeployerImpl.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.model.Release;
 import com.liferay.portal.kernel.portlet.ConfigurationAction;
 import com.liferay.portal.kernel.portlet.FriendlyURLMapper;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -125,6 +126,15 @@ public class CETDeployerImpl implements CETDeployer {
 				cet.getExternalReferenceCode()));
 	}
 
+	private String[] _prepareURLs(long lastModified, String[] urls) {
+		for (int i = 0; i < urls.length; i++) {
+			urls[i] = HttpComponentsUtil.addParameter(
+				urls[i], "t", lastModified);
+		}
+
+		return urls;
+	}
+
 	private ServiceRegistration<ConfigurationAction>
 		_registerConfigurationAction(CET cet) {
 
@@ -172,13 +182,16 @@ public class CETDeployerImpl implements CETDeployer {
 				"javax.portlet.version", "3.0"
 			).build();
 
+		long lastModified = System.currentTimeMillis();
+
 		if (customElementCET != null) {
 			String cssURLs = customElementCET.getCSSURLs();
 
 			if (Validator.isNotNull(cssURLs)) {
 				dictionary.put(
 					"com.liferay.portlet.header-portal-css",
-					cssURLs.split(StringPool.NEW_LINE));
+					_prepareURLs(
+						lastModified, cssURLs.split(StringPool.NEW_LINE)));
 			}
 
 			String urls = customElementCET.getURLs();
@@ -192,7 +205,8 @@ public class CETDeployerImpl implements CETDeployer {
 			}
 
 			dictionary.put(
-				"com.liferay.portlet.header-portal-javascript", urlsArray);
+				"com.liferay.portlet.header-portal-javascript",
+				_prepareURLs(lastModified, urlsArray));
 		}
 		else if (iFrameCET != null) {
 			dictionary.put(


### PR DESCRIPTION
Some customers want to invalidate the caches when a new version is deployed so Brian has proposed  to add a t= parameter to every JS and CSS URL of custom elements to begin with and see how the model fits for the future.

The timestamp value is the last deployment of the client extension (note that this makes it update every time the client extension is redeployed or whenever the server is reboot).

This is how requests look like now:

![image](https://user-images.githubusercontent.com/3273630/207376163-54e78cb6-a5b2-4777-8716-a8e80048f934.png)

Those are the requests before and after redeployment of a custom element client extension (2 before, 2 after).