### PR TITLE
Lps 173746

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/UpdateFormItemConfigMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/UpdateFormItemConfigMVCActionCommandTest.java
@@ -99,6 +99,7 @@ import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.runtime.ServiceComponentRuntime;
 import org.osgi.service.component.runtime.dto.ComponentDescriptionDTO;
+import org.osgi.util.promise.Promise;
 
 import org.springframework.mock.web.MockHttpServletRequest;
 
@@ -790,8 +791,9 @@ public class UpdateFormItemConfigMVCActionCommandTest {
 	private class ComponentEnablerTemporarySwapper implements AutoCloseable {
 
 		public ComponentEnablerTemporarySwapper(
-			String bundleSymbolicName, String componentClassName,
-			boolean enabled) {
+				String bundleSymbolicName, String componentClassName,
+				boolean enabled)
+			throws Exception {
 
 			BundleContext bundleContext = SystemBundleUtil.getBundleContext();
 
@@ -817,12 +819,16 @@ public class UpdateFormItemConfigMVCActionCommandTest {
 				_componentDescriptionDTO);
 
 			if (enabled) {
-				_serviceComponentRuntime.enableComponent(
+				Promise<?> promise = _serviceComponentRuntime.enableComponent(
 					_componentDescriptionDTO);
+
+				promise.getValue();
 			}
 			else {
-				_serviceComponentRuntime.disableComponent(
+				Promise<?> promise = _serviceComponentRuntime.disableComponent(
 					_componentDescriptionDTO);
+
+				promise.getValue();
 			}
 		}
 
@@ -833,12 +839,16 @@ public class UpdateFormItemConfigMVCActionCommandTest {
 			}
 
 			if (_componentEnabled) {
-				_serviceComponentRuntime.enableComponent(
+				Promise<?> promise = _serviceComponentRuntime.enableComponent(
 					_componentDescriptionDTO);
+
+				promise.getValue();
 			}
 			else {
-				_serviceComponentRuntime.disableComponent(
+				Promise<?> promise = _serviceComponentRuntime.disableComponent(
 					_componentDescriptionDTO);
+
+				promise.getValue();
 			}
 		}
 

--- a/modules/apps/portal-language/portal-language-extender/src/main/java/com/liferay/portal/language/extender/internal/LanguageResourcesExtender.java
+++ b/modules/apps/portal-language/portal-language-extender/src/main/java/com/liferay/portal/language/extender/internal/LanguageResourcesExtender.java
@@ -36,6 +36,7 @@ import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleEvent;
 import org.osgi.framework.Constants;
+import org.osgi.framework.ServiceFactory;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.framework.wiring.BundleCapability;
 import org.osgi.framework.wiring.BundleWiring;
@@ -156,13 +157,31 @@ public class LanguageResourcesExtender
 
 			Locale locale = LocaleUtil.fromLanguageId(languageId, false);
 
-			ResourceBundle resourceBundle = ResourceBundle.getBundle(
-				baseName, locale, bundleWiring.getClassLoader(),
-				UTF8Control.INSTANCE);
-
 			ServiceRegistration<?> serviceRegistration =
 				_bundleContext.registerService(
-					ResourceBundle.class, resourceBundle,
+					ResourceBundle.class,
+					new ServiceFactory<ResourceBundle>() {
+
+						@Override
+						public ResourceBundle getService(
+							Bundle bundle,
+							ServiceRegistration<ResourceBundle>
+								serviceRegistration) {
+
+							return ResourceBundle.getBundle(
+								baseName, locale, bundleWiring.getClassLoader(),
+								UTF8Control.INSTANCE);
+						}
+
+						@Override
+						public void ungetService(
+							Bundle bundle,
+							ServiceRegistration<ResourceBundle>
+								serviceRegistration,
+							ResourceBundle resourceBundle) {
+						}
+
+					},
 					HashMapDictionaryBuilder.<String, Object>put(
 						Constants.SERVICE_RANKING, serviceRanking
 					).put(


### PR DESCRIPTION
@kevhlee please SF https://github.com/brianchandotcom/liferay-portal/commit/8bf5f239cbcf616086c4e74e9611ceb81ab89822

Basically ServiceComponentRuntime.disableComponent() and enableComponent() return a Promise object. The enable/disable operation is async. Caller can use the Promise.getValue() to sync waiting for the operation to finish.
In production code, something we do Promise.getValue(), sometime we don't to allow async for performance reasons.

But in test code, we should always do Promise.getValue() to prevent race condition. In test, stability is the top priority.

Please enforce all usages of ServiceComponentRuntime.disableComponent() and enableComponent() in test code must take the returning Promise and call getValue() on it. Don't enforce this in production code.