### PR TITLE
LPS-171559 Improvements for upgrade performance test

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -16281,6 +16281,24 @@ url=${short.hostname}:8080</echo>
 
 		<get-java-jdk-home type="${java.jdk.bundle.type}" version="${java.jdk.bundle.version}" />
 
+		<get-testcase-property property.name="custom.startup.timeout" />
+
+		<if>
+			<isset property="custom.startup.timeout" />
+			<then>
+				<math
+					datatype="int"
+					operand1="${custom.startup.timeout}"
+					operand2="1000"
+					operation="*"
+					result="upgrade.client.timeout"
+				/>
+			</then>
+			<else>
+				<property name="upgrade.client.timeout" value="900000" />
+			</else>
+		</if>
+
 		<trycatch property="upgrade.error">
 			<try>
 				<if>
@@ -16291,7 +16309,7 @@ url=${short.hostname}:8080</echo>
 							failonerror="true"
 							fork="true"
 							jar="${liferay.home}/tools/portal-tools-db-upgrade-client/com.liferay.portal.tools.db.upgrade.client.jar"
-							timeout="900000"
+							timeout="${upgrade.client.timeout}"
 						>
 							<env key="JAVA_HOME" value="${java.jdk.home}" />
 							<env key="WAS_HOME" value="${app.server.dir}" />
@@ -16303,7 +16321,7 @@ url=${short.hostname}:8080</echo>
 							failonerror="true"
 							fork="true"
 							jar="${liferay.home}/tools/portal-tools-db-upgrade-client/com.liferay.portal.tools.db.upgrade.client.jar"
-							timeout="900000"
+							timeout="${upgrade.client.timeout}"
 						>
 							<env key="JAVA_HOME" value="${java.jdk.home}" />
 						</java>
@@ -16315,7 +16333,15 @@ url=${short.hostname}:8080</echo>
 					<param name="process.name" value="DBUpgrader" />
 				</antcall>
 
-				<fail message="${upgrade.error}" />
+				<if>
+					<isset property="custom.startup.timeout" />
+					<then>
+						<fail message="${upgrade.error}. Failed to complete the upgrade in ${custom.startup.timeout} seconds." />
+					</then>
+					<else>
+						<fail message="${upgrade.error}" />
+					</else>
+				</if>
 			</catch>
 		</trycatch>
 	</target>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/DatabasePartitioningUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/DatabasePartitioningUpgrade.testcase
@@ -4,7 +4,6 @@ definition {
 	property app.server.types = "tomcat";
 	property database.partition.enabled = "true";
 	property database.types = "mysql";
-	property liferay.online.properties = "true";
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property test.assert.warning.exceptions = "true";
@@ -31,6 +30,7 @@ definition {
 	@priority = "5"
 	test CanUpgradePartitionedDatabase7413U33 {
 		property data.archive.type = "data-archive-portal-partition";
+		property liferay.online.properties = "true";
 		property portal.upgrades = "true";
 		property portal.version = "7.4.13.u33";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/DatabasePartitioningUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/DatabasePartitioningUpgrade.testcase
@@ -12,6 +12,7 @@ definition {
 
 	@priority = "5"
 	test CanUpgradeLargePartitionedDatabase7413U47 {
+		property ci.retries.disabled = "true";
 		property custom.properties = "upgrade.database.auto.run=true";
 		property custom.startup.timeout = "300";
 		property data.archive.type = "data-archive-portal-partition-large";
@@ -20,6 +21,7 @@ definition {
 		property portal.upstream = "false";
 		property portal.version = "7.4.13.u47";
 		property skip.upgrade-legacy-database = "true";
+		property test.assert.warning.exceptions = "false";
 
 		User.firstLoginUI(
 			password = "1234",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/DatabasePartitioningUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/DatabasePartitioningUpgrade.testcase
@@ -11,7 +11,7 @@ definition {
 	property testray.main.component.name = "Database Partitioning";
 
 	@priority = "5"
-	test CanUpgradeLargePartitionedDatabase7413U47 {
+	test CanAutoUpgradeLargePartitionedDatabase7413U47 {
 		property ci.retries.disabled = "true";
 		property custom.properties = "upgrade.database.auto.run=true";
 		property custom.startup.timeout = "300";
@@ -21,6 +21,23 @@ definition {
 		property portal.upstream = "false";
 		property portal.version = "7.4.13.u47";
 		property skip.upgrade-legacy-database = "true";
+		property test.assert.warning.exceptions = "false";
+
+		User.firstLoginUI(
+			password = "1234",
+			specificURL = "http://www.able.com:8080",
+			userEmailAddress = "test@www.able.com");
+	}
+
+	@priority = "5"
+	test CanUpgradeLargePartitionedDatabase7413U47 {
+		property ci.retries.disabled = "true";
+		property custom.startup.timeout = "300";
+		property data.archive.type = "data-archive-portal-partition-large";
+		property minimum.slave.ram = "24";
+		property portal.release = "false";
+		property portal.upstream = "false";
+		property portal.version = "7.4.13.u47";
 		property test.assert.warning.exceptions = "false";
 
 		User.firstLoginUI(

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/DatabasePartitioningUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/DatabasePartitioningUpgrade.testcase
@@ -32,7 +32,7 @@ definition {
 	@priority = "5"
 	test CanUpgradeLargePartitionedDatabase7413U47 {
 		property ci.retries.disabled = "true";
-		property custom.startup.timeout = "480";
+		property custom.startup.timeout = "490";
 		property data.archive.type = "data-archive-portal-partition-large";
 		property minimum.slave.ram = "24";
 		property portal.release = "false";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/DatabasePartitioningUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/DatabasePartitioningUpgrade.testcase
@@ -32,7 +32,7 @@ definition {
 	@priority = "5"
 	test CanUpgradeLargePartitionedDatabase7413U47 {
 		property ci.retries.disabled = "true";
-		property custom.startup.timeout = "300";
+		property custom.startup.timeout = "480";
 		property data.archive.type = "data-archive-portal-partition-large";
 		property minimum.slave.ram = "24";
 		property portal.release = "false";


### PR DESCRIPTION
**Test Plan:**
- Removed testing LOL properties since "this test should be valid for all installations. Only the tests executed in LXC should have those properties" 
- Removed failure on warnings because we are testing performance
- Limit the tests to run once on CI if they fail out
- Add test to run with the upgrade tool alongside having the auto-upgrade test
- Add custom timeout for upgrade tool

**JIRA Ticket:**
https://issues.liferay.com/browse/LPS-171559

Tested here: https://github.com/susanchen3/liferay-portal/pull/104
Reviewed here: https://github.com/vicnate5/liferay-portal/pull/2223#issuecomment-1364154158
