### PR TITLE
LPS-172108 Links are missing in display pages and page templates

### DIFF
--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
@@ -485,13 +485,6 @@ public class BundleSiteInitializer implements SiteInitializer {
 							siteNavigationMenuItemSettingsBuilder));
 
 			_invoke(
-				() -> _addLayoutPageTemplates(
-					assetListEntryIdsStringUtilReplaceValues,
-					documentsStringUtilReplaceValues,
-					objectDefinitionIdsAndObjectEntryIdsStringUtilReplaceValues,
-					serviceContext,
-					taxonomyCategoryIdsStringUtilReplaceValues));
-			_invoke(
 				() -> _addOrUpdateNotificationTemplates(
 					documentsStringUtilReplaceValues,
 					objectDefinitionIdsAndObjectEntryIdsStringUtilReplaceValues,
@@ -509,6 +502,17 @@ public class BundleSiteInitializer implements SiteInitializer {
 					documentsStringUtilReplaceValues,
 					objectDefinitionIdsAndObjectEntryIdsStringUtilReplaceValues,
 					serviceContext));
+
+			// LPS-172108 Layouts have to be created first so that links in page
+			// templates work
+
+			_invoke(
+				() -> _addLayoutPageTemplates(
+					assetListEntryIdsStringUtilReplaceValues,
+					documentsStringUtilReplaceValues,
+					objectDefinitionIdsAndObjectEntryIdsStringUtilReplaceValues,
+					serviceContext,
+					taxonomyCategoryIdsStringUtilReplaceValues));
 
 			// TODO Review order/dependency
 


### PR DESCRIPTION
## Motivation

[Link to task](https://issues.liferay.com/browse/LPS-172108)

In [LPS-143303](https://issues.liferay.com/browse/LPS-143303) we split the way we added layouts through the site initializer. First we create the entry, and then we specify the content. This is done so that we could add links in page templates and display pages.

This was changed in [LPS-168479](https://issues.liferay.com/browse/LPS-168479) by accident, so in this PR que are using the correct order again.


## Change summary:

* Move the method to create the display pages and page templates so it's executed after the layouts are created


## Test Scenario

* Follow the steps in the ticket

![extranet](https://user-images.githubusercontent.com/4267448/211555682-878a2ca9-2ef0-472c-b70e-15ac5e69a86a.gif)