### PR TITLE
LPS-171082 Only update emailAddressVerified to true if the user is newly created during LDAP import

### DIFF
--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
@@ -1798,7 +1798,10 @@ public class LDAPUserImporterImpl implements LDAPUserImporter, UserImporter {
 			serviceContext.setModifiedDate(modifiedDate);
 		}
 
-		_userLocalService.updateEmailAddressVerified(user.getUserId(), true);
+		if (isNew) {
+			_userLocalService.updateEmailAddressVerified(
+				user.getUserId(), true);
+		}
 
 		user = _userLocalService.updateUser(
 			user.getUserId(), password, StringPool.BLANK, StringPool.BLANK,


### PR DESCRIPTION
[LPS-171082](https://issues.liferay.com/browse/LPS-171082)
Original pr - https://github.com/liferay-appsec/liferay-portal/pull/949

As part of the login, the user data is updated, including the field indicating the email validation. 

### Changes
the method that updates the user when logging in has been modified, so that it does not set that the email has been verified if it is a new user