### PR TITLE
[TS] LPS-171713 Configuration is sent twice when Search preferences are saved for the second time

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -24,6 +24,7 @@
 	action="<%= configurationActionURL %>"
 	method="post"
 	name="fm"
+	onSubmit='<%= "if (" + liferayPortletResponse.getNamespace() + "saveConfiguration) {event.preventDefault(); " + liferayPortletResponse.getNamespace() + "saveConfiguration();}" %>'
 >
 	<aui:input name="<%= Constants.CMD %>" type="hidden" value="<%= Constants.UPDATE %>" />
 	<aui:input name="tabs2" type="hidden" value='<%= ParamUtil.getString(request, "tabs2") %>' />

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/facets/configuration/asset_entries.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/facets/configuration/asset_entries.jsp
@@ -64,21 +64,22 @@ for (AssetRendererFactory<?> assetRendererFactory : assetEntriesSearchFacet.getA
 />
 
 <script>
-	var form = document.<portlet:namespace />fm;
+	function <portlet:namespace />saveConfiguration() {
+		var form = document.<portlet:namespace />fm;
 
-	var currentAssetTypes = Liferay.Util.getFormElement(form, 'currentAssetTypes');
+		var currentAssetTypes = Liferay.Util.getFormElement(
+			form,
+			'currentAssetTypes'
+		);
 
-	if (currentAssetTypes) {
-		form.addEventListener('submit', (event) => {
-			event.preventDefault();
+		var data = {};
 
-			var data = {};
-
+		if (currentAssetTypes) {
 			data[
 				'<%= assetEntriesSearchFacet.getClassName() + "assetTypes" %>'
 			] = Liferay.Util.getSelectedOptionValues(currentAssetTypes);
+		}
 
-			Liferay.Util.postForm(form, {data: data});
-		});
+		Liferay.Util.postForm(form, {data: data});
 	}
 </script>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/type/facet/configuration.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/type/facet/configuration.jsp
@@ -59,6 +59,7 @@ TypeFacetPortletPreferences typeFacetPortletPreferences = new com.liferay.portal
 	action="<%= configurationActionURL %>"
 	method="post"
 	name="fm"
+	onSubmit='<%= "event.preventDefault(); " + liferayPortletResponse.getNamespace() + "saveConfiguration();" %>'
 >
 	<aui:input name="<%= Constants.CMD %>" type="hidden" value="<%= Constants.UPDATE %>" />
 	<aui:input name="redirect" type="hidden" value="<%= configurationRenderURL %>" />
@@ -115,21 +116,22 @@ TypeFacetPortletPreferences typeFacetPortletPreferences = new com.liferay.portal
 </liferay-frontend:edit-form>
 
 <script>
-	var form = document.<portlet:namespace />fm;
+	function <portlet:namespace />saveConfiguration() {
+		var form = document.<portlet:namespace />fm;
 
-	var currentAssetTypes = Liferay.Util.getFormElement(form, 'currentAssetTypes');
+		var currentAssetTypes = Liferay.Util.getFormElement(
+			form,
+			'currentAssetTypes'
+		);
 
-	if (currentAssetTypes) {
-		form.addEventListener('submit', (event) => {
-			event.preventDefault();
+		var data = {};
 
-			var data = {};
-
+		if (currentAssetTypes) {
 			data[
 				'<%= PortletPreferencesJspUtil.getInputName(TypeFacetPortletPreferences.PREFERENCE_KEY_ASSET_TYPES) %>'
 			] = Liferay.Util.getSelectedOptionValues(currentAssetTypes);
+		}
 
-			Liferay.Util.postForm(form, {data: data});
-		});
+		Liferay.Util.postForm(form, {data: data});
 	}
 </script>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-171713

Tested here: https://github.com/liferay-search/liferay-portal/pull/720
Failures are unrelated

Original message:

Hi team,

The following solution fixes the bug reported in [LPS-171713](https://issues.liferay.com/browse/LPS-171713), which is only reproducible when SPA is enabled.

The root cause is that the event registered is not properly unregistered when the portlet is destroyed.

The approach followed in the proposed solution is to use the attribute onSubmit of the taglib liferay-frontend:edit-form.

Could you please review it?

Please, also let me know if further clarifications are needed.

Thanks in advance!