### PR TITLE
LPS-166565: Rename listener

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/ml/embedding/instance/lifecycle/TextEmbeddingFieldCreationPortalInstanceLifecycleListener.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/ml/embedding/instance/lifecycle/TextEmbeddingFieldCreationPortalInstanceLifecycleListener.java
@@ -42,7 +42,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Petteri Karttunen
  */
 @Component(enabled = false, service = PortalInstanceLifecycleListener.class)
-public class EmbeddingFieldCreationPortalInstanceLifecycleListener
+public class TextEmbeddingFieldCreationPortalInstanceLifecycleListener
 	extends BasePortalInstanceLifecycleListener {
 
 	@Override
@@ -124,7 +124,7 @@ public class EmbeddingFieldCreationPortalInstanceLifecycleListener
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(
-		EmbeddingFieldCreationPortalInstanceLifecycleListener.class);
+		TextEmbeddingFieldCreationPortalInstanceLifecycleListener.class);
 
 	@Reference
 	private IndexInformation _indexInformation;


### PR DESCRIPTION
A follow-up to https://github.com/brianchandotcom/liferay-portal/pull/129310

@brianchandotcom just a clarification of original intent:

The original naming of the listener "EmbeddingField..." and not "TextEmbedding" was by purpose because we'll probably have other embedding fields and I wanted this same listener to prepare to take care of them all without need for renaming later. 

In that sense I think it's matching with some of the recant naming changes in the API. There are now generic:

- EmbeddingProviderConfiguration
- EmbeddingProviderInformation
- EmbeddingRetriever API
- EmbeddingProviderValidationResult

And extensions for TextEmbedding when required.

But sure, currently we have only this one type of embedding, TextEmbedding.