### PR TITLE
LPS-172697: Fix r_oneToManyrelationshipName_c_objectParentERC missing in nested relationship node

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
@@ -153,6 +153,32 @@ public class ObjectEntryDTOConverter
 		}
 	}
 
+	private void _addRelationshipNames(
+		Map<String, Object> map, ObjectField objectField, long objectEntryId,
+		String objectFieldName, ObjectRelationship objectRelationship,
+		Map<String, Serializable> values) {
+
+		String objectRelationshipERCObjectFieldName =
+			ObjectFieldSettingUtil.getValue(
+				ObjectFieldSettingConstants.
+					NAME_OBJECT_RELATIONSHIP_ERC_OBJECT_FIELD_NAME,
+				objectField);
+
+		String relatedObjectEntryERC = GetterUtil.getString(
+			values.get(objectRelationshipERCObjectFieldName));
+
+		if (GetterUtil.getBoolean(PropsUtil.get("feature.flag.LPS-161364")) &&
+			(map.get(objectRelationship.getName()) == null)) {
+
+			map.put(
+				objectRelationship.getName() + "ERC", relatedObjectEntryERC);
+		}
+
+		map.put(objectFieldName, objectEntryId);
+
+		map.put(objectRelationshipERCObjectFieldName, relatedObjectEntryERC);
+	}
+
 	private DTOConverterContext _getDTOConverterContext(
 		DTOConverterContext dtoConverterContext, long objectEntryId) {
 
@@ -538,29 +564,23 @@ public class ObjectEntryDTOConverter
 					}
 				}
 
-				map.put(objectFieldName, objectEntryId);
+				_addRelationshipNames(
+					map, objectField, objectEntryId, objectFieldName,
+					objectRelationship, values);
+			}
+			else if ((nestedFieldsDepth == 0) &&
+					 Objects.equals(
+						 objectField.getRelationshipType(),
+						 ObjectRelationshipConstants.TYPE_ONE_TO_MANY)) {
 
-				String objectRelationshipERCObjectFieldName =
-					ObjectFieldSettingUtil.getValue(
-						ObjectFieldSettingConstants.
-							NAME_OBJECT_RELATIONSHIP_ERC_OBJECT_FIELD_NAME,
-						objectField);
+				ObjectRelationship objectRelationship =
+					_objectRelationshipLocalService.
+						fetchObjectRelationshipByObjectFieldId2(
+							objectField.getObjectFieldId());
 
-				String relatedObjectEntryERC = GetterUtil.getString(
-					values.get(objectRelationshipERCObjectFieldName));
-
-				if (GetterUtil.getBoolean(
-						PropsUtil.get("feature.flag.LPS-161364")) &&
-					(map.get(objectRelationship.getName()) == null)) {
-
-					map.put(
-						objectRelationship.getName() + "ERC",
-						relatedObjectEntryERC);
-				}
-
-				map.put(
-					objectRelationshipERCObjectFieldName,
-					relatedObjectEntryERC);
+				_addRelationshipNames(
+					map, objectField, (long)serializable, objectFieldName,
+					objectRelationship, values);
 			}
 			else {
 				map.put(objectFieldName, serializable);

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -184,6 +184,50 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
+	public void testGetRelationshipERCFieldInOneToManyRelationshipUsingNestedFields()
+		throws Exception {
+
+		PropsUtil.addProperties(
+			UnicodePropertiesBuilder.setProperty(
+				"feature.flag.LPS-161364", "true"
+			).build());
+
+		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		JSONObject jsonObject = HTTPTestUtil.invoke(
+			null,
+			StringBundler.concat(
+				_objectDefinition1.getRESTContextPath(), "?nestedFields=",
+				_objectRelationship.getName()),
+			Http.Method.GET);
+
+		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
+
+		Assert.assertEquals(1, itemsJSONArray.length());
+
+		JSONObject itemJSONObject = itemsJSONArray.getJSONObject(0);
+
+		JSONArray relationshipJSONArray = itemJSONObject.getJSONArray(
+			_objectRelationship.getName());
+
+		Assert.assertEquals(1, relationshipJSONArray.length());
+
+		JSONObject relatedObjectEntryJSONObject =
+			relationshipJSONArray.getJSONObject(0);
+
+		Assert.assertEquals(
+			relatedObjectEntryJSONObject.getString(
+				_objectRelationship.getName() + "ERC"),
+			_objectEntry1.getExternalReferenceCode());
+
+		PropsUtil.addProperties(
+			UnicodePropertiesBuilder.setProperty(
+				"feature.flag.LPS-161364", "false"
+			).build());
+	}
+
+	@Test
 	public void testPutByExternalReferenceCodeManyToManyRelationship()
 		throws Exception {
 


### PR DESCRIPTION
**What is new?**
- Allow and support r_oneToManyrelationshipName_c_objectParentERC in the nested relationship node.

**How to reproduce this?**
1. Deploy `object-rest-impl`
2. Enable the following feature flag: `feature.flag.LPS-161364`
3. Create a University object and University entry.
4. Create a Student object and Student entry.
5. Create a relationship 1-M `studentUniversity` in University and relate two created entries.
6. Request`http://localhost:8080/o/c/universities/{universityId}?nestedFields=studentUniversity`

```
{
    "dateCreated": "2023-01-16T10:53:41Z",
    "dateModified": "2023-01-16T10:53:41Z",
    "externalReferenceCode": "aebbdc69-37ff-d9e1-b552-c687dad8a2f4",
    "id": 44135,
    "status": {
        "code": 0,
        "label": "approved",
        "label_i18n": "Approved"
    },
    "studentUniversity": [
        {
            "creator": {
                "additionalName": "",
                "contentType": "UserAccount",
                "familyName": "Test",
                "givenName": "Test",
                "id": 20125,
                "name": "Test Test"
            },
            "dateCreated": "2023-01-16T12:29:07Z",
            "dateModified": "2023-01-16T12:41:31Z",
            "externalReferenceCode": "33e477d7-a7f8-ef58-42c6-3f1cb4a71770",
            "id": 44631,
            "status": {
                "code": 0,
                "label": "approved",
                "label_i18n": "Approved"
            },
            "studentUniversityERC": "aebbdc69-37ff-d9e1-b552-c687dad8a2f4",
            "r_studentUniversity_c_universityId": 44135,
            "r_studentUniversity_c_universityERC": "aebbdc69-37ff-d9e1-b552-c687dad8a2f4"
        }
    ]
}
```
**JIRA Ticket**
https://issues.liferay.com/browse/LPS-172697