### PR TITLE
LPS-170788 Create test to validate the isolation of the objects for different companyIds

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -16,6 +16,7 @@ package com.liferay.object.rest.internal.deployer;
 
 import com.liferay.object.action.engine.ObjectActionEngine;
 import com.liferay.object.deployer.ObjectDefinitionDeployer;
+import com.liferay.object.exception.NoSuchObjectDefinitionException;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.related.models.ObjectRelatedModelsProviderRegistry;
 import com.liferay.object.rest.dto.v1_0.ObjectEntry;
@@ -73,7 +74,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.ws.rs.NotFoundException;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.ext.ExceptionMapper;
@@ -147,7 +147,8 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 	}
 
 	public ObjectDefinition getObjectDefinition(
-		long companyId, String restContextPath) {
+			long companyId, String restContextPath)
+		throws Exception {
 
 		ObjectDefinition objectDefinition = null;
 
@@ -159,7 +160,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 		}
 
 		if (objectDefinition == null) {
-			throw new NotFoundException();
+			throw new NoSuchObjectDefinitionException();
 		}
 
 		return objectDefinition;

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/jaxrs/context/provider/ObjectDefinitionContextProvider.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/jaxrs/context/provider/ObjectDefinitionContextProvider.java
@@ -16,6 +16,8 @@ package com.liferay.object.rest.internal.jaxrs.context.provider;
 
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.rest.internal.deployer.ObjectDefinitionDeployerImpl;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
 
@@ -55,9 +57,21 @@ public class ObjectDefinitionContextProvider
 		restContextPath = StringUtil.removeFirst(restContextPath, "/o");
 		restContextPath = StringUtil.replaceLast(restContextPath, '/', "");
 
-		return _objectDefinitionDeployerImpl.getObjectDefinition(
-			companyId, restContextPath);
+		try {
+			return _objectDefinitionDeployerImpl.getObjectDefinition(
+				companyId, restContextPath);
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(exception);
+			}
+
+			throw new RuntimeException(exception);
+		}
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		ObjectDefinitionContextProvider.class);
 
 	private final ObjectDefinitionDeployerImpl _objectDefinitionDeployerImpl;
 	private final Portal _portal;

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/OpenAPIResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/OpenAPIResourceTest.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.rest.internal.resource.v1_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.object.field.util.ObjectFieldUtil;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.rest.internal.resource.v1_0.test.util.HTTPTestUtil;
+import com.liferay.object.rest.internal.resource.v1_0.test.util.ObjectDefinitionTestUtil;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.CompanyTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.Collections;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Carlos Correa
+ */
+@RunWith(Arquillian.class)
+public class OpenAPIResourceTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_company = CompanyTestUtil.addCompany();
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		_objectDefinition1 = ObjectDefinitionTestUtil.publishObjectDefinition(
+			Collections.singletonList(
+				ObjectFieldUtil.createObjectField(
+					"Text", "String", true, true, null,
+					RandomTestUtil.randomString(), _OBJECT_FIELD_NAME, false)));
+	}
+
+	@Test
+	public void testGetOpenAPI() throws Exception {
+		_user = UserTestUtil.addUser(_company);
+
+		_objectDefinition2 = ObjectDefinitionTestUtil.publishObjectDefinition(
+			Collections.singletonList(
+				ObjectFieldUtil.createObjectField(
+					"Text", "String", true, true, null,
+					RandomTestUtil.randomString(), _OBJECT_FIELD_NAME, false)),
+			_user.getUserId());
+
+		JSONObject jsonObject = HTTPTestUtil.invoke(
+			null, "/openapi", Http.Method.GET);
+
+		JSONArray jsonArray = jsonObject.getJSONArray(
+			_objectDefinition1.getRESTContextPath());
+
+		Assert.assertEquals(1, jsonArray.length());
+		Assert.assertEquals(
+			"http://localhost:8080/o" +
+				_objectDefinition1.getRESTContextPath() + "/openapi.yaml",
+			jsonArray.get(0));
+
+		jsonObject = HTTPTestUtil.invoke(
+			null, _objectDefinition1.getRESTContextPath() + "/openapi.json",
+			Http.Method.GET);
+
+		Assert.assertNotNull(jsonObject.getString("openapi"));
+
+		Assert.assertNull(
+			jsonObject.getJSONArray(_objectDefinition2.getRESTContextPath()));
+
+		jsonObject = HTTPTestUtil.invoke(
+			null, _objectDefinition2.getRESTContextPath() + "/openapi.json",
+			Http.Method.GET);
+
+		Assert.assertEquals("NOT_FOUND", jsonObject.getString("status"));
+	}
+
+	private static final String _OBJECT_FIELD_NAME =
+		"x" + RandomTestUtil.randomString();
+
+	private static Company _company;
+
+	@DeleteAfterTestRun
+	private ObjectDefinition _objectDefinition1;
+
+	@DeleteAfterTestRun
+	private ObjectDefinition _objectDefinition2;
+
+	@DeleteAfterTestRun
+	private User _user;
+
+}

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/util/ObjectDefinitionTestUtil.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/util/ObjectDefinitionTestUtil.java
@@ -33,9 +33,17 @@ public class ObjectDefinitionTestUtil {
 			List<ObjectField> objectFields)
 		throws Exception {
 
+		return publishObjectDefinition(
+			objectFields, TestPropsValues.getUserId());
+	}
+
+	public static ObjectDefinition publishObjectDefinition(
+			List<ObjectField> objectFields, long userId)
+		throws Exception {
+
 		ObjectDefinition objectDefinition =
 			ObjectDefinitionLocalServiceUtil.addCustomObjectDefinition(
-				TestPropsValues.getUserId(), false,
+				userId, false,
 				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
 				"A" + RandomTestUtil.randomString(), null, null,
 				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
@@ -43,8 +51,7 @@ public class ObjectDefinitionTestUtil {
 				ObjectDefinitionConstants.STORAGE_TYPE_DEFAULT, objectFields);
 
 		return ObjectDefinitionLocalServiceUtil.publishCustomObjectDefinition(
-			TestPropsValues.getUserId(),
-			objectDefinition.getObjectDefinitionId());
+			userId, objectDefinition.getObjectDefinitionId());
 	}
 
 }


### PR DESCRIPTION
PR forwarded manually from: https://github.com/liferay-headless/liferay-portal/pull/922

---

This PR contains a test to validate the isolation of the Object's for different companyIds. The test validates the API Explorer does not show any object that does not belong to the current company. Furthermore, it is also tested the OpenAPI endpoint returns 404 if the object does not exist for the current company.

A more accurate exception will be thrown when the ObjectDefinition does not exist. With that, apart from providing more info in the log trace about which problem is, no error trace is printed, and a warn trace is printed instead, as the `NoSuchModelExceptionMapper` will deal the exception instead of the JAX-RS default `NotFoundExceptionMapper`.