### PR TITLE
LPS-172852 Prevent widget title gets saved without clicking on '✓' icon.

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -91,7 +91,7 @@
 											.get('boundingBox')
 											.contains(event.target)
 									) {
-										editable.save();
+										editable.fire('stopEditing');
 									}
 								}
 							);


### PR DESCRIPTION
Manually forwarded: https://github.com/liferay-frontend/liferay-portal/pull/2965