### PR TITLE
LPS-166413 Mark companies in deletion so jobs do not run during that process. This fails with DB Partition only since the Company schema/tables no longer exist

### DIFF
--- a/modules/apps/account/account-service/build.gradle
+++ b/modules/apps/account/account-service/build.gradle
@@ -5,6 +5,7 @@ buildService {
 
 dependencies {
 	compileOnly group: "com.liferay", name: "biz.aQute.bnd.annotation", version: "4.2.0.LIFERAY-PATCHED-2"
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "com.sun.mail", name: "jakarta.mail", version: "1.6.6"
 	compileOnly group: "commons-validator", name: "commons-validator", version: "1.7"

--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/model/listener/AccountGroupModelListener.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/model/listener/AccountGroupModelListener.java
@@ -20,7 +20,7 @@ import com.liferay.account.service.AccountGroupLocalService;
 import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.ModelListener;
-import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.util.PortalInstances;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -33,7 +33,7 @@ public class AccountGroupModelListener extends BaseModelListener<AccountGroup> {
 
 	@Override
 	public void onAfterRemove(AccountGroup accountGroup) {
-		if (CompanyThreadLocal.isDeleteInProcess()) {
+		if (PortalInstances.isCurrentCompanyInDeletionProcess()) {
 			return;
 		}
 

--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/model/listener/RoleModelListener.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/model/listener/RoleModelListener.java
@@ -27,12 +27,12 @@ import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.ModelListener;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.role.RoleConstants;
-import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.ResourceLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.UserGroupRoleLocalService;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.util.PortalInstances;
 
 import java.util.Objects;
 
@@ -108,7 +108,7 @@ public class RoleModelListener extends BaseModelListener<Role> {
 
 	@Override
 	public void onBeforeRemove(Role role) throws ModelListenerException {
-		if (CompanyThreadLocal.isDeleteInProcess()) {
+		if (PortalInstances.isCurrentCompanyInDeletionProcess()) {
 			return;
 		}
 

--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountEntryLocalServiceImpl.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountEntryLocalServiceImpl.java
@@ -63,7 +63,6 @@ import com.liferay.portal.kernel.search.IndexableType;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistryUtil;
 import com.liferay.portal.kernel.search.SearchContext;
-import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.OrganizationLocalService;
@@ -96,6 +95,7 @@ import com.liferay.portal.search.sort.FieldSort;
 import com.liferay.portal.search.sort.SortFieldBuilder;
 import com.liferay.portal.search.sort.SortOrder;
 import com.liferay.portal.search.sort.Sorts;
+import com.liferay.portal.util.PortalInstances;
 import com.liferay.users.admin.kernel.file.uploads.UserFileUploadsSettings;
 
 import java.io.Serializable;
@@ -314,7 +314,7 @@ public class AccountEntryLocalServiceImpl
 
 	@Override
 	public void deleteAccountEntriesByCompanyId(long companyId) {
-		if (!CompanyThreadLocal.isDeleteInProcess()) {
+		if (!PortalInstances.isCurrentCompanyInDeletionProcess()) {
 			throw new UnsupportedOperationException(
 				"Deleting account entries by company must be called when " +
 					"deleting a company");

--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountRoleLocalServiceImpl.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountRoleLocalServiceImpl.java
@@ -35,7 +35,6 @@ import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistryUtil;
 import com.liferay.portal.kernel.search.SortFactory;
-import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.ResourceLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
@@ -55,6 +54,7 @@ import com.liferay.portal.search.searcher.SearchRequestBuilder;
 import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.searcher.SearchResponse;
 import com.liferay.portal.search.searcher.Searcher;
+import com.liferay.portal.util.PortalInstances;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -197,7 +197,7 @@ public class AccountRoleLocalServiceImpl
 	public void deleteAccountRolesByCompanyId(long companyId)
 		throws PortalException {
 
-		if (!CompanyThreadLocal.isDeleteInProcess()) {
+		if (!PortalInstances.isCurrentCompanyInDeletionProcess()) {
 			throw new UnsupportedOperationException(
 				"Deleting account roles by company must be called when " +
 					"deleting a company");

--- a/modules/apps/dispatch/dispatch-service/build.gradle
+++ b/modules/apps/dispatch/dispatch-service/build.gradle
@@ -3,6 +3,7 @@ buildService {
 }
 
 dependencies {
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"

--- a/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/service/impl/DispatchTriggerLocalServiceImpl.java
+++ b/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/service/impl/DispatchTriggerLocalServiceImpl.java
@@ -36,7 +36,6 @@ import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.scheduler.SchedulerException;
-import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.ResourceLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
@@ -44,6 +43,7 @@ import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortalRunMode;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.util.PortalInstances;
 
 import java.util.Date;
 import java.util.List;
@@ -121,7 +121,7 @@ public class DispatchTriggerLocalServiceImpl
 		throws PortalException {
 
 		if (dispatchTrigger.isSystem() &&
-			!CompanyThreadLocal.isDeleteInProcess() &&
+			!PortalInstances.isCurrentCompanyInDeletionProcess() &&
 			!PortalRunMode.isTestMode()) {
 
 			return dispatchTrigger;

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/model/listener/DLStorageQuotaDLFileVersionModelListener.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/model/listener/DLStorageQuotaDLFileVersionModelListener.java
@@ -22,7 +22,7 @@ import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.ModelListener;
-import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.util.PortalInstances;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -46,7 +46,7 @@ public class DLStorageQuotaDLFileVersionModelListener
 	public void onAfterRemove(DLFileVersion dlFileVersion)
 		throws ModelListenerException {
 
-		if (CompanyThreadLocal.isDeleteInProcess()) {
+		if (PortalInstances.isCurrentCompanyInDeletionProcess()) {
 			return;
 		}
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMTemplateLocalServiceImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMTemplateLocalServiceImpl.java
@@ -56,7 +56,6 @@ import com.liferay.portal.kernel.search.IndexableType;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistryUtil;
 import com.liferay.portal.kernel.search.SearchContext;
-import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.ImageLocalService;
 import com.liferay.portal.kernel.service.ResourceLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -73,6 +72,7 @@ import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.util.PortalInstances;
 
 import java.io.File;
 import java.io.IOException;
@@ -427,7 +427,7 @@ public class DDMTemplateLocalServiceImpl
 
 		// Template
 
-		if (!CompanyThreadLocal.isDeleteInProcess()) {
+		if (!PortalInstances.isCurrentCompanyInDeletionProcess()) {
 			int count = _ddmTemplateLinkPersistence.countByTemplateId(
 				template.getTemplateId());
 

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/PortletDataContextFactoryImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/PortletDataContextFactoryImpl.java
@@ -25,7 +25,6 @@ import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.lock.LockManager;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
-import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -37,6 +36,7 @@ import com.liferay.portal.kernel.xml.Element;
 import com.liferay.portal.kernel.xml.SAXReaderUtil;
 import com.liferay.portal.kernel.zip.ZipReader;
 import com.liferay.portal.kernel.zip.ZipWriter;
+import com.liferay.portal.util.PortalInstances;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -231,7 +231,7 @@ public class PortletDataContextFactoryImpl
 			}
 		}
 		catch (Exception exception) {
-			if (CompanyThreadLocal.isDeleteInProcess()) {
+			if (PortalInstances.isCurrentCompanyInDeletionProcess()) {
 				PortletDataException portletDataException =
 					new PortletDataException(
 						PortletDataException.COMPANY_BEING_DELETED, exception);
@@ -256,7 +256,7 @@ public class PortletDataContextFactoryImpl
 			}
 		}
 		catch (Exception exception) {
-			if (CompanyThreadLocal.isDeleteInProcess()) {
+			if (PortalInstances.isCurrentCompanyInDeletionProcess()) {
 				PortletDataException portletDataException =
 					new PortletDataException(
 						PortletDataException.COMPANY_BEING_DELETED, exception);

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -117,6 +117,7 @@ import com.liferay.portal.kernel.workflow.WorkflowInstanceManager;
 import com.liferay.portal.search.batch.DynamicQueryBatchIndexingActionableFactory;
 import com.liferay.portal.search.spi.model.query.contributor.ModelPreFilterContributor;
 import com.liferay.portal.search.spi.model.registrar.ModelSearchRegistrarHelper;
+import com.liferay.portal.util.PortalInstances;
 
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -338,7 +339,7 @@ public class ObjectDefinitionLocalServiceImpl
 			ObjectDefinition objectDefinition)
 		throws PortalException {
 
-		if (!CompanyThreadLocal.isDeleteInProcess() &&
+		if (!PortalInstances.isCurrentCompanyInDeletionProcess() &&
 			!PortalRunMode.isTestMode() && objectDefinition.isSystem()) {
 
 			throw new RequiredObjectDefinitionException();

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/buffer/BufferedIndexerInvocationHandler.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/buffer/BufferedIndexerInvocationHandler.java
@@ -21,12 +21,12 @@ import com.liferay.portal.kernel.model.ClassedModel;
 import com.liferay.portal.kernel.model.ResourcedModel;
 import com.liferay.portal.kernel.search.Bufferable;
 import com.liferay.portal.kernel.search.Indexer;
-import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.PersistedModelLocalService;
 import com.liferay.portal.kernel.service.PersistedModelLocalServiceRegistry;
 import com.liferay.portal.kernel.util.MethodKey;
 import com.liferay.portal.search.configuration.IndexerRegistryConfiguration;
 import com.liferay.portal.search.index.IndexStatusManager;
+import com.liferay.portal.util.PortalInstances;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationHandler;
@@ -77,7 +77,7 @@ public class BufferedIndexerInvocationHandler implements InvocationHandler {
 			return null;
 		}
 
-		if (CompanyThreadLocal.isDeleteInProcess()) {
+		if (PortalInstances.isCurrentCompanyInDeletionProcess()) {
 			if (_log.isDebugEnabled()) {
 				_log.debug(
 					"Skipping indexer request buffer because a company " +

--- a/modules/apps/portal-security/portal-security-service-access-policy-service/src/main/java/com/liferay/portal/security/service/access/policy/service/impl/SAPEntryLocalServiceImpl.java
+++ b/modules/apps/portal-security/portal-security-service-access-policy-service/src/main/java/com/liferay/portal/security/service/access/policy/service/impl/SAPEntryLocalServiceImpl.java
@@ -24,7 +24,6 @@ import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.role.RoleConstants;
-import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.ResourceLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
@@ -45,6 +44,7 @@ import com.liferay.portal.security.service.access.policy.exception.SAPEntryNameE
 import com.liferay.portal.security.service.access.policy.exception.SAPEntryTitleException;
 import com.liferay.portal.security.service.access.policy.model.SAPEntry;
 import com.liferay.portal.security.service.access.policy.service.base.SAPEntryLocalServiceBaseImpl;
+import com.liferay.portal.util.PortalInstances;
 
 import java.util.List;
 import java.util.Locale;
@@ -179,7 +179,9 @@ public class SAPEntryLocalServiceImpl extends SAPEntryLocalServiceBaseImpl {
 	@Override
 	@SystemEvent(type = SystemEventConstants.TYPE_DELETE)
 	public SAPEntry deleteSAPEntry(SAPEntry sapEntry) throws PortalException {
-		if (sapEntry.isSystem() && !CompanyThreadLocal.isDeleteInProcess()) {
+		if (sapEntry.isSystem() &&
+			!PortalInstances.isCurrentCompanyInDeletionProcess()) {
+
 			throw new RequiredSAPEntryException();
 		}
 

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/messaging/test/BaseDBPartitionMessageBusInterceptorTestCase.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/messaging/test/BaseDBPartitionMessageBusInterceptorTestCase.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.util.PortalInstances;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -228,7 +229,7 @@ public abstract class BaseDBPartitionMessageBusInterceptorTestCase
 				DBPartitionUtil.class, "_DATABASE_PARTITION_ENABLED", true);
 
 		try (SafeCloseable safeCloseable =
-				DBPartitionUtil.setCompanyInDeletionProcess(
+				PortalInstances.setCompanyInDeletionProcess(
 					_activeCompanyIds[0])) {
 
 			_countDownLatch = new CountDownLatch(_activeCompanyIds.length);

--- a/modules/apps/portal/portal-db-partition/build.gradle
+++ b/modules/apps/portal/portal-db-partition/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	compileOnly group: "com.liferay", name: "biz.aQute.bnd.annotation", version: "4.2.0.LIFERAY-PATCHED-2"
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "org.osgi", name: "org.osgi.annotation.versioning", version: "1.1.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"

--- a/modules/apps/portal/portal-db-partition/src/main/java/com/liferay/portal/db/partition/internal/messaging/DBPartitionMessageBusInterceptor.java
+++ b/modules/apps/portal/portal-db-partition/src/main/java/com/liferay/portal/db/partition/internal/messaging/DBPartitionMessageBusInterceptor.java
@@ -61,7 +61,7 @@ public class DBPartitionMessageBusInterceptor implements MessageBusInterceptor {
 			_companyLocalService.forEachCompany(
 				company -> {
 					if (!company.isActive() ||
-						DBPartitionUtil.isCompanyInDeletion(
+						DBPartitionUtil.isCompanyInDeletionProcess(
 							company.getCompanyId())) {
 
 						return;

--- a/modules/apps/portal/portal-db-partition/src/main/java/com/liferay/portal/db/partition/internal/messaging/DBPartitionMessageBusInterceptor.java
+++ b/modules/apps/portal/portal-db-partition/src/main/java/com/liferay/portal/db/partition/internal/messaging/DBPartitionMessageBusInterceptor.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.db.partition.internal.messaging;
 
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
+import com.liferay.portal.db.partition.DBPartitionUtil;
 import com.liferay.portal.db.partition.internal.configuration.DBPartitionConfiguration;
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.messaging.MessageBus;
@@ -59,7 +60,10 @@ public class DBPartitionMessageBusInterceptor implements MessageBusInterceptor {
 
 			_companyLocalService.forEachCompany(
 				company -> {
-					if (!company.isActive()) {
+					if (!company.isActive() ||
+						DBPartitionUtil.isCompanyInDeletion(
+							company.getCompanyId())) {
+
 						return;
 					}
 

--- a/modules/apps/portal/portal-db-partition/src/main/java/com/liferay/portal/db/partition/internal/messaging/DBPartitionMessageBusInterceptor.java
+++ b/modules/apps/portal/portal-db-partition/src/main/java/com/liferay/portal/db/partition/internal/messaging/DBPartitionMessageBusInterceptor.java
@@ -15,7 +15,6 @@
 package com.liferay.portal.db.partition.internal.messaging;
 
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
-import com.liferay.portal.db.partition.DBPartitionUtil;
 import com.liferay.portal.db.partition.internal.configuration.DBPartitionConfiguration;
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.messaging.MessageBus;
@@ -26,6 +25,7 @@ import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Props;
 import com.liferay.portal.kernel.util.SetUtil;
+import com.liferay.portal.util.PortalInstances;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -61,7 +61,7 @@ public class DBPartitionMessageBusInterceptor implements MessageBusInterceptor {
 			_companyLocalService.forEachCompany(
 				company -> {
 					if (!company.isActive() ||
-						DBPartitionUtil.isCompanyInDeletionProcess(
+						PortalInstances.isCompanyInDeletionProcess(
 							company.getCompanyId())) {
 
 						return;

--- a/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
+++ b/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
@@ -163,10 +163,6 @@ public class DBPartitionUtil {
 		return companyId;
 	}
 
-	public static boolean isCompanyInDeletionProcess(long companyId) {
-		return _companyIdsInDeletionProcess.contains(companyId);
-	}
-
 	public static boolean isPartitionEnabled() {
 		return _DATABASE_PARTITION_ENABLED;
 	}
@@ -183,22 +179,6 @@ public class DBPartitionUtil {
 		}
 
 		return _dropDBPartition(companyId);
-	}
-
-	public static SafeCloseable setCompanyInDeletionProcess(long companyId) {
-		if (!_DATABASE_PARTITION_ENABLED) {
-			return () -> {
-			};
-		}
-
-		if (_companyIdsInDeletionProcess.contains(companyId)) {
-			throw new UnsupportedOperationException(
-				companyId + " is already in deletion");
-		}
-
-		_companyIdsInDeletionProcess.add(companyId);
-
-		return () -> _companyIdsInDeletionProcess.remove(companyId);
 	}
 
 	public static void setDefaultCompanyId(Connection connection)
@@ -810,8 +790,6 @@ public class DBPartitionUtil {
 		DBPartitionUtil.class);
 
 	private static final List<Long> _companyIds = new CopyOnWriteArrayList<>();
-	private static final List<Long> _companyIdsInDeletionProcess =
-		new CopyOnWriteArrayList<>();
 	private static final Set<String> _controlTableNames = new HashSet<>(
 		Arrays.asList("company", "virtualhost"));
 	private static volatile long _defaultCompanyId;

--- a/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
+++ b/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
@@ -163,6 +163,10 @@ public class DBPartitionUtil {
 		return companyId;
 	}
 
+	public static boolean isCompanyInDeletion(long companyId) {
+		return _inDeletionCompanyIds.contains(companyId);
+	}
+
 	public static boolean isPartitionEnabled() {
 		return _DATABASE_PARTITION_ENABLED;
 	}
@@ -202,6 +206,17 @@ public class DBPartitionUtil {
 		if (_DATABASE_PARTITION_ENABLED) {
 			_defaultCompanyId = companyId;
 		}
+	}
+
+	public static SafeCloseable setInDeletionCompany(long companyId) {
+		if (_inDeletionCompanyIds.contains(companyId)) {
+			throw new UnsupportedOperationException(
+				companyId + " is already in deletion");
+		}
+
+		_inDeletionCompanyIds.add(companyId);
+
+		return () -> _inDeletionCompanyIds.remove(companyId);
 	}
 
 	public static DataSource wrapDataSource(DataSource dataSource)
@@ -794,5 +809,7 @@ public class DBPartitionUtil {
 		Arrays.asList("company", "virtualhost"));
 	private static volatile long _defaultCompanyId;
 	private static String _defaultSchemaName;
+	private static final List<Long> _inDeletionCompanyIds =
+		new CopyOnWriteArrayList<>();
 
 }

--- a/portal-impl/src/com/liferay/portal/search/IndexableAdvice.java
+++ b/portal-impl/src/com/liferay/portal/search/IndexableAdvice.java
@@ -26,8 +26,8 @@ import com.liferay.portal.kernel.search.IndexableType;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistryUtil;
 import com.liferay.portal.kernel.search.SearchException;
-import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.util.PortalInstances;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
@@ -75,11 +75,11 @@ public class IndexableAdvice extends ChainableMethodAdvice {
 			return;
 		}
 
-		if (CompanyThreadLocal.isDeleteInProcess() ||
+		if (PortalInstances.isCurrentCompanyInDeletionProcess() ||
 			IndexWriterHelperUtil.isIndexReadOnly()) {
 
 			if (_log.isDebugEnabled()) {
-				if (CompanyThreadLocal.isDeleteInProcess()) {
+				if (PortalInstances.isCurrentCompanyInDeletionProcess()) {
 					_log.debug(
 						"Skip indexing because company delete is in process");
 				}

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -1228,7 +1228,7 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 
 		if (DBPartitionUtil.isPartitionEnabled()) {
 			try (SafeCloseable safeCloseable =
-					DBPartitionUtil.setInDeletionCompany(companyId)) {
+					DBPartitionUtil.setCompanyInDeletionProcess(companyId)) {
 
 				_clearCompanyCache(companyId);
 				_clearVirtualHostCache(companyId);

--- a/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
@@ -86,7 +86,6 @@ import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.scheduler.SchedulerEngineHelperUtil;
 import com.liferay.portal.kernel.scheduler.StorageType;
 import com.liferay.portal.kernel.search.reindexer.ReindexerBridge;
-import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.HttpPrincipal;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.auth.RemoteAuthException;
@@ -164,6 +163,7 @@ import com.liferay.portal.service.http.ClassNameServiceHttp;
 import com.liferay.portal.service.http.GroupServiceHttp;
 import com.liferay.portal.theme.ThemeLoader;
 import com.liferay.portal.theme.ThemeLoaderFactory;
+import com.liferay.portal.util.PortalInstances;
 import com.liferay.portal.util.PropsValues;
 import com.liferay.social.kernel.service.SocialActivityLocalService;
 import com.liferay.social.kernel.service.SocialActivitySettingLocalService;
@@ -865,7 +865,7 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 
 			if (((group.isCompany() && !group.isCompanyStagingGroup()) ||
 				 PortalUtil.isSystemGroup(group.getGroupKey())) &&
-				!CompanyThreadLocal.isDeleteInProcess()) {
+				!PortalInstances.isCurrentCompanyInDeletionProcess()) {
 
 				throw new RequiredGroupException.MustNotDeleteSystemGroup(
 					group.getGroupId());

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutPrototypeLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutPrototypeLocalServiceImpl.java
@@ -28,7 +28,6 @@ import com.liferay.portal.kernel.model.LayoutPrototype;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
-import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.ResourceLocalService;
@@ -42,6 +41,7 @@ import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.base.LayoutPrototypeLocalServiceBaseImpl;
+import com.liferay.portal.util.PortalInstances;
 
 import java.util.Date;
 import java.util.List;
@@ -132,7 +132,7 @@ public class LayoutPrototypeLocalServiceImpl
 
 		// Group
 
-		if (!CompanyThreadLocal.isDeleteInProcess()) {
+		if (!PortalInstances.isCurrentCompanyInDeletionProcess()) {
 			int count = _layoutPersistence.countByC_L(
 				layoutPrototype.getCompanyId(), layoutPrototype.getUuid());
 

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutSetPrototypeLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutSetPrototypeLocalServiceImpl.java
@@ -23,7 +23,6 @@ import com.liferay.portal.kernel.model.LayoutSetPrototype;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
-import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -35,6 +34,7 @@ import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.service.base.LayoutSetPrototypeLocalServiceBaseImpl;
+import com.liferay.portal.util.PortalInstances;
 
 import java.util.Date;
 import java.util.List;
@@ -136,7 +136,7 @@ public class LayoutSetPrototypeLocalServiceImpl
 
 		// Group
 
-		if (!CompanyThreadLocal.isDeleteInProcess()) {
+		if (!PortalInstances.isCurrentCompanyInDeletionProcess()) {
 			long count = _layoutSetPersistence.countByC_L(
 				layoutSetPrototype.getCompanyId(),
 				layoutSetPrototype.getUuid());

--- a/portal-impl/src/com/liferay/portal/service/impl/OrganizationLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/OrganizationLocalServiceImpl.java
@@ -53,7 +53,6 @@ import com.liferay.portal.kernel.search.SearchException;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.SortFactoryUtil;
 import com.liferay.portal.kernel.search.reindexer.ReindexerBridge;
-import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.AddressLocalService;
 import com.liferay.portal.kernel.service.EmailAddressLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
@@ -90,6 +89,7 @@ import com.liferay.portal.kernel.util.comparator.OrganizationIdComparator;
 import com.liferay.portal.kernel.util.comparator.OrganizationNameComparator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.service.base.OrganizationLocalServiceBaseImpl;
+import com.liferay.portal.util.PortalInstances;
 import com.liferay.portal.util.PropsValues;
 import com.liferay.portlet.usersadmin.search.OrganizationUsersSearcher;
 import com.liferay.users.admin.kernel.file.uploads.UserFileUploadsSettings;
@@ -518,7 +518,7 @@ public class OrganizationLocalServiceImpl
 	public Organization deleteOrganization(Organization organization)
 		throws PortalException {
 
-		if (!CompanyThreadLocal.isDeleteInProcess()) {
+		if (!PortalInstances.isCurrentCompanyInDeletionProcess()) {
 			int count1 = organizationPersistence.countByC_P(
 				organization.getCompanyId(), organization.getOrganizationId());
 			int count2 = _userFinder.countByKeywords(

--- a/portal-impl/src/com/liferay/portal/service/impl/PasswordPolicyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PasswordPolicyLocalServiceImpl.java
@@ -27,7 +27,6 @@ import com.liferay.portal.kernel.model.PasswordPolicyRel;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
-import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.ldap.LDAPSettingsUtil;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.PasswordPolicyRelLocalService;
@@ -41,6 +40,7 @@ import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.service.base.PasswordPolicyLocalServiceBaseImpl;
+import com.liferay.portal.util.PortalInstances;
 import com.liferay.portal.util.PropsValues;
 
 import java.util.List;
@@ -202,7 +202,7 @@ public class PasswordPolicyLocalServiceImpl
 		throws PortalException {
 
 		if (passwordPolicy.isDefaultPolicy() &&
-			!CompanyThreadLocal.isDeleteInProcess()) {
+			!PortalInstances.isCurrentCompanyInDeletionProcess()) {
 
 			throw new RequiredPasswordPolicyException();
 		}

--- a/portal-impl/src/com/liferay/portal/service/impl/RoleLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/RoleLocalServiceImpl.java
@@ -72,7 +72,6 @@ import com.liferay.portal.kernel.portlet.PortletProviderUtil;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistryUtil;
 import com.liferay.portal.kernel.search.SearchException;
-import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
@@ -108,6 +107,7 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.security.permission.PermissionCacheUtil;
 import com.liferay.portal.service.base.RoleLocalServiceBaseImpl;
+import com.liferay.portal.util.PortalInstances;
 import com.liferay.portal.util.PropsUtil;
 import com.liferay.portal.util.PropsValues;
 import com.liferay.users.admin.kernel.util.UsersAdminUtil;
@@ -448,7 +448,9 @@ public class RoleLocalServiceImpl extends RoleLocalServiceBaseImpl {
 		type = SystemEventConstants.TYPE_DELETE
 	)
 	public Role deleteRole(Role role) throws PortalException {
-		if (role.isSystem() && !CompanyThreadLocal.isDeleteInProcess()) {
+		if (role.isSystem() &&
+			!PortalInstances.isCurrentCompanyInDeletionProcess()) {
+
 			throw new RequiredRoleException();
 		}
 

--- a/portal-impl/src/com/liferay/portal/service/impl/SystemEventLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/SystemEventLocalServiceImpl.java
@@ -24,7 +24,6 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.SystemEvent;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
-import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.persistence.CompanyPersistence;
@@ -34,6 +33,7 @@ import com.liferay.portal.kernel.systemevent.SystemEventHierarchyEntry;
 import com.liferay.portal.kernel.systemevent.SystemEventHierarchyEntryThreadLocal;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.service.base.SystemEventLocalServiceBaseImpl;
+import com.liferay.portal.util.PortalInstances;
 import com.liferay.portal.util.PropsValues;
 
 import java.util.Calendar;
@@ -188,7 +188,7 @@ public class SystemEventLocalServiceImpl
 			}
 		}
 
-		if (!CompanyThreadLocal.isDeleteInProcess()) {
+		if (!PortalInstances.isCurrentCompanyInDeletionProcess()) {
 			Company company = _companyPersistence.findByPrimaryKey(companyId);
 
 			Group companyGroup = company.getGroup();

--- a/portal-impl/src/com/liferay/portal/service/impl/UserGroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserGroupLocalServiceImpl.java
@@ -52,7 +52,6 @@ import com.liferay.portal.kernel.search.SearchException;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.SortFactoryUtil;
 import com.liferay.portal.kernel.search.reindexer.ReindexerBridge;
-import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.security.exportimport.UserGroupImportTransactionThreadLocal;
 import com.liferay.portal.kernel.service.GroupLocalService;
@@ -77,6 +76,7 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.service.base.UserGroupLocalServiceBaseImpl;
 import com.liferay.portal.service.persistence.constants.UserGroupFinderConstants;
+import com.liferay.portal.util.PortalInstances;
 import com.liferay.portal.util.PropsValues;
 import com.liferay.users.admin.kernel.util.UsersAdminUtil;
 
@@ -366,7 +366,7 @@ public class UserGroupLocalServiceImpl extends UserGroupLocalServiceBaseImpl {
 	public UserGroup deleteUserGroup(UserGroup userGroup)
 		throws PortalException {
 
-		if (!CompanyThreadLocal.isDeleteInProcess()) {
+		if (!PortalInstances.isCurrentCompanyInDeletionProcess()) {
 			int count = _userFinder.countByKeywords(
 				userGroup.getCompanyId(), null,
 				WorkflowConstants.STATUS_APPROVED,

--- a/portal-impl/src/com/liferay/portal/util/PortalInstances.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalInstances.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.util;
 
 import com.liferay.petra.io.StreamUtil;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.events.EventsProcessorUtil;
 import com.liferay.portal.kernel.cookies.CookiesManagerUtil;
@@ -451,6 +452,15 @@ public class PortalInstances {
 		return false;
 	}
 
+	public static boolean isCompanyInDeletionProcess(long companyId) {
+		return _companyIdsInDeletionProcess.contains(companyId);
+	}
+
+	public static boolean isCurrentCompanyInDeletionProcess() {
+		return _companyIdsInDeletionProcess.contains(
+			CompanyThreadLocal.getCompanyId());
+	}
+
 	public static boolean isVirtualHostsIgnoreHost(String host) {
 		return _virtualHostsIgnoreHosts.contains(host);
 	}
@@ -487,6 +497,17 @@ public class PortalInstances {
 		getWebIds();
 
 		WebAppPool.remove(companyId, WebKeys.PORTLET_CATEGORY);
+	}
+
+	public static SafeCloseable setCompanyInDeletionProcess(long companyId) {
+		if (_companyIdsInDeletionProcess.contains(companyId)) {
+			throw new UnsupportedOperationException(
+				companyId + " is already in deletion");
+		}
+
+		_companyIdsInDeletionProcess.add(companyId);
+
+		return () -> _companyIdsInDeletionProcess.remove(companyId);
 	}
 
 	private static long _getCompanyIdByHost(
@@ -631,6 +652,8 @@ public class PortalInstances {
 	private static final Set<String> _autoLoginIgnoreHosts;
 	private static final Set<String> _autoLoginIgnorePaths;
 	private static final CopyOnWriteArrayList<Long> _companyIds;
+	private static final List<Long> _companyIdsInDeletionProcess =
+		new CopyOnWriteArrayList<>();
 	private static final Set<String> _virtualHostsIgnoreHosts;
 	private static final Set<String> _virtualHostsIgnorePaths;
 	private static String[] _webIds;

--- a/portal-impl/src/com/liferay/portal/util/packageinfo
+++ b/portal-impl/src/com/liferay/portal/util/packageinfo
@@ -1,1 +1,1 @@
-version 41.0.0
+version 41.1.0

--- a/portal-kernel/src/com/liferay/portal/kernel/security/auth/CompanyThreadLocal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/auth/CompanyThreadLocal.java
@@ -41,10 +41,6 @@ public class CompanyThreadLocal {
 		return companyId;
 	}
 
-	public static boolean isDeleteInProcess() {
-		return _deleteInProcess.get();
-	}
-
 	public static boolean isInitializingPortalInstance() {
 		return _initializingPortalInstance.get();
 	}
@@ -69,10 +65,6 @@ public class CompanyThreadLocal {
 		if (_setCompanyId(companyId)) {
 			CTCollectionThreadLocal.removeCTCollectionId();
 		}
-	}
-
-	public static void setDeleteInProcess(boolean deleteInProcess) {
-		_deleteInProcess.set(deleteInProcess);
 	}
 
 	public static SafeCloseable setInitializingCompanyIdWithSafeCloseable(
@@ -153,10 +145,6 @@ public class CompanyThreadLocal {
 		new CentralizedThreadLocal<>(
 			CompanyThreadLocal.class + "._companyId",
 			() -> CompanyConstants.SYSTEM);
-	private static final ThreadLocal<Boolean> _deleteInProcess =
-		new CentralizedThreadLocal<>(
-			CompanyThreadLocal.class + "._deleteInProcess",
-			() -> Boolean.FALSE);
 	private static final CentralizedThreadLocal<Boolean>
 		_initializingPortalInstance = new CentralizedThreadLocal<>(
 			CompanyThreadLocal.class + "._initializingPortalInstance",

--- a/portal-kernel/src/com/liferay/portal/kernel/security/auth/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/auth/packageinfo
@@ -1,1 +1,1 @@
-version 5.1.0
+version 6.0.0


### PR DESCRIPTION
- LPS-166413 New API to know if a company is being deleted when database partitioning is active
- LPS-166413 Applying the new API to the company deletion process
- LPS-166413 When a scheduled job is intercepted with database partitioning active, if the company is under deletion, we skip the job fo that company
- LPS-166413 Take into account when DB Partition is not enabled, just in case. Rewording
- LPS-166413 Adding tests to be sure jobs do not run when a company is being deleted. This fails with DB Partition only because it does not find the schema/table
- LPS-166413 Simplifying similar implementations in one single point at PortalInstances class
- LPS-166413 Applying new API to all uses in the portal
