### PR TITLE
Lps 173735

### DIFF
--- a/modules/apps/portal-osgi-debug/portal-osgi-debug-impl/src/main/java/com/liferay/portal/osgi/debug/internal/osgi/commands/SystemCheckOSGiCommands.java
+++ b/modules/apps/portal-osgi-debug/portal-osgi-debug-impl/src/main/java/com/liferay/portal/osgi/debug/internal/osgi/commands/SystemCheckOSGiCommands.java
@@ -41,7 +41,7 @@ import org.osgi.util.tracker.ServiceTracker;
  */
 @Component(
 	property = {"osgi.command.function=check", "osgi.command.scope=system"},
-	service = {}
+	service = SystemCheckOSGiCommands.class
 )
 public class SystemCheckOSGiCommands {
 

--- a/modules/apps/portal/portal-verify-extender/src/main/java/com/liferay/portal/verify/extender/internal/osgi/commands/VerifyProcessTrackerOSGiCommands.java
+++ b/modules/apps/portal/portal-verify-extender/src/main/java/com/liferay/portal/verify/extender/internal/osgi/commands/VerifyProcessTrackerOSGiCommands.java
@@ -62,7 +62,7 @@ import org.osgi.service.component.annotations.Reference;
 		"osgi.command.function=help", "osgi.command.function=list",
 		"osgi.command.function=show", "osgi.command.scope=verify"
 	},
-	service = {}
+	service = VerifyProcessTrackerOSGiCommands.class
 )
 public class VerifyProcessTrackerOSGiCommands {
 


### PR DESCRIPTION
@MrJohn1911 @GabrielHenriquedev @rafaprax
It is not about which service type OSGi commands are registered, it is just about whether it is a service or not. Gogo shell runtime collects commands by filter of properties, not types. Removing service completely basically is removing the command.