### PR TITLE
LPS-171359 BulkDocumentRequestExecutorImpl should not make any retry attempts by default

### DIFF
--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/document/BulkDocumentRequestExecutorImpl.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/document/BulkDocumentRequestExecutorImpl.java
@@ -182,10 +182,17 @@ public class BulkDocumentRequestExecutorImpl
 			}
 			catch (Exception exception) {
 				if (i++ >= _numberOfTries) {
-					if (_numberOfTries > 1) {
+					if (_numberOfTries == 1) {
+						_log.error("The retry failed to get a bulk response");
+					}
+					else if (_numberOfTries == 2) {
+						_log.error(
+							"Both retries failed to get a bulk response");
+					}
+					else if (_numberOfTries > 2) {
 						_log.error(
 							"All " + _numberOfTries +
-								" tries failed to get a bulk response");
+								" retries failed to get a bulk response");
 					}
 
 					throw new RuntimeException(exception);
@@ -193,10 +200,10 @@ public class BulkDocumentRequestExecutorImpl
 
 				_log.error(
 					StringBundler.concat(
-						"There was an exception during getting a response to ",
-						"a request from the search server, retrying after ",
-						_waitInSeconds, " seconds (", i, "/", _numberOfTries,
-						"). ", exception));
+						"There was an exception while getting a response from ",
+						"the search engine, will retry in ", _waitInSeconds,
+						" seconds (", i, "/", _numberOfTries, "). ",
+						exception));
 
 				try {
 					Thread.sleep(_waitInSeconds * Time.SECOND);

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/document/configuration/BulkDocumentRequestRetryConfiguration.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/document/configuration/BulkDocumentRequestRetryConfiguration.java
@@ -27,7 +27,7 @@ import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClass
 )
 public interface BulkDocumentRequestRetryConfiguration {
 
-	@Meta.AD(deflt = "1", required = false)
+	@Meta.AD(deflt = "0", required = false)
 	public int numberOfTries();
 
 	@Meta.AD(deflt = "60", required = false)


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-171359

Tested in https://github.com/BryanEngler/liferay-portal/pull/717. Manually forwarding since `relevant` failed due to unrelated failures.