### PR TITLE
LPS-171290 configuring the Category Facet with the vocabulary layout the ordering options don't take effect

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/facet/display/context/builder/AssetCategoriesSearchFacetDisplayContextBuilder.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/facet/display/context/builder/AssetCategoriesSearchFacetDisplayContextBuilder.java
@@ -351,6 +351,12 @@ public class AssetCategoriesSearchFacetDisplayContextBuilder
 
 			vocabularyBucketDisplayContexts.add(bucketDisplayContext);
 
+			if (_order != null) {
+				vocabularyBucketDisplayContexts.sort(
+					BucketDisplayContextComparatorFactoryUtil.
+						getBucketDisplayContextComparator(_order));
+			}
+
 			bucketDisplayContextsMap.put(
 				vocabularyName, vocabularyBucketDisplayContexts);
 		}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-171290

Tested in https://github.com/liferay-search/liferay-portal/pull/722
Failures are unrelated