### PR TITLE
LPS-173707 Use SessionMessages.add(PortletRequest, ...) so that we don't cause tons of success messages to be displayed for other portlets

### DIFF
--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/portlet/action/CheckoutCTCollectionMVCActionCommand.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/portlet/action/CheckoutCTCollectionMVCActionCommand.java
@@ -67,7 +67,7 @@ public class CheckoutCTCollectionMVCActionCommand extends BaseMVCActionCommand {
 		hideDefaultSuccessMessage(actionRequest);
 
 		SessionMessages.add(
-			_portal.getHttpServletRequest(actionRequest), "requestProcessed",
+			actionRequest, "requestProcessed",
 			ParamUtil.getString(actionRequest, "successMessage"));
 
 		String redirect = ParamUtil.getString(actionRequest, "redirect");

--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/portlet/action/UpdateGlobalPublicationsConfigurationMVCActionCommand.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/portlet/action/UpdateGlobalPublicationsConfigurationMVCActionCommand.java
@@ -112,7 +112,7 @@ public class UpdateGlobalPublicationsConfigurationMVCActionCommand
 		hideDefaultSuccessMessage(actionRequest);
 
 		SessionMessages.add(
-			_portal.getHttpServletRequest(actionRequest), "requestProcessed",
+			actionRequest, "requestProcessed",
 			_language.get(
 				themeDisplay.getLocale(), "the-configuration-has-been-saved"));
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-173707

`relevant`, `sf`, and `publications` passed testing in https://github.com/liferay-publications/liferay-portal/pull/388. Manually forwarding this since `relevant` failed due to unrelated failures.