### PR TITLE
LPS-155081 Headless APIs miss error message when fail

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/jaxrs/exception/mapper/ObjectEntryManagerHttpExceptionMapper.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/jaxrs/exception/mapper/ObjectEntryManagerHttpExceptionMapper.java
@@ -37,9 +37,4 @@ public class ObjectEntryManagerHttpExceptionMapper
 			objectEntryManagerHttpException.getMessage());
 	}
 
-	@Override
-	protected boolean isSanitize() {
-		return false;
-	}
-
 }

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/jaxrs/exception/mapper/ObjectEntryValuesExceptionMapper.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/jaxrs/exception/mapper/ObjectEntryValuesExceptionMapper.java
@@ -37,9 +37,4 @@ public class ObjectEntryValuesExceptionMapper
 			objectEntryValuesException.getMessage());
 	}
 
-	@Override
-	protected boolean isSanitize() {
-		return false;
-	}
-
 }

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/jaxrs/exception/mapper/ObjectValidationRuleEngineExceptionMapper.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/jaxrs/exception/mapper/ObjectValidationRuleEngineExceptionMapper.java
@@ -36,9 +36,4 @@ public class ObjectValidationRuleEngineExceptionMapper
 			objectValidationRuleEngineException.getMessage());
 	}
 
-	@Override
-	protected boolean isSanitize() {
-		return false;
-	}
-
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/jaxrs/exception/mapper/BaseExceptionMapper.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/jaxrs/exception/mapper/BaseExceptionMapper.java
@@ -68,7 +68,7 @@ public abstract class BaseExceptionMapper<T extends Throwable>
 	protected abstract Problem getProblem(T exception);
 
 	protected boolean isSanitize() {
-		return true;
+		return false;
 	}
 
 	@Context

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/exception/mapper/ExceptionMapper.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/exception/mapper/ExceptionMapper.java
@@ -68,7 +68,8 @@ public class ExceptionMapper extends BaseExceptionMapper<Exception> {
 		_log.error(exception);
 
 		return new Problem(
-			Response.Status.INTERNAL_SERVER_ERROR, exception.getMessage());
+			Response.Status.INTERNAL_SERVER_ERROR,
+			Response.Status.INTERNAL_SERVER_ERROR.getReasonPhrase());
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/exception/mapper/JsonMappingExceptionMapper.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/exception/mapper/JsonMappingExceptionMapper.java
@@ -48,9 +48,7 @@ public class JsonMappingExceptionMapper
 		);
 
 		return new Problem(
-			jsonMappingException.getLocalizedMessage(),
-			Response.Status.BAD_REQUEST, "Unable to map JSON path: " + path,
-			"JsonMappingException");
+			Response.Status.BAD_REQUEST, "Unable to map JSON path: " + path);
 	}
 
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/exception/mapper/NoSuchModelExceptionMapper.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/exception/mapper/NoSuchModelExceptionMapper.java
@@ -36,9 +36,4 @@ public class NoSuchModelExceptionMapper
 			Response.Status.NOT_FOUND, noSuchModelException.getMessage());
 	}
 
-	@Override
-	protected boolean isSanitize() {
-		return false;
-	}
-
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/exception/mapper/UnrecognizedPropertyExceptionMapper.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/exception/mapper/UnrecognizedPropertyExceptionMapper.java
@@ -63,9 +63,4 @@ public class UnrecognizedPropertyExceptionMapper
 		return new Problem(Response.Status.BAD_REQUEST, sb.toString());
 	}
 
-	@Override
-	protected boolean isSanitize() {
-		return false;
-	}
-
 }


### PR DESCRIPTION
Hi Brian, I'm sending this PR directly becasue it could not pass CI [due to unrelated test failures](https://github.com/liferay-headless/liferay-portal/pull/928#issuecomment-1361248812).

With this PR we want to return error messages back into API response, dedicated Exception Mappers will return a specific error message, while all other uncaught exception with just return status 500 with message "Internal Server Error" so we don't leak any security sensitive info.

Please review, thank you.