### PR TITLE
LPS-171999 Support now operation with OData

### DIFF
--- a/modules/apps/portal-odata/portal-odata-api/bnd.bnd
+++ b/modules/apps/portal-odata/portal-odata-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal OData API
 Bundle-SymbolicName: com.liferay.portal.odata.api
-Bundle-Version: 4.0.7
+Bundle-Version: 4.1.0
 Export-Package:\
 	com.liferay.portal.odata.entity,\
 	com.liferay.portal.odata.filter,\

--- a/modules/apps/portal-odata/portal-odata-api/src/main/java/com/liferay/portal/odata/filter/expression/MethodExpression.java
+++ b/modules/apps/portal-odata/portal-odata-api/src/main/java/com/liferay/portal/odata/filter/expression/MethodExpression.java
@@ -41,7 +41,7 @@ public interface MethodExpression extends Expression {
 
 	public static enum Type {
 
-		CONTAINS, STARTS_WITH
+		CONTAINS, NOW, STARTS_WITH
 
 	}
 

--- a/modules/apps/portal-odata/portal-odata-api/src/main/resources/com/liferay/portal/odata/filter/expression/packageinfo
+++ b/modules/apps/portal-odata/portal-odata-api/src/main/resources/com/liferay/portal/odata/filter/expression/packageinfo
@@ -1,1 +1,1 @@
-version 2.1.0
+version 2.2.0

--- a/modules/apps/portal-odata/portal-odata-impl/src/main/java/com/liferay/portal/odata/internal/filter/ExpressionVisitorImpl.java
+++ b/modules/apps/portal-odata/portal-odata-impl/src/main/java/com/liferay/portal/odata/internal/filter/ExpressionVisitorImpl.java
@@ -227,8 +227,7 @@ public class ExpressionVisitorImpl implements ExpressionVisitor<Object> {
 			return _contains(
 				(EntityField)expressions.get(0), expressions.get(1), _locale);
 		}
-
-		if (type == MethodExpression.Type.STARTS_WITH) {
+		else if (type == MethodExpression.Type.STARTS_WITH) {
 			if (expressions.size() != 2) {
 				throw new UnsupportedOperationException(
 					StringBundler.concat(

--- a/modules/apps/portal-odata/portal-odata-impl/src/main/java/com/liferay/portal/odata/internal/filter/ExpressionVisitorImpl.java
+++ b/modules/apps/portal-odata/portal-odata-impl/src/main/java/com/liferay/portal/odata/internal/filter/ExpressionVisitorImpl.java
@@ -227,6 +227,16 @@ public class ExpressionVisitorImpl implements ExpressionVisitor<Object> {
 			return _contains(
 				(EntityField)expressions.get(0), expressions.get(1), _locale);
 		}
+		else if (type == MethodExpression.Type.NOW) {
+			if (!expressions.isEmpty()) {
+				throw new UnsupportedOperationException(
+					StringBundler.concat(
+						"Unsupported method visitMethodExpression with method",
+						"type ", type, " and ", expressions.size(), "params"));
+			}
+
+			return _normalizeDateLiteral(ISO8601Utils.format(_now));
+		}
 		else if (type == MethodExpression.Type.STARTS_WITH) {
 			if (expressions.size() != 2) {
 				throw new UnsupportedOperationException(
@@ -590,5 +600,6 @@ public class ExpressionVisitorImpl implements ExpressionVisitor<Object> {
 	private final Format _format;
 	private final Locale _locale;
 	private final NestedFieldQueryHelper _nestedFieldQueryHelper;
+	private final Date _now = new Date();
 
 }

--- a/modules/apps/portal-odata/portal-odata-impl/src/main/java/com/liferay/portal/odata/internal/filter/expression/ExpressionVisitorImpl.java
+++ b/modules/apps/portal-odata/portal-odata-impl/src/main/java/com/liferay/portal/odata/internal/filter/expression/ExpressionVisitorImpl.java
@@ -196,6 +196,10 @@ public class ExpressionVisitorImpl implements ExpressionVisitor<Expression> {
 			return new MethodExpressionImpl(
 				expressions, MethodExpression.Type.CONTAINS);
 		}
+		else if (methodKind == MethodKind.NOW) {
+			return new MethodExpressionImpl(
+				expressions, MethodExpression.Type.NOW);
+		}
 		else if (methodKind == MethodKind.STARTSWITH) {
 			return new MethodExpressionImpl(
 				expressions, MethodExpression.Type.STARTS_WITH);

--- a/modules/apps/portal-odata/portal-odata-impl/src/main/java/com/liferay/portal/odata/internal/filter/expression/ExpressionVisitorImpl.java
+++ b/modules/apps/portal-odata/portal-odata-impl/src/main/java/com/liferay/portal/odata/internal/filter/expression/ExpressionVisitorImpl.java
@@ -196,8 +196,7 @@ public class ExpressionVisitorImpl implements ExpressionVisitor<Expression> {
 			return new MethodExpressionImpl(
 				expressions, MethodExpression.Type.CONTAINS);
 		}
-
-		if (methodKind == MethodKind.STARTSWITH) {
+		else if (methodKind == MethodKind.STARTSWITH) {
 			return new MethodExpressionImpl(
 				expressions, MethodExpression.Type.STARTS_WITH);
 		}

--- a/modules/apps/portal-odata/portal-odata-impl/src/test/java/com/liferay/portal/odata/internal/filter/ExpressionVisitorImplTest.java
+++ b/modules/apps/portal-odata/portal-odata-impl/src/test/java/com/liferay/portal/odata/internal/filter/ExpressionVisitorImplTest.java
@@ -52,9 +52,13 @@ import com.liferay.portal.search.internal.query.NestedFieldQueryHelperImpl;
 import com.liferay.portal.search.query.NestedFieldQueryHelper;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 
+import java.time.Instant;
+
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -685,6 +689,35 @@ public class ExpressionVisitorImplTest {
 		Assert.assertEquals("keywords", entityField2.getName());
 		Assert.assertEquals(
 			EntityField.Type.COLLECTION, entityField2.getType());
+	}
+
+	@Test
+	public void testVisitMethodExpressionWithNow() throws ParseException {
+		Date initialDate = new Date();
+
+		Instant initialInstant = initialDate.toInstant();
+
+		SimpleDateFormat simpleDateFormat = new SimpleDateFormat(
+			"yyyyMMddHHmmss");
+
+		ExpressionVisitorImpl expressionVisitorImpl = new ExpressionVisitorImpl(
+			simpleDateFormat, LocaleUtil.getDefault(), _entityModel,
+			nestedFieldQueryHelper);
+
+		Date actualDate = simpleDateFormat.parse(
+			(String)expressionVisitorImpl.visitMethodExpression(
+				Collections.emptyList(), MethodExpression.Type.NOW));
+
+		Instant actualInstant = Instant.ofEpochMilli(actualDate.getTime());
+
+		Date finalDate = new Date();
+
+		Instant finalInstant = finalDate.toInstant();
+
+		Assert.assertTrue(
+			actualInstant.getEpochSecond() >= initialInstant.getEpochSecond());
+		Assert.assertTrue(
+			actualInstant.getEpochSecond() <= finalInstant.getEpochSecond());
 	}
 
 	@Test

--- a/modules/apps/portal-odata/portal-odata-impl/src/test/java/com/liferay/portal/odata/internal/filter/FilterParserImplTest.java
+++ b/modules/apps/portal-odata/portal-odata-impl/src/test/java/com/liferay/portal/odata/internal/filter/FilterParserImplTest.java
@@ -301,6 +301,38 @@ public class FilterParserImplTest {
 	}
 
 	@Test
+	public void testParseWithEqBinaryExpressionWithDateTimeOffsetAndNowMethod()
+		throws ExpressionVisitException {
+
+		Expression expression = _filterParserImpl.parse(
+			"dateTimeExternal ge now()");
+
+		BinaryExpression binaryExpression = (BinaryExpression)expression;
+
+		Assert.assertEquals(
+			BinaryExpression.Operation.GE, binaryExpression.getOperation());
+
+		MemberExpression memberExpression =
+			(MemberExpression)binaryExpression.getLeftOperationExpression();
+
+		PrimitivePropertyExpression primitivePropertyExpression =
+			(PrimitivePropertyExpression)memberExpression.getExpression();
+
+		Assert.assertEquals(
+			"dateTimeExternal", primitivePropertyExpression.getName());
+
+		MethodExpression methodExpression =
+			(MethodExpression)binaryExpression.getRightOperationExpression();
+
+		Assert.assertEquals(
+			MethodExpression.Type.NOW, methodExpression.getType());
+
+		List<Expression> expressions = methodExpression.getExpressions();
+
+		Assert.assertTrue(expressions.isEmpty());
+	}
+
+	@Test
 	public void testParseWithEqBinaryExpressionWithDateTimeWithInvalidType() {
 		AbstractThrowableAssert exception = Assertions.assertThatThrownBy(
 			() -> _filterParserImpl.parse("dateTimeExternal ge 2012-05-29")

--- a/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/odata/ExpressionVisitorImpl.java
+++ b/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/odata/ExpressionVisitorImpl.java
@@ -223,6 +223,16 @@ public class ExpressionVisitorImpl implements ExpressionVisitor<Object> {
 			return _getOperationJSONObject(
 				String.valueOf(type), expressions.get(0), expressions.get(1));
 		}
+		else if (type == MethodExpression.Type.NOW) {
+			if (!expressions.isEmpty()) {
+				throw new UnsupportedOperationException(
+					StringBundler.concat(
+						"Unsupported method visitMethodExpression with method ",
+						"type ", type, " and ", expressions.size(), "params"));
+			}
+
+			return String.valueOf(type);
+		}
 
 		throw new UnsupportedOperationException(
 			"Unsupported method visitMethodExpression with method type " +

--- a/modules/apps/segments/segments-web/src/test/java/com/liferay/segments/web/internal/odata/ExpressionVisitorImplTest.java
+++ b/modules/apps/segments/segments-web/src/test/java/com/liferay/segments/web/internal/odata/ExpressionVisitorImplTest.java
@@ -424,9 +424,7 @@ public class ExpressionVisitorImplTest {
 	}
 
 	@Test
-	public void testVisitMethodExpressionWithContains()
-		throws ExpressionVisitException {
-
+	public void testVisitMethodExpressionWithContains() {
 		Map<String, EntityField> entityFieldsMap =
 			_entityModel.getEntityFieldsMap();
 
@@ -446,6 +444,17 @@ public class ExpressionVisitorImplTest {
 				"value", "title1"
 			).toString(),
 			jsonObject.toString());
+	}
+
+	@Test
+	public void testVisitMethodExpressionWithNow() {
+		String visitNowMethodExpression =
+			(String)_expressionVisitorImpl.visitMethodExpression(
+				Collections.emptyList(), MethodExpression.Type.NOW);
+
+		Assert.assertEquals(
+			String.valueOf(MethodExpression.Type.NOW),
+			visitNowMethodExpression);
 	}
 
 	@Test

--- a/modules/apps/segments/segments-web/src/test/java/com/liferay/segments/web/internal/odata/ExpressionVisitorImplTest.java
+++ b/modules/apps/segments/segments-web/src/test/java/com/liferay/segments/web/internal/odata/ExpressionVisitorImplTest.java
@@ -448,13 +448,10 @@ public class ExpressionVisitorImplTest {
 
 	@Test
 	public void testVisitMethodExpressionWithNow() {
-		String visitNowMethodExpression =
-			(String)_expressionVisitorImpl.visitMethodExpression(
-				Collections.emptyList(), MethodExpression.Type.NOW);
-
 		Assert.assertEquals(
 			String.valueOf(MethodExpression.Type.NOW),
-			visitNowMethodExpression);
+			_expressionVisitorImpl.visitMethodExpression(
+				Collections.emptyList(), MethodExpression.Type.NOW));
 	}
 
 	@Test


### PR DESCRIPTION
Motivation
=======
We need to support the now operation in order to support AC Event Segments in DXP

[Link to story or ticket](https://issues.liferay.com/browse/LPS-171785 )
[Link to technical task](https://issues.liferay.com/browse/LPS-171999 )

Proposed Solution
========
Support Now operation in OData

Steps to Verify:
----------------
No Functional changes.
Integration tests have been provided in this PR

Original PR:
----------------
https://github.com/liferay-tango/liferay-portal/pull/3142

Forwading directly, since the failing tests are not related with this PR
