### PR TITLE
LPS-170299 Implement merge of FDS Autocomplete and Selection filters

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-api/bnd.bnd
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Frontend Data Set API
 Bundle-SymbolicName: com.liferay.frontend.data.set.api
-Bundle-Version: 11.2.2
+Bundle-Version: 11.3.0
 Export-Package:\
 	com.liferay.frontend.data.set.constants,\
 	com.liferay.frontend.data.set.filter,\

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/filter/BaseSelectionFDSFilter.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/filter/BaseSelectionFDSFilter.java
@@ -16,6 +16,7 @@ package com.liferay.frontend.data.set.filter;
 
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.ResourceBundle;
@@ -25,17 +26,40 @@ import java.util.ResourceBundle;
  */
 public abstract class BaseSelectionFDSFilter implements FDSFilter {
 
+	public String getAPIURL() {
+		return null;
+	}
+
+	public String getItemKey() {
+		return null;
+	}
+
+	public String getItemLabel() {
+		return null;
+	}
+
+	public String getPlaceholder() {
+		return "search";
+	}
+
 	public ResourceBundle getResourceBundle(Locale locale) {
 		return ResourceBundleUtil.getBundle(
 			"content.Language", locale, getClass());
 	}
 
-	public abstract List<SelectionFDSFilterItem> getSelectionFDSFilterItems(
-		Locale locale);
+	public List<SelectionFDSFilterItem> getSelectionFDSFilterItems(
+		Locale locale) {
+
+		return Collections.emptyList();
+	}
 
 	@Override
 	public String getType() {
 		return "selection";
+	}
+
+	public boolean isAutocompleteEnabled() {
+		return false;
 	}
 
 	public boolean isMultiple() {

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/resources/com/liferay/frontend/data/set/filter/packageinfo
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/resources/com/liferay/frontend/data/set/filter/packageinfo
@@ -1,1 +1,1 @@
-version 6.0.0
+version 6.1.0

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/filter/SelectionFDSFilterContextContributor.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/filter/SelectionFDSFilterContextContributor.java
@@ -79,11 +79,30 @@ public class SelectionFDSFilterContextContributor
 				));
 		}
 
-		return HashMapBuilder.<String, Object>put(
-			"items", jsonArray
-		).put(
-			"multiple", baseSelectionFDSFilter.isMultiple()
-		).build();
+		HashMapBuilder.HashMapWrapper<String, Object> builder =
+			HashMapBuilder.<String, Object>put(
+				"autocompleteEnabled",
+				baseSelectionFDSFilter.isAutocompleteEnabled()
+			).put(
+				"items", jsonArray
+			).put(
+				"multiple", baseSelectionFDSFilter.isMultiple()
+			);
+
+		if (baseSelectionFDSFilter.isAutocompleteEnabled()) {
+			builder.put(
+				"apiURL", baseSelectionFDSFilter.getAPIURL()
+			).put(
+				"inputPlaceholder",
+				_language.get(locale, baseSelectionFDSFilter.getPlaceholder())
+			).put(
+				"itemKey", baseSelectionFDSFilter.getItemKey()
+			).put(
+				"itemLabel", baseSelectionFDSFilter.getItemLabel()
+			);
+		}
+
+		return builder.build();
 	}
 
 	@Reference

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/filter/ColorSelectionFDSFilter.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/filter/ColorSelectionFDSFilter.java
@@ -51,7 +51,11 @@ public class ColorSelectionFDSFilter extends BaseSelectionFDSFilter {
 		return HashMapBuilder.<String, Object>put(
 			"exclude", false
 		).put(
-			"itemsValues", new String[] {"Blue", "Green", "Yellow"}
+			"selectedItems",
+			ListUtil.fromArray(
+				new SelectionFDSFilterItem("Blue", "Blue"),
+				new SelectionFDSFilterItem("Green", "Green"),
+				new SelectionFDSFilterItem("Yellow", "Yellow"))
 		).build();
 	}
 

--- a/modules/apps/object/object-api/bnd.bnd
+++ b/modules/apps/object/object-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Object API
 Bundle-SymbolicName: com.liferay.object.api
-Bundle-Version: 51.0.1
+Bundle-Version: 52.0.0
 Export-Package:\
 	com.liferay.object.action.engine,\
 	com.liferay.object.action.executor,\

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/field/filter/parser/BaseObjectFieldFilterStrategy.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/field/filter/parser/BaseObjectFieldFilterStrategy.java
@@ -52,7 +52,7 @@ public abstract class BaseObjectFieldFilterStrategy
 			ObjectViewFilterColumnConstants.FILTER_TYPE_EXCLUDES.equals(
 				objectViewFilterColumn.getFilterType())
 		).put(
-			"itemsValues", getItemsValues()
+			"selectedItems", getSelectionFDSFilterItems()
 		).build();
 	}
 

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/field/filter/parser/ObjectFieldFilterStrategy.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/field/filter/parser/ObjectFieldFilterStrategy.java
@@ -15,8 +15,10 @@
 package com.liferay.object.field.filter.parser;
 
 import com.liferay.frontend.data.set.filter.FDSFilter;
+import com.liferay.frontend.data.set.filter.SelectionFDSFilterItem;
 import com.liferay.portal.kernel.exception.PortalException;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -26,7 +28,8 @@ public interface ObjectFieldFilterStrategy {
 
 	public FDSFilter getFDSFilter() throws PortalException;
 
-	public Object getItemsValues() throws PortalException;
+	public List<SelectionFDSFilterItem> getSelectionFDSFilterItems()
+		throws PortalException;
 
 	public Map<String, Object> parse() throws PortalException;
 

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/field/filter/parser/OneToManyObjectFieldFilterStrategy.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/field/filter/parser/OneToManyObjectFieldFilterStrategy.java
@@ -127,10 +127,10 @@ public class OneToManyObjectFieldFilterStrategy
 	public List<SelectionFDSFilterItem> getSelectionFDSFilterItems()
 		throws PortalException {
 
+		JSONArray jsonArray = getJSONArray();
+
 		List<SelectionFDSFilterItem> selectionFDSFilterItems =
 			new ArrayList<>();
-
-		JSONArray jsonArray = getJSONArray();
 
 		if (_objectDefinition1.isSystem()) {
 			for (int i = 0; i < jsonArray.length(); i++) {

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/field/filter/parser/OneToManyObjectFieldFilterStrategy.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/field/filter/parser/OneToManyObjectFieldFilterStrategy.java
@@ -15,8 +15,9 @@
 package com.liferay.object.field.filter.parser;
 
 import com.liferay.frontend.data.set.filter.FDSFilter;
+import com.liferay.frontend.data.set.filter.SelectionFDSFilterItem;
 import com.liferay.object.exception.ObjectViewFilterColumnException;
-import com.liferay.object.field.frontend.data.set.filter.OneToManyAutocompleteFDSFilter;
+import com.liferay.object.field.frontend.data.set.filter.OneToManySelectionFDSFilter;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.model.ObjectField;
@@ -37,7 +38,6 @@ import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.service.PersistedModelLocalService;
 import com.liferay.portal.kernel.service.PersistedModelLocalServiceRegistry;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -45,7 +45,6 @@ import com.liferay.portal.kernel.util.Validator;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 
 /**
  * @author Feliphe Marinho
@@ -119,31 +118,31 @@ public class OneToManyObjectFieldFilterStrategy
 			restContextPath = "/o" + objectDefinition1.getRESTContextPath();
 		}
 
-		return new OneToManyAutocompleteFDSFilter(
+		return new OneToManySelectionFDSFilter(
 			parse(), restContextPath, titleObjectField.getLabel(locale),
 			_objectField.getName(), titleObjectField.getName());
 	}
 
 	@Override
-	public List<Map<String, Object>> getItemsValues() throws PortalException {
-		List<Map<String, Object>> itemsValues = new ArrayList<>();
+	public List<SelectionFDSFilterItem> getSelectionFDSFilterItems()
+		throws PortalException {
+
+		List<SelectionFDSFilterItem> selectionFDSFilterItems =
+			new ArrayList<>();
 
 		JSONArray jsonArray = getJSONArray();
 
 		if (_objectDefinition1.isSystem()) {
 			for (int i = 0; i < jsonArray.length(); i++) {
-				itemsValues.add(
-					HashMapBuilder.<String, Object>put(
-						"label",
+				selectionFDSFilterItems.add(
+					new SelectionFDSFilterItem(
 						_objectEntryLocalService.getTitleValue(
 							_objectDefinition1.getObjectDefinitionId(),
-							GetterUtil.getLong(jsonArray.get(i)))
-					).put(
-						"value", jsonArray.getLong(i)
-					).build());
+							GetterUtil.getLong(jsonArray.get(i))),
+						jsonArray.getLong(i)));
 			}
 
-			return itemsValues;
+			return selectionFDSFilterItems;
 		}
 
 		for (int i = 0; i < jsonArray.length(); i++) {
@@ -155,22 +154,21 @@ public class OneToManyObjectFieldFilterStrategy
 				continue;
 			}
 
-			itemsValues.add(
-				HashMapBuilder.<String, Object>put(
-					"label", objectEntry.getTitleValue()
-				).put(
-					"value", objectEntry.getObjectEntryId()
-				).build());
+			selectionFDSFilterItems.add(
+				new SelectionFDSFilterItem(
+					objectEntry.getTitleValue(),
+					objectEntry.getObjectEntryId()));
 		}
 
-		return itemsValues;
+		return selectionFDSFilterItems;
 	}
 
 	@Override
 	public String toValueSummary() throws PortalException {
 		return StringUtil.merge(
 			ListUtil.toList(
-				getItemsValues(), itemValue -> itemValue.get("label")),
+				getSelectionFDSFilterItems(),
+				selectionFDSFilterItem -> selectionFDSFilterItem.getLabel()),
 			StringPool.COMMA_AND_SPACE);
 	}
 

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/field/filter/parser/PicklistObjectFieldFilterStrategy.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/field/filter/parser/PicklistObjectFieldFilterStrategy.java
@@ -15,26 +15,25 @@
 package com.liferay.object.field.filter.parser;
 
 import com.liferay.frontend.data.set.filter.FDSFilter;
+import com.liferay.frontend.data.set.filter.SelectionFDSFilterItem;
 import com.liferay.list.type.model.ListTypeDefinition;
 import com.liferay.list.type.model.ListTypeEntry;
 import com.liferay.list.type.service.ListTypeDefinitionLocalService;
 import com.liferay.list.type.service.ListTypeEntryLocalService;
 import com.liferay.object.constants.ObjectFieldConstants;
-import com.liferay.object.field.frontend.data.set.filter.ListTypeEntryAutocompleteFDSFilter;
+import com.liferay.object.field.frontend.data.set.filter.ListTypeEntrySelectionFDSFilter;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.ObjectViewFilterColumn;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONException;
-import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 
 /**
  * @author Feliphe Marinho
@@ -63,7 +62,7 @@ public class PicklistObjectFieldFilterStrategy
 			_listTypeDefinitionLocalService.getListTypeDefinition(
 				_objectField.getListTypeDefinitionId());
 
-		return new ListTypeEntryAutocompleteFDSFilter(
+		return new ListTypeEntrySelectionFDSFilter(
 			StringUtil.equals(
 				_objectField.getBusinessType(),
 				ObjectFieldConstants.BUSINESS_TYPE_MULTISELECT_PICKLIST),
@@ -72,8 +71,11 @@ public class PicklistObjectFieldFilterStrategy
 	}
 
 	@Override
-	public List<Map<String, String>> getItemsValues() throws JSONException {
-		List<Map<String, String>> itemsValues = new ArrayList<>();
+	public List<SelectionFDSFilterItem> getSelectionFDSFilterItems()
+		throws JSONException {
+
+		List<SelectionFDSFilterItem> selectionFDSFilterItems =
+			new ArrayList<>();
 
 		JSONArray jsonArray = getJSONArray();
 
@@ -82,22 +84,20 @@ public class PicklistObjectFieldFilterStrategy
 				_listTypeEntryLocalService.fetchListTypeEntry(
 					_listTypeDefinitionId, jsonArray.getString(i));
 
-			itemsValues.add(
-				HashMapBuilder.put(
-					"label", listTypeEntry.getName(locale)
-				).put(
-					"value", jsonArray.getString(i)
-				).build());
+			selectionFDSFilterItems.add(
+				new SelectionFDSFilterItem(
+					listTypeEntry.getName(locale), jsonArray.getString(i)));
 		}
 
-		return itemsValues;
+		return selectionFDSFilterItems;
 	}
 
 	@Override
 	public String toValueSummary() throws PortalException {
 		return StringUtil.merge(
 			ListUtil.toList(
-				getItemsValues(), itemValue -> itemValue.get("label")),
+				getSelectionFDSFilterItems(),
+				selectionFDSFilterItem -> selectionFDSFilterItem.getLabel()),
 			StringPool.COMMA_AND_SPACE);
 	}
 

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/field/filter/parser/PicklistObjectFieldFilterStrategy.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/field/filter/parser/PicklistObjectFieldFilterStrategy.java
@@ -74,10 +74,10 @@ public class PicklistObjectFieldFilterStrategy
 	public List<SelectionFDSFilterItem> getSelectionFDSFilterItems()
 		throws JSONException {
 
+		JSONArray jsonArray = getJSONArray();
+
 		List<SelectionFDSFilterItem> selectionFDSFilterItems =
 			new ArrayList<>();
-
-		JSONArray jsonArray = getJSONArray();
 
 		for (int i = 0; i < jsonArray.length(); i++) {
 			ListTypeEntry listTypeEntry =

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/field/filter/parser/StatusSystemObjectFieldFilterStrategy.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/field/filter/parser/StatusSystemObjectFieldFilterStrategy.java
@@ -56,10 +56,10 @@ public class StatusSystemObjectFieldFilterStrategy
 	public List<SelectionFDSFilterItem> getSelectionFDSFilterItems()
 		throws JSONException {
 
+		JSONArray jsonArray = getJSONArray();
+
 		List<SelectionFDSFilterItem> selectionFDSFilterItems =
 			new ArrayList<>();
-
-		JSONArray jsonArray = getJSONArray();
 
 		for (int i = 0; i < jsonArray.length(); i++) {
 			Integer status = (Integer)jsonArray.get(i);

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/field/filter/parser/StatusSystemObjectFieldFilterStrategy.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/field/filter/parser/StatusSystemObjectFieldFilterStrategy.java
@@ -15,6 +15,7 @@
 package com.liferay.object.field.filter.parser;
 
 import com.liferay.frontend.data.set.filter.FDSFilter;
+import com.liferay.frontend.data.set.filter.SelectionFDSFilterItem;
 import com.liferay.object.exception.ObjectViewFilterColumnException;
 import com.liferay.object.field.frontend.data.set.filter.ObjectEntryStatusSelectionFDSFilter;
 import com.liferay.object.model.ObjectViewFilterColumn;
@@ -52,25 +53,34 @@ public class StatusSystemObjectFieldFilterStrategy
 	}
 
 	@Override
-	public List<Integer> getItemsValues() throws JSONException {
+	public List<SelectionFDSFilterItem> getSelectionFDSFilterItems()
+		throws JSONException {
+
+		List<SelectionFDSFilterItem> selectionFDSFilterItems =
+			new ArrayList<>();
+
 		JSONArray jsonArray = getJSONArray();
 
-		List<Integer> statuses = new ArrayList<>();
-
 		for (int i = 0; i < jsonArray.length(); i++) {
-			statuses.add((Integer)jsonArray.get(i));
+			Integer status = (Integer)jsonArray.get(i);
+
+			selectionFDSFilterItems.add(
+				new SelectionFDSFilterItem(
+					_language.get(
+						locale, WorkflowConstants.getStatusLabel(status)),
+					status));
 		}
 
-		return statuses;
+		return selectionFDSFilterItems;
 	}
 
 	@Override
 	public String toValueSummary() throws PortalException {
 		return StringUtil.merge(
 			ListUtil.toList(
-				getItemsValues(),
-				itemValue -> _language.get(
-					locale, WorkflowConstants.getStatusLabel(itemValue))),
+				getSelectionFDSFilterItems(),
+				getSelectionFDSFilterItem ->
+					getSelectionFDSFilterItem.getLabel()),
 			StringPool.COMMA_AND_SPACE);
 	}
 
@@ -79,7 +89,7 @@ public class StatusSystemObjectFieldFilterStrategy
 		super.validate();
 
 		try {
-			getItemsValues();
+			getSelectionFDSFilterItems();
 		}
 		catch (Exception exception) {
 			throw new ObjectViewFilterColumnException(

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/field/frontend/data/set/filter/ListTypeEntrySelectionFDSFilter.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/field/frontend/data/set/filter/ListTypeEntrySelectionFDSFilter.java
@@ -15,17 +15,16 @@
 package com.liferay.object.field.frontend.data.set.filter;
 
 import com.liferay.frontend.data.set.constants.FDSEntityFieldTypes;
-import com.liferay.frontend.data.set.filter.BaseAutocompleteFDSFilter;
+import com.liferay.frontend.data.set.filter.BaseSelectionFDSFilter;
 
 import java.util.Map;
 
 /**
  * @author Feliphe Marinho
  */
-public class ListTypeEntryAutocompleteFDSFilter
-	extends BaseAutocompleteFDSFilter {
+public class ListTypeEntrySelectionFDSFilter extends BaseSelectionFDSFilter {
 
-	public ListTypeEntryAutocompleteFDSFilter(
+	public ListTypeEntrySelectionFDSFilter(
 		boolean collection, String id, String label, long listTypeDefinitionId,
 		Map<String, Object> preloadedData) {
 
@@ -74,6 +73,11 @@ public class ListTypeEntryAutocompleteFDSFilter
 	@Override
 	public Map<String, Object> getPreloadedData() {
 		return _preloadedData;
+	}
+
+	@Override
+	public boolean isAutocompleteEnabled() {
+		return true;
 	}
 
 	private final boolean _collection;

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/field/frontend/data/set/filter/OneToManySelectionFDSFilter.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/field/frontend/data/set/filter/OneToManySelectionFDSFilter.java
@@ -15,16 +15,16 @@
 package com.liferay.object.field.frontend.data.set.filter;
 
 import com.liferay.frontend.data.set.constants.FDSEntityFieldTypes;
-import com.liferay.frontend.data.set.filter.BaseAutocompleteFDSFilter;
+import com.liferay.frontend.data.set.filter.BaseSelectionFDSFilter;
 
 import java.util.Map;
 
 /**
  * @author Paulo ALbuquerque
  */
-public class OneToManyAutocompleteFDSFilter extends BaseAutocompleteFDSFilter {
+public class OneToManySelectionFDSFilter extends BaseSelectionFDSFilter {
 
-	public OneToManyAutocompleteFDSFilter(
+	public OneToManySelectionFDSFilter(
 		Map<String, Object> preloadedData, String restContextPath,
 		String titleObjectFieldLabel, String relationshipObjectFieldName,
 		String titleObjectFieldName) {
@@ -69,6 +69,11 @@ public class OneToManyAutocompleteFDSFilter extends BaseAutocompleteFDSFilter {
 	@Override
 	public Map<String, Object> getPreloadedData() {
 		return _preloadedData;
+	}
+
+	@Override
+	public boolean isAutocompleteEnabled() {
+		return true;
 	}
 
 	private final Map<String, Object> _preloadedData;

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/field/filter/parser/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/field/filter/parser/packageinfo
@@ -1,1 +1,1 @@
-version 4.0.0
+version 5.0.0

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/field/frontend/data/set/filter/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/field/frontend/data/set/filter/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 3.0.0


### PR DESCRIPTION
Related issue: https://issues.liferay.com/browse/LPS-170299

### References

- [LPS-170299 Implement merge of FDS Autocomplete and Selection filters](https://issues.liferay.com/browse/LPS-170299)
- This is a followup on https://github.com/liferay-frontend/liferay-portal/pull/2893

### What is the goal of this PR?

Hey @liferay-objects ! We are merging Autocomplete and Selection FDS filters. They are very similar, with a lot of code duplication. After this PR, autocomplete will be a feature of `SelectionFilter`, with relevant UI activated by `autocompleteEnabled` prop. 

Original intention was to migrate filter usages in separate PRs, but there is a [problem with format of preloaded data](https://github.com/liferay-frontend/liferay-portal/pull/2893#pullrequestreview-1217656977). The format is currently different in Autocomplete and Selection filters. As this is currently used only in `objects-api`, it makes sense to make the migration along with the original changes in `frontend-data-set` modules. When we are already making the change, I took the opportunity to rename awkward `itemsValues` into `selectionFDSFilterItems`, changing the related code in `objects-api`.

**Please review the parts in `objects-api`**! If you wish, feel free to review the FI parts as well :slightly_smiling_face: 

Note that two filters in Objects scope, 'one-to-many' and 'create/modify' data, do not seem to get applied to data. This seems to be a bug in `master`. Filter odata string, before and after this PR, should be the same.


### What does it look like?

Some trivial changes in UI, padding of filter items.

![screen](https://user-images.githubusercontent.com/5435511/207897100-7a761fbf-6078-445a-94e3-31ca9b575c6a.png)


### Steps to reproduce

1. Deploy `frontend-data-set-sample-web`.
2. Place `Frontend Data Set Sample` widget on any page.
3. Create an Object, based on Frontend Data Set Samples
4. Create a View, with some preloaded values for filters


cc: @markocikos 