### PR TITLE
LPS-172594 Add remaining filters

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
@@ -247,67 +247,55 @@ public class PredicateExpressionVisitorImpl
 	public Object visitMethodExpression(
 		List<Object> expressions, MethodExpression.Type type) {
 
-		if (type == MethodExpression.Type.CONTAINS) {
-			if (expressions.size() != 2) {
-				throw new UnsupportedOperationException(
-					StringBundler.concat(
-						"Unsupported method visitMethodExpression with method ",
-						"type ", type, " and ", expressions.size(), "params"));
-			}
-
+		if (expressions.size() == 2) {
 			String left = (String)expressions.get(0);
 			Object fieldValue = expressions.get(1);
 
 			Predicate predicate = null;
 
-			if (_isComplexProperExpression(left)) {
-				predicate = _getPredicateForRelationships(
-					left,
-					(objectFieldName, relatedObjectDefinitionId) -> _contains(
-						objectFieldName, fieldValue,
-						relatedObjectDefinitionId));
-			}
-			else {
-				predicate = _contains(left, fieldValue, _objectDefinitionId);
-			}
+			if (type == MethodExpression.Type.CONTAINS) {
+				if (_isComplexProperExpression(left)) {
+					predicate = _getPredicateForRelationships(
+						left,
+						(objectFieldName, relatedObjectDefinitionId) ->
+							_contains(
+								objectFieldName, fieldValue,
+								relatedObjectDefinitionId));
+				}
+				else {
+					predicate = _contains(
+						left, fieldValue, _objectDefinitionId);
+				}
 
-			if (predicate != null) {
-				return predicate;
-			}
-		}
-
-		if (type == MethodExpression.Type.STARTS_WITH) {
-			if (expressions.size() != 2) {
-				throw new UnsupportedOperationException(
-					StringBundler.concat(
-						"Unsupported method visitMethodExpression with method",
-						"type ", type, " and ", expressions.size(), "params"));
+				if (predicate != null) {
+					return predicate;
+				}
 			}
 
-			String left = (String)expressions.get(0);
-			Object fieldValue = expressions.get(1);
+			if (type == MethodExpression.Type.STARTS_WITH) {
+				if (_isComplexProperExpression(left)) {
+					predicate = _getPredicateForRelationships(
+						left,
+						(objectFieldName, relatedObjectDefinitionId) ->
+							_startsWith(
+								objectFieldName, fieldValue,
+								relatedObjectDefinitionId));
+				}
+				else {
+					predicate = _startsWith(
+						left, fieldValue, _objectDefinitionId);
+				}
 
-			Predicate predicate = null;
-
-			if (_isComplexProperExpression(left)) {
-				predicate = _getPredicateForRelationships(
-					left,
-					(objectFieldName, relatedObjectDefinitionId) -> _startsWith(
-						objectFieldName, fieldValue,
-						relatedObjectDefinitionId));
-			}
-			else {
-				predicate = _startsWith(left, fieldValue, _objectDefinitionId);
-			}
-
-			if (predicate != null) {
-				return predicate;
+				if (predicate != null) {
+					return predicate;
+				}
 			}
 		}
 
 		throw new UnsupportedOperationException(
-			"Unsupported method visitMethodExpression with method type " +
-				type);
+			StringBundler.concat(
+				"Unsupported method visitMethodExpression with method type ",
+				type, " and ", expressions.size(), "params"));
 	}
 
 	@Override

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
@@ -295,7 +295,7 @@ public class PredicateExpressionVisitorImpl
 		throw new UnsupportedOperationException(
 			StringBundler.concat(
 				"Unsupported method visitMethodExpression with method type ",
-				type, " and ", expressions.size(), " params"));
+				type, " and ", expressions.size(), " parameters"));
 	}
 
 	@Override

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
@@ -295,7 +295,7 @@ public class PredicateExpressionVisitorImpl
 		throw new UnsupportedOperationException(
 			StringBundler.concat(
 				"Unsupported method visitMethodExpression with method type ",
-				type, " and ", expressions.size(), "params"));
+				type, " and ", expressions.size(), " params"));
 	}
 
 	@Override

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
@@ -545,7 +545,7 @@ public class PredicateExpressionVisitorImpl
 			ObjectRelationship objectRelationship, Predicate predicate)
 		throws Exception {
 
-		ObjectDefinition objectDefinition1 =
+		ObjectDefinition objectDefinition =
 			ObjectDefinitionLocalServiceUtil.getObjectDefinition(
 				_objectDefinitionId);
 
@@ -553,7 +553,7 @@ public class PredicateExpressionVisitorImpl
 			objectRelatedModelsPredicateProvider =
 				_objectRelatedModelsPredicateProviderRegistry.
 					getObjectRelatedModelsPredicateProvider(
-						objectDefinition1.getClassName(),
+						objectDefinition.getClassName(),
 						objectRelationship.getType());
 
 		return objectRelatedModelsPredicateProvider.getPredicate(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
@@ -515,15 +515,15 @@ public class PredicateExpressionVisitorImpl
 
 		String leftString = (String)left;
 
-		String[] complexPropertyChunks = leftString.split(StringPool.SLASH);
+		String[] leftStringParts = leftString.split(StringPool.SLASH);
 
-		String relationshipName = complexPropertyChunks[0];
+		String relationshipName = leftStringParts[0];
 
 		ObjectRelationship objectRelationship = _fetchObjectRelationship(
 			relationshipName);
 
 		if (objectRelationship != null) {
-			String objectFieldName = complexPropertyChunks[1];
+			String objectFieldName = leftStringParts[1];
 
 			try {
 				return _getPredicateForRelationships(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
@@ -175,12 +175,12 @@ public class PredicateExpressionVisitorImpl
 				predicate = _getPredicateForRelationships(
 					left,
 					(objectFieldName, relatedObjectDefinitionId) ->
-						_getINPredicate(
+						_getInPredicate(
 							objectFieldName, relatedObjectDefinitionId,
 							rights));
 			}
 			else {
-				predicate = _getINPredicate(left, _objectDefinitionId, rights);
+				predicate = _getInPredicate(left, _objectDefinitionId, rights);
 			}
 
 			return predicate;
@@ -444,7 +444,7 @@ public class PredicateExpressionVisitorImpl
 		return null;
 	}
 
-	private Predicate _getINPredicate(
+	private Predicate _getInPredicate(
 		Object left, long objectDefinitionId, List<Object> rights) {
 
 		return _getColumn(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
@@ -271,8 +271,7 @@ public class PredicateExpressionVisitorImpl
 					return predicate;
 				}
 			}
-
-			if (type == MethodExpression.Type.STARTS_WITH) {
+			else if (type == MethodExpression.Type.STARTS_WITH) {
 				if (_isComplexProperExpression(left)) {
 					predicate = _getPredicateForRelationships(
 						left,

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
@@ -284,7 +284,25 @@ public class PredicateExpressionVisitorImpl
 						"type ", type, " and ", expressions.size(), "params"));
 			}
 
-			return _startsWith(expressions.get(0), expressions.get(1));
+			String left = (String)expressions.get(0);
+			Object fieldValue = expressions.get(1);
+
+			Predicate predicate = null;
+
+			if (_isComplexProperExpression(left)) {
+				predicate = _getPredicateForRelationships(
+					left,
+					(objectFieldName, relatedObjectDefinitionId) -> _startsWith(
+						objectFieldName, fieldValue,
+						relatedObjectDefinitionId));
+			}
+			else {
+				predicate = _startsWith(left, fieldValue, _objectDefinitionId);
+			}
+
+			if (predicate != null) {
+				return predicate;
+			}
 		}
 
 		throw new UnsupportedOperationException(
@@ -639,11 +657,13 @@ public class PredicateExpressionVisitorImpl
 		return false;
 	}
 
-	private Predicate _startsWith(Object fieldName, Object fieldValue) {
-		Column<?, Object> column = _getColumn(fieldName, _objectDefinitionId);
+	private Predicate _startsWith(
+		Object fieldName, Object fieldValue, long objectDefinitionId) {
+
+		Column<?, Object> column = _getColumn(fieldName, objectDefinitionId);
 
 		return column.like(
-			_getValue(fieldName, _objectDefinitionId, fieldValue) +
+			_getValue(fieldName, objectDefinitionId, fieldValue) +
 				StringPool.PERCENT);
 	}
 

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -43,6 +43,8 @@ import com.liferay.portal.util.PropsUtil;
 
 import java.util.Collections;
 
+import javax.ws.rs.NotSupportedException;
+
 import org.hamcrest.CoreMatchers;
 
 import org.junit.Assert;
@@ -89,148 +91,15 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
-	public void testFilterByRelatedObjectDefinitionSystemObjectField()
-		throws Exception {
-
+	public void testFilterObjectEntriesByRelatedObjects() throws Exception {
 		PropsUtil.addProperties(
 			UnicodePropertiesBuilder.setProperty(
 				"feature.flag.LPS-154672", "true"
 			).build());
 
-		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
-			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
-
-		_testFilterByRelatedObjectDefinitionSystemObjectField(
-			_objectRelationship);
-
-		_objectRelationshipLocalService.deleteObjectRelationship(
-			_objectRelationship);
-
-		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
-			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
-
-		_testFilterByRelatedObjectDefinitionSystemObjectField(
-			_objectRelationship);
-
-		PropsUtil.addProperties(
-			UnicodePropertiesBuilder.setProperty(
-				"feature.flag.LPS-154672", "false"
-			).build());
-	}
-
-	@Test
-	public void testFilterObjectEntriesByRelatedObjectsUsingContainsOperatorInManyToManyRelationship()
-		throws Exception {
-
-		PropsUtil.addProperties(
-			UnicodePropertiesBuilder.setProperty(
-				"feature.flag.LPS-154672", "true"
-			).build());
-
-		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
-			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
-
-		_testFilterObjectEntriesByRelatedObjectsUsingContainsOperatorInBothSidesOfRelationship();
-
-		PropsUtil.addProperties(
-			UnicodePropertiesBuilder.setProperty(
-				"feature.flag.LPS-154672", "false"
-			).build());
-	}
-
-	@Test
-	public void testFilterObjectEntriesByRelatedObjectsUsingContainsOperatorInOneToManyRelationship()
-		throws Exception {
-
-		PropsUtil.addProperties(
-			UnicodePropertiesBuilder.setProperty(
-				"feature.flag.LPS-154672", "true"
-			).build());
-
-		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
-			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
-
-		_testFilterObjectEntriesByRelatedObjectsUsingContainsOperatorInBothSidesOfRelationship();
-
-		PropsUtil.addProperties(
-			UnicodePropertiesBuilder.setProperty(
-				"feature.flag.LPS-154672", "false"
-			).build());
-	}
-
-	@Test
-	public void testFilterObjectEntriesByRelatedObjectsUsingINOperatorInManyToManyRelationship()
-		throws Exception {
-
-		PropsUtil.addProperties(
-			UnicodePropertiesBuilder.setProperty(
-				"feature.flag.LPS-154672", "true"
-			).build());
-
-		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
-			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
-
-		_testFilterObjectEntriesByRelatedObjectsUsingINOperatorInBothSidesOfRelationship();
-
-		PropsUtil.addProperties(
-			UnicodePropertiesBuilder.setProperty(
-				"feature.flag.LPS-154672", "false"
-			).build());
-	}
-
-	@Test
-	public void testFilterObjectEntriesByRelatedObjectsUsingINOperatorInOneToManyRelationship()
-		throws Exception {
-
-		PropsUtil.addProperties(
-			UnicodePropertiesBuilder.setProperty(
-				"feature.flag.LPS-154672", "true"
-			).build());
-
-		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
-			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
-
-		_testFilterObjectEntriesByRelatedObjectsUsingINOperatorInBothSidesOfRelationship();
-
-		PropsUtil.addProperties(
-			UnicodePropertiesBuilder.setProperty(
-				"feature.flag.LPS-154672", "false"
-			).build());
-	}
-
-	@Test
-	public void testFilterObjectEntriesByRelatedObjectsUsingStartsWithOperatorInManyToManyRelationship()
-		throws Exception {
-
-		PropsUtil.addProperties(
-			UnicodePropertiesBuilder.setProperty(
-				"feature.flag.LPS-154672", "true"
-			).build());
-
-		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
-			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
-
-		_testFilterObjectEntriesByRelatedObjectsUsingStartsWithOperatorInBothSidesOfRelationship();
-
-		PropsUtil.addProperties(
-			UnicodePropertiesBuilder.setProperty(
-				"feature.flag.LPS-154672", "false"
-			).build());
-	}
-
-	@Test
-	public void testFilterObjectEntriesByRelatedObjectsUsingStartsWithOperatorInOneToManyRelationship()
-		throws Exception {
-
-		PropsUtil.addProperties(
-			UnicodePropertiesBuilder.setProperty(
-				"feature.flag.LPS-154672", "true"
-			).build());
-
-		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
-			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
-
-		_testFilterObjectEntriesByRelatedObjectsUsingStartsWithOperatorInBothSidesOfRelationship();
+		for (FilterOperator operator : FilterOperator.values()) {
+			_testFilterObjectEntriesByRelatedObjects(operator);
+		}
 
 		PropsUtil.addProperties(
 			UnicodePropertiesBuilder.setProperty(
@@ -419,134 +288,132 @@ public class ObjectEntryResourceTest {
 	}
 
 	private void _testFilterByRelatedObjectDefinitionSystemObjectField(
-			ObjectRelationship objectRelationship)
+			ObjectRelationship objectRelationship, FilterOperator operator)
 		throws Exception {
 
 		_testFilterByRelatedObjectDefinitionSystemObjectField(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1, _objectDefinition1,
-			objectRelationship, _objectEntry2.getObjectEntryId());
+			objectRelationship, operator, _objectEntry2.getObjectEntryId());
+
 		_testFilterByRelatedObjectDefinitionSystemObjectField(
 			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2, _objectDefinition2,
-			objectRelationship, _objectEntry1.getObjectEntryId());
+			objectRelationship, operator, _objectEntry1.getObjectEntryId());
 	}
 
 	private void _testFilterByRelatedObjectDefinitionSystemObjectField(
 			String expectedObjectFieldName, String expectedObjectFieldValue,
 			ObjectDefinition objectDefinition,
-			ObjectRelationship objectRelationship, long relatedObjectEntryId)
+			ObjectRelationship objectRelationship, FilterOperator operator,
+			long relatedObjectEntryId)
 		throws Exception {
 
 		String endpoint = StringBundler.concat(
 			objectDefinition.getRESTContextPath(), "?filter=",
-			objectRelationship.getName(), "/id%20eq%20'",
+			objectRelationship.getName(), "/id%20", operator.getValue(), "%20'",
 			String.valueOf(relatedObjectEntryId), StringPool.APOSTROPHE);
 
-		JSONObject jsonObject = HTTPTestUtil.invoke(
-			null, endpoint, Http.Method.GET);
-
-		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
-
-		Assert.assertEquals(1, itemsJSONArray.length());
-
-		JSONObject itemJSONObject = itemsJSONArray.getJSONObject(0);
-
-		Assert.assertEquals(
-			expectedObjectFieldValue,
-			itemJSONObject.getString(expectedObjectFieldName));
+		_testFilterObjectEntriesByRelatedObjectsUsingAnOperator(
+			endpoint, expectedObjectFieldName, expectedObjectFieldValue);
 	}
 
-	private void _testFilterObjectEntriesByRelatedObjectsUsingContainsOperator(
-			String expectedObjectFieldName, String expectedObjectFieldValue,
-			ObjectDefinition objectDefinition, String relatedObjectFieldName,
-			String relatedObjectFieldValue)
+	private void _testFilterObjectEntriesByRelatedObjects(
+			FilterOperator operator)
 		throws Exception {
 
-		String endpoint = StringBundler.concat(
-			objectDefinition.getRESTContextPath(), "?filter=contains(",
-			_objectRelationship.getName(), StringPool.SLASH,
-			relatedObjectFieldName, StringPool.COMMA, StringPool.APOSTROPHE,
-			relatedObjectFieldValue, StringPool.APOSTROPHE,
-			StringPool.CLOSE_PARENTHESIS);
+		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
-		JSONObject jsonObject = HTTPTestUtil.invoke(
-			null, endpoint, Http.Method.GET);
+		_testFilterObjectEntriesByRelatedObjectsInBothSidesOfRelationship(
+			_objectRelationship, operator);
 
-		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
+		_objectRelationshipLocalService.deleteObjectRelationship(
+			_objectRelationship);
 
-		Assert.assertEquals(1, itemsJSONArray.length());
+		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
-		JSONObject itemJSONObject = itemsJSONArray.getJSONObject(0);
-
-		Assert.assertEquals(
-			expectedObjectFieldValue,
-			itemJSONObject.getString(expectedObjectFieldName));
-	}
-
-	private void _testFilterObjectEntriesByRelatedObjectsUsingContainsOperatorInBothSidesOfRelationship()
-		throws Exception {
-
-		_testFilterObjectEntriesByRelatedObjectsUsingContainsOperator(
-			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1, _objectDefinition1,
-			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2);
-
-		_testFilterObjectEntriesByRelatedObjectsUsingContainsOperator(
-			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2, _objectDefinition2,
-			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1);
-	}
-
-	private void _testFilterObjectEntriesByRelatedObjectsUsingINOperator(
-			String expectedObjectFieldName, String expectedObjectFieldValue,
-			ObjectDefinition objectDefinition, String relatedObjectFieldName,
-			String relatedObjectFieldValue)
-		throws Exception {
-
-		String endpoint = StringBundler.concat(
-			objectDefinition.getRESTContextPath(), "?filter=",
-			_objectRelationship.getName(), StringPool.SLASH,
-			relatedObjectFieldName, "%20in%20('", RandomTestUtil.randomString(),
-			StringPool.APOSTROPHE, StringPool.COMMA, StringPool.APOSTROPHE,
-			relatedObjectFieldValue, StringPool.APOSTROPHE,
-			StringPool.CLOSE_PARENTHESIS);
-
-		JSONObject jsonObject = HTTPTestUtil.invoke(
-			null, endpoint, Http.Method.GET);
-
-		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
-
-		Assert.assertEquals(1, itemsJSONArray.length());
-
-		JSONObject itemJSONObject = itemsJSONArray.getJSONObject(0);
-
-		Assert.assertEquals(
-			expectedObjectFieldValue,
-			itemJSONObject.getString(expectedObjectFieldName));
-	}
-
-	private void _testFilterObjectEntriesByRelatedObjectsUsingINOperatorInBothSidesOfRelationship()
-		throws Exception {
-
-		_testFilterObjectEntriesByRelatedObjectsUsingINOperator(
-			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1, _objectDefinition1,
-			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2);
-
-		_testFilterObjectEntriesByRelatedObjectsUsingINOperator(
-			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2, _objectDefinition2,
-			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1);
+		_testFilterObjectEntriesByRelatedObjectsInBothSidesOfRelationship(
+			_objectRelationship, operator);
 	}
 
 	private void
-			_testFilterObjectEntriesByRelatedObjectsUsingStartsWithOperator(
-				String expectedObjectFieldName, String expectedObjectFieldValue,
-				ObjectDefinition objectDefinition,
-				String relatedObjectFieldName, String relatedObjectFieldValue)
+			_testFilterObjectEntriesByRelatedObjectsInBothSidesOfRelationship(
+				ObjectRelationship objectRelationship, FilterOperator operator)
 		throws Exception {
 
-		String endpoint = StringBundler.concat(
-			objectDefinition.getRESTContextPath(), "?filter=startswith(",
-			_objectRelationship.getName(), StringPool.SLASH,
-			relatedObjectFieldName, StringPool.COMMA, StringPool.APOSTROPHE,
-			relatedObjectFieldValue.substring(0, 1), StringPool.APOSTROPHE,
-			StringPool.CLOSE_PARENTHESIS);
+		_testFilterObjectEntriesByRelatedObjectsUsingAnOperator(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1, objectRelationship,
+			_objectDefinition1, operator, _OBJECT_FIELD_NAME_2,
+			_OBJECT_FIELD_VALUE_2);
+
+		_testFilterObjectEntriesByRelatedObjectsUsingAnOperator(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2, objectRelationship,
+			_objectDefinition2, operator, _OBJECT_FIELD_NAME_1,
+			_OBJECT_FIELD_VALUE_1);
+	}
+
+	private void _testFilterObjectEntriesByRelatedObjectsUsingAnOperator(
+			String expectedObjectFieldName, String expectedObjectFieldValue,
+			ObjectRelationship objectRelationship,
+			ObjectDefinition objectDefinition, FilterOperator operator,
+			String relatedObjectFieldName, String relatedObjectFieldValue)
+		throws Exception {
+
+		String endpoint = objectDefinition.getRESTContextPath() + "?filter=";
+
+		if (operator == FilterOperator.CONTAINS) {
+			endpoint = endpoint.concat(
+				StringBundler.concat(
+					operator.getValue(), StringPool.OPEN_PARENTHESIS,
+					objectRelationship.getName(), StringPool.SLASH,
+					relatedObjectFieldName, StringPool.COMMA,
+					StringPool.APOSTROPHE,
+					relatedObjectFieldValue.substring(1, 2),
+					StringPool.APOSTROPHE, StringPool.CLOSE_PARENTHESIS));
+		}
+		else if (operator == FilterOperator.EQ) {
+			_testFilterByRelatedObjectDefinitionSystemObjectField(
+				objectRelationship, operator);
+
+			endpoint = endpoint.concat(
+				StringBundler.concat(
+					objectRelationship.getName(), StringPool.SLASH,
+					relatedObjectFieldName, "%20", operator.getValue(), "%20'",
+					relatedObjectFieldValue, StringPool.APOSTROPHE));
+		}
+		else if (operator == FilterOperator.IN) {
+			endpoint = endpoint.concat(
+				StringBundler.concat(
+					objectRelationship.getName(), StringPool.SLASH,
+					relatedObjectFieldName, "%20", operator.getValue(), "%20('",
+					RandomTestUtil.randomString(), StringPool.APOSTROPHE,
+					StringPool.COMMA, StringPool.APOSTROPHE,
+					relatedObjectFieldValue, StringPool.APOSTROPHE,
+					StringPool.CLOSE_PARENTHESIS));
+		}
+		else if (operator == FilterOperator.STARTS_WITH) {
+			endpoint = endpoint.concat(
+				StringBundler.concat(
+					operator.getValue(), StringPool.OPEN_PARENTHESIS,
+					objectRelationship.getName(), StringPool.SLASH,
+					relatedObjectFieldName, StringPool.COMMA,
+					StringPool.APOSTROPHE,
+					relatedObjectFieldValue.substring(0, 1),
+					StringPool.APOSTROPHE, StringPool.CLOSE_PARENTHESIS));
+		}
+		else {
+			throw new NotSupportedException(
+				"Operation " + operator.name() + "is not supported");
+		}
+
+		_testFilterObjectEntriesByRelatedObjectsUsingAnOperator(
+			endpoint, expectedObjectFieldName, expectedObjectFieldValue);
+	}
+
+	private void _testFilterObjectEntriesByRelatedObjectsUsingAnOperator(
+			String endpoint, String expectedObjectFieldName,
+			String expectedObjectFieldValue)
+		throws Exception {
 
 		JSONObject jsonObject = HTTPTestUtil.invoke(
 			null, endpoint, Http.Method.GET);
@@ -560,18 +427,6 @@ public class ObjectEntryResourceTest {
 		Assert.assertEquals(
 			expectedObjectFieldValue,
 			itemJSONObject.getString(expectedObjectFieldName));
-	}
-
-	private void _testFilterObjectEntriesByRelatedObjectsUsingStartsWithOperatorInBothSidesOfRelationship()
-		throws Exception {
-
-		_testFilterObjectEntriesByRelatedObjectsUsingStartsWithOperator(
-			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1, _objectDefinition1,
-			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2);
-
-		_testFilterObjectEntriesByRelatedObjectsUsingStartsWithOperator(
-			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2, _objectDefinition2,
-			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1);
 	}
 
 	private void _testGetNestedFieldDetailsInOneToManyRelationships(
@@ -628,5 +483,21 @@ public class ObjectEntryResourceTest {
 
 	@Inject
 	private ObjectRelationshipLocalService _objectRelationshipLocalService;
+
+	private enum FilterOperator {
+
+		CONTAINS("contains"), EQ("eq"), IN("in"), STARTS_WITH("startswith");
+
+		public String getValue() {
+			return _value;
+		}
+
+		private FilterOperator(String value) {
+			_value = value;
+		}
+
+		private final String _value;
+
+	}
 
 }

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -97,8 +97,8 @@ public class ObjectEntryResourceTest {
 				"feature.flag.LPS-154672", "true"
 			).build());
 
-		for (FilterOperator operator : FilterOperator.values()) {
-			_testFilterObjectEntriesByRelatedObjectEntries(operator);
+		for (FilterOperator filterOperator : FilterOperator.values()) {
+			_testFilterObjectEntriesByRelatedObjectEntries(filterOperator);
 		}
 
 		PropsUtil.addProperties(
@@ -288,28 +288,28 @@ public class ObjectEntryResourceTest {
 	}
 
 	private void _testFilterByRelatedObjectDefinitionSystemObjectField(
-			ObjectRelationship objectRelationship, FilterOperator operator)
+			ObjectRelationship objectRelationship, FilterOperator filterOperator)
 		throws Exception {
 
 		_testFilterByRelatedObjectDefinitionSystemObjectField(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1, _objectDefinition1,
-			objectRelationship, operator, _objectEntry2.getObjectEntryId());
+			objectRelationship, filterOperator, _objectEntry2.getObjectEntryId());
 
 		_testFilterByRelatedObjectDefinitionSystemObjectField(
 			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2, _objectDefinition2,
-			objectRelationship, operator, _objectEntry1.getObjectEntryId());
+			objectRelationship, filterOperator, _objectEntry1.getObjectEntryId());
 	}
 
 	private void _testFilterByRelatedObjectDefinitionSystemObjectField(
 			String expectedObjectFieldName, String expectedObjectFieldValue,
 			ObjectDefinition objectDefinition,
-			ObjectRelationship objectRelationship, FilterOperator operator,
+			ObjectRelationship objectRelationship, FilterOperator filterOperator,
 			long relatedObjectEntryId)
 		throws Exception {
 
 		String endpoint = StringBundler.concat(
 			objectDefinition.getRESTContextPath(), "?filter=",
-			objectRelationship.getName(), "/id%20", operator.getValue(), "%20'",
+			objectRelationship.getName(), "/id%20", filterOperator.getValue(), "%20'",
 			String.valueOf(relatedObjectEntryId), StringPool.APOSTROPHE);
 
 		_testFilterObjectEntriesByRelatedObjectEntriesUsingAnOperator(
@@ -317,14 +317,14 @@ public class ObjectEntryResourceTest {
 	}
 
 	private void _testFilterObjectEntriesByRelatedObjectEntries(
-			FilterOperator operator)
+			FilterOperator filterOperator)
 		throws Exception {
 
 		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
 		_testFilterObjectEntriesByRelatedObjectEntriesInBothSidesOfRelationship(
-			_objectRelationship, operator);
+			_objectRelationship, filterOperator);
 
 		_objectRelationshipLocalService.deleteObjectRelationship(
 			_objectRelationship);
@@ -333,68 +333,68 @@ public class ObjectEntryResourceTest {
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
 		_testFilterObjectEntriesByRelatedObjectEntriesInBothSidesOfRelationship(
-			_objectRelationship, operator);
+			_objectRelationship, filterOperator);
 	}
 
 	private void
 			_testFilterObjectEntriesByRelatedObjectEntriesInBothSidesOfRelationship(
-				ObjectRelationship objectRelationship, FilterOperator operator)
+				ObjectRelationship objectRelationship, FilterOperator filterOperator)
 		throws Exception {
 
 		_testFilterObjectEntriesByRelatedObjectEntriesUsingAnOperator(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1, objectRelationship,
-			_objectDefinition1, operator, _OBJECT_FIELD_NAME_2,
+			_objectDefinition1, filterOperator, _OBJECT_FIELD_NAME_2,
 			_OBJECT_FIELD_VALUE_2);
 
 		_testFilterObjectEntriesByRelatedObjectEntriesUsingAnOperator(
 			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2, objectRelationship,
-			_objectDefinition2, operator, _OBJECT_FIELD_NAME_1,
+			_objectDefinition2, filterOperator, _OBJECT_FIELD_NAME_1,
 			_OBJECT_FIELD_VALUE_1);
 	}
 
 	private void _testFilterObjectEntriesByRelatedObjectEntriesUsingAnOperator(
 			String expectedObjectFieldName, String expectedObjectFieldValue,
 			ObjectRelationship objectRelationship,
-			ObjectDefinition objectDefinition, FilterOperator operator,
+			ObjectDefinition objectDefinition, FilterOperator filterOperator,
 			String relatedObjectFieldName, String relatedObjectFieldValue)
 		throws Exception {
 
 		String endpoint = objectDefinition.getRESTContextPath() + "?filter=";
 
-		if (operator == FilterOperator.CONTAINS) {
+		if (filterOperator == FilterOperator.CONTAINS) {
 			endpoint = endpoint.concat(
 				StringBundler.concat(
-					operator.getValue(), StringPool.OPEN_PARENTHESIS,
+					filterOperator.getValue(), StringPool.OPEN_PARENTHESIS,
 					objectRelationship.getName(), StringPool.SLASH,
 					relatedObjectFieldName, StringPool.COMMA,
 					StringPool.APOSTROPHE,
 					relatedObjectFieldValue.substring(1, 2),
 					StringPool.APOSTROPHE, StringPool.CLOSE_PARENTHESIS));
 		}
-		else if (operator == FilterOperator.EQ) {
+		else if (filterOperator == FilterOperator.EQ) {
 			_testFilterByRelatedObjectDefinitionSystemObjectField(
-				objectRelationship, operator);
+				objectRelationship, filterOperator);
 
 			endpoint = endpoint.concat(
 				StringBundler.concat(
 					objectRelationship.getName(), StringPool.SLASH,
-					relatedObjectFieldName, "%20", operator.getValue(), "%20'",
+					relatedObjectFieldName, "%20", filterOperator.getValue(), "%20'",
 					relatedObjectFieldValue, StringPool.APOSTROPHE));
 		}
-		else if (operator == FilterOperator.IN) {
+		else if (filterOperator == FilterOperator.IN) {
 			endpoint = endpoint.concat(
 				StringBundler.concat(
 					objectRelationship.getName(), StringPool.SLASH,
-					relatedObjectFieldName, "%20", operator.getValue(), "%20('",
+					relatedObjectFieldName, "%20", filterOperator.getValue(), "%20('",
 					RandomTestUtil.randomString(), StringPool.APOSTROPHE,
 					StringPool.COMMA, StringPool.APOSTROPHE,
 					relatedObjectFieldValue, StringPool.APOSTROPHE,
 					StringPool.CLOSE_PARENTHESIS));
 		}
-		else if (operator == FilterOperator.STARTS_WITH) {
+		else if (filterOperator == FilterOperator.STARTS_WITH) {
 			endpoint = endpoint.concat(
 				StringBundler.concat(
-					operator.getValue(), StringPool.OPEN_PARENTHESIS,
+					filterOperator.getValue(), StringPool.OPEN_PARENTHESIS,
 					objectRelationship.getName(), StringPool.SLASH,
 					relatedObjectFieldName, StringPool.COMMA,
 					StringPool.APOSTROPHE,
@@ -403,7 +403,7 @@ public class ObjectEntryResourceTest {
 		}
 		else {
 			throw new NotSupportedException(
-				"Operation " + operator.name() + "is not supported");
+				"Operation " + filterOperator.name() + "is not supported");
 		}
 
 		_testFilterObjectEntriesByRelatedObjectEntriesUsingAnOperator(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -91,14 +91,14 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
-	public void testFilterObjectEntriesByRelatedObjects() throws Exception {
+	public void testFilterObjectEntriesByRelatedObjectEntries() throws Exception {
 		PropsUtil.addProperties(
 			UnicodePropertiesBuilder.setProperty(
 				"feature.flag.LPS-154672", "true"
 			).build());
 
 		for (FilterOperator operator : FilterOperator.values()) {
-			_testFilterObjectEntriesByRelatedObjects(operator);
+			_testFilterObjectEntriesByRelatedObjectEntries(operator);
 		}
 
 		PropsUtil.addProperties(
@@ -312,18 +312,18 @@ public class ObjectEntryResourceTest {
 			objectRelationship.getName(), "/id%20", operator.getValue(), "%20'",
 			String.valueOf(relatedObjectEntryId), StringPool.APOSTROPHE);
 
-		_testFilterObjectEntriesByRelatedObjectsUsingAnOperator(
+		_testFilterObjectEntriesByRelatedObjectEntriesUsingAnOperator(
 			endpoint, expectedObjectFieldName, expectedObjectFieldValue);
 	}
 
-	private void _testFilterObjectEntriesByRelatedObjects(
+	private void _testFilterObjectEntriesByRelatedObjectEntries(
 			FilterOperator operator)
 		throws Exception {
 
 		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
-		_testFilterObjectEntriesByRelatedObjectsInBothSidesOfRelationship(
+		_testFilterObjectEntriesByRelatedObjectEntriesInBothSidesOfRelationship(
 			_objectRelationship, operator);
 
 		_objectRelationshipLocalService.deleteObjectRelationship(
@@ -332,27 +332,27 @@ public class ObjectEntryResourceTest {
 		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
-		_testFilterObjectEntriesByRelatedObjectsInBothSidesOfRelationship(
+		_testFilterObjectEntriesByRelatedObjectEntriesInBothSidesOfRelationship(
 			_objectRelationship, operator);
 	}
 
 	private void
-			_testFilterObjectEntriesByRelatedObjectsInBothSidesOfRelationship(
+			_testFilterObjectEntriesByRelatedObjectEntriesInBothSidesOfRelationship(
 				ObjectRelationship objectRelationship, FilterOperator operator)
 		throws Exception {
 
-		_testFilterObjectEntriesByRelatedObjectsUsingAnOperator(
+		_testFilterObjectEntriesByRelatedObjectEntriesUsingAnOperator(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1, objectRelationship,
 			_objectDefinition1, operator, _OBJECT_FIELD_NAME_2,
 			_OBJECT_FIELD_VALUE_2);
 
-		_testFilterObjectEntriesByRelatedObjectsUsingAnOperator(
+		_testFilterObjectEntriesByRelatedObjectEntriesUsingAnOperator(
 			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2, objectRelationship,
 			_objectDefinition2, operator, _OBJECT_FIELD_NAME_1,
 			_OBJECT_FIELD_VALUE_1);
 	}
 
-	private void _testFilterObjectEntriesByRelatedObjectsUsingAnOperator(
+	private void _testFilterObjectEntriesByRelatedObjectEntriesUsingAnOperator(
 			String expectedObjectFieldName, String expectedObjectFieldValue,
 			ObjectRelationship objectRelationship,
 			ObjectDefinition objectDefinition, FilterOperator operator,
@@ -406,11 +406,11 @@ public class ObjectEntryResourceTest {
 				"Operation " + operator.name() + "is not supported");
 		}
 
-		_testFilterObjectEntriesByRelatedObjectsUsingAnOperator(
+		_testFilterObjectEntriesByRelatedObjectEntriesUsingAnOperator(
 			endpoint, expectedObjectFieldName, expectedObjectFieldValue);
 	}
 
-	private void _testFilterObjectEntriesByRelatedObjectsUsingAnOperator(
+	private void _testFilterObjectEntriesByRelatedObjectEntriesUsingAnOperator(
 			String endpoint, String expectedObjectFieldName,
 			String expectedObjectFieldValue)
 		throws Exception {

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -119,6 +119,46 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
+	public void testFilterObjectEntriesByRelatedObjectsUsingContainsOperatorInManyToManyRelationship()
+		throws Exception {
+
+		PropsUtil.addProperties(
+			UnicodePropertiesBuilder.setProperty(
+				"feature.flag.LPS-154672", "true"
+			).build());
+
+		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		_testFilterObjectEntriesByRelatedObjectsUsingContainsOperatorInBothSidesOfRelationship();
+
+		PropsUtil.addProperties(
+			UnicodePropertiesBuilder.setProperty(
+				"feature.flag.LPS-154672", "false"
+			).build());
+	}
+
+	@Test
+	public void testFilterObjectEntriesByRelatedObjectsUsingContainsOperatorInOneToManyRelationship()
+		throws Exception {
+
+		PropsUtil.addProperties(
+			UnicodePropertiesBuilder.setProperty(
+				"feature.flag.LPS-154672", "true"
+			).build());
+
+		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		_testFilterObjectEntriesByRelatedObjectsUsingContainsOperatorInBothSidesOfRelationship();
+
+		PropsUtil.addProperties(
+			UnicodePropertiesBuilder.setProperty(
+				"feature.flag.LPS-154672", "false"
+			).build());
+	}
+
+	@Test
 	public void testFilterObjectEntriesByRelatedObjectsUsingINOperatorInManyToManyRelationship()
 		throws Exception {
 
@@ -373,6 +413,45 @@ public class ObjectEntryResourceTest {
 		Assert.assertEquals(
 			expectedObjectFieldValue,
 			itemJSONObject.getString(expectedObjectFieldName));
+	}
+
+	private void _testFilterObjectEntriesByRelatedObjectsUsingContainsOperator(
+			String expectedObjectFieldName, String expectedObjectFieldValue,
+			ObjectDefinition objectDefinition, String relatedObjectFieldName,
+			String relatedObjectFieldValue)
+		throws Exception {
+
+		String endpoint = StringBundler.concat(
+			objectDefinition.getRESTContextPath(), "?filter=contains(",
+			_objectRelationship.getName(), StringPool.SLASH,
+			relatedObjectFieldName, StringPool.COMMA, StringPool.APOSTROPHE,
+			relatedObjectFieldValue, StringPool.APOSTROPHE,
+			StringPool.CLOSE_PARENTHESIS);
+
+		JSONObject jsonObject = HTTPTestUtil.invoke(
+			null, endpoint, Http.Method.GET);
+
+		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
+
+		Assert.assertEquals(1, itemsJSONArray.length());
+
+		JSONObject itemJSONObject = itemsJSONArray.getJSONObject(0);
+
+		Assert.assertEquals(
+			expectedObjectFieldValue,
+			itemJSONObject.getString(expectedObjectFieldName));
+	}
+
+	private void _testFilterObjectEntriesByRelatedObjectsUsingContainsOperatorInBothSidesOfRelationship()
+		throws Exception {
+
+		_testFilterObjectEntriesByRelatedObjectsUsingContainsOperator(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1, _objectDefinition1,
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2);
+
+		_testFilterObjectEntriesByRelatedObjectsUsingContainsOperator(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2, _objectDefinition2,
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1);
 	}
 
 	private void _testFilterObjectEntriesByRelatedObjectsUsingINOperator(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -199,6 +199,46 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
+	public void testFilterObjectEntriesByRelatedObjectsUsingStartsWithOperatorInManyToManyRelationship()
+		throws Exception {
+
+		PropsUtil.addProperties(
+			UnicodePropertiesBuilder.setProperty(
+				"feature.flag.LPS-154672", "true"
+			).build());
+
+		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		_testFilterObjectEntriesByRelatedObjectsUsingStartsWithOperatorInBothSidesOfRelationship();
+
+		PropsUtil.addProperties(
+			UnicodePropertiesBuilder.setProperty(
+				"feature.flag.LPS-154672", "false"
+			).build());
+	}
+
+	@Test
+	public void testFilterObjectEntriesByRelatedObjectsUsingStartsWithOperatorInOneToManyRelationship()
+		throws Exception {
+
+		PropsUtil.addProperties(
+			UnicodePropertiesBuilder.setProperty(
+				"feature.flag.LPS-154672", "true"
+			).build());
+
+		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		_testFilterObjectEntriesByRelatedObjectsUsingStartsWithOperatorInBothSidesOfRelationship();
+
+		PropsUtil.addProperties(
+			UnicodePropertiesBuilder.setProperty(
+				"feature.flag.LPS-154672", "false"
+			).build());
+	}
+
+	@Test
 	public void testGetNestedFieldDetailsInOneToManyRelationships()
 		throws Exception {
 
@@ -490,6 +530,46 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2);
 
 		_testFilterObjectEntriesByRelatedObjectsUsingINOperator(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2, _objectDefinition2,
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1);
+	}
+
+	private void
+			_testFilterObjectEntriesByRelatedObjectsUsingStartsWithOperator(
+				String expectedObjectFieldName, String expectedObjectFieldValue,
+				ObjectDefinition objectDefinition,
+				String relatedObjectFieldName, String relatedObjectFieldValue)
+		throws Exception {
+
+		String endpoint = StringBundler.concat(
+			objectDefinition.getRESTContextPath(), "?filter=startswith(",
+			_objectRelationship.getName(), StringPool.SLASH,
+			relatedObjectFieldName, StringPool.COMMA, StringPool.APOSTROPHE,
+			relatedObjectFieldValue.substring(0, 1), StringPool.APOSTROPHE,
+			StringPool.CLOSE_PARENTHESIS);
+
+		JSONObject jsonObject = HTTPTestUtil.invoke(
+			null, endpoint, Http.Method.GET);
+
+		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
+
+		Assert.assertEquals(1, itemsJSONArray.length());
+
+		JSONObject itemJSONObject = itemsJSONArray.getJSONObject(0);
+
+		Assert.assertEquals(
+			expectedObjectFieldValue,
+			itemJSONObject.getString(expectedObjectFieldName));
+	}
+
+	private void _testFilterObjectEntriesByRelatedObjectsUsingStartsWithOperatorInBothSidesOfRelationship()
+		throws Exception {
+
+		_testFilterObjectEntriesByRelatedObjectsUsingStartsWithOperator(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1, _objectDefinition1,
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2);
+
+		_testFilterObjectEntriesByRelatedObjectsUsingStartsWithOperator(
 			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2, _objectDefinition2,
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1);
 	}

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -91,7 +91,9 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
-	public void testFilterObjectEntriesByRelatedObjectEntries() throws Exception {
+	public void testFilterObjectEntriesByRelatedObjectEntries()
+		throws Exception {
+
 		PropsUtil.addProperties(
 			UnicodePropertiesBuilder.setProperty(
 				"feature.flag.LPS-154672", "true"
@@ -288,29 +290,32 @@ public class ObjectEntryResourceTest {
 	}
 
 	private void _testFilterByRelatedObjectDefinitionSystemObjectField(
-			FilterOperator filterOperator, ObjectRelationship objectRelationship)
+			FilterOperator filterOperator,
+			ObjectRelationship objectRelationship)
 		throws Exception {
 
 		_testFilterByRelatedObjectDefinitionSystemObjectField(
-			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1, filterOperator, _objectDefinition1,
-			objectRelationship, _objectEntry2.getObjectEntryId());
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1, filterOperator,
+			_objectDefinition1, objectRelationship,
+			_objectEntry2.getObjectEntryId());
 
 		_testFilterByRelatedObjectDefinitionSystemObjectField(
-			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2, filterOperator, _objectDefinition2,
-			objectRelationship, _objectEntry1.getObjectEntryId());
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2, filterOperator,
+			_objectDefinition2, objectRelationship,
+			_objectEntry1.getObjectEntryId());
 	}
 
 	private void _testFilterByRelatedObjectDefinitionSystemObjectField(
 			String expectedObjectFieldName, String expectedObjectFieldValue,
 			FilterOperator filterOperator, ObjectDefinition objectDefinition,
-			ObjectRelationship objectRelationship,
-			long relatedObjectEntryId)
+			ObjectRelationship objectRelationship, long relatedObjectEntryId)
 		throws Exception {
 
 		String endpoint = StringBundler.concat(
 			objectDefinition.getRESTContextPath(), "?filter=",
-			objectRelationship.getName(), "/id%20", filterOperator.getValue(), "%20'",
-			String.valueOf(relatedObjectEntryId), StringPool.APOSTROPHE);
+			objectRelationship.getName(), "/id%20", filterOperator.getValue(),
+			"%20'", String.valueOf(relatedObjectEntryId),
+			StringPool.APOSTROPHE);
 
 		_testFilterObjectEntriesByRelatedObjectEntriesUsingAnOperator(
 			endpoint, expectedObjectFieldName, expectedObjectFieldValue);
@@ -338,7 +343,8 @@ public class ObjectEntryResourceTest {
 
 	private void
 			_testFilterObjectEntriesByRelatedObjectEntriesInBothSidesOfRelationship(
-				ObjectRelationship objectRelationship, FilterOperator filterOperator)
+				ObjectRelationship objectRelationship,
+				FilterOperator filterOperator)
 		throws Exception {
 
 		_testFilterObjectEntriesByRelatedObjectEntriesUsingAnOperator(
@@ -378,18 +384,18 @@ public class ObjectEntryResourceTest {
 			endpoint = endpoint.concat(
 				StringBundler.concat(
 					objectRelationship.getName(), StringPool.SLASH,
-					relatedObjectFieldName, "%20", filterOperator.getValue(), "%20'",
-					relatedObjectFieldValue, StringPool.APOSTROPHE));
+					relatedObjectFieldName, "%20", filterOperator.getValue(),
+					"%20'", relatedObjectFieldValue, StringPool.APOSTROPHE));
 		}
 		else if (filterOperator == FilterOperator.IN) {
 			endpoint = endpoint.concat(
 				StringBundler.concat(
 					objectRelationship.getName(), StringPool.SLASH,
-					relatedObjectFieldName, "%20", filterOperator.getValue(), "%20('",
-					RandomTestUtil.randomString(), StringPool.APOSTROPHE,
-					StringPool.COMMA, StringPool.APOSTROPHE,
-					relatedObjectFieldValue, StringPool.APOSTROPHE,
-					StringPool.CLOSE_PARENTHESIS));
+					relatedObjectFieldName, "%20", filterOperator.getValue(),
+					"%20('", RandomTestUtil.randomString(),
+					StringPool.APOSTROPHE, StringPool.COMMA,
+					StringPool.APOSTROPHE, relatedObjectFieldValue,
+					StringPool.APOSTROPHE, StringPool.CLOSE_PARENTHESIS));
 		}
 		else if (filterOperator == FilterOperator.STARTS_WITH) {
 			endpoint = endpoint.concat(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -288,22 +288,22 @@ public class ObjectEntryResourceTest {
 	}
 
 	private void _testFilterByRelatedObjectDefinitionSystemObjectField(
-			ObjectRelationship objectRelationship, FilterOperator filterOperator)
+			FilterOperator filterOperator, ObjectRelationship objectRelationship)
 		throws Exception {
 
 		_testFilterByRelatedObjectDefinitionSystemObjectField(
-			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1, _objectDefinition1,
-			objectRelationship, filterOperator, _objectEntry2.getObjectEntryId());
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1, filterOperator, _objectDefinition1,
+			objectRelationship, _objectEntry2.getObjectEntryId());
 
 		_testFilterByRelatedObjectDefinitionSystemObjectField(
-			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2, _objectDefinition2,
-			objectRelationship, filterOperator, _objectEntry1.getObjectEntryId());
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2, filterOperator, _objectDefinition2,
+			objectRelationship, _objectEntry1.getObjectEntryId());
 	}
 
 	private void _testFilterByRelatedObjectDefinitionSystemObjectField(
 			String expectedObjectFieldName, String expectedObjectFieldValue,
-			ObjectDefinition objectDefinition,
-			ObjectRelationship objectRelationship, FilterOperator filterOperator,
+			FilterOperator filterOperator, ObjectDefinition objectDefinition,
+			ObjectRelationship objectRelationship,
 			long relatedObjectEntryId)
 		throws Exception {
 
@@ -373,7 +373,7 @@ public class ObjectEntryResourceTest {
 		}
 		else if (filterOperator == FilterOperator.EQ) {
 			_testFilterByRelatedObjectDefinitionSystemObjectField(
-				objectRelationship, filterOperator);
+				filterOperator, objectRelationship);
 
 			endpoint = endpoint.concat(
 				StringBundler.concat(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -119,6 +119,46 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
+	public void testFilterObjectEntriesByRelatedObjectsUsingINOperatorInManyToManyRelationship()
+		throws Exception {
+
+		PropsUtil.addProperties(
+			UnicodePropertiesBuilder.setProperty(
+				"feature.flag.LPS-154672", "true"
+			).build());
+
+		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		_testFilterObjectEntriesByRelatedObjectsUsingINOperatorInBothSidesOfRelationship();
+
+		PropsUtil.addProperties(
+			UnicodePropertiesBuilder.setProperty(
+				"feature.flag.LPS-154672", "false"
+			).build());
+	}
+
+	@Test
+	public void testFilterObjectEntriesByRelatedObjectsUsingINOperatorInOneToManyRelationship()
+		throws Exception {
+
+		PropsUtil.addProperties(
+			UnicodePropertiesBuilder.setProperty(
+				"feature.flag.LPS-154672", "true"
+			).build());
+
+		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		_testFilterObjectEntriesByRelatedObjectsUsingINOperatorInBothSidesOfRelationship();
+
+		PropsUtil.addProperties(
+			UnicodePropertiesBuilder.setProperty(
+				"feature.flag.LPS-154672", "false"
+			).build());
+	}
+
+	@Test
 	public void testGetNestedFieldDetailsInOneToManyRelationships()
 		throws Exception {
 
@@ -333,6 +373,46 @@ public class ObjectEntryResourceTest {
 		Assert.assertEquals(
 			expectedObjectFieldValue,
 			itemJSONObject.getString(expectedObjectFieldName));
+	}
+
+	private void _testFilterObjectEntriesByRelatedObjectsUsingINOperator(
+			String expectedObjectFieldName, String expectedObjectFieldValue,
+			ObjectDefinition objectDefinition, String relatedObjectFieldName,
+			String relatedObjectFieldValue)
+		throws Exception {
+
+		String endpoint = StringBundler.concat(
+			objectDefinition.getRESTContextPath(), "?filter=",
+			_objectRelationship.getName(), StringPool.SLASH,
+			relatedObjectFieldName, "%20in%20('", RandomTestUtil.randomString(),
+			StringPool.APOSTROPHE, StringPool.COMMA, StringPool.APOSTROPHE,
+			relatedObjectFieldValue, StringPool.APOSTROPHE,
+			StringPool.CLOSE_PARENTHESIS);
+
+		JSONObject jsonObject = HTTPTestUtil.invoke(
+			null, endpoint, Http.Method.GET);
+
+		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
+
+		Assert.assertEquals(1, itemsJSONArray.length());
+
+		JSONObject itemJSONObject = itemsJSONArray.getJSONObject(0);
+
+		Assert.assertEquals(
+			expectedObjectFieldValue,
+			itemJSONObject.getString(expectedObjectFieldName));
+	}
+
+	private void _testFilterObjectEntriesByRelatedObjectsUsingINOperatorInBothSidesOfRelationship()
+		throws Exception {
+
+		_testFilterObjectEntriesByRelatedObjectsUsingINOperator(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1, _objectDefinition1,
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2);
+
+		_testFilterObjectEntriesByRelatedObjectsUsingINOperator(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2, _objectDefinition2,
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1);
 	}
 
 	private void _testGetNestedFieldDetailsInOneToManyRelationships(


### PR DESCRIPTION
NOTE: I don't find any extra naming changes for matching the Object's convention

---

cc/ @LuismiBarcos

Followed-up from: https://github.com/brianchandotcom/liferay-portal/pull/129214, https://github.com/ccorreagg/liferay-portal/pull/18

Forwarded manually from: https://github.com/liferay-headless/liferay-portal/pull/977

Related ticket: [LPS-172594](https://issues.liferay.com/browse/LPS-172594)
____
## Purpose of the PR
The PR adds support for the following filter operators: `contains`, `startswith`, and `in` when filtering by fields of a related object.

### Filter `contains`
Now it is possible to use a filter like: `filter=contains(relationshipName/relatedObjectFieldName, 'lus')`

For example: 
```
## Get students
curl "http://localhost:8080/o/c/students?filter=contains(studentSubjects/subjectName, 'lus')" 
```
This will return all the students that study a subject whose name contains the string `lus`, like "Calculus"

### Filter `startswith`

Now it is possible to use a filter like: `filter=startswith(relationshipName/relatedObjectFieldName, 'Cal')`

For example: 
```
## Get students
curl "http://localhost:8080/o/c/students?filter=startswith(studentSubjects/subjectName, 'Cal')" 
```
This will return all the students that study a subject whose name starts with the string `Cal`, like "Calculus"

### Filter `in`

Now it is possible to use a filter like: `filter=studentSubjects/subjectName in ('Programming','Calculus')`

For example: 
```
## Get students
curl "http://localhost:8080/o/c/students?filter=studentSubjects/subjectName in ('Programming','Calculus')" 
```
This will return all the students that study a subject whose name is on the given list.


## How to test it
Deploy the `object-rest-impl` module
Remember to enable this feature flag: `feature.flag.LPS-154672=true`