### PR TITLE
LPS-172619 Make IdP redirect message hidable

### DIFF
--- a/modules/dxp/apps/saml/saml-api/bnd.bnd
+++ b/modules/dxp/apps/saml/saml-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay SAML API
 Bundle-SymbolicName: com.liferay.saml.api
-Bundle-Version: 7.0.1
+Bundle-Version: 7.1.0
 Export-Package:\
 	com.liferay.saml.constants,\
 	com.liferay.saml.runtime,\

--- a/modules/dxp/apps/saml/saml-api/src/main/java/com/liferay/saml/constants/SamlWebKeys.java
+++ b/modules/dxp/apps/saml/saml-api/src/main/java/com/liferay/saml/constants/SamlWebKeys.java
@@ -34,6 +34,9 @@ public interface SamlWebKeys {
 
 	public static final String SAML_ENTITY_ID = "SAML_ENTITY_ID";
 
+	public static final String SAML_IDP_REDIRECT_MESSAGE =
+		"SAML_IDP_REDIRECT_MESSAGE";
+
 	public static final String SAML_IDP_SP_CONNECTION =
 		"SAML_IDP_SP_CONNECTION";
 

--- a/modules/dxp/apps/saml/saml-api/src/main/resources/com/liferay/saml/constants/packageinfo
+++ b/modules/dxp/apps/saml/saml-api/src/main/resources/com/liferay/saml/constants/packageinfo
@@ -1,1 +1,1 @@
-version 2.4.0
+version 2.5.0

--- a/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/struts/SamlLoginAction.java
+++ b/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/struts/SamlLoginAction.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.security.auth.AuthTokenUtil;
 import com.liferay.portal.kernel.struts.StrutsAction;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -119,6 +120,14 @@ public class SamlLoginAction extends BaseSamlStrutsAction {
 			}
 		}
 
+		if (!_hideIdpRedirectMessage) {
+			httpServletRequest.setAttribute(
+				SamlWebKeys.SAML_IDP_REDIRECT_MESSAGE,
+				_language.get(
+					httpServletRequest,
+					"redirecting-to-your-identity-provider"));
+		}
+
 		httpServletRequest.setAttribute(
 			SamlWebKeys.SAML_SSO_LOGIN_CONTEXT,
 			_toJSONObject(samlSpIdpConnections));
@@ -126,7 +135,7 @@ public class SamlLoginAction extends BaseSamlStrutsAction {
 		JspUtil.dispatch(
 			httpServletRequest, httpServletResponse,
 			"/portal/saml/select_idp.jsp",
-			"please-select-your-identity-provider", false);
+			"please-select-your-identity-provider", _hideIdpRedirectMessage);
 
 		return null;
 	}
@@ -166,6 +175,9 @@ public class SamlLoginAction extends BaseSamlStrutsAction {
 
 	@Reference
 	private JSONFactory _jsonFactory;
+
+	@Reference
+	private Language _language;
 
 	@Reference
 	private Portal _portal;

--- a/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/struts/SamlLoginAction.java
+++ b/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/struts/SamlLoginAction.java
@@ -33,12 +33,14 @@ import com.liferay.saml.runtime.servlet.profile.SamlSpIdpConnectionsProfile;
 import com.liferay.saml.util.JspUtil;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
@@ -58,6 +60,12 @@ public class SamlLoginAction extends BaseSamlStrutsAction {
 		}
 
 		return false;
+	}
+
+	@Activate
+	protected void activate(Map<String, Object> properties) {
+		_hideIdpRedirectMessage = GetterUtil.getBoolean(
+			properties.get("hide.idp.redirect.message"));
 	}
 
 	@Override
@@ -153,6 +161,8 @@ public class SamlLoginAction extends BaseSamlStrutsAction {
 
 		return JSONUtil.put("relevantIdpConnections", jsonArray);
 	}
+
+	private boolean _hideIdpRedirectMessage;
 
 	@Reference
 	private JSONFactory _jsonFactory;

--- a/portal-web/docroot/html/portal/saml/select_idp.jsp
+++ b/portal-web/docroot/html/portal/saml/select_idp.jsp
@@ -19,6 +19,8 @@
 <%
 String redirect = ParamUtil.getString(request, "redirect");
 
+String samlIdPRedirectMessage = GetterUtil.getString(request.getAttribute("SAML_IDP_REDIRECT_MESSAGE"));
+
 JSONObject samlSsoLoginContextJSONObject = (JSONObject)request.getAttribute("SAML_SSO_LOGIN_CONTEXT");
 
 JSONArray relevantIdpConnectionsJSONArray = samlSsoLoginContextJSONObject.getJSONArray("relevantIdpConnections");
@@ -30,7 +32,7 @@ JSONArray relevantIdpConnectionsJSONArray = samlSsoLoginContextJSONObject.getJSO
 
 	<c:choose>
 		<c:when test="<%= relevantIdpConnectionsJSONArray.length() == 1 %>">
-			<p><liferay-ui:message key="redirecting-to-your-identity-provider" /></p>
+			<p><%= samlIdPRedirectMessage %></p>
 
 			<%
 			JSONObject relevantIdpConnectionJSONObject = relevantIdpConnectionsJSONArray.getJSONObject(0);


### PR DESCRIPTION
Hi Brian. Forwarding liferay-appsec/liferay-portal/pull/974 direct because getting unrelated `ci:test:relevant` failures and `ci:forward:force` appears to require that to pass. Thanks!