### PR TITLE
LPS-172594 Add remaining filters

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
@@ -247,67 +247,55 @@ public class PredicateExpressionVisitorImpl
 	public Object visitMethodExpression(
 		List<Object> expressions, MethodExpression.Type type) {
 
-		if (type == MethodExpression.Type.CONTAINS) {
-			if (expressions.size() != 2) {
-				throw new UnsupportedOperationException(
-					StringBundler.concat(
-						"Unsupported method visitMethodExpression with method ",
-						"type ", type, " and ", expressions.size(), "params"));
-			}
-
+		if (expressions.size() == 2) {
 			String left = (String)expressions.get(0);
 			Object fieldValue = expressions.get(1);
 
 			Predicate predicate = null;
 
-			if (_isComplexProperExpression(left)) {
-				predicate = _getPredicateForRelationships(
-					left,
-					(objectFieldName, relatedObjectDefinitionId) -> _contains(
-						objectFieldName, fieldValue,
-						relatedObjectDefinitionId));
-			}
-			else {
-				predicate = _contains(left, fieldValue, _objectDefinitionId);
-			}
+			if (type == MethodExpression.Type.CONTAINS) {
+				if (_isComplexProperExpression(left)) {
+					predicate = _getPredicateForRelationships(
+						left,
+						(objectFieldName, relatedObjectDefinitionId) ->
+							_contains(
+								objectFieldName, fieldValue,
+								relatedObjectDefinitionId));
+				}
+				else {
+					predicate = _contains(
+						left, fieldValue, _objectDefinitionId);
+				}
 
-			if (predicate != null) {
-				return predicate;
-			}
-		}
-
-		if (type == MethodExpression.Type.STARTS_WITH) {
-			if (expressions.size() != 2) {
-				throw new UnsupportedOperationException(
-					StringBundler.concat(
-						"Unsupported method visitMethodExpression with method",
-						"type ", type, " and ", expressions.size(), "params"));
+				if (predicate != null) {
+					return predicate;
+				}
 			}
 
-			String left = (String)expressions.get(0);
-			Object fieldValue = expressions.get(1);
+			if (type == MethodExpression.Type.STARTS_WITH) {
+				if (_isComplexProperExpression(left)) {
+					predicate = _getPredicateForRelationships(
+						left,
+						(objectFieldName, relatedObjectDefinitionId) ->
+							_startsWith(
+								objectFieldName, fieldValue,
+								relatedObjectDefinitionId));
+				}
+				else {
+					predicate = _startsWith(
+						left, fieldValue, _objectDefinitionId);
+				}
 
-			Predicate predicate = null;
-
-			if (_isComplexProperExpression(left)) {
-				predicate = _getPredicateForRelationships(
-					left,
-					(objectFieldName, relatedObjectDefinitionId) -> _startsWith(
-						objectFieldName, fieldValue,
-						relatedObjectDefinitionId));
-			}
-			else {
-				predicate = _startsWith(left, fieldValue, _objectDefinitionId);
-			}
-
-			if (predicate != null) {
-				return predicate;
+				if (predicate != null) {
+					return predicate;
+				}
 			}
 		}
 
 		throw new UnsupportedOperationException(
-			"Unsupported method visitMethodExpression with method type " +
-				type);
+			StringBundler.concat(
+				"Unsupported method visitMethodExpression with method type ",
+				type, " and ", expressions.size(), "params"));
 	}
 
 	@Override

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
@@ -26,6 +26,7 @@ import com.liferay.object.rest.internal.odata.entity.v1_0.ObjectEntryEntityModel
 import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalServiceUtil;
+import com.liferay.petra.function.UnsafeBiFunction;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.sql.dsl.Column;
 import com.liferay.petra.sql.dsl.expression.Predicate;
@@ -43,7 +44,6 @@ import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.odata.entity.ComplexEntityField;
 import com.liferay.portal.odata.entity.EntityField;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.expression.BinaryExpression;
@@ -59,7 +59,6 @@ import com.liferay.portal.odata.filter.expression.LiteralExpression;
 import com.liferay.portal.odata.filter.expression.MemberExpression;
 import com.liferay.portal.odata.filter.expression.MethodExpression;
 import com.liferay.portal.odata.filter.expression.PrimitivePropertyExpression;
-import com.liferay.portal.odata.filter.expression.PropertyExpression;
 import com.liferay.portal.odata.filter.expression.UnaryExpression;
 
 import java.text.DateFormat;
@@ -96,7 +95,19 @@ public class PredicateExpressionVisitorImpl
 	public Predicate visitBinaryExpressionOperation(
 		BinaryExpression.Operation operation, Object left, Object right) {
 
-		Predicate predicate = _getPredicate(operation, left, right);
+		Predicate predicate = null;
+
+		if (_isComplexProperExpression(left)) {
+			predicate = _getPredicateForRelationships(
+				left,
+				(objectFieldName, relatedObjectDefinitionId) -> _getPredicate(
+					objectFieldName, relatedObjectDefinitionId, operation,
+					right));
+		}
+		else {
+			predicate = _getPredicate(
+				left, _objectDefinitionId, operation, right);
+		}
 
 		if (predicate != null) {
 			return predicate;
@@ -131,31 +142,7 @@ public class PredicateExpressionVisitorImpl
 			ComplexPropertyExpression complexPropertyExpression)
 		throws ExpressionVisitException {
 
-		_objectRelationship = _fetchObjectRelationship(
-			complexPropertyExpression.getName());
-
-		EntityModel entityModel = _getObjectDefinitionEntityModel(
-			_objectDefinitionId);
-
-		Map<String, EntityField> entityFieldsMap =
-			entityModel.getEntityFieldsMap();
-
-		ComplexEntityField complexEntityField =
-			(ComplexEntityField)entityFieldsMap.get(
-				complexPropertyExpression.getName());
-
-		Map<String, EntityField> complexEntityFieldEntityFieldsMap =
-			complexEntityField.getEntityFieldsMap();
-
-		PropertyExpression propertyExpression =
-			complexPropertyExpression.getPropertyExpression();
-
-		EntityField entityField = complexEntityFieldEntityFieldsMap.get(
-			propertyExpression.getName());
-
-		_relatedFieldName = entityField.getName();
-
-		return entityField.getName();
+		return complexPropertyExpression.toString();
 	}
 
 	@Override
@@ -182,13 +169,21 @@ public class PredicateExpressionVisitorImpl
 		throws ExpressionVisitException {
 
 		if (Objects.equals(ListExpression.Operation.IN, operation)) {
-			Column<?, Object> column = _getColumn(left, _objectDefinitionId);
+			Predicate predicate = null;
 
-			return column.in(
-				TransformUtil.transformToArray(
-					rights,
-					right -> _getValue(left, _objectDefinitionId, right),
-					Object.class));
+			if (_isComplexProperExpression(left)) {
+				predicate = _getPredicateForRelationships(
+					left,
+					(objectFieldName, relatedObjectDefinitionId) ->
+						_getINPredicate(
+							objectFieldName, relatedObjectDefinitionId,
+							rights));
+			}
+			else {
+				predicate = _getINPredicate(left, _objectDefinitionId, rights);
+			}
+
+			return predicate;
 		}
 
 		throw new UnsupportedOperationException(
@@ -423,6 +418,18 @@ public class PredicateExpressionVisitorImpl
 		return null;
 	}
 
+	private Predicate _getINPredicate(
+		Object left, long objectDefinitionId, List<Object> rights) {
+
+		return _getColumn(
+			left, objectDefinitionId
+		).in(
+			TransformUtil.transformToArray(
+				rights, right -> _getValue(left, objectDefinitionId, right),
+				Object.class)
+		);
+	}
+
 	private EntityModel _getObjectDefinitionEntityModel(
 		long objectDefinitionId) {
 
@@ -438,7 +445,8 @@ public class PredicateExpressionVisitorImpl
 	}
 
 	private Predicate _getPredicate(
-		BinaryExpression.Operation operation, Object left, Object right) {
+		Object left, long objectDefinitionId,
+		BinaryExpression.Operation operation, Object right) {
 
 		Predicate predicate = null;
 
@@ -454,7 +462,7 @@ public class PredicateExpressionVisitorImpl
 		}
 		else {
 			ObjectField objectField = _objectFieldLocalService.fetchObjectField(
-				_objectDefinitionId, String.valueOf(left));
+				objectDefinitionId, String.valueOf(left));
 
 			if ((objectField != null) &&
 				StringUtil.equals(
@@ -469,26 +477,46 @@ public class PredicateExpressionVisitorImpl
 			return predicate;
 		}
 
-		if (_objectRelationship != null) {
-			try {
-				return _getPredicateForRelationships(operation, left, right);
-			}
-			catch (Exception exception) {
-				if (_log.isDebugEnabled()) {
-					_log.debug(exception);
-				}
-
-				return null;
-			}
-		}
-
 		return _getExpressionPredicate(
-			_getColumn(left, _objectDefinitionId), operation,
-			_getValue(left, _objectDefinitionId, right));
+			_getColumn(left, objectDefinitionId), operation,
+			_getValue(left, objectDefinitionId, right));
 	}
 
 	private Predicate _getPredicateForRelationships(
-			BinaryExpression.Operation operation, Object left, Object right)
+		Object left,
+		UnsafeBiFunction<String, Long, Predicate, Exception>
+			getRelatedObjectFieldPredicateUnsafeBiFunction) {
+
+		String leftString = (String)left;
+
+		String[] complexPropertyChunks = leftString.split(StringPool.SLASH);
+
+		String relationshipName = complexPropertyChunks[0];
+
+		ObjectRelationship objectRelationship = _fetchObjectRelationship(
+			relationshipName);
+
+		if (objectRelationship != null) {
+			String objectFieldName = complexPropertyChunks[1];
+
+			try {
+				return _getPredicateForRelationships(
+					objectRelationship,
+					getRelatedObjectFieldPredicateUnsafeBiFunction.apply(
+						objectFieldName,
+						_getRelatedObjectDefinitionId(
+							_objectDefinitionId, objectRelationship)));
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		}
+
+		return null;
+	}
+
+	private Predicate _getPredicateForRelationships(
+			ObjectRelationship objectRelationship, Predicate predicate)
 		throws Exception {
 
 		ObjectDefinition objectDefinition1 =
@@ -500,16 +528,10 @@ public class PredicateExpressionVisitorImpl
 				_objectRelatedModelsPredicateProviderRegistry.
 					getObjectRelatedModelsPredicateProvider(
 						objectDefinition1.getClassName(),
-						_objectRelationship.getType());
-
-		long relatedObjectDefinitionId = _getRelatedObjectDefinitionId(
-			_objectDefinitionId, _objectRelationship);
+						objectRelationship.getType());
 
 		return objectRelatedModelsPredicateProvider.getPredicate(
-			_objectRelationship,
-			_getExpressionPredicate(
-				_getColumn(_relatedFieldName, relatedObjectDefinitionId),
-				operation, _getValue(left, relatedObjectDefinitionId, right)));
+			objectRelationship, predicate);
 	}
 
 	private long _getRelatedObjectDefinitionId(
@@ -584,6 +606,16 @@ public class PredicateExpressionVisitorImpl
 		}
 	}
 
+	private boolean _isComplexProperExpression(Object object) {
+		if (object instanceof String) {
+			String string = (String)object;
+
+			return string.contains(StringPool.SLASH);
+		}
+
+		return false;
+	}
+
 	private Predicate _startsWith(Object fieldName, Object fieldValue) {
 		Column<?, Object> column = _getColumn(fieldName, _objectDefinitionId);
 
@@ -603,7 +635,5 @@ public class PredicateExpressionVisitorImpl
 	private final ObjectFieldLocalService _objectFieldLocalService;
 	private final ObjectRelatedModelsPredicateProviderRegistry
 		_objectRelatedModelsPredicateProviderRegistry;
-	private ObjectRelationship _objectRelationship;
-	private String _relatedFieldName;
 
 }

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
@@ -284,7 +284,25 @@ public class PredicateExpressionVisitorImpl
 						"type ", type, " and ", expressions.size(), "params"));
 			}
 
-			return _startsWith(expressions.get(0), expressions.get(1));
+			String left = (String)expressions.get(0);
+			Object fieldValue = expressions.get(1);
+
+			Predicate predicate = null;
+
+			if (_isComplexProperExpression(left)) {
+				predicate = _getPredicateForRelationships(
+					left,
+					(objectFieldName, relatedObjectDefinitionId) -> _startsWith(
+						objectFieldName, fieldValue,
+						relatedObjectDefinitionId));
+			}
+			else {
+				predicate = _startsWith(left, fieldValue, _objectDefinitionId);
+			}
+
+			if (predicate != null) {
+				return predicate;
+			}
 		}
 
 		throw new UnsupportedOperationException(
@@ -636,11 +654,13 @@ public class PredicateExpressionVisitorImpl
 		return false;
 	}
 
-	private Predicate _startsWith(Object fieldName, Object fieldValue) {
-		Column<?, Object> column = _getColumn(fieldName, _objectDefinitionId);
+	private Predicate _startsWith(
+		Object fieldName, Object fieldValue, long objectDefinitionId) {
+
+		Column<?, Object> column = _getColumn(fieldName, objectDefinitionId);
 
 		return column.like(
-			_getValue(fieldName, _objectDefinitionId, fieldValue) +
+			_getValue(fieldName, objectDefinitionId, fieldValue) +
 				StringPool.PERCENT);
 	}
 

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -43,6 +43,8 @@ import com.liferay.portal.util.PropsUtil;
 
 import java.util.Collections;
 
+import javax.ws.rs.NotSupportedException;
+
 import org.hamcrest.CoreMatchers;
 
 import org.junit.Assert;
@@ -89,148 +91,15 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
-	public void testFilterByRelatedObjectDefinitionSystemObjectField()
-		throws Exception {
-
+	public void testFilterObjectEntriesByRelatedObjects() throws Exception {
 		PropsUtil.addProperties(
 			UnicodePropertiesBuilder.setProperty(
 				"feature.flag.LPS-154672", "true"
 			).build());
 
-		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
-			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
-
-		_testFilterByRelatedObjectDefinitionSystemObjectField(
-			_objectRelationship);
-
-		_objectRelationshipLocalService.deleteObjectRelationship(
-			_objectRelationship);
-
-		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
-			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
-
-		_testFilterByRelatedObjectDefinitionSystemObjectField(
-			_objectRelationship);
-
-		PropsUtil.addProperties(
-			UnicodePropertiesBuilder.setProperty(
-				"feature.flag.LPS-154672", "false"
-			).build());
-	}
-
-	@Test
-	public void testFilterObjectEntriesByRelatedObjectsUsingContainsOperatorInManyToManyRelationship()
-		throws Exception {
-
-		PropsUtil.addProperties(
-			UnicodePropertiesBuilder.setProperty(
-				"feature.flag.LPS-154672", "true"
-			).build());
-
-		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
-			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
-
-		_testFilterObjectEntriesByRelatedObjectsUsingContainsOperatorInBothSidesOfRelationship();
-
-		PropsUtil.addProperties(
-			UnicodePropertiesBuilder.setProperty(
-				"feature.flag.LPS-154672", "false"
-			).build());
-	}
-
-	@Test
-	public void testFilterObjectEntriesByRelatedObjectsUsingContainsOperatorInOneToManyRelationship()
-		throws Exception {
-
-		PropsUtil.addProperties(
-			UnicodePropertiesBuilder.setProperty(
-				"feature.flag.LPS-154672", "true"
-			).build());
-
-		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
-			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
-
-		_testFilterObjectEntriesByRelatedObjectsUsingContainsOperatorInBothSidesOfRelationship();
-
-		PropsUtil.addProperties(
-			UnicodePropertiesBuilder.setProperty(
-				"feature.flag.LPS-154672", "false"
-			).build());
-	}
-
-	@Test
-	public void testFilterObjectEntriesByRelatedObjectsUsingINOperatorInManyToManyRelationship()
-		throws Exception {
-
-		PropsUtil.addProperties(
-			UnicodePropertiesBuilder.setProperty(
-				"feature.flag.LPS-154672", "true"
-			).build());
-
-		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
-			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
-
-		_testFilterObjectEntriesByRelatedObjectsUsingINOperatorInBothSidesOfRelationship();
-
-		PropsUtil.addProperties(
-			UnicodePropertiesBuilder.setProperty(
-				"feature.flag.LPS-154672", "false"
-			).build());
-	}
-
-	@Test
-	public void testFilterObjectEntriesByRelatedObjectsUsingINOperatorInOneToManyRelationship()
-		throws Exception {
-
-		PropsUtil.addProperties(
-			UnicodePropertiesBuilder.setProperty(
-				"feature.flag.LPS-154672", "true"
-			).build());
-
-		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
-			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
-
-		_testFilterObjectEntriesByRelatedObjectsUsingINOperatorInBothSidesOfRelationship();
-
-		PropsUtil.addProperties(
-			UnicodePropertiesBuilder.setProperty(
-				"feature.flag.LPS-154672", "false"
-			).build());
-	}
-
-	@Test
-	public void testFilterObjectEntriesByRelatedObjectsUsingStartsWithOperatorInManyToManyRelationship()
-		throws Exception {
-
-		PropsUtil.addProperties(
-			UnicodePropertiesBuilder.setProperty(
-				"feature.flag.LPS-154672", "true"
-			).build());
-
-		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
-			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
-
-		_testFilterObjectEntriesByRelatedObjectsUsingStartsWithOperatorInBothSidesOfRelationship();
-
-		PropsUtil.addProperties(
-			UnicodePropertiesBuilder.setProperty(
-				"feature.flag.LPS-154672", "false"
-			).build());
-	}
-
-	@Test
-	public void testFilterObjectEntriesByRelatedObjectsUsingStartsWithOperatorInOneToManyRelationship()
-		throws Exception {
-
-		PropsUtil.addProperties(
-			UnicodePropertiesBuilder.setProperty(
-				"feature.flag.LPS-154672", "true"
-			).build());
-
-		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
-			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
-
-		_testFilterObjectEntriesByRelatedObjectsUsingStartsWithOperatorInBothSidesOfRelationship();
+		for (FilterOperator operator : FilterOperator.values()) {
+			_testFilterObjectEntriesByRelatedObjects(operator);
+		}
 
 		PropsUtil.addProperties(
 			UnicodePropertiesBuilder.setProperty(
@@ -419,134 +288,132 @@ public class ObjectEntryResourceTest {
 	}
 
 	private void _testFilterByRelatedObjectDefinitionSystemObjectField(
-			ObjectRelationship objectRelationship)
+			ObjectRelationship objectRelationship, FilterOperator operator)
 		throws Exception {
 
 		_testFilterByRelatedObjectDefinitionSystemObjectField(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1, _objectDefinition1,
-			objectRelationship, _objectEntry2.getObjectEntryId());
+			objectRelationship, operator, _objectEntry2.getObjectEntryId());
+
 		_testFilterByRelatedObjectDefinitionSystemObjectField(
 			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2, _objectDefinition2,
-			objectRelationship, _objectEntry1.getObjectEntryId());
+			objectRelationship, operator, _objectEntry1.getObjectEntryId());
 	}
 
 	private void _testFilterByRelatedObjectDefinitionSystemObjectField(
 			String expectedObjectFieldName, String expectedObjectFieldValue,
 			ObjectDefinition objectDefinition,
-			ObjectRelationship objectRelationship, long relatedObjectEntryId)
+			ObjectRelationship objectRelationship, FilterOperator operator,
+			long relatedObjectEntryId)
 		throws Exception {
 
 		String endpoint = StringBundler.concat(
 			objectDefinition.getRESTContextPath(), "?filter=",
-			objectRelationship.getName(), "/id%20eq%20'",
+			objectRelationship.getName(), "/id%20", operator.getValue(), "%20'",
 			String.valueOf(relatedObjectEntryId), StringPool.APOSTROPHE);
 
-		JSONObject jsonObject = HTTPTestUtil.invoke(
-			null, endpoint, Http.Method.GET);
-
-		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
-
-		Assert.assertEquals(1, itemsJSONArray.length());
-
-		JSONObject itemJSONObject = itemsJSONArray.getJSONObject(0);
-
-		Assert.assertEquals(
-			expectedObjectFieldValue,
-			itemJSONObject.getString(expectedObjectFieldName));
+		_testFilterObjectEntriesByRelatedObjectsUsingAnOperator(
+			endpoint, expectedObjectFieldName, expectedObjectFieldValue);
 	}
 
-	private void _testFilterObjectEntriesByRelatedObjectsUsingContainsOperator(
-			String expectedObjectFieldName, String expectedObjectFieldValue,
-			ObjectDefinition objectDefinition, String relatedObjectFieldName,
-			String relatedObjectFieldValue)
+	private void _testFilterObjectEntriesByRelatedObjects(
+			FilterOperator operator)
 		throws Exception {
 
-		String endpoint = StringBundler.concat(
-			objectDefinition.getRESTContextPath(), "?filter=contains(",
-			_objectRelationship.getName(), StringPool.SLASH,
-			relatedObjectFieldName, StringPool.COMMA, StringPool.APOSTROPHE,
-			relatedObjectFieldValue, StringPool.APOSTROPHE,
-			StringPool.CLOSE_PARENTHESIS);
+		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
-		JSONObject jsonObject = HTTPTestUtil.invoke(
-			null, endpoint, Http.Method.GET);
+		_testFilterObjectEntriesByRelatedObjectsInBothSidesOfRelationship(
+			_objectRelationship, operator);
 
-		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
+		_objectRelationshipLocalService.deleteObjectRelationship(
+			_objectRelationship);
 
-		Assert.assertEquals(1, itemsJSONArray.length());
+		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
-		JSONObject itemJSONObject = itemsJSONArray.getJSONObject(0);
-
-		Assert.assertEquals(
-			expectedObjectFieldValue,
-			itemJSONObject.getString(expectedObjectFieldName));
-	}
-
-	private void _testFilterObjectEntriesByRelatedObjectsUsingContainsOperatorInBothSidesOfRelationship()
-		throws Exception {
-
-		_testFilterObjectEntriesByRelatedObjectsUsingContainsOperator(
-			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1, _objectDefinition1,
-			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2);
-
-		_testFilterObjectEntriesByRelatedObjectsUsingContainsOperator(
-			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2, _objectDefinition2,
-			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1);
-	}
-
-	private void _testFilterObjectEntriesByRelatedObjectsUsingINOperator(
-			String expectedObjectFieldName, String expectedObjectFieldValue,
-			ObjectDefinition objectDefinition, String relatedObjectFieldName,
-			String relatedObjectFieldValue)
-		throws Exception {
-
-		String endpoint = StringBundler.concat(
-			objectDefinition.getRESTContextPath(), "?filter=",
-			_objectRelationship.getName(), StringPool.SLASH,
-			relatedObjectFieldName, "%20in%20('", RandomTestUtil.randomString(),
-			StringPool.APOSTROPHE, StringPool.COMMA, StringPool.APOSTROPHE,
-			relatedObjectFieldValue, StringPool.APOSTROPHE,
-			StringPool.CLOSE_PARENTHESIS);
-
-		JSONObject jsonObject = HTTPTestUtil.invoke(
-			null, endpoint, Http.Method.GET);
-
-		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
-
-		Assert.assertEquals(1, itemsJSONArray.length());
-
-		JSONObject itemJSONObject = itemsJSONArray.getJSONObject(0);
-
-		Assert.assertEquals(
-			expectedObjectFieldValue,
-			itemJSONObject.getString(expectedObjectFieldName));
-	}
-
-	private void _testFilterObjectEntriesByRelatedObjectsUsingINOperatorInBothSidesOfRelationship()
-		throws Exception {
-
-		_testFilterObjectEntriesByRelatedObjectsUsingINOperator(
-			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1, _objectDefinition1,
-			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2);
-
-		_testFilterObjectEntriesByRelatedObjectsUsingINOperator(
-			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2, _objectDefinition2,
-			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1);
+		_testFilterObjectEntriesByRelatedObjectsInBothSidesOfRelationship(
+			_objectRelationship, operator);
 	}
 
 	private void
-			_testFilterObjectEntriesByRelatedObjectsUsingStartsWithOperator(
-				String expectedObjectFieldName, String expectedObjectFieldValue,
-				ObjectDefinition objectDefinition,
-				String relatedObjectFieldName, String relatedObjectFieldValue)
+			_testFilterObjectEntriesByRelatedObjectsInBothSidesOfRelationship(
+				ObjectRelationship objectRelationship, FilterOperator operator)
 		throws Exception {
 
-		String endpoint = StringBundler.concat(
-			objectDefinition.getRESTContextPath(), "?filter=startswith(",
-			_objectRelationship.getName(), StringPool.SLASH,
-			relatedObjectFieldName, StringPool.COMMA, StringPool.APOSTROPHE,
-			relatedObjectFieldValue.substring(0, 1), StringPool.APOSTROPHE,
-			StringPool.CLOSE_PARENTHESIS);
+		_testFilterObjectEntriesByRelatedObjectsUsingAnOperator(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1, objectRelationship,
+			_objectDefinition1, operator, _OBJECT_FIELD_NAME_2,
+			_OBJECT_FIELD_VALUE_2);
+
+		_testFilterObjectEntriesByRelatedObjectsUsingAnOperator(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2, objectRelationship,
+			_objectDefinition2, operator, _OBJECT_FIELD_NAME_1,
+			_OBJECT_FIELD_VALUE_1);
+	}
+
+	private void _testFilterObjectEntriesByRelatedObjectsUsingAnOperator(
+			String expectedObjectFieldName, String expectedObjectFieldValue,
+			ObjectRelationship objectRelationship,
+			ObjectDefinition objectDefinition, FilterOperator operator,
+			String relatedObjectFieldName, String relatedObjectFieldValue)
+		throws Exception {
+
+		String endpoint = objectDefinition.getRESTContextPath() + "?filter=";
+
+		if (operator == FilterOperator.CONTAINS) {
+			endpoint = endpoint.concat(
+				StringBundler.concat(
+					operator.getValue(), StringPool.OPEN_PARENTHESIS,
+					objectRelationship.getName(), StringPool.SLASH,
+					relatedObjectFieldName, StringPool.COMMA,
+					StringPool.APOSTROPHE,
+					relatedObjectFieldValue.substring(1, 2),
+					StringPool.APOSTROPHE, StringPool.CLOSE_PARENTHESIS));
+		}
+		else if (operator == FilterOperator.EQ) {
+			_testFilterByRelatedObjectDefinitionSystemObjectField(
+				objectRelationship, operator);
+
+			endpoint = endpoint.concat(
+				StringBundler.concat(
+					objectRelationship.getName(), StringPool.SLASH,
+					relatedObjectFieldName, "%20", operator.getValue(), "%20'",
+					relatedObjectFieldValue, StringPool.APOSTROPHE));
+		}
+		else if (operator == FilterOperator.IN) {
+			endpoint = endpoint.concat(
+				StringBundler.concat(
+					objectRelationship.getName(), StringPool.SLASH,
+					relatedObjectFieldName, "%20", operator.getValue(), "%20('",
+					RandomTestUtil.randomString(), StringPool.APOSTROPHE,
+					StringPool.COMMA, StringPool.APOSTROPHE,
+					relatedObjectFieldValue, StringPool.APOSTROPHE,
+					StringPool.CLOSE_PARENTHESIS));
+		}
+		else if (operator == FilterOperator.STARTS_WITH) {
+			endpoint = endpoint.concat(
+				StringBundler.concat(
+					operator.getValue(), StringPool.OPEN_PARENTHESIS,
+					objectRelationship.getName(), StringPool.SLASH,
+					relatedObjectFieldName, StringPool.COMMA,
+					StringPool.APOSTROPHE,
+					relatedObjectFieldValue.substring(0, 1),
+					StringPool.APOSTROPHE, StringPool.CLOSE_PARENTHESIS));
+		}
+		else {
+			throw new NotSupportedException(
+				"Operation " + operator.name() + "is not supported");
+		}
+
+		_testFilterObjectEntriesByRelatedObjectsUsingAnOperator(
+			endpoint, expectedObjectFieldName, expectedObjectFieldValue);
+	}
+
+	private void _testFilterObjectEntriesByRelatedObjectsUsingAnOperator(
+			String endpoint, String expectedObjectFieldName,
+			String expectedObjectFieldValue)
+		throws Exception {
 
 		JSONObject jsonObject = HTTPTestUtil.invoke(
 			null, endpoint, Http.Method.GET);
@@ -560,18 +427,6 @@ public class ObjectEntryResourceTest {
 		Assert.assertEquals(
 			expectedObjectFieldValue,
 			itemJSONObject.getString(expectedObjectFieldName));
-	}
-
-	private void _testFilterObjectEntriesByRelatedObjectsUsingStartsWithOperatorInBothSidesOfRelationship()
-		throws Exception {
-
-		_testFilterObjectEntriesByRelatedObjectsUsingStartsWithOperator(
-			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1, _objectDefinition1,
-			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2);
-
-		_testFilterObjectEntriesByRelatedObjectsUsingStartsWithOperator(
-			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2, _objectDefinition2,
-			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1);
 	}
 
 	private void _testGetNestedFieldDetailsInOneToManyRelationships(
@@ -628,5 +483,21 @@ public class ObjectEntryResourceTest {
 
 	@Inject
 	private ObjectRelationshipLocalService _objectRelationshipLocalService;
+
+	private enum FilterOperator {
+
+		CONTAINS("contains"), EQ("eq"), IN("in"), STARTS_WITH("startswith");
+
+		public String getValue() {
+			return _value;
+		}
+
+		private FilterOperator(String value) {
+			_value = value;
+		}
+
+		private final String _value;
+
+	}
 
 }

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -119,6 +119,46 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
+	public void testFilterObjectEntriesByRelatedObjectsUsingContainsOperatorInManyToManyRelationship()
+		throws Exception {
+
+		PropsUtil.addProperties(
+			UnicodePropertiesBuilder.setProperty(
+				"feature.flag.LPS-154672", "true"
+			).build());
+
+		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		_testFilterObjectEntriesByRelatedObjectsUsingContainsOperatorInBothSidesOfRelationship();
+
+		PropsUtil.addProperties(
+			UnicodePropertiesBuilder.setProperty(
+				"feature.flag.LPS-154672", "false"
+			).build());
+	}
+
+	@Test
+	public void testFilterObjectEntriesByRelatedObjectsUsingContainsOperatorInOneToManyRelationship()
+		throws Exception {
+
+		PropsUtil.addProperties(
+			UnicodePropertiesBuilder.setProperty(
+				"feature.flag.LPS-154672", "true"
+			).build());
+
+		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		_testFilterObjectEntriesByRelatedObjectsUsingContainsOperatorInBothSidesOfRelationship();
+
+		PropsUtil.addProperties(
+			UnicodePropertiesBuilder.setProperty(
+				"feature.flag.LPS-154672", "false"
+			).build());
+	}
+
+	@Test
 	public void testFilterObjectEntriesByRelatedObjectsUsingINOperatorInManyToManyRelationship()
 		throws Exception {
 
@@ -373,6 +413,45 @@ public class ObjectEntryResourceTest {
 		Assert.assertEquals(
 			expectedObjectFieldValue,
 			itemJSONObject.getString(expectedObjectFieldName));
+	}
+
+	private void _testFilterObjectEntriesByRelatedObjectsUsingContainsOperator(
+			String expectedObjectFieldName, String expectedObjectFieldValue,
+			ObjectDefinition objectDefinition, String relatedObjectFieldName,
+			String relatedObjectFieldValue)
+		throws Exception {
+
+		String endpoint = StringBundler.concat(
+			objectDefinition.getRESTContextPath(), "?filter=contains(",
+			_objectRelationship.getName(), StringPool.SLASH,
+			relatedObjectFieldName, StringPool.COMMA, StringPool.APOSTROPHE,
+			relatedObjectFieldValue, StringPool.APOSTROPHE,
+			StringPool.CLOSE_PARENTHESIS);
+
+		JSONObject jsonObject = HTTPTestUtil.invoke(
+			null, endpoint, Http.Method.GET);
+
+		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
+
+		Assert.assertEquals(1, itemsJSONArray.length());
+
+		JSONObject itemJSONObject = itemsJSONArray.getJSONObject(0);
+
+		Assert.assertEquals(
+			expectedObjectFieldValue,
+			itemJSONObject.getString(expectedObjectFieldName));
+	}
+
+	private void _testFilterObjectEntriesByRelatedObjectsUsingContainsOperatorInBothSidesOfRelationship()
+		throws Exception {
+
+		_testFilterObjectEntriesByRelatedObjectsUsingContainsOperator(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1, _objectDefinition1,
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2);
+
+		_testFilterObjectEntriesByRelatedObjectsUsingContainsOperator(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2, _objectDefinition2,
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1);
 	}
 
 	private void _testFilterObjectEntriesByRelatedObjectsUsingINOperator(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -199,6 +199,46 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
+	public void testFilterObjectEntriesByRelatedObjectsUsingStartsWithOperatorInManyToManyRelationship()
+		throws Exception {
+
+		PropsUtil.addProperties(
+			UnicodePropertiesBuilder.setProperty(
+				"feature.flag.LPS-154672", "true"
+			).build());
+
+		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		_testFilterObjectEntriesByRelatedObjectsUsingStartsWithOperatorInBothSidesOfRelationship();
+
+		PropsUtil.addProperties(
+			UnicodePropertiesBuilder.setProperty(
+				"feature.flag.LPS-154672", "false"
+			).build());
+	}
+
+	@Test
+	public void testFilterObjectEntriesByRelatedObjectsUsingStartsWithOperatorInOneToManyRelationship()
+		throws Exception {
+
+		PropsUtil.addProperties(
+			UnicodePropertiesBuilder.setProperty(
+				"feature.flag.LPS-154672", "true"
+			).build());
+
+		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		_testFilterObjectEntriesByRelatedObjectsUsingStartsWithOperatorInBothSidesOfRelationship();
+
+		PropsUtil.addProperties(
+			UnicodePropertiesBuilder.setProperty(
+				"feature.flag.LPS-154672", "false"
+			).build());
+	}
+
+	@Test
 	public void testGetNestedFieldDetailsInOneToManyRelationships()
 		throws Exception {
 
@@ -490,6 +530,46 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2);
 
 		_testFilterObjectEntriesByRelatedObjectsUsingINOperator(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2, _objectDefinition2,
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1);
+	}
+
+	private void
+			_testFilterObjectEntriesByRelatedObjectsUsingStartsWithOperator(
+				String expectedObjectFieldName, String expectedObjectFieldValue,
+				ObjectDefinition objectDefinition,
+				String relatedObjectFieldName, String relatedObjectFieldValue)
+		throws Exception {
+
+		String endpoint = StringBundler.concat(
+			objectDefinition.getRESTContextPath(), "?filter=startswith(",
+			_objectRelationship.getName(), StringPool.SLASH,
+			relatedObjectFieldName, StringPool.COMMA, StringPool.APOSTROPHE,
+			relatedObjectFieldValue.substring(0, 1), StringPool.APOSTROPHE,
+			StringPool.CLOSE_PARENTHESIS);
+
+		JSONObject jsonObject = HTTPTestUtil.invoke(
+			null, endpoint, Http.Method.GET);
+
+		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
+
+		Assert.assertEquals(1, itemsJSONArray.length());
+
+		JSONObject itemJSONObject = itemsJSONArray.getJSONObject(0);
+
+		Assert.assertEquals(
+			expectedObjectFieldValue,
+			itemJSONObject.getString(expectedObjectFieldName));
+	}
+
+	private void _testFilterObjectEntriesByRelatedObjectsUsingStartsWithOperatorInBothSidesOfRelationship()
+		throws Exception {
+
+		_testFilterObjectEntriesByRelatedObjectsUsingStartsWithOperator(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1, _objectDefinition1,
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2);
+
+		_testFilterObjectEntriesByRelatedObjectsUsingStartsWithOperator(
 			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2, _objectDefinition2,
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1);
 	}

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -119,6 +119,46 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
+	public void testFilterObjectEntriesByRelatedObjectsUsingINOperatorInManyToManyRelationship()
+		throws Exception {
+
+		PropsUtil.addProperties(
+			UnicodePropertiesBuilder.setProperty(
+				"feature.flag.LPS-154672", "true"
+			).build());
+
+		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		_testFilterObjectEntriesByRelatedObjectsUsingINOperatorInBothSidesOfRelationship();
+
+		PropsUtil.addProperties(
+			UnicodePropertiesBuilder.setProperty(
+				"feature.flag.LPS-154672", "false"
+			).build());
+	}
+
+	@Test
+	public void testFilterObjectEntriesByRelatedObjectsUsingINOperatorInOneToManyRelationship()
+		throws Exception {
+
+		PropsUtil.addProperties(
+			UnicodePropertiesBuilder.setProperty(
+				"feature.flag.LPS-154672", "true"
+			).build());
+
+		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		_testFilterObjectEntriesByRelatedObjectsUsingINOperatorInBothSidesOfRelationship();
+
+		PropsUtil.addProperties(
+			UnicodePropertiesBuilder.setProperty(
+				"feature.flag.LPS-154672", "false"
+			).build());
+	}
+
+	@Test
 	public void testGetNestedFieldDetailsInOneToManyRelationships()
 		throws Exception {
 
@@ -333,6 +373,46 @@ public class ObjectEntryResourceTest {
 		Assert.assertEquals(
 			expectedObjectFieldValue,
 			itemJSONObject.getString(expectedObjectFieldName));
+	}
+
+	private void _testFilterObjectEntriesByRelatedObjectsUsingINOperator(
+			String expectedObjectFieldName, String expectedObjectFieldValue,
+			ObjectDefinition objectDefinition, String relatedObjectFieldName,
+			String relatedObjectFieldValue)
+		throws Exception {
+
+		String endpoint = StringBundler.concat(
+			objectDefinition.getRESTContextPath(), "?filter=",
+			_objectRelationship.getName(), StringPool.SLASH,
+			relatedObjectFieldName, "%20in%20('", RandomTestUtil.randomString(),
+			StringPool.APOSTROPHE, StringPool.COMMA, StringPool.APOSTROPHE,
+			relatedObjectFieldValue, StringPool.APOSTROPHE,
+			StringPool.CLOSE_PARENTHESIS);
+
+		JSONObject jsonObject = HTTPTestUtil.invoke(
+			null, endpoint, Http.Method.GET);
+
+		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
+
+		Assert.assertEquals(1, itemsJSONArray.length());
+
+		JSONObject itemJSONObject = itemsJSONArray.getJSONObject(0);
+
+		Assert.assertEquals(
+			expectedObjectFieldValue,
+			itemJSONObject.getString(expectedObjectFieldName));
+	}
+
+	private void _testFilterObjectEntriesByRelatedObjectsUsingINOperatorInBothSidesOfRelationship()
+		throws Exception {
+
+		_testFilterObjectEntriesByRelatedObjectsUsingINOperator(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1, _objectDefinition1,
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2);
+
+		_testFilterObjectEntriesByRelatedObjectsUsingINOperator(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2, _objectDefinition2,
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1);
 	}
 
 	private void _testGetNestedFieldDetailsInOneToManyRelationships(


### PR DESCRIPTION
cc/ @LuismiBarcos

Forwarded manually from: https://github.com/liferay-headless/liferay-portal/pull/977

Related ticket: [LPS-172594](https://issues.liferay.com/browse/LPS-172594)
____
## Purpose of the PR
The PR adds support for the following filter operators: `contains`, `startswith`, and `in` when filtering by fields of a related object.

### Filter `contains`
Now it is possible to use a filter like: `filter=contains(relationshipName/relatedObjectFieldName, 'lus')`

For example: 
```
## Get students
curl "http://localhost:8080/o/c/students?filter=contains(studentSubjects/subjectName, 'lus')" 
```
This will return all the students that study a subject whose name contains the string `lus`, like "Calculus"

### Filter `startswith`

Now it is possible to use a filter like: `filter=startswith(relationshipName/relatedObjectFieldName, 'Cal')`

For example: 
```
## Get students
curl "http://localhost:8080/o/c/students?filter=startswith(studentSubjects/subjectName, 'Cal')" 
```
This will return all the students that study a subject whose name starts with the string `Cal`, like "Calculus"

### Filter `in`

Now it is possible to use a filter like: `filter=studentSubjects/subjectName in ('Programming','Calculus')`

For example: 
```
## Get students
curl "http://localhost:8080/o/c/students?filter=studentSubjects/subjectName in ('Programming','Calculus')" 
```
This will return all the students that study a subject whose name is on the given list.


## How to test it
Deploy the `object-rest-impl` module
Remember to enable this feature flag: `feature.flag.LPS-154672=true`