### PR TITLE
Revert LPS-155544

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
@@ -19,7 +19,6 @@ import com.liferay.document.library.kernel.service.DLAppService;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
 import com.liferay.document.library.util.DLURLHelper;
 import com.liferay.dynamic.data.mapping.expression.DDMExpressionFactory;
-import com.liferay.dynamic.data.mapping.util.NumericDDMFormFieldUtil;
 import com.liferay.list.type.model.ListTypeEntry;
 import com.liferay.list.type.service.ListTypeEntryLocalService;
 import com.liferay.object.constants.ObjectFieldConstants;
@@ -70,8 +69,6 @@ import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
 import java.io.Serializable;
-
-import java.text.DecimalFormat;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -455,18 +452,6 @@ public class ObjectEntryDTOConverter
 							name = dlFileEntry.getFileName();
 						}
 					});
-			}
-			else if (Objects.equals(
-						objectField.getBusinessType(),
-						ObjectFieldConstants.BUSINESS_TYPE_PRECISION_DECIMAL)) {
-
-				DecimalFormat defaultDecimalFormat =
-					NumericDDMFormFieldUtil.getDecimalFormat(
-						dtoConverterContext.getLocale());
-
-				serializable = defaultDecimalFormat.format(serializable);
-
-				map.put(objectFieldName, serializable);
 			}
 			else if (Objects.equals(
 						objectField.getBusinessType(),

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
@@ -460,11 +460,11 @@ public class ObjectEntryDTOConverter
 						objectField.getBusinessType(),
 						ObjectFieldConstants.BUSINESS_TYPE_PRECISION_DECIMAL)) {
 
-				DecimalFormat decimalFormat =
+				DecimalFormat defaultDecimalFormat =
 					NumericDDMFormFieldUtil.getDecimalFormat(
 						dtoConverterContext.getLocale());
 
-				serializable = decimalFormat.format(serializable);
+				serializable = defaultDecimalFormat.format(serializable);
 
 				map.put(objectFieldName, serializable);
 			}

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -365,7 +365,8 @@ public class DefaultObjectEntryManagerImplTest {
 				).put(
 					"picklistObjectFieldName", listTypeEntryKey
 				).put(
-					"precisionDecimalObjectFieldName", "0.1234567891234567"
+					"precisionDecimalObjectFieldName",
+					new BigDecimal(0.1234567891234567, MathContext.DECIMAL64)
 				).put(
 					"richTextObjectFieldName",
 					StringBundler.concat(
@@ -380,23 +381,6 @@ public class DefaultObjectEntryManagerImplTest {
 			childObjectEntry1,
 			_objectEntryManager.addObjectEntry(
 				_dtoConverterContext, _objectDefinition2, childObjectEntry1,
-				ObjectDefinitionConstants.SCOPE_COMPANY));
-
-		childObjectEntry1 = new ObjectEntry() {
-			{
-				properties = HashMapBuilder.<String, Object>put(
-					"precisionDecimalObjectFieldName", "0,123456789123456"
-				).build();
-			}
-		};
-
-		_assertEquals(
-			childObjectEntry1,
-			_objectEntryManager.addObjectEntry(
-				new DefaultDTOConverterContext(
-					false, Collections.emptyMap(), _dtoConverterRegistry, null,
-					LocaleUtil.SPAIN, null, _adminUser),
-				_objectDefinition2, childObjectEntry1,
 				ObjectDefinitionConstants.SCOPE_COMPANY));
 
 		_assertEquals(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -2913,14 +2913,8 @@ public class ObjectEntryLocalServiceImpl
 			}
 		}
 		else if (sqlType == Types.DECIMAL) {
-			String valueString = String.valueOf(value);
-
-			if (valueString.contains(StringPool.COMMA)) {
-				valueString = StringUtil.replace(
-					valueString, CharPool.COMMA, CharPool.PERIOD);
-			}
-
-			preparedStatement.setBigDecimal(index, new BigDecimal(valueString));
+			preparedStatement.setBigDecimal(
+				index, new BigDecimal(String.valueOf(value)));
 		}
 		else if (sqlType == Types.DOUBLE) {
 			preparedStatement.setDouble(index, GetterUtil.getDouble(value));


### PR DESCRIPTION
Hi Brian, I had to revert this behavior because it is impacting the Solutions team.

This behavior returns the precision decimal as a String in the API instead of the number format.

Related issue: https://issues.liferay.com/browse/LPS-155544