### PR TITLE
LPS-170938 Remove duplicate logic in unlink relationship test cases

### DIFF
--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -98,323 +98,142 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
-	public void testDeleteManyToManyCustomObjectDefinition1WithCustomObjectDefinition2()
+	public void testDeleteCustomObjectDefinition1WithCustomObjectDefinition2()
 		throws Exception {
 
-		String name = StringUtil.randomId();
+		Long irrelevantCurrentObjectId = RandomTestUtil.randomLong();
 
 		_objectRelationship = _addObjectRelationship(
-			name, _objectEntry1.getPrimaryKey(), _objectEntry2.getPrimaryKey(),
+			StringUtil.randomId(), _objectEntry1.getPrimaryKey(),
+			_objectEntry2.getPrimaryKey(),
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
-		JSONObject jsonObject = HTTPTestUtil.invoke(
-			null,
-			com.liferay.petra.string.StringBundler.concat(
-				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
-				_objectEntry1.getPrimaryKey(), StringPool.SLASH,
-				_objectRelationship.getName()),
-			Http.Method.GET);
-
-		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
-
-		Assert.assertEquals(1, itemsJSONArray.length());
-
-		HTTPTestUtil.invoke(
-			null,
+		_testDeleteOneToManyAndManyToManyCustomObjectWithCustomObject(
 			com.liferay.petra.string.StringBundler.concat(
 				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
 				_objectEntry1.getPrimaryKey(), StringPool.SLASH,
 				_objectRelationship.getName(), StringPool.SLASH,
 				_objectEntry2.getPrimaryKey()),
-			Http.Method.DELETE);
-
-		jsonObject = HTTPTestUtil.invoke(
-			null,
 			com.liferay.petra.string.StringBundler.concat(
 				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
 				_objectEntry1.getPrimaryKey(), StringPool.SLASH,
-				_objectRelationship.getName()),
-			Http.Method.GET);
-
-		itemsJSONArray = jsonObject.getJSONArray("items");
-
-		Assert.assertEquals(0, itemsJSONArray.length());
-	}
-
-	@Test
-	public void testDeleteManyToManyCustomObjectDefinition2WithCustomObjectDefinition1()
-		throws Exception {
-
-		String name = StringUtil.randomId();
+				_objectRelationship.getName()));
 
 		_objectRelationship = _addObjectRelationship(
-			name, _objectEntry1.getPrimaryKey(), _objectEntry2.getPrimaryKey(),
+			StringUtil.randomId(), _objectEntry1.getPrimaryKey(),
+			_objectEntry2.getPrimaryKey(),
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
-		JSONObject jsonObject = HTTPTestUtil.invoke(
-			null,
-			com.liferay.petra.string.StringBundler.concat(
-				_objectDefinition2.getRESTContextPath(), StringPool.SLASH,
-				_objectEntry2.getPrimaryKey(), StringPool.SLASH,
-				_objectRelationship.getName()),
-			Http.Method.GET);
-
-		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
-
-		Assert.assertEquals(1, itemsJSONArray.length());
-
-		HTTPTestUtil.invoke(
-			null,
+		_testDeleteOneToManyAndManyToManyCustomObjectWithCustomObject(
 			com.liferay.petra.string.StringBundler.concat(
 				_objectDefinition2.getRESTContextPath(), StringPool.SLASH,
 				_objectEntry2.getPrimaryKey(), StringPool.SLASH,
 				_objectRelationship.getName(), StringPool.SLASH,
 				_objectEntry1.getPrimaryKey()),
-			Http.Method.DELETE);
-
-		jsonObject = HTTPTestUtil.invoke(
-			null,
 			com.liferay.petra.string.StringBundler.concat(
 				_objectDefinition2.getRESTContextPath(), StringPool.SLASH,
 				_objectEntry2.getPrimaryKey(), StringPool.SLASH,
-				_objectRelationship.getName()),
-			Http.Method.GET);
-
-		itemsJSONArray = jsonObject.getJSONArray("items");
-
-		Assert.assertEquals(0, itemsJSONArray.length());
-	}
-
-	@Test
-	public void testDeleteManyToManyCustomObjectDefinition2WithCustomObjectDefinition1NotFound()
-		throws Exception {
-
-		Long irrelevantCurrentObjectId = RandomTestUtil.randomLong();
-
-		String name = StringUtil.randomId();
+				_objectRelationship.getName()));
 
 		_objectRelationship = _addObjectRelationship(
-			name, _objectEntry1.getPrimaryKey(), _objectEntry2.getPrimaryKey(),
+			StringUtil.randomId(), _objectEntry1.getPrimaryKey(),
+			_objectEntry2.getPrimaryKey(),
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
-		JSONObject jsonObject = HTTPTestUtil.invoke(
-			null,
+		_testDeleteOneToManyAndManyToManyCustomObjectWithCustomObjectNotFound(
 			com.liferay.petra.string.StringBundler.concat(
 				_objectDefinition2.getRESTContextPath(), StringPool.SLASH,
 				irrelevantCurrentObjectId, StringPool.SLASH,
 				_objectRelationship.getName(), StringPool.SLASH,
 				_objectEntry1.getPrimaryKey()),
-			Http.Method.DELETE);
-
-		Assert.assertEquals("NOT_FOUND", jsonObject.getString("status"));
-
-		jsonObject = HTTPTestUtil.invoke(
-			null,
 			com.liferay.petra.string.StringBundler.concat(
 				_objectDefinition2.getRESTContextPath(), StringPool.SLASH,
 				_objectEntry2.getPrimaryKey(), StringPool.SLASH,
 				_objectRelationship.getName(), StringPool.SLASH,
 				irrelevantCurrentObjectId),
-			Http.Method.DELETE);
-
-		Assert.assertEquals("NOT_FOUND", jsonObject.getString("status"));
-
-		jsonObject = HTTPTestUtil.invoke(
-			null,
 			com.liferay.petra.string.StringBundler.concat(
 				_objectDefinition2.getRESTContextPath(), StringPool.SLASH,
 				_objectEntry2.getPrimaryKey(), StringPool.SLASH,
-				_objectRelationship.getName()),
-			Http.Method.GET);
-
-		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
-
-		Assert.assertEquals(1, itemsJSONArray.length());
-	}
-
-	@Test
-	public void testDeleteManyToManyCustomObjectDefinitionWithCustomObjectDefinition2NotFound()
-		throws Exception {
-
-		Long irrelevantCurrentObjectId = RandomTestUtil.randomLong();
-
-		String name = StringUtil.randomId();
+				_objectRelationship.getName()));
 
 		_objectRelationship = _addObjectRelationship(
-			name, _objectEntry1.getPrimaryKey(), _objectEntry2.getPrimaryKey(),
+			StringUtil.randomId(), _objectEntry1.getPrimaryKey(),
+			_objectEntry2.getPrimaryKey(),
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
-		JSONObject jsonObject = HTTPTestUtil.invoke(
-			null,
+		_testDeleteOneToManyAndManyToManyCustomObjectWithCustomObjectNotFound(
 			com.liferay.petra.string.StringBundler.concat(
 				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
 				irrelevantCurrentObjectId, StringPool.SLASH,
 				_objectRelationship.getName(), StringPool.SLASH,
 				_objectEntry2.getPrimaryKey()),
-			Http.Method.DELETE);
-
-		Assert.assertEquals("NOT_FOUND", jsonObject.getString("status"));
-
-		jsonObject = HTTPTestUtil.invoke(
-			null,
 			com.liferay.petra.string.StringBundler.concat(
 				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
 				_objectEntry1.getPrimaryKey(), StringPool.SLASH,
 				_objectRelationship.getName(), StringPool.SLASH,
 				irrelevantCurrentObjectId),
-			Http.Method.DELETE);
-
-		Assert.assertEquals("NOT_FOUND", jsonObject.getString("status"));
-
-		jsonObject = HTTPTestUtil.invoke(
-			null,
 			com.liferay.petra.string.StringBundler.concat(
 				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
 				_objectEntry1.getPrimaryKey(), StringPool.SLASH,
-				_objectRelationship.getName()),
-			Http.Method.GET);
-
-		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
-
-		Assert.assertEquals(1, itemsJSONArray.length());
-	}
-
-	@Test
-	public void testDeleteOneToManyCustomObjectDefinition1WithCustomObjectDefinition2()
-		throws Exception {
-
-		String name = StringUtil.randomId();
+				_objectRelationship.getName()));
 
 		_objectRelationship = _addObjectRelationship(
-			name, _objectEntry1.getPrimaryKey(), _objectEntry2.getPrimaryKey(),
+			StringUtil.randomId(), _objectEntry1.getPrimaryKey(),
+			_objectEntry2.getPrimaryKey(),
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
-		JSONObject jsonObject = HTTPTestUtil.invoke(
-			null,
-			com.liferay.petra.string.StringBundler.concat(
-				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
-				_objectEntry1.getPrimaryKey(), StringPool.SLASH,
-				_objectRelationship.getName()),
-			Http.Method.GET);
-
-		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
-
-		Assert.assertEquals(1, itemsJSONArray.length());
-
-		HTTPTestUtil.invoke(
-			null,
+		_testDeleteOneToManyAndManyToManyCustomObjectWithCustomObject(
 			com.liferay.petra.string.StringBundler.concat(
 				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
 				_objectEntry1.getPrimaryKey(), StringPool.SLASH,
 				_objectRelationship.getName(), StringPool.SLASH,
 				_objectEntry2.getPrimaryKey()),
-			Http.Method.DELETE);
-
-		jsonObject = HTTPTestUtil.invoke(
-			null,
 			com.liferay.petra.string.StringBundler.concat(
 				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
 				_objectEntry1.getPrimaryKey(), StringPool.SLASH,
-				_objectRelationship.getName()),
-			Http.Method.GET);
-
-		itemsJSONArray = jsonObject.getJSONArray("items");
-
-		Assert.assertEquals(0, itemsJSONArray.length());
-	}
-
-	@Test
-	public void testDeleteOneToManyCustomObjectDefinition1WithCustomObjectDefinition2NotFound()
-		throws Exception {
-
-		Long irrelevantCurrentObjectId = RandomTestUtil.randomLong();
-
-		String name = StringUtil.randomId();
+				_objectRelationship.getName()));
 
 		_objectRelationship = _addObjectRelationship(
-			name, _objectEntry1.getPrimaryKey(), _objectEntry2.getPrimaryKey(),
+			StringUtil.randomId(), _objectEntry1.getPrimaryKey(),
+			_objectEntry2.getPrimaryKey(),
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
-		JSONObject jsonObject = HTTPTestUtil.invoke(
-			null,
+		_testDeleteOneToManyAndManyToManyCustomObjectWithCustomObjectNotFound(
 			com.liferay.petra.string.StringBundler.concat(
 				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
 				irrelevantCurrentObjectId, StringPool.SLASH,
 				_objectRelationship.getName(), StringPool.SLASH,
 				_objectEntry2.getPrimaryKey()),
-			Http.Method.DELETE);
-
-		Assert.assertEquals("NOT_FOUND", jsonObject.getString("status"));
-
-		jsonObject = HTTPTestUtil.invoke(
-			null,
 			com.liferay.petra.string.StringBundler.concat(
 				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
 				_objectEntry1.getPrimaryKey(), StringPool.SLASH,
 				_objectRelationship.getName(), StringPool.SLASH,
 				irrelevantCurrentObjectId),
-			Http.Method.DELETE);
-
-		Assert.assertEquals("NOT_FOUND", jsonObject.getString("status"));
-
-		jsonObject = HTTPTestUtil.invoke(
-			null,
 			com.liferay.petra.string.StringBundler.concat(
 				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
 				_objectEntry1.getPrimaryKey(), StringPool.SLASH,
-				_objectRelationship.getName()),
-			Http.Method.GET);
-
-		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
-
-		Assert.assertEquals(1, itemsJSONArray.length());
-	}
-
-	@Test
-	public void testDeleteOneToManyCustomObjectDefinition2WithCustomObjectDefinition1NotFound()
-		throws Exception {
-
-		Long irrelevantCurrentObjectId = RandomTestUtil.randomLong();
-
-		String name = StringUtil.randomId();
+				_objectRelationship.getName()));
 
 		_objectRelationship = _addObjectRelationship(
-			name, _objectEntry1.getPrimaryKey(), _objectEntry2.getPrimaryKey(),
+			StringUtil.randomId(), _objectEntry1.getPrimaryKey(),
+			_objectEntry2.getPrimaryKey(),
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
-		JSONObject jsonObject = HTTPTestUtil.invoke(
-			null,
+		_testDeleteOneToManyAndManyToManyCustomObjectWithCustomObjectNotFound(
 			com.liferay.petra.string.StringBundler.concat(
 				_objectDefinition2.getRESTContextPath(), StringPool.SLASH,
 				irrelevantCurrentObjectId, StringPool.SLASH,
 				_objectRelationship.getName(), StringPool.SLASH,
 				_objectEntry1.getPrimaryKey()),
-			Http.Method.DELETE);
-
-		Assert.assertEquals("NOT_FOUND", jsonObject.getString("status"));
-
-		jsonObject = HTTPTestUtil.invoke(
-			null,
 			com.liferay.petra.string.StringBundler.concat(
 				_objectDefinition2.getRESTContextPath(), StringPool.SLASH,
 				_objectEntry2.getPrimaryKey(), StringPool.SLASH,
 				_objectRelationship.getName(), StringPool.SLASH,
 				irrelevantCurrentObjectId),
-			Http.Method.DELETE);
-
-		Assert.assertEquals("NOT_FOUND", jsonObject.getString("status"));
-
-		jsonObject = HTTPTestUtil.invoke(
-			null,
 			com.liferay.petra.string.StringBundler.concat(
 				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
 				_objectEntry1.getPrimaryKey(), StringPool.SLASH,
-				_objectRelationship.getName()),
-			Http.Method.GET);
-
-		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
-
-		Assert.assertEquals(1, itemsJSONArray.length());
+				_objectRelationship.getName()));
 	}
 
 	@Test
@@ -572,6 +391,49 @@ public class ObjectEntryResourceTest {
 			objectRelationship, TestPropsValues.getUserId());
 
 		return objectRelationship;
+	}
+
+	private void _testDeleteOneToManyAndManyToManyCustomObjectWithCustomObject(
+			String deleteEndpoint, String getEndpoint)
+		throws Exception {
+
+		JSONObject jsonObject = HTTPTestUtil.invoke(
+			null, getEndpoint, Http.Method.GET);
+
+		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
+
+		Assert.assertEquals(1, itemsJSONArray.length());
+
+		HTTPTestUtil.invoke(null, deleteEndpoint, Http.Method.DELETE);
+
+		jsonObject = HTTPTestUtil.invoke(null, getEndpoint, Http.Method.GET);
+
+		itemsJSONArray = jsonObject.getJSONArray("items");
+
+		Assert.assertEquals(0, itemsJSONArray.length());
+	}
+
+	private void
+			_testDeleteOneToManyAndManyToManyCustomObjectWithCustomObjectNotFound(
+				String deleteEndpoint1, String deleteEndpoint2,
+				String getEndpoint)
+		throws Exception {
+
+		JSONObject jsonObject = HTTPTestUtil.invoke(
+			null, deleteEndpoint1, Http.Method.DELETE);
+
+		Assert.assertEquals("NOT_FOUND", jsonObject.getString("status"));
+
+		jsonObject = HTTPTestUtil.invoke(
+			null, deleteEndpoint2, Http.Method.DELETE);
+
+		Assert.assertEquals("NOT_FOUND", jsonObject.getString("status"));
+
+		jsonObject = HTTPTestUtil.invoke(null, getEndpoint, Http.Method.GET);
+
+		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
+
+		Assert.assertEquals(1, itemsJSONArray.length());
 	}
 
 	private void _testGetNestedFieldDetailsInOneToManyRelationships(


### PR DESCRIPTION
**What is new?**
- Update all test cases related to unlink Object Relationship to remove duplicate logic. Just providing the endpoint in every test case
- Brian requested changes in https://github.com/brianchandotcom/liferay-portal/pull/127857#issuecomment-1358018055

**JIRA Ticket:**
https://issues.liferay.com/browse/LPS-170938