### PR TITLE
LPS-172200 Do not check generic types for return when checking class field

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaMapBuilderGenericsCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaMapBuilderGenericsCheck.java
@@ -182,6 +182,10 @@ public class JavaMapBuilderGenericsCheck extends BaseJavaTermCheck {
 		if (Objects.equals(matcher.group(2), "return")) {
 			JavaSignature javaSignature = javaTerm.getSignature();
 
+			if (javaSignature == null) {
+				return null;
+			}
+
 			mapTypeName = javaSignature.getReturnType();
 		}
 		else {

--- a/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/JavaSourceProcessorTest.java
+++ b/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/JavaSourceProcessorTest.java
@@ -365,6 +365,11 @@ public class JavaSourceProcessorTest extends BaseSourceProcessorTestCase {
 	}
 
 	@Test
+	public void testMapBuilderGenerics() throws Exception {
+		test("MapBuilderGenerics.testjava");
+	}
+
+	@Test
 	public void testMissingAuthor() throws Exception {
 		test("MissingAuthor.testjava", "Missing author", 20);
 	}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/MapBuilderGenerics.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/MapBuilderGenerics.testjava
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.source.formatter.dependencies;
+
+/**
+ * @author Qi Zhang
+ */
+public class MapBuilderGenerics {
+
+	protected static final TestClass testClass = new TestClass() {
+
+		@Override
+		public Map<String, String> testMethod1() {
+			return HashMapBuilder.<String, String>put(
+				"title", "title"
+			).build();
+		}
+
+		@Override
+		public Map<String, Object> testMethod2() {
+			return HashMapBuilder.put(
+				"title", "title"
+			).build();
+		}
+
+	};
+
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/MapBuilderGenerics.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/MapBuilderGenerics.testjava
@@ -14,6 +14,10 @@
 
 package com.liferay.source.formatter.dependencies;
 
+import com.liferay.portal.kernel.util.HashMapBuilder;
+
+import java.util.Map;
+
 /**
  * @author Qi Zhang
  */

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/MapBuilderGenerics.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/MapBuilderGenerics.testjava
@@ -14,6 +14,10 @@
 
 package com.liferay.source.formatter.dependencies;
 
+import com.liferay.portal.kernel.util.HashMapBuilder;
+
+import java.util.Map;
+
 /**
  * @author Qi Zhang
  */

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/MapBuilderGenerics.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/MapBuilderGenerics.testjava
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.source.formatter.dependencies;
+
+/**
+ * @author Qi Zhang
+ */
+public class MapBuilderGenerics {
+
+	protected static final TestClass testClass = new TestClass() {
+
+		@Override
+		public Map<String, String> testMethod1() {
+			return HashMapBuilder.put(
+				"title", "title"
+			).build();
+		}
+
+		@Override
+		public Map<String, Object> testMethod2() {
+			return HashMapBuilder.<String, Object>put(
+				"title", "title"
+			).build();
+		}
+
+	};
+
+}


### PR DESCRIPTION
SF bug: https://issues.liferay.com/browse/LPS-172200

Tested [here](https://github.com/ling-alan-huang/liferay-portal/pull/1590), unrelated failures.