### PR TITLE
LPS-139647 Add dummy upgrade steps because of the backports

### DIFF
--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/registry/LayoutPageTemplateServiceUpgradeStepRegistrator.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/registry/LayoutPageTemplateServiceUpgradeStepRegistrator.java
@@ -23,7 +23,7 @@ import com.liferay.layout.page.template.internal.upgrade.v1_2_0.LayoutPageTempla
 import com.liferay.layout.page.template.internal.upgrade.v2_0_0.util.LayoutPageTemplateCollectionTable;
 import com.liferay.layout.page.template.internal.upgrade.v2_0_0.util.LayoutPageTemplateEntryTable;
 import com.liferay.layout.page.template.internal.upgrade.v2_1_0.LayoutUpgradeProcess;
-import com.liferay.layout.page.template.internal.upgrade.v3_1_3.ResourcePermissionUpgradeProcess;
+import com.liferay.layout.page.template.internal.upgrade.v3_1_4.ResourcePermissionUpgradeProcess;
 import com.liferay.layout.page.template.internal.upgrade.v3_3_0.LayoutPageTemplateStructureRelUpgradeProcess;
 import com.liferay.layout.page.template.internal.upgrade.v3_4_1.FragmentEntryLinkEditableValuesUpgradeProcess;
 import com.liferay.portal.kernel.service.CompanyLocalService;
@@ -113,11 +113,13 @@ public class LayoutPageTemplateServiceUpgradeStepRegistrator
 
 		registry.register("3.1.1", "3.1.2", new DummyUpgradeStep());
 
-		registry.register(
-			"3.1.2", "3.1.3", new ResourcePermissionUpgradeProcess());
+		registry.register("3.1.2", "3.1.3", new DummyUpgradeStep());
 
 		registry.register(
-			"3.1.3", "3.2.0",
+			"3.1.3", "3.1.4", new ResourcePermissionUpgradeProcess());
+
+		registry.register(
+			"3.1.4", "3.2.0",
 			new com.liferay.layout.page.template.internal.upgrade.v3_2_0.
 				LayoutPageTemplateCollectionUpgradeProcess(),
 			new com.liferay.layout.page.template.internal.upgrade.v3_2_0.
@@ -162,8 +164,10 @@ public class LayoutPageTemplateServiceUpgradeStepRegistrator
 				ResourcePermissionUpgradeProcess(
 					_resourcePermissionLocalService));
 
+		registry.register("3.4.3", "3.4.4", new DummyUpgradeStep());
+
 		registry.register(
-			"3.4.3", "3.5.0",
+			"3.4.4", "3.5.0",
 			new com.liferay.layout.page.template.internal.upgrade.v3_5_0.
 				LayoutPageTemplateStructureRelUpgradeProcess());
 

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v3_1_4/ResourcePermissionUpgradeProcess.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v3_1_4/ResourcePermissionUpgradeProcess.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.layout.page.template.internal.upgrade.v3_1_3;
+package com.liferay.layout.page.template.internal.upgrade.v3_1_4;
 
 import com.liferay.layout.admin.constants.LayoutAdminPortletKeys;
 import com.liferay.layout.page.template.admin.constants.LayoutPageTemplateAdminPortletKeys;


### PR DESCRIPTION
Manually forwarding as test failures are unrelated. 

Original PR: https://github.com/liferay-uniform/liferay-portal/pull/880

---

Hi uniform team,
I worked on this [LPS-139647](https://issues.liferay.com/browse/LPS-139647) and I want to backport the upgrade process to 7.3.x and 7.2.x. To do so, I need to create dummy upgrade steps on master first.

This is the continuation of https://github.com/liferay-uniform/liferay-portal/pull/837

Addressing [achaparro](https://github.com/achaparro)'s concern about whether the upgrade process is rerunnable I think that on a second run it won't do anything because the data will already be purged and it does not do anything else besides data manipulation.

cc: @markgulacsy
