### PR TITLE
LPS-171287 Avoid getResourceName when ObjectDefinition is System

### DIFF
--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/display/context/ObjectEntryDisplayContext.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/display/context/ObjectEntryDisplayContext.java
@@ -350,12 +350,12 @@ public class ObjectEntryDisplayContext {
 			_objectScopeProviderRegistry.getObjectScopeProvider(
 				objectDefinition2.getScope());
 
-		if (ObjectEntryServiceUtil.hasPortletResourcePermission(
+		if (!objectDefinition1.isSystem() && !objectDefinition2.isSystem() &&
+			ObjectEntryServiceUtil.hasPortletResourcePermission(
 				objectScopeProvider.getGroupId(
 					_objectRequestHelper.getRequest()),
 				objectDefinition2.getObjectDefinitionId(),
 				ObjectActionKeys.ADD_OBJECT_ENTRY) &&
-			!objectDefinition1.isSystem() && !objectDefinition2.isSystem() &&
 			!(StringUtil.equals(
 				objectDefinition1.getScope(),
 				ObjectDefinitionConstants.SCOPE_COMPANY) &&


### PR DESCRIPTION
Unrelated CI errors [here](https://github.com/liferay-objects/liferay-portal/pull/1522#issuecomment-1354015480).