### PR TITLE
LPS-171347 | master

### DIFF
--- a/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/resource/v1_0/SuggestionResourceImpl.java
+++ b/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/resource/v1_0/SuggestionResourceImpl.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.search.constants.SearchContextAttributes;
 import com.liferay.portal.search.rest.configuration.SearchSuggestionsCompanyConfiguration;
 import com.liferay.portal.search.rest.dto.v1_0.Suggestion;
 import com.liferay.portal.search.rest.dto.v1_0.SuggestionsContributorConfiguration;
@@ -174,7 +175,8 @@ public class SuggestionResourceImpl extends BaseSuggestionResourceImpl {
 
 		SearchContext searchContext = new SearchContext();
 
-		searchContext.setAttribute("search.empty.search", Boolean.TRUE);
+		searchContext.setAttribute(
+			SearchContextAttributes.ATTRIBUTE_KEY_EMPTY_SEARCH, Boolean.TRUE);
 		searchContext.setAttribute(
 			"search.experiences.ip.address",
 			contextHttpServletRequest.getRemoteAddr());

--- a/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/resource/v1_0/SuggestionResourceImpl.java
+++ b/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/resource/v1_0/SuggestionResourceImpl.java
@@ -174,6 +174,7 @@ public class SuggestionResourceImpl extends BaseSuggestionResourceImpl {
 
 		SearchContext searchContext = new SearchContext();
 
+		searchContext.setAttribute("search.empty.search", Boolean.TRUE);
 		searchContext.setAttribute(
 			"search.experiences.ip.address",
 			contextHttpServletRequest.getRemoteAddr());

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/suggestions/spi/SXPBlueprintSuggestionsContributor.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/suggestions/spi/SXPBlueprintSuggestionsContributor.java
@@ -40,6 +40,7 @@ import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.search.constants.SearchContextAttributes;
 import com.liferay.portal.search.document.Document;
 import com.liferay.portal.search.hits.SearchHit;
 import com.liferay.portal.search.hits.SearchHits;
@@ -294,6 +295,10 @@ public class SXPBlueprintSuggestionsContributor
 			size
 		).withSearchContext(
 			searchContext2 -> {
+				searchContext2.setAttribute(
+					SearchContextAttributes.ATTRIBUTE_KEY_EMPTY_SEARCH,
+					searchContext1.getAttribute(
+						SearchContextAttributes.ATTRIBUTE_KEY_EMPTY_SEARCH));
 				searchContext2.setAttribute(
 					"search.experiences.blueprint.id", sxpBlueprintId);
 				searchContext2.setAttribute(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-171347

It was not possible to see the preview because search.empty.search attribute was not added in the search context, so I added it and it will not cause any problem because we have the threshold characters with 2 as the default value. Only if the user wants to change it to zero, the empty search in the suggestions will happen.

Tested in https://github.com/liferay-search/liferay-portal/pull/715
[Failures](https://issues.liferay.com/browse/LPS-171634) are unrelated

cc: @gustavolimav