### PR TITLE
LPS-164521 - solving failure in integration tests - LRQA-79041

### DIFF
--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/resolver/DefaultUserResolverTest.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/resolver/DefaultUserResolverTest.java
@@ -658,7 +658,7 @@ public class DefaultUserResolverTest extends BaseSamlTestCase {
 
 		Mockito.when(
 			samlPeerBindingLocalService.fetchSamlPeerBinding(
-				Mockito.any(Long.class), Mockito.nullable(String.class),
+				Mockito.any(Long.class), false, Mockito.nullable(String.class),
 				Mockito.nullable(String.class), Mockito.nullable(String.class),
 				Mockito.nullable(String.class))
 		).thenReturn(


### PR DESCRIPTION
[LRQA-79041](https://issues.liferay.com/browse/LRQA-79041)

### Problem
In [the commit](https://github.com/liferay/liferay-portal/commit/d19c6a5900e5d1470ed3fde248594ff27afe48c8) of  [LPS-164521](https://issues.liferay.com/browse/LPS-164521) the method names have been removed and changed. These changes cause the _fetchSamlPeerBinding_ method to have one more parameter, and then, the integration test fails.

### Solution
Adding the parameter to the method in the integration test.

