### PR TITLE
LPS-171330 Update Semantic Search tests after Text Embedding Provider rename

### DIFF
--- a/build-test-semantic-search.xml
+++ b/build-test-semantic-search.xml
@@ -41,8 +41,8 @@ RUN python -c "from txtai.api import API; API('config.yml', False)"</echo>
 				<arg value="docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' ${container.prefix}_txtai" />
 			</exec>
 
-			<echo file="${liferay.home}/osgi/configs/com.liferay.search.experiences.configuration.SemanticSearchConfiguration.config">sentenceTransformer="txtai"
-sentenceTransformerEnabled="true"
+			<echo file="${liferay.home}/osgi/configs/com.liferay.search.experiences.configuration.SemanticSearchConfiguration.config">textEmbeddingProvider="txtai"
+textEmbeddingsEnabled="true"
 txtaiHostAddress="http://${txtai.container.ip}:8000"</echo>
 		</sequential>
 	</macrodef>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/search/searchexperiences/SemanticSearch.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/search/searchexperiences/SemanticSearch.testcase
@@ -22,67 +22,67 @@ definition {
 	}
 
 	@description = "This is a use case for LPS-168704."
-	test AssertBlacklistedSentenceTransformersAreUnavailable {
+	test AssertBlacklistedTextEmbeddingProvidersAreUnavailable {
 		property custom.properties = "feature.flag.LPS-163688=true";
 		property osgi.module.configuration.file.names = "com.liferay.portal.component.blacklist.internal.configuration.ComponentBlacklistConfiguration.config";
-		property osgi.module.configurations = "blacklistComponentNames=[\"com.liferay.search.experiences.internal.ml.sentence.embedding.TXTAISentenceTransformer\",\"com.liferay.search.experiences.internal.ml.sentence.embedding.HuggingFaceInferenceAPISentenceTransformer\"]";
-		property test.name.skip.portal.instance = "SemanticSearch#AssertBlacklistedSentenceTransformersAreUnavailable";
+		property osgi.module.configurations = "blacklistComponentNames=[\"com.liferay.search.experiences.internal.ml.text.embedding.TXTAITextEmbeddingProvider\",\"com.liferay.search.experiences.internal.ml.text.embedding.HuggingFaceInferenceAPITextEmbeddingProvider\"]";
+		property test.name.skip.portal.instance = "SemanticSearch#AssertBlacklistedTextEmbeddingProvidersAreUnavailable";
 
-		WaitForConsoleTextPresent(value1 = "Disabling com.liferay.search.experiences.internal.ml.sentence.embedding.TXTAISentenceTransformer");
+		WaitForConsoleTextPresent(value1 = "Disabling com.liferay.search.experiences.internal.ml.text.embedding.TXTAITextEmbeddingProvider");
 
-		WaitForConsoleTextPresent(value1 = "Disabling com.liferay.search.experiences.internal.ml.sentence.embedding.HuggingFaceInferenceAPISentenceTransformer");
+		WaitForConsoleTextPresent(value1 = "Disabling com.liferay.search.experiences.internal.ml.text.embedding.HuggingFaceInferenceAPITextEmbeddingProvider");
 
 		SystemSettings.openToConfigInSystemSettings(portletId = "com.liferay.search.experiences.configuration.SemanticSearchConfiguration");
 
 		AssertElementNotPresent(
-			key_fieldLabel = "Sentence Transformer",
+			key_fieldLabel = "Text Embedding Provider",
 			key_value = "txtai",
 			locator1 = "Select#GENERIC_SELECT_VALUE");
 
 		AssertElementNotPresent(
-			key_fieldLabel = "Sentence Transformer",
+			key_fieldLabel = "Text Embedding Provider",
 			key_value = "Hugging Face Inference API",
 			locator1 = "Select#GENERIC_SELECT_VALUE");
 
 		PortalSettings.openToConfigInInstanceSettings(portletId = "com.liferay.search.experiences.configuration.SemanticSearchConfiguration");
 
 		AssertElementNotPresent(
-			key_fieldLabel = "Sentence Transformer",
+			key_fieldLabel = "Text Embedding Provider",
 			key_value = "txtai",
 			locator1 = "Select#GENERIC_SELECT_VALUE");
 
 		AssertElementNotPresent(
-			key_fieldLabel = "Sentence Transformer",
+			key_fieldLabel = "Text Embedding Provider",
 			key_value = "Hugging Face Inference API",
 			locator1 = "Select#GENERIC_SELECT_VALUE");
 
 		OSGiConfig.deleteOSGiConfigFile(osgiConfigFileName = "com.liferay.portal.component.blacklist.internal.configuration.ComponentBlacklistConfiguration.config");
 
-		WaitForConsoleTextPresent(value1 = "Enabling com.liferay.search.experiences.internal.ml.sentence.embedding.TXTAISentenceTransformer");
+		WaitForConsoleTextPresent(value1 = "Enabling com.liferay.search.experiences.internal.ml.text.embedding.TXTAITextEmbeddingProvider");
 
-		WaitForConsoleTextPresent(value1 = "Enabling com.liferay.search.experiences.internal.ml.sentence.embedding.HuggingFaceInferenceAPISentenceTransformer");
+		WaitForConsoleTextPresent(value1 = "Enabling com.liferay.search.experiences.internal.ml.text.embedding.HuggingFaceInferenceAPITextEmbeddingProvider");
 
 		Refresh();
 
 		AssertElementPresent(
-			key_fieldLabel = "Sentence Transformer",
+			key_fieldLabel = "Text Embedding Provider",
 			key_value = "txtai",
 			locator1 = "Select#GENERIC_SELECT_VALUE");
 
 		AssertElementPresent(
-			key_fieldLabel = "Sentence Transformer",
+			key_fieldLabel = "Text Embedding Provider",
 			key_value = "Hugging Face Inference API",
 			locator1 = "Select#GENERIC_SELECT_VALUE");
 
 		SystemSettings.openToConfigInSystemSettings(portletId = "com.liferay.search.experiences.configuration.SemanticSearchConfiguration");
 
 		AssertElementPresent(
-			key_fieldLabel = "Sentence Transformer",
+			key_fieldLabel = "Text Embedding Provider",
 			key_value = "txtai",
 			locator1 = "Select#GENERIC_SELECT_VALUE");
 
 		AssertElementPresent(
-			key_fieldLabel = "Sentence Transformer",
+			key_fieldLabel = "Text Embedding Provider",
 			key_value = "Hugging Face Inference API",
 			locator1 = "Select#GENERIC_SELECT_VALUE");
 	}
@@ -301,7 +301,7 @@ definition {
 		PortalSettings.openToConfigInInstanceSettings(portletId = "com.liferay.search.experiences.configuration.SemanticSearchConfiguration");
 
 		Select(
-			ariaLabel = "Sentence Transformer",
+			ariaLabel = "Text Embedding Provider",
 			locator1 = "Select#ANY_ARIA_LABEL",
 			value1 = "txtai");
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-171330

Sending directly because changes were made to build-test-semantic-search.xml and relevant would have run many unnecessary tests due to it's location. Only semantic search functional tests would be affected by changes to that file and they were all passing with these changes in https://github.com/joshchong/liferay-portal/pull/623