### PR TITLE
LPS-160028 AC Segments are not being sync with DXP

### DIFF
--- a/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/messaging/CheckIndividualSegmentsMessageListener.java
+++ b/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/messaging/CheckIndividualSegmentsMessageListener.java
@@ -39,7 +39,7 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	configurationPid = "com.liferay.segments.asah.connector.internal.configuration.SegmentsAsahConfiguration",
-	configurationPolicy = ConfigurationPolicy.OPTIONAL,
+	configurationPolicy = ConfigurationPolicy.OPTIONAL, immediate = true,
 	service = CheckIndividualSegmentsMessageListener.class
 )
 public class CheckIndividualSegmentsMessageListener


### PR DESCRIPTION
Motivation
=======
AC Segments are not being sync with DXP[Link to story or ticket](https://issues.liferay.com/browse/LPS-160028)

Proposed Solution
========
We need to set **CheckIndividualSegmentsMessageListener** as **immediate**.

There is no tracker/service looking for this message listener, so as no other OSGi service looks up for it,  it never activates, so the Job that syncs the AC segments is never registered.

Steps to Verify:
----------------
1. Create a Segment at AC
1. Update synchronization time to 1 minute
1. Check segment's admin
1. The segment should be visible in DXP after 1 minute

Notes:
----------------

No integration test has been included, since we can't test that the job is correctly executed.

Original PR: https://github.com/liferay-tango/liferay-portal/pull/3133
Failing tests not related with this PR, that is the reason we are sending directly to Brian.