### PR TITLE
LPS-163446: Inconsistency between the REST APIs and the UI using permissions

### DIFF
--- a/modules/apps/analytics/analytics-settings-rest-impl/src/main/java/com/liferay/analytics/settings/rest/internal/resource/v1_0/BaseChannelResourceImpl.java
+++ b/modules/apps/analytics/analytics-settings-rest-impl/src/main/java/com/liferay/analytics/settings/rest/internal/resource/v1_0/BaseChannelResourceImpl.java
@@ -17,27 +17,41 @@ package com.liferay.analytics.settings.rest.internal.resource.v1_0;
 import com.liferay.analytics.settings.rest.dto.v1_0.Channel;
 import com.liferay.analytics.settings.rest.resource.v1_0.ChannelResource;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -234,8 +248,7 @@ public abstract class BaseChannelResourceImpl implements ChannelResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -247,8 +260,8 @@ public abstract class BaseChannelResourceImpl implements ChannelResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -261,8 +274,7 @@ public abstract class BaseChannelResourceImpl implements ChannelResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -276,8 +288,8 @@ public abstract class BaseChannelResourceImpl implements ChannelResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -305,6 +317,115 @@ public abstract class BaseChannelResourceImpl implements ChannelResource {
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseChannelResourceImpl.class);

--- a/modules/apps/analytics/analytics-settings-rest-impl/src/main/java/com/liferay/analytics/settings/rest/internal/resource/v1_0/BaseCommerceChannelResourceImpl.java
+++ b/modules/apps/analytics/analytics-settings-rest-impl/src/main/java/com/liferay/analytics/settings/rest/internal/resource/v1_0/BaseCommerceChannelResourceImpl.java
@@ -17,27 +17,41 @@ package com.liferay.analytics.settings.rest.internal.resource.v1_0;
 import com.liferay.analytics.settings.rest.dto.v1_0.CommerceChannel;
 import com.liferay.analytics.settings.rest.resource.v1_0.CommerceChannelResource;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -203,8 +217,7 @@ public abstract class BaseCommerceChannelResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -216,8 +229,8 @@ public abstract class BaseCommerceChannelResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -230,8 +243,7 @@ public abstract class BaseCommerceChannelResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -245,8 +257,8 @@ public abstract class BaseCommerceChannelResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -274,6 +286,115 @@ public abstract class BaseCommerceChannelResourceImpl
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseCommerceChannelResourceImpl.class);

--- a/modules/apps/analytics/analytics-settings-rest-impl/src/main/java/com/liferay/analytics/settings/rest/internal/resource/v1_0/BaseContactAccountGroupResourceImpl.java
+++ b/modules/apps/analytics/analytics-settings-rest-impl/src/main/java/com/liferay/analytics/settings/rest/internal/resource/v1_0/BaseContactAccountGroupResourceImpl.java
@@ -17,27 +17,41 @@ package com.liferay.analytics.settings.rest.internal.resource.v1_0;
 import com.liferay.analytics.settings.rest.dto.v1_0.ContactAccountGroup;
 import com.liferay.analytics.settings.rest.resource.v1_0.ContactAccountGroupResource;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -205,8 +219,7 @@ public abstract class BaseContactAccountGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -218,8 +231,8 @@ public abstract class BaseContactAccountGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -232,8 +245,7 @@ public abstract class BaseContactAccountGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -247,8 +259,8 @@ public abstract class BaseContactAccountGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -276,6 +288,115 @@ public abstract class BaseContactAccountGroupResourceImpl
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseContactAccountGroupResourceImpl.class);

--- a/modules/apps/analytics/analytics-settings-rest-impl/src/main/java/com/liferay/analytics/settings/rest/internal/resource/v1_0/BaseContactConfigurationResourceImpl.java
+++ b/modules/apps/analytics/analytics-settings-rest-impl/src/main/java/com/liferay/analytics/settings/rest/internal/resource/v1_0/BaseContactConfigurationResourceImpl.java
@@ -17,23 +17,38 @@ package com.liferay.analytics.settings.rest.internal.resource.v1_0;
 import com.liferay.analytics.settings.rest.dto.v1_0.ContactConfiguration;
 import com.liferay.analytics.settings.rest.resource.v1_0.ContactConfigurationResource;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -196,8 +211,7 @@ public abstract class BaseContactConfigurationResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -209,8 +223,8 @@ public abstract class BaseContactConfigurationResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -223,8 +237,7 @@ public abstract class BaseContactConfigurationResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -238,8 +251,8 @@ public abstract class BaseContactConfigurationResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -267,6 +280,115 @@ public abstract class BaseContactConfigurationResourceImpl
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseContactConfigurationResourceImpl.class);

--- a/modules/apps/analytics/analytics-settings-rest-impl/src/main/java/com/liferay/analytics/settings/rest/internal/resource/v1_0/BaseContactOrganizationResourceImpl.java
+++ b/modules/apps/analytics/analytics-settings-rest-impl/src/main/java/com/liferay/analytics/settings/rest/internal/resource/v1_0/BaseContactOrganizationResourceImpl.java
@@ -17,27 +17,41 @@ package com.liferay.analytics.settings.rest.internal.resource.v1_0;
 import com.liferay.analytics.settings.rest.dto.v1_0.ContactOrganization;
 import com.liferay.analytics.settings.rest.resource.v1_0.ContactOrganizationResource;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -205,8 +219,7 @@ public abstract class BaseContactOrganizationResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -218,8 +231,8 @@ public abstract class BaseContactOrganizationResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -232,8 +245,7 @@ public abstract class BaseContactOrganizationResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -247,8 +259,8 @@ public abstract class BaseContactOrganizationResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -276,6 +288,115 @@ public abstract class BaseContactOrganizationResourceImpl
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseContactOrganizationResourceImpl.class);

--- a/modules/apps/analytics/analytics-settings-rest-impl/src/main/java/com/liferay/analytics/settings/rest/internal/resource/v1_0/BaseContactUserGroupResourceImpl.java
+++ b/modules/apps/analytics/analytics-settings-rest-impl/src/main/java/com/liferay/analytics/settings/rest/internal/resource/v1_0/BaseContactUserGroupResourceImpl.java
@@ -17,27 +17,41 @@ package com.liferay.analytics.settings.rest.internal.resource.v1_0;
 import com.liferay.analytics.settings.rest.dto.v1_0.ContactUserGroup;
 import com.liferay.analytics.settings.rest.resource.v1_0.ContactUserGroupResource;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -203,8 +217,7 @@ public abstract class BaseContactUserGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -216,8 +229,8 @@ public abstract class BaseContactUserGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -230,8 +243,7 @@ public abstract class BaseContactUserGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -245,8 +257,8 @@ public abstract class BaseContactUserGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -274,6 +286,115 @@ public abstract class BaseContactUserGroupResourceImpl
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseContactUserGroupResourceImpl.class);

--- a/modules/apps/analytics/analytics-settings-rest-impl/src/main/java/com/liferay/analytics/settings/rest/internal/resource/v1_0/BaseDataSourceResourceImpl.java
+++ b/modules/apps/analytics/analytics-settings-rest-impl/src/main/java/com/liferay/analytics/settings/rest/internal/resource/v1_0/BaseDataSourceResourceImpl.java
@@ -17,23 +17,38 @@ package com.liferay.analytics.settings.rest.internal.resource.v1_0;
 import com.liferay.analytics.settings.rest.dto.v1_0.DataSourceToken;
 import com.liferay.analytics.settings.rest.resource.v1_0.DataSourceResource;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -185,8 +200,7 @@ public abstract class BaseDataSourceResourceImpl implements DataSourceResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -198,8 +212,8 @@ public abstract class BaseDataSourceResourceImpl implements DataSourceResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -212,8 +226,7 @@ public abstract class BaseDataSourceResourceImpl implements DataSourceResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -227,8 +240,8 @@ public abstract class BaseDataSourceResourceImpl implements DataSourceResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -256,6 +269,115 @@ public abstract class BaseDataSourceResourceImpl implements DataSourceResource {
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseDataSourceResourceImpl.class);

--- a/modules/apps/analytics/analytics-settings-rest-impl/src/main/java/com/liferay/analytics/settings/rest/internal/resource/v1_0/BaseFieldResourceImpl.java
+++ b/modules/apps/analytics/analytics-settings-rest-impl/src/main/java/com/liferay/analytics/settings/rest/internal/resource/v1_0/BaseFieldResourceImpl.java
@@ -17,27 +17,41 @@ package com.liferay.analytics.settings.rest.internal.resource.v1_0;
 import com.liferay.analytics.settings.rest.dto.v1_0.Field;
 import com.liferay.analytics.settings.rest.resource.v1_0.FieldResource;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -393,8 +407,7 @@ public abstract class BaseFieldResourceImpl implements FieldResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -406,8 +419,8 @@ public abstract class BaseFieldResourceImpl implements FieldResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -420,8 +433,7 @@ public abstract class BaseFieldResourceImpl implements FieldResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -435,8 +447,8 @@ public abstract class BaseFieldResourceImpl implements FieldResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -464,6 +476,115 @@ public abstract class BaseFieldResourceImpl implements FieldResource {
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseFieldResourceImpl.class);

--- a/modules/apps/analytics/analytics-settings-rest-impl/src/main/java/com/liferay/analytics/settings/rest/internal/resource/v1_0/BaseFieldSummaryResourceImpl.java
+++ b/modules/apps/analytics/analytics-settings-rest-impl/src/main/java/com/liferay/analytics/settings/rest/internal/resource/v1_0/BaseFieldSummaryResourceImpl.java
@@ -17,23 +17,38 @@ package com.liferay.analytics.settings.rest.internal.resource.v1_0;
 import com.liferay.analytics.settings.rest.dto.v1_0.FieldSummary;
 import com.liferay.analytics.settings.rest.resource.v1_0.FieldSummaryResource;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -170,8 +185,7 @@ public abstract class BaseFieldSummaryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -183,8 +197,8 @@ public abstract class BaseFieldSummaryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -197,8 +211,7 @@ public abstract class BaseFieldSummaryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -212,8 +225,8 @@ public abstract class BaseFieldSummaryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -241,6 +254,115 @@ public abstract class BaseFieldSummaryResourceImpl
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseFieldSummaryResourceImpl.class);

--- a/modules/apps/analytics/analytics-settings-rest-impl/src/main/java/com/liferay/analytics/settings/rest/internal/resource/v1_0/BaseSiteResourceImpl.java
+++ b/modules/apps/analytics/analytics-settings-rest-impl/src/main/java/com/liferay/analytics/settings/rest/internal/resource/v1_0/BaseSiteResourceImpl.java
@@ -17,27 +17,41 @@ package com.liferay.analytics.settings.rest.internal.resource.v1_0;
 import com.liferay.analytics.settings.rest.dto.v1_0.Site;
 import com.liferay.analytics.settings.rest.resource.v1_0.SiteResource;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -200,8 +214,7 @@ public abstract class BaseSiteResourceImpl implements SiteResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -213,8 +226,8 @@ public abstract class BaseSiteResourceImpl implements SiteResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -227,8 +240,7 @@ public abstract class BaseSiteResourceImpl implements SiteResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -242,8 +254,8 @@ public abstract class BaseSiteResourceImpl implements SiteResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -271,6 +283,115 @@ public abstract class BaseSiteResourceImpl implements SiteResource {
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseSiteResourceImpl.class);

--- a/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/BaseFieldResourceImpl.java
+++ b/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/BaseFieldResourceImpl.java
@@ -17,25 +17,39 @@ package com.liferay.batch.planner.rest.internal.resource.v1_0;
 import com.liferay.batch.planner.rest.dto.v1_0.Field;
 import com.liferay.batch.planner.rest.resource.v1_0.FieldResource;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -192,8 +206,7 @@ public abstract class BaseFieldResourceImpl implements FieldResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -205,8 +218,8 @@ public abstract class BaseFieldResourceImpl implements FieldResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -219,8 +232,7 @@ public abstract class BaseFieldResourceImpl implements FieldResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -234,8 +246,8 @@ public abstract class BaseFieldResourceImpl implements FieldResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -263,6 +275,115 @@ public abstract class BaseFieldResourceImpl implements FieldResource {
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseFieldResourceImpl.class);

--- a/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/BasePlanResourceImpl.java
+++ b/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/BasePlanResourceImpl.java
@@ -17,26 +17,40 @@ package com.liferay.batch.planner.rest.internal.resource.v1_0;
 import com.liferay.batch.planner.rest.dto.v1_0.Plan;
 import com.liferay.batch.planner.rest.resource.v1_0.PlanResource;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -327,8 +341,7 @@ public abstract class BasePlanResourceImpl implements PlanResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -340,8 +353,8 @@ public abstract class BasePlanResourceImpl implements PlanResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -354,8 +367,7 @@ public abstract class BasePlanResourceImpl implements PlanResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -369,8 +381,8 @@ public abstract class BasePlanResourceImpl implements PlanResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -398,6 +410,115 @@ public abstract class BasePlanResourceImpl implements PlanResource {
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BasePlanResourceImpl.class);

--- a/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/BaseSiteScopeResourceImpl.java
+++ b/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/BaseSiteScopeResourceImpl.java
@@ -17,25 +17,39 @@ package com.liferay.batch.planner.rest.internal.resource.v1_0;
 import com.liferay.batch.planner.rest.dto.v1_0.SiteScope;
 import com.liferay.batch.planner.rest.resource.v1_0.SiteScopeResource;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -192,8 +206,7 @@ public abstract class BaseSiteScopeResourceImpl implements SiteScopeResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -205,8 +218,8 @@ public abstract class BaseSiteScopeResourceImpl implements SiteScopeResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -219,8 +232,7 @@ public abstract class BaseSiteScopeResourceImpl implements SiteScopeResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -234,8 +246,8 @@ public abstract class BaseSiteScopeResourceImpl implements SiteScopeResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -263,6 +275,115 @@ public abstract class BaseSiteScopeResourceImpl implements SiteScopeResource {
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseSiteScopeResourceImpl.class);

--- a/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/BaseKeywordResourceImpl.java
+++ b/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/BaseKeywordResourceImpl.java
@@ -19,25 +19,39 @@ import com.liferay.bulk.rest.dto.v1_0.Keyword;
 import com.liferay.bulk.rest.dto.v1_0.KeywordBulkSelection;
 import com.liferay.bulk.rest.resource.v1_0.KeywordResource;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -211,8 +225,7 @@ public abstract class BaseKeywordResourceImpl implements KeywordResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -224,8 +237,8 @@ public abstract class BaseKeywordResourceImpl implements KeywordResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -238,8 +251,7 @@ public abstract class BaseKeywordResourceImpl implements KeywordResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -253,8 +265,8 @@ public abstract class BaseKeywordResourceImpl implements KeywordResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -282,6 +294,115 @@ public abstract class BaseKeywordResourceImpl implements KeywordResource {
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseKeywordResourceImpl.class);

--- a/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/BaseSelectionResourceImpl.java
+++ b/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/BaseSelectionResourceImpl.java
@@ -18,23 +18,38 @@ import com.liferay.bulk.rest.dto.v1_0.DocumentBulkSelection;
 import com.liferay.bulk.rest.dto.v1_0.Selection;
 import com.liferay.bulk.rest.resource.v1_0.SelectionResource;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -174,8 +189,7 @@ public abstract class BaseSelectionResourceImpl implements SelectionResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -187,8 +201,8 @@ public abstract class BaseSelectionResourceImpl implements SelectionResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -201,8 +215,7 @@ public abstract class BaseSelectionResourceImpl implements SelectionResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -216,8 +229,8 @@ public abstract class BaseSelectionResourceImpl implements SelectionResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -245,6 +258,115 @@ public abstract class BaseSelectionResourceImpl implements SelectionResource {
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseSelectionResourceImpl.class);

--- a/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/BaseStatusResourceImpl.java
+++ b/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/BaseStatusResourceImpl.java
@@ -17,23 +17,38 @@ package com.liferay.bulk.rest.internal.resource.v1_0;
 import com.liferay.bulk.rest.dto.v1_0.Status;
 import com.liferay.bulk.rest.resource.v1_0.StatusResource;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -169,8 +184,7 @@ public abstract class BaseStatusResourceImpl implements StatusResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -182,8 +196,8 @@ public abstract class BaseStatusResourceImpl implements StatusResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -196,8 +210,7 @@ public abstract class BaseStatusResourceImpl implements StatusResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -211,8 +224,8 @@ public abstract class BaseStatusResourceImpl implements StatusResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -240,6 +253,115 @@ public abstract class BaseStatusResourceImpl implements StatusResource {
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseStatusResourceImpl.class);

--- a/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/BaseTaxonomyCategoryResourceImpl.java
+++ b/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/BaseTaxonomyCategoryResourceImpl.java
@@ -17,23 +17,38 @@ package com.liferay.bulk.rest.internal.resource.v1_0;
 import com.liferay.bulk.rest.dto.v1_0.TaxonomyCategoryBulkSelection;
 import com.liferay.bulk.rest.resource.v1_0.TaxonomyCategoryResource;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -194,8 +209,7 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -207,8 +221,8 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -221,8 +235,7 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -236,8 +249,8 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -265,6 +278,115 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseTaxonomyCategoryResourceImpl.class);

--- a/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/BaseTaxonomyVocabularyResourceImpl.java
+++ b/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/BaseTaxonomyVocabularyResourceImpl.java
@@ -18,25 +18,39 @@ import com.liferay.bulk.rest.dto.v1_0.DocumentBulkSelection;
 import com.liferay.bulk.rest.dto.v1_0.TaxonomyVocabulary;
 import com.liferay.bulk.rest.resource.v1_0.TaxonomyVocabularyResource;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -191,8 +205,7 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -204,8 +217,8 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -218,8 +231,7 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -233,8 +245,8 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -262,6 +274,115 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseTaxonomyVocabularyResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountAddressResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountAddressResourceImpl.java
@@ -20,15 +20,21 @@ import com.liferay.headless.commerce.admin.account.resource.v1_0.AccountAddressR
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -44,13 +50,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -705,7 +718,7 @@ public abstract class BaseAccountAddressResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<AccountAddress> accountAddresses,
+			Collection<AccountAddress> accountAddresses,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -715,7 +728,7 @@ public abstract class BaseAccountAddressResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<AccountAddress> accountAddresses,
+			Collection<AccountAddress> accountAddresses,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -785,7 +798,7 @@ public abstract class BaseAccountAddressResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<AccountAddress> accountAddresses,
+			Collection<AccountAddress> accountAddresses,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -834,7 +847,7 @@ public abstract class BaseAccountAddressResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<AccountAddress>,
+			<Collection<AccountAddress>,
 			 UnsafeConsumer<AccountAddress, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -1017,8 +1030,7 @@ public abstract class BaseAccountAddressResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -1030,8 +1042,8 @@ public abstract class BaseAccountAddressResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -1044,8 +1056,7 @@ public abstract class BaseAccountAddressResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -1059,8 +1070,8 @@ public abstract class BaseAccountAddressResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -1076,9 +1087,8 @@ public abstract class BaseAccountAddressResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<AccountAddress>,
-		 UnsafeConsumer<AccountAddress, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<AccountAddress>, UnsafeConsumer<AccountAddress, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -1094,6 +1104,115 @@ public abstract class BaseAccountAddressResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseAccountAddressResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountChannelEntryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountChannelEntryResourceImpl.java
@@ -20,15 +20,21 @@ import com.liferay.headless.commerce.admin.account.resource.v1_0.AccountChannelE
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -44,13 +50,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -2435,7 +2448,7 @@ public abstract class BaseAccountChannelEntryResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<AccountChannelEntry> accountChannelEntries,
+			Collection<AccountChannelEntry> accountChannelEntries,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -2445,7 +2458,7 @@ public abstract class BaseAccountChannelEntryResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<AccountChannelEntry> accountChannelEntries,
+			Collection<AccountChannelEntry> accountChannelEntries,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -2514,7 +2527,7 @@ public abstract class BaseAccountChannelEntryResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<AccountChannelEntry> accountChannelEntries,
+			Collection<AccountChannelEntry> accountChannelEntries,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -2528,7 +2541,7 @@ public abstract class BaseAccountChannelEntryResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<AccountChannelEntry>,
+			<Collection<AccountChannelEntry>,
 			 UnsafeConsumer<AccountChannelEntry, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -2707,8 +2720,7 @@ public abstract class BaseAccountChannelEntryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -2720,8 +2732,8 @@ public abstract class BaseAccountChannelEntryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -2734,8 +2746,7 @@ public abstract class BaseAccountChannelEntryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -2749,8 +2760,8 @@ public abstract class BaseAccountChannelEntryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -2766,7 +2777,7 @@ public abstract class BaseAccountChannelEntryResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<AccountChannelEntry>,
+		<Collection<AccountChannelEntry>,
 		 UnsafeConsumer<AccountChannelEntry, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -2784,6 +2795,115 @@ public abstract class BaseAccountChannelEntryResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseAccountChannelEntryResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountGroupResourceImpl.java
@@ -20,15 +20,21 @@ import com.liferay.headless.commerce.admin.account.resource.v1_0.AccountGroupRes
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -44,13 +50,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -510,7 +523,7 @@ public abstract class BaseAccountGroupResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<AccountGroup> accountGroups,
+			Collection<AccountGroup> accountGroups,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -544,7 +557,7 @@ public abstract class BaseAccountGroupResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<AccountGroup> accountGroups,
+			Collection<AccountGroup> accountGroups,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -613,7 +626,7 @@ public abstract class BaseAccountGroupResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<AccountGroup> accountGroups,
+			Collection<AccountGroup> accountGroups,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -653,9 +666,8 @@ public abstract class BaseAccountGroupResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<AccountGroup>,
-			 UnsafeConsumer<AccountGroup, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<AccountGroup>, UnsafeConsumer<AccountGroup, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -832,8 +844,7 @@ public abstract class BaseAccountGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -845,8 +856,8 @@ public abstract class BaseAccountGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -859,8 +870,7 @@ public abstract class BaseAccountGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -874,8 +884,8 @@ public abstract class BaseAccountGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -891,9 +901,8 @@ public abstract class BaseAccountGroupResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<AccountGroup>,
-		 UnsafeConsumer<AccountGroup, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<AccountGroup>, UnsafeConsumer<AccountGroup, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -909,6 +918,115 @@ public abstract class BaseAccountGroupResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseAccountGroupResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountMemberResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountMemberResourceImpl.java
@@ -20,15 +20,21 @@ import com.liferay.headless.commerce.admin.account.resource.v1_0.AccountMemberRe
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -44,13 +50,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -540,7 +553,7 @@ public abstract class BaseAccountMemberResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<AccountMember> accountMembers,
+			Collection<AccountMember> accountMembers,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -550,7 +563,7 @@ public abstract class BaseAccountMemberResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<AccountMember> accountMembers,
+			Collection<AccountMember> accountMembers,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -619,7 +632,7 @@ public abstract class BaseAccountMemberResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<AccountMember> accountMembers,
+			Collection<AccountMember> accountMembers,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -633,7 +646,7 @@ public abstract class BaseAccountMemberResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<AccountMember>,
+			<Collection<AccountMember>,
 			 UnsafeConsumer<AccountMember, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -812,8 +825,7 @@ public abstract class BaseAccountMemberResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -825,8 +837,8 @@ public abstract class BaseAccountMemberResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -839,8 +851,7 @@ public abstract class BaseAccountMemberResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -854,8 +865,8 @@ public abstract class BaseAccountMemberResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -871,9 +882,8 @@ public abstract class BaseAccountMemberResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<AccountMember>,
-		 UnsafeConsumer<AccountMember, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<AccountMember>, UnsafeConsumer<AccountMember, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -889,6 +899,115 @@ public abstract class BaseAccountMemberResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseAccountMemberResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountOrganizationResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountOrganizationResourceImpl.java
@@ -20,15 +20,21 @@ import com.liferay.headless.commerce.admin.account.resource.v1_0.AccountOrganiza
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -44,13 +50,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -471,7 +484,7 @@ public abstract class BaseAccountOrganizationResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<AccountOrganization> accountOrganizations,
+			Collection<AccountOrganization> accountOrganizations,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -481,7 +494,7 @@ public abstract class BaseAccountOrganizationResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<AccountOrganization> accountOrganizations,
+			Collection<AccountOrganization> accountOrganizations,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -550,7 +563,7 @@ public abstract class BaseAccountOrganizationResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<AccountOrganization> accountOrganizations,
+			Collection<AccountOrganization> accountOrganizations,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -564,7 +577,7 @@ public abstract class BaseAccountOrganizationResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<AccountOrganization>,
+			<Collection<AccountOrganization>,
 			 UnsafeConsumer<AccountOrganization, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -743,8 +756,7 @@ public abstract class BaseAccountOrganizationResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -756,8 +768,8 @@ public abstract class BaseAccountOrganizationResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -770,8 +782,7 @@ public abstract class BaseAccountOrganizationResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -785,8 +796,8 @@ public abstract class BaseAccountOrganizationResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -802,7 +813,7 @@ public abstract class BaseAccountOrganizationResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<AccountOrganization>,
+		<Collection<AccountOrganization>,
 		 UnsafeConsumer<AccountOrganization, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -820,6 +831,115 @@ public abstract class BaseAccountOrganizationResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseAccountOrganizationResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountResourceImpl.java
@@ -20,15 +20,21 @@ import com.liferay.headless.commerce.admin.account.resource.v1_0.AccountResource
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -45,13 +51,20 @@ import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTa
 import com.liferay.portal.vulcan.multipart.MultipartBody;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -583,8 +596,7 @@ public abstract class BaseAccountResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<Account> accounts,
-			Map<String, Serializable> parameters)
+			Collection<Account> accounts, Map<String, Serializable> parameters)
 		throws Exception {
 
 		UnsafeConsumer<Account, Exception> accountUnsafeConsumer = null;
@@ -614,8 +626,7 @@ public abstract class BaseAccountResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<Account> accounts,
-			Map<String, Serializable> parameters)
+			Collection<Account> accounts, Map<String, Serializable> parameters)
 		throws Exception {
 
 		for (Account account : accounts) {
@@ -683,8 +694,7 @@ public abstract class BaseAccountResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<Account> accounts,
-			Map<String, Serializable> parameters)
+			Collection<Account> accounts, Map<String, Serializable> parameters)
 		throws Exception {
 
 		UnsafeConsumer<Account, Exception> accountUnsafeConsumer = null;
@@ -721,8 +731,8 @@ public abstract class BaseAccountResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<Account>, UnsafeConsumer<Account, Exception>,
-			 Exception> contextBatchUnsafeConsumer) {
+			<Collection<Account>, UnsafeConsumer<Account, Exception>, Exception>
+				contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -899,8 +909,7 @@ public abstract class BaseAccountResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -912,8 +921,8 @@ public abstract class BaseAccountResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -926,8 +935,7 @@ public abstract class BaseAccountResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -941,8 +949,8 @@ public abstract class BaseAccountResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -958,8 +966,8 @@ public abstract class BaseAccountResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<Account>, UnsafeConsumer<Account, Exception>,
-		 Exception> contextBatchUnsafeConsumer;
+		<Collection<Account>, UnsafeConsumer<Account, Exception>, Exception>
+			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -975,6 +983,115 @@ public abstract class BaseAccountResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseAccountResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseUserResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseUserResourceImpl.java
@@ -17,23 +17,38 @@ package com.liferay.headless.commerce.admin.account.internal.resource.v1_0;
 import com.liferay.headless.commerce.admin.account.dto.v1_0.User;
 import com.liferay.headless.commerce.admin.account.resource.v1_0.UserResource;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -187,8 +202,7 @@ public abstract class BaseUserResourceImpl implements UserResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -200,8 +214,8 @@ public abstract class BaseUserResourceImpl implements UserResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -214,8 +228,7 @@ public abstract class BaseUserResourceImpl implements UserResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -229,8 +242,8 @@ public abstract class BaseUserResourceImpl implements UserResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -258,6 +271,115 @@ public abstract class BaseUserResourceImpl implements UserResource {
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseUserResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseAttachmentResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseAttachmentResourceImpl.java
@@ -21,15 +21,21 @@ import com.liferay.headless.commerce.admin.catalog.resource.v1_0.AttachmentResou
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -45,13 +51,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -679,7 +692,7 @@ public abstract class BaseAttachmentResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<Attachment> attachments,
+			Collection<Attachment> attachments,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -689,7 +702,7 @@ public abstract class BaseAttachmentResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<Attachment> attachments,
+			Collection<Attachment> attachments,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -758,7 +771,7 @@ public abstract class BaseAttachmentResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<Attachment> attachments,
+			Collection<Attachment> attachments,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -772,9 +785,8 @@ public abstract class BaseAttachmentResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<Attachment>,
-			 UnsafeConsumer<Attachment, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<Attachment>, UnsafeConsumer<Attachment, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -951,8 +963,7 @@ public abstract class BaseAttachmentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -964,8 +975,8 @@ public abstract class BaseAttachmentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -978,8 +989,7 @@ public abstract class BaseAttachmentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -993,8 +1003,8 @@ public abstract class BaseAttachmentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -1010,9 +1020,8 @@ public abstract class BaseAttachmentResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<Attachment>,
-		 UnsafeConsumer<Attachment, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<Attachment>, UnsafeConsumer<Attachment, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -1028,6 +1037,115 @@ public abstract class BaseAttachmentResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseAttachmentResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseCatalogResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseCatalogResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.catalog.resource.v1_0.CatalogResource
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -513,8 +526,7 @@ public abstract class BaseCatalogResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<Catalog> catalogs,
-			Map<String, Serializable> parameters)
+			Collection<Catalog> catalogs, Map<String, Serializable> parameters)
 		throws Exception {
 
 		UnsafeConsumer<Catalog, Exception> catalogUnsafeConsumer = null;
@@ -544,8 +556,7 @@ public abstract class BaseCatalogResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<Catalog> catalogs,
-			Map<String, Serializable> parameters)
+			Collection<Catalog> catalogs, Map<String, Serializable> parameters)
 		throws Exception {
 
 		for (Catalog catalog : catalogs) {
@@ -613,8 +624,7 @@ public abstract class BaseCatalogResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<Catalog> catalogs,
-			Map<String, Serializable> parameters)
+			Collection<Catalog> catalogs, Map<String, Serializable> parameters)
 		throws Exception {
 
 		UnsafeConsumer<Catalog, Exception> catalogUnsafeConsumer = null;
@@ -651,8 +661,8 @@ public abstract class BaseCatalogResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<Catalog>, UnsafeConsumer<Catalog, Exception>,
-			 Exception> contextBatchUnsafeConsumer) {
+			<Collection<Catalog>, UnsafeConsumer<Catalog, Exception>, Exception>
+				contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -829,8 +839,7 @@ public abstract class BaseCatalogResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -842,8 +851,8 @@ public abstract class BaseCatalogResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -856,8 +865,7 @@ public abstract class BaseCatalogResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -871,8 +879,8 @@ public abstract class BaseCatalogResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -888,8 +896,8 @@ public abstract class BaseCatalogResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<Catalog>, UnsafeConsumer<Catalog, Exception>,
-		 Exception> contextBatchUnsafeConsumer;
+		<Collection<Catalog>, UnsafeConsumer<Catalog, Exception>, Exception>
+			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -905,6 +913,115 @@ public abstract class BaseCatalogResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseCatalogResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseCategoryResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.catalog.resource.v1_0.CategoryResourc
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -226,7 +239,7 @@ public abstract class BaseCategoryResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<Category> categories,
+			Collection<Category> categories,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -236,7 +249,7 @@ public abstract class BaseCategoryResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<Category> categories,
+			Collection<Category> categories,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -305,7 +318,7 @@ public abstract class BaseCategoryResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<Category> categories,
+			Collection<Category> categories,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -319,9 +332,8 @@ public abstract class BaseCategoryResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<Category>,
-			 UnsafeConsumer<Category, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<Category>, UnsafeConsumer<Category, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -498,8 +510,7 @@ public abstract class BaseCategoryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -511,8 +522,8 @@ public abstract class BaseCategoryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -525,8 +536,7 @@ public abstract class BaseCategoryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -540,8 +550,8 @@ public abstract class BaseCategoryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -557,8 +567,8 @@ public abstract class BaseCategoryResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<Category>, UnsafeConsumer<Category, Exception>,
-		 Exception> contextBatchUnsafeConsumer;
+		<Collection<Category>, UnsafeConsumer<Category, Exception>, Exception>
+			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -574,6 +584,115 @@ public abstract class BaseCategoryResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseCategoryResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseDiagramResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseDiagramResourceImpl.java
@@ -17,23 +17,38 @@ package com.liferay.headless.commerce.admin.catalog.internal.resource.v1_0;
 import com.liferay.headless.commerce.admin.catalog.dto.v1_0.Diagram;
 import com.liferay.headless.commerce.admin.catalog.resource.v1_0.DiagramResource;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -313,8 +328,7 @@ public abstract class BaseDiagramResourceImpl implements DiagramResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -326,8 +340,8 @@ public abstract class BaseDiagramResourceImpl implements DiagramResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -340,8 +354,7 @@ public abstract class BaseDiagramResourceImpl implements DiagramResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -355,8 +368,8 @@ public abstract class BaseDiagramResourceImpl implements DiagramResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -384,6 +397,115 @@ public abstract class BaseDiagramResourceImpl implements DiagramResource {
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseDiagramResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseMappedProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseMappedProductResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.catalog.resource.v1_0.MappedProductRe
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -453,7 +466,7 @@ public abstract class BaseMappedProductResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<MappedProduct> mappedProducts,
+			Collection<MappedProduct> mappedProducts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -463,7 +476,7 @@ public abstract class BaseMappedProductResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<MappedProduct> mappedProducts,
+			Collection<MappedProduct> mappedProducts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -533,7 +546,7 @@ public abstract class BaseMappedProductResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<MappedProduct> mappedProducts,
+			Collection<MappedProduct> mappedProducts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -573,7 +586,7 @@ public abstract class BaseMappedProductResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<MappedProduct>,
+			<Collection<MappedProduct>,
 			 UnsafeConsumer<MappedProduct, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -752,8 +765,7 @@ public abstract class BaseMappedProductResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -765,8 +777,8 @@ public abstract class BaseMappedProductResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -779,8 +791,7 @@ public abstract class BaseMappedProductResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -794,8 +805,8 @@ public abstract class BaseMappedProductResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -811,9 +822,8 @@ public abstract class BaseMappedProductResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<MappedProduct>,
-		 UnsafeConsumer<MappedProduct, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<MappedProduct>, UnsafeConsumer<MappedProduct, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -829,6 +839,115 @@ public abstract class BaseMappedProductResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseMappedProductResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseOptionCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseOptionCategoryResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.catalog.resource.v1_0.OptionCategoryR
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -341,7 +354,7 @@ public abstract class BaseOptionCategoryResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<OptionCategory> optionCategories,
+			Collection<OptionCategory> optionCategories,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -375,7 +388,7 @@ public abstract class BaseOptionCategoryResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<OptionCategory> optionCategories,
+			Collection<OptionCategory> optionCategories,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -445,7 +458,7 @@ public abstract class BaseOptionCategoryResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<OptionCategory> optionCategories,
+			Collection<OptionCategory> optionCategories,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -487,7 +500,7 @@ public abstract class BaseOptionCategoryResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<OptionCategory>,
+			<Collection<OptionCategory>,
 			 UnsafeConsumer<OptionCategory, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -666,8 +679,7 @@ public abstract class BaseOptionCategoryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -679,8 +691,8 @@ public abstract class BaseOptionCategoryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -693,8 +705,7 @@ public abstract class BaseOptionCategoryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -708,8 +719,8 @@ public abstract class BaseOptionCategoryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -725,9 +736,8 @@ public abstract class BaseOptionCategoryResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<OptionCategory>,
-		 UnsafeConsumer<OptionCategory, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<OptionCategory>, UnsafeConsumer<OptionCategory, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -743,6 +753,115 @@ public abstract class BaseOptionCategoryResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseOptionCategoryResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseOptionResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseOptionResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.catalog.resource.v1_0.OptionResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -434,8 +447,7 @@ public abstract class BaseOptionResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<Option> options,
-			Map<String, Serializable> parameters)
+			Collection<Option> options, Map<String, Serializable> parameters)
 		throws Exception {
 
 		UnsafeConsumer<Option, Exception> optionUnsafeConsumer = null;
@@ -465,8 +477,7 @@ public abstract class BaseOptionResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<Option> options,
-			Map<String, Serializable> parameters)
+			Collection<Option> options, Map<String, Serializable> parameters)
 		throws Exception {
 
 		for (Option option : options) {
@@ -534,8 +545,7 @@ public abstract class BaseOptionResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<Option> options,
-			Map<String, Serializable> parameters)
+			Collection<Option> options, Map<String, Serializable> parameters)
 		throws Exception {
 
 		UnsafeConsumer<Option, Exception> optionUnsafeConsumer = null;
@@ -572,8 +582,8 @@ public abstract class BaseOptionResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<Option>, UnsafeConsumer<Option, Exception>,
-			 Exception> contextBatchUnsafeConsumer) {
+			<Collection<Option>, UnsafeConsumer<Option, Exception>, Exception>
+				contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -750,8 +760,7 @@ public abstract class BaseOptionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -763,8 +772,8 @@ public abstract class BaseOptionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -777,8 +786,7 @@ public abstract class BaseOptionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -792,8 +800,8 @@ public abstract class BaseOptionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -809,8 +817,8 @@ public abstract class BaseOptionResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<Option>, UnsafeConsumer<Option, Exception>,
-		 Exception> contextBatchUnsafeConsumer;
+		<Collection<Option>, UnsafeConsumer<Option, Exception>, Exception>
+			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -826,6 +834,115 @@ public abstract class BaseOptionResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseOptionResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseOptionValueResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseOptionValueResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.catalog.resource.v1_0.OptionValueReso
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -544,7 +557,7 @@ public abstract class BaseOptionValueResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<OptionValue> optionValues,
+			Collection<OptionValue> optionValues,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -554,7 +567,7 @@ public abstract class BaseOptionValueResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<OptionValue> optionValues,
+			Collection<OptionValue> optionValues,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -624,7 +637,7 @@ public abstract class BaseOptionValueResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<OptionValue> optionValues,
+			Collection<OptionValue> optionValues,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -663,9 +676,8 @@ public abstract class BaseOptionValueResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<OptionValue>,
-			 UnsafeConsumer<OptionValue, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<OptionValue>, UnsafeConsumer<OptionValue, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -842,8 +854,7 @@ public abstract class BaseOptionValueResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -855,8 +866,8 @@ public abstract class BaseOptionValueResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -869,8 +880,7 @@ public abstract class BaseOptionValueResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -884,8 +894,8 @@ public abstract class BaseOptionValueResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -901,9 +911,8 @@ public abstract class BaseOptionValueResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<OptionValue>,
-		 UnsafeConsumer<OptionValue, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<OptionValue>, UnsafeConsumer<OptionValue, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -919,6 +928,115 @@ public abstract class BaseOptionValueResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseOptionValueResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BasePinResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BasePinResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.catalog.resource.v1_0.PinResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -353,8 +366,7 @@ public abstract class BasePinResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<Pin> pins,
-			Map<String, Serializable> parameters)
+			Collection<Pin> pins, Map<String, Serializable> parameters)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -363,8 +375,7 @@ public abstract class BasePinResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<Pin> pins,
-			Map<String, Serializable> parameters)
+			Collection<Pin> pins, Map<String, Serializable> parameters)
 		throws Exception {
 
 		for (Pin pin : pins) {
@@ -433,8 +444,7 @@ public abstract class BasePinResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<Pin> pins,
-			Map<String, Serializable> parameters)
+			Collection<Pin> pins, Map<String, Serializable> parameters)
 		throws Exception {
 
 		UnsafeConsumer<Pin, Exception> pinUnsafeConsumer = null;
@@ -471,8 +481,8 @@ public abstract class BasePinResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<Pin>, UnsafeConsumer<Pin, Exception>,
-			 Exception> contextBatchUnsafeConsumer) {
+			<Collection<Pin>, UnsafeConsumer<Pin, Exception>, Exception>
+				contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -649,8 +659,7 @@ public abstract class BasePinResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -662,8 +671,8 @@ public abstract class BasePinResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -676,8 +685,7 @@ public abstract class BasePinResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -691,8 +699,8 @@ public abstract class BasePinResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -708,7 +716,7 @@ public abstract class BasePinResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<Pin>, UnsafeConsumer<Pin, Exception>, Exception>
+		<Collection<Pin>, UnsafeConsumer<Pin, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
@@ -725,6 +733,115 @@ public abstract class BasePinResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BasePinResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductAccountGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductAccountGroupResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.catalog.resource.v1_0.ProductAccountG
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -285,7 +298,7 @@ public abstract class BaseProductAccountGroupResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<ProductAccountGroup> productAccountGroups,
+			Collection<ProductAccountGroup> productAccountGroups,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -295,7 +308,7 @@ public abstract class BaseProductAccountGroupResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<ProductAccountGroup> productAccountGroups,
+			Collection<ProductAccountGroup> productAccountGroups,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -365,7 +378,7 @@ public abstract class BaseProductAccountGroupResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<ProductAccountGroup> productAccountGroups,
+			Collection<ProductAccountGroup> productAccountGroups,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -379,7 +392,7 @@ public abstract class BaseProductAccountGroupResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<ProductAccountGroup>,
+			<Collection<ProductAccountGroup>,
 			 UnsafeConsumer<ProductAccountGroup, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -558,8 +571,7 @@ public abstract class BaseProductAccountGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -571,8 +583,8 @@ public abstract class BaseProductAccountGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -585,8 +597,7 @@ public abstract class BaseProductAccountGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -600,8 +611,8 @@ public abstract class BaseProductAccountGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -617,7 +628,7 @@ public abstract class BaseProductAccountGroupResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<ProductAccountGroup>,
+		<Collection<ProductAccountGroup>,
 		 UnsafeConsumer<ProductAccountGroup, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -635,6 +646,115 @@ public abstract class BaseProductAccountGroupResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseProductAccountGroupResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductChannelResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.catalog.resource.v1_0.ProductChannelR
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -275,7 +288,7 @@ public abstract class BaseProductChannelResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<ProductChannel> productChannels,
+			Collection<ProductChannel> productChannels,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -285,7 +298,7 @@ public abstract class BaseProductChannelResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<ProductChannel> productChannels,
+			Collection<ProductChannel> productChannels,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -355,7 +368,7 @@ public abstract class BaseProductChannelResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<ProductChannel> productChannels,
+			Collection<ProductChannel> productChannels,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -369,7 +382,7 @@ public abstract class BaseProductChannelResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<ProductChannel>,
+			<Collection<ProductChannel>,
 			 UnsafeConsumer<ProductChannel, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -548,8 +561,7 @@ public abstract class BaseProductChannelResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -561,8 +573,8 @@ public abstract class BaseProductChannelResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -575,8 +587,7 @@ public abstract class BaseProductChannelResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -590,8 +601,8 @@ public abstract class BaseProductChannelResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -607,9 +618,8 @@ public abstract class BaseProductChannelResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<ProductChannel>,
-		 UnsafeConsumer<ProductChannel, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<ProductChannel>, UnsafeConsumer<ProductChannel, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -625,6 +635,115 @@ public abstract class BaseProductChannelResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseProductChannelResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductConfigurationResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductConfigurationResourceImpl.java
@@ -17,23 +17,38 @@ package com.liferay.headless.commerce.admin.catalog.internal.resource.v1_0;
 import com.liferay.headless.commerce.admin.catalog.dto.v1_0.ProductConfiguration;
 import com.liferay.headless.commerce.admin.catalog.resource.v1_0.ProductConfigurationResource;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -301,8 +316,7 @@ public abstract class BaseProductConfigurationResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -314,8 +328,8 @@ public abstract class BaseProductConfigurationResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -328,8 +342,7 @@ public abstract class BaseProductConfigurationResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -343,8 +356,8 @@ public abstract class BaseProductConfigurationResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -372,6 +385,115 @@ public abstract class BaseProductConfigurationResourceImpl
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseProductConfigurationResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductGroupProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductGroupProductResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.catalog.resource.v1_0.ProductGroupPro
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -381,7 +394,7 @@ public abstract class BaseProductGroupProductResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<ProductGroupProduct> productGroupProducts,
+			Collection<ProductGroupProduct> productGroupProducts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -391,7 +404,7 @@ public abstract class BaseProductGroupProductResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<ProductGroupProduct> productGroupProducts,
+			Collection<ProductGroupProduct> productGroupProducts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -461,7 +474,7 @@ public abstract class BaseProductGroupProductResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<ProductGroupProduct> productGroupProducts,
+			Collection<ProductGroupProduct> productGroupProducts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -475,7 +488,7 @@ public abstract class BaseProductGroupProductResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<ProductGroupProduct>,
+			<Collection<ProductGroupProduct>,
 			 UnsafeConsumer<ProductGroupProduct, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -654,8 +667,7 @@ public abstract class BaseProductGroupProductResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -667,8 +679,8 @@ public abstract class BaseProductGroupProductResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -681,8 +693,7 @@ public abstract class BaseProductGroupProductResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -696,8 +707,8 @@ public abstract class BaseProductGroupProductResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -713,7 +724,7 @@ public abstract class BaseProductGroupProductResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<ProductGroupProduct>,
+		<Collection<ProductGroupProduct>,
 		 UnsafeConsumer<ProductGroupProduct, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -731,6 +742,115 @@ public abstract class BaseProductGroupProductResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseProductGroupProductResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductGroupResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.catalog.resource.v1_0.ProductGroupRes
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -428,7 +441,7 @@ public abstract class BaseProductGroupResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<ProductGroup> productGroups,
+			Collection<ProductGroup> productGroups,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -462,7 +475,7 @@ public abstract class BaseProductGroupResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<ProductGroup> productGroups,
+			Collection<ProductGroup> productGroups,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -531,7 +544,7 @@ public abstract class BaseProductGroupResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<ProductGroup> productGroups,
+			Collection<ProductGroup> productGroups,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -571,9 +584,8 @@ public abstract class BaseProductGroupResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<ProductGroup>,
-			 UnsafeConsumer<ProductGroup, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<ProductGroup>, UnsafeConsumer<ProductGroup, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -750,8 +762,7 @@ public abstract class BaseProductGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -763,8 +774,8 @@ public abstract class BaseProductGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -777,8 +788,7 @@ public abstract class BaseProductGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -792,8 +802,8 @@ public abstract class BaseProductGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -809,9 +819,8 @@ public abstract class BaseProductGroupResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<ProductGroup>,
-		 UnsafeConsumer<ProductGroup, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<ProductGroup>, UnsafeConsumer<ProductGroup, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -827,6 +836,115 @@ public abstract class BaseProductGroupResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseProductGroupResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductOptionResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductOptionResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.catalog.resource.v1_0.ProductOptionRe
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -409,7 +422,7 @@ public abstract class BaseProductOptionResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<ProductOption> productOptions,
+			Collection<ProductOption> productOptions,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -419,7 +432,7 @@ public abstract class BaseProductOptionResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<ProductOption> productOptions,
+			Collection<ProductOption> productOptions,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -489,7 +502,7 @@ public abstract class BaseProductOptionResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<ProductOption> productOptions,
+			Collection<ProductOption> productOptions,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -529,7 +542,7 @@ public abstract class BaseProductOptionResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<ProductOption>,
+			<Collection<ProductOption>,
 			 UnsafeConsumer<ProductOption, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -708,8 +721,7 @@ public abstract class BaseProductOptionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -721,8 +733,8 @@ public abstract class BaseProductOptionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -735,8 +747,7 @@ public abstract class BaseProductOptionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -750,8 +761,8 @@ public abstract class BaseProductOptionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -767,9 +778,8 @@ public abstract class BaseProductOptionResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<ProductOption>,
-		 UnsafeConsumer<ProductOption, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<ProductOption>, UnsafeConsumer<ProductOption, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -785,6 +795,115 @@ public abstract class BaseProductOptionResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseProductOptionResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductOptionValueResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductOptionValueResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.catalog.resource.v1_0.ProductOptionVa
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -216,7 +229,7 @@ public abstract class BaseProductOptionValueResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<ProductOptionValue> productOptionValues,
+			Collection<ProductOptionValue> productOptionValues,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -226,7 +239,7 @@ public abstract class BaseProductOptionValueResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<ProductOptionValue> productOptionValues,
+			Collection<ProductOptionValue> productOptionValues,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -295,7 +308,7 @@ public abstract class BaseProductOptionValueResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<ProductOptionValue> productOptionValues,
+			Collection<ProductOptionValue> productOptionValues,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -309,7 +322,7 @@ public abstract class BaseProductOptionValueResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<ProductOptionValue>,
+			<Collection<ProductOptionValue>,
 			 UnsafeConsumer<ProductOptionValue, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -488,8 +501,7 @@ public abstract class BaseProductOptionValueResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -501,8 +513,8 @@ public abstract class BaseProductOptionValueResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -515,8 +527,7 @@ public abstract class BaseProductOptionValueResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -530,8 +541,8 @@ public abstract class BaseProductOptionValueResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -547,7 +558,7 @@ public abstract class BaseProductOptionValueResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<ProductOptionValue>,
+		<Collection<ProductOptionValue>,
 		 UnsafeConsumer<ProductOptionValue, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -565,6 +576,115 @@ public abstract class BaseProductOptionValueResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseProductOptionValueResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.catalog.resource.v1_0.ProductResource
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -652,8 +665,7 @@ public abstract class BaseProductResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<Product> products,
-			Map<String, Serializable> parameters)
+			Collection<Product> products, Map<String, Serializable> parameters)
 		throws Exception {
 
 		UnsafeConsumer<Product, Exception> productUnsafeConsumer = null;
@@ -683,8 +695,7 @@ public abstract class BaseProductResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<Product> products,
-			Map<String, Serializable> parameters)
+			Collection<Product> products, Map<String, Serializable> parameters)
 		throws Exception {
 
 		for (Product product : products) {
@@ -752,8 +763,7 @@ public abstract class BaseProductResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<Product> products,
-			Map<String, Serializable> parameters)
+			Collection<Product> products, Map<String, Serializable> parameters)
 		throws Exception {
 
 		UnsafeConsumer<Product, Exception> productUnsafeConsumer = null;
@@ -790,8 +800,8 @@ public abstract class BaseProductResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<Product>, UnsafeConsumer<Product, Exception>,
-			 Exception> contextBatchUnsafeConsumer) {
+			<Collection<Product>, UnsafeConsumer<Product, Exception>, Exception>
+				contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -968,8 +978,7 @@ public abstract class BaseProductResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -981,8 +990,8 @@ public abstract class BaseProductResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -995,8 +1004,7 @@ public abstract class BaseProductResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -1010,8 +1018,8 @@ public abstract class BaseProductResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -1027,8 +1035,8 @@ public abstract class BaseProductResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<Product>, UnsafeConsumer<Product, Exception>,
-		 Exception> contextBatchUnsafeConsumer;
+		<Collection<Product>, UnsafeConsumer<Product, Exception>, Exception>
+			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -1044,6 +1052,115 @@ public abstract class BaseProductResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseProductResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductShippingConfigurationResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductShippingConfigurationResourceImpl.java
@@ -17,23 +17,38 @@ package com.liferay.headless.commerce.admin.catalog.internal.resource.v1_0;
 import com.liferay.headless.commerce.admin.catalog.dto.v1_0.ProductShippingConfiguration;
 import com.liferay.headless.commerce.admin.catalog.resource.v1_0.ProductShippingConfigurationResource;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -302,8 +317,7 @@ public abstract class BaseProductShippingConfigurationResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -315,8 +329,8 @@ public abstract class BaseProductShippingConfigurationResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -329,8 +343,7 @@ public abstract class BaseProductShippingConfigurationResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -344,8 +357,8 @@ public abstract class BaseProductShippingConfigurationResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -373,6 +386,115 @@ public abstract class BaseProductShippingConfigurationResourceImpl
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductSpecificationResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductSpecificationResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.catalog.resource.v1_0.ProductSpecific
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -210,7 +223,7 @@ public abstract class BaseProductSpecificationResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<ProductSpecification> productSpecifications,
+			Collection<ProductSpecification> productSpecifications,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -220,7 +233,7 @@ public abstract class BaseProductSpecificationResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<ProductSpecification> productSpecifications,
+			Collection<ProductSpecification> productSpecifications,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -289,7 +302,7 @@ public abstract class BaseProductSpecificationResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<ProductSpecification> productSpecifications,
+			Collection<ProductSpecification> productSpecifications,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -303,7 +316,7 @@ public abstract class BaseProductSpecificationResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<ProductSpecification>,
+			<Collection<ProductSpecification>,
 			 UnsafeConsumer<ProductSpecification, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -482,8 +495,7 @@ public abstract class BaseProductSpecificationResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -495,8 +507,8 @@ public abstract class BaseProductSpecificationResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -509,8 +521,7 @@ public abstract class BaseProductSpecificationResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -524,8 +535,8 @@ public abstract class BaseProductSpecificationResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -541,7 +552,7 @@ public abstract class BaseProductSpecificationResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<ProductSpecification>,
+		<Collection<ProductSpecification>,
 		 UnsafeConsumer<ProductSpecification, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -559,6 +570,115 @@ public abstract class BaseProductSpecificationResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseProductSpecificationResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductSubscriptionConfigurationResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductSubscriptionConfigurationResourceImpl.java
@@ -17,23 +17,38 @@ package com.liferay.headless.commerce.admin.catalog.internal.resource.v1_0;
 import com.liferay.headless.commerce.admin.catalog.dto.v1_0.ProductSubscriptionConfiguration;
 import com.liferay.headless.commerce.admin.catalog.resource.v1_0.ProductSubscriptionConfigurationResource;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -306,8 +321,7 @@ public abstract class BaseProductSubscriptionConfigurationResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -319,8 +333,8 @@ public abstract class BaseProductSubscriptionConfigurationResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -333,8 +347,7 @@ public abstract class BaseProductSubscriptionConfigurationResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -348,8 +361,8 @@ public abstract class BaseProductSubscriptionConfigurationResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -377,6 +390,115 @@ public abstract class BaseProductSubscriptionConfigurationResourceImpl
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductTaxConfigurationResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductTaxConfigurationResourceImpl.java
@@ -17,23 +17,38 @@ package com.liferay.headless.commerce.admin.catalog.internal.resource.v1_0;
 import com.liferay.headless.commerce.admin.catalog.dto.v1_0.ProductTaxConfiguration;
 import com.liferay.headless.commerce.admin.catalog.resource.v1_0.ProductTaxConfigurationResource;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -302,8 +317,7 @@ public abstract class BaseProductTaxConfigurationResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -315,8 +329,8 @@ public abstract class BaseProductTaxConfigurationResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -329,8 +343,7 @@ public abstract class BaseProductTaxConfigurationResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -344,8 +357,8 @@ public abstract class BaseProductTaxConfigurationResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -373,6 +386,115 @@ public abstract class BaseProductTaxConfigurationResourceImpl
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseProductTaxConfigurationResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseRelatedProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseRelatedProductResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.catalog.resource.v1_0.RelatedProductR
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -415,7 +428,7 @@ public abstract class BaseRelatedProductResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<RelatedProduct> relatedProducts,
+			Collection<RelatedProduct> relatedProducts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -425,7 +438,7 @@ public abstract class BaseRelatedProductResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<RelatedProduct> relatedProducts,
+			Collection<RelatedProduct> relatedProducts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -495,7 +508,7 @@ public abstract class BaseRelatedProductResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<RelatedProduct> relatedProducts,
+			Collection<RelatedProduct> relatedProducts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -509,7 +522,7 @@ public abstract class BaseRelatedProductResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<RelatedProduct>,
+			<Collection<RelatedProduct>,
 			 UnsafeConsumer<RelatedProduct, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -688,8 +701,7 @@ public abstract class BaseRelatedProductResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -701,8 +713,8 @@ public abstract class BaseRelatedProductResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -715,8 +727,7 @@ public abstract class BaseRelatedProductResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -730,8 +741,8 @@ public abstract class BaseRelatedProductResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -747,9 +758,8 @@ public abstract class BaseRelatedProductResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<RelatedProduct>,
-		 UnsafeConsumer<RelatedProduct, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<RelatedProduct>, UnsafeConsumer<RelatedProduct, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -765,6 +775,115 @@ public abstract class BaseRelatedProductResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseRelatedProductResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseSkuResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseSkuResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.catalog.resource.v1_0.SkuResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -562,8 +575,7 @@ public abstract class BaseSkuResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<Sku> skus,
-			Map<String, Serializable> parameters)
+			Collection<Sku> skus, Map<String, Serializable> parameters)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -572,8 +584,7 @@ public abstract class BaseSkuResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<Sku> skus,
-			Map<String, Serializable> parameters)
+			Collection<Sku> skus, Map<String, Serializable> parameters)
 		throws Exception {
 
 		for (Sku sku : skus) {
@@ -641,8 +652,7 @@ public abstract class BaseSkuResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<Sku> skus,
-			Map<String, Serializable> parameters)
+			Collection<Sku> skus, Map<String, Serializable> parameters)
 		throws Exception {
 
 		UnsafeConsumer<Sku, Exception> skuUnsafeConsumer = null;
@@ -679,8 +689,8 @@ public abstract class BaseSkuResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<Sku>, UnsafeConsumer<Sku, Exception>,
-			 Exception> contextBatchUnsafeConsumer) {
+			<Collection<Sku>, UnsafeConsumer<Sku, Exception>, Exception>
+				contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -857,8 +867,7 @@ public abstract class BaseSkuResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -870,8 +879,8 @@ public abstract class BaseSkuResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -884,8 +893,7 @@ public abstract class BaseSkuResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -899,8 +907,8 @@ public abstract class BaseSkuResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -916,7 +924,7 @@ public abstract class BaseSkuResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<Sku>, UnsafeConsumer<Sku, Exception>, Exception>
+		<Collection<Sku>, UnsafeConsumer<Sku, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
@@ -933,6 +941,115 @@ public abstract class BaseSkuResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseSkuResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseSpecificationResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseSpecificationResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.catalog.resource.v1_0.SpecificationRe
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -348,7 +361,7 @@ public abstract class BaseSpecificationResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<Specification> specifications,
+			Collection<Specification> specifications,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -382,7 +395,7 @@ public abstract class BaseSpecificationResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<Specification> specifications,
+			Collection<Specification> specifications,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -451,7 +464,7 @@ public abstract class BaseSpecificationResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<Specification> specifications,
+			Collection<Specification> specifications,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -491,7 +504,7 @@ public abstract class BaseSpecificationResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<Specification>,
+			<Collection<Specification>,
 			 UnsafeConsumer<Specification, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -670,8 +683,7 @@ public abstract class BaseSpecificationResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -683,8 +695,8 @@ public abstract class BaseSpecificationResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -697,8 +709,7 @@ public abstract class BaseSpecificationResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -712,8 +723,8 @@ public abstract class BaseSpecificationResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -729,9 +740,8 @@ public abstract class BaseSpecificationResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<Specification>,
-		 UnsafeConsumer<Specification, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<Specification>, UnsafeConsumer<Specification, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -747,6 +757,115 @@ public abstract class BaseSpecificationResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseSpecificationResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseChannelResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.channel.resource.v1_0.ChannelResource
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -589,8 +602,7 @@ public abstract class BaseChannelResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<Channel> channels,
-			Map<String, Serializable> parameters)
+			Collection<Channel> channels, Map<String, Serializable> parameters)
 		throws Exception {
 
 		UnsafeConsumer<Channel, Exception> channelUnsafeConsumer = null;
@@ -626,8 +638,7 @@ public abstract class BaseChannelResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<Channel> channels,
-			Map<String, Serializable> parameters)
+			Collection<Channel> channels, Map<String, Serializable> parameters)
 		throws Exception {
 
 		for (Channel channel : channels) {
@@ -695,8 +706,7 @@ public abstract class BaseChannelResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<Channel> channels,
-			Map<String, Serializable> parameters)
+			Collection<Channel> channels, Map<String, Serializable> parameters)
 		throws Exception {
 
 		UnsafeConsumer<Channel, Exception> channelUnsafeConsumer = null;
@@ -740,8 +750,8 @@ public abstract class BaseChannelResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<Channel>, UnsafeConsumer<Channel, Exception>,
-			 Exception> contextBatchUnsafeConsumer) {
+			<Collection<Channel>, UnsafeConsumer<Channel, Exception>, Exception>
+				contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -921,8 +931,7 @@ public abstract class BaseChannelResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -934,8 +943,8 @@ public abstract class BaseChannelResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -948,8 +957,7 @@ public abstract class BaseChannelResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -963,8 +971,8 @@ public abstract class BaseChannelResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -980,8 +988,8 @@ public abstract class BaseChannelResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<Channel>, UnsafeConsumer<Channel, Exception>,
-		 Exception> contextBatchUnsafeConsumer;
+		<Collection<Channel>, UnsafeConsumer<Channel, Exception>, Exception>
+			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -997,6 +1005,115 @@ public abstract class BaseChannelResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseChannelResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseOrderTypeResourceImpl.java
@@ -17,23 +17,38 @@ package com.liferay.headless.commerce.admin.channel.internal.resource.v1_0;
 import com.liferay.headless.commerce.admin.channel.dto.v1_0.OrderType;
 import com.liferay.headless.commerce.admin.channel.resource.v1_0.OrderTypeResource;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -217,8 +232,7 @@ public abstract class BaseOrderTypeResourceImpl implements OrderTypeResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -230,8 +244,8 @@ public abstract class BaseOrderTypeResourceImpl implements OrderTypeResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -244,8 +258,7 @@ public abstract class BaseOrderTypeResourceImpl implements OrderTypeResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -259,8 +272,8 @@ public abstract class BaseOrderTypeResourceImpl implements OrderTypeResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -288,6 +301,115 @@ public abstract class BaseOrderTypeResourceImpl implements OrderTypeResource {
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseOrderTypeResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BasePaymentMethodGroupRelOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BasePaymentMethodGroupRelOrderTypeResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.channel.resource.v1_0.PaymentMethodGr
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -264,7 +277,7 @@ public abstract class BasePaymentMethodGroupRelOrderTypeResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<PaymentMethodGroupRelOrderType>
+			Collection<PaymentMethodGroupRelOrderType>
 				paymentMethodGroupRelOrderTypes,
 			Map<String, Serializable> parameters)
 		throws Exception {
@@ -275,7 +288,7 @@ public abstract class BasePaymentMethodGroupRelOrderTypeResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<PaymentMethodGroupRelOrderType>
+			Collection<PaymentMethodGroupRelOrderType>
 				paymentMethodGroupRelOrderTypes,
 			Map<String, Serializable> parameters)
 		throws Exception {
@@ -350,7 +363,7 @@ public abstract class BasePaymentMethodGroupRelOrderTypeResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<PaymentMethodGroupRelOrderType>
+			Collection<PaymentMethodGroupRelOrderType>
 				paymentMethodGroupRelOrderTypes,
 			Map<String, Serializable> parameters)
 		throws Exception {
@@ -365,7 +378,7 @@ public abstract class BasePaymentMethodGroupRelOrderTypeResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<PaymentMethodGroupRelOrderType>,
+			<Collection<PaymentMethodGroupRelOrderType>,
 			 UnsafeConsumer<PaymentMethodGroupRelOrderType, Exception>,
 			 Exception> contextBatchUnsafeConsumer) {
 
@@ -544,8 +557,7 @@ public abstract class BasePaymentMethodGroupRelOrderTypeResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -557,8 +569,8 @@ public abstract class BasePaymentMethodGroupRelOrderTypeResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -571,8 +583,7 @@ public abstract class BasePaymentMethodGroupRelOrderTypeResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -586,8 +597,8 @@ public abstract class BasePaymentMethodGroupRelOrderTypeResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -603,7 +614,7 @@ public abstract class BasePaymentMethodGroupRelOrderTypeResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<PaymentMethodGroupRelOrderType>,
+		<Collection<PaymentMethodGroupRelOrderType>,
 		 UnsafeConsumer<PaymentMethodGroupRelOrderType, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -621,6 +632,115 @@ public abstract class BasePaymentMethodGroupRelOrderTypeResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BasePaymentMethodGroupRelTermResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BasePaymentMethodGroupRelTermResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.channel.resource.v1_0.PaymentMethodGr
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -262,8 +275,7 @@ public abstract class BasePaymentMethodGroupRelTermResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<PaymentMethodGroupRelTerm>
-				paymentMethodGroupRelTerms,
+			Collection<PaymentMethodGroupRelTerm> paymentMethodGroupRelTerms,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -273,8 +285,7 @@ public abstract class BasePaymentMethodGroupRelTermResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<PaymentMethodGroupRelTerm>
-				paymentMethodGroupRelTerms,
+			Collection<PaymentMethodGroupRelTerm> paymentMethodGroupRelTerms,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -347,8 +358,7 @@ public abstract class BasePaymentMethodGroupRelTermResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<PaymentMethodGroupRelTerm>
-				paymentMethodGroupRelTerms,
+			Collection<PaymentMethodGroupRelTerm> paymentMethodGroupRelTerms,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -362,7 +372,7 @@ public abstract class BasePaymentMethodGroupRelTermResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<PaymentMethodGroupRelTerm>,
+			<Collection<PaymentMethodGroupRelTerm>,
 			 UnsafeConsumer<PaymentMethodGroupRelTerm, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -541,8 +551,7 @@ public abstract class BasePaymentMethodGroupRelTermResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -554,8 +563,8 @@ public abstract class BasePaymentMethodGroupRelTermResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -568,8 +577,7 @@ public abstract class BasePaymentMethodGroupRelTermResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -583,8 +591,8 @@ public abstract class BasePaymentMethodGroupRelTermResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -600,7 +608,7 @@ public abstract class BasePaymentMethodGroupRelTermResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<PaymentMethodGroupRelTerm>,
+		<Collection<PaymentMethodGroupRelTerm>,
 		 UnsafeConsumer<PaymentMethodGroupRelTerm, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -618,6 +626,115 @@ public abstract class BasePaymentMethodGroupRelTermResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BasePaymentMethodGroupRelTermResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseShippingFixedOptionOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseShippingFixedOptionOrderTypeResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.channel.resource.v1_0.ShippingFixedOp
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -263,7 +276,7 @@ public abstract class BaseShippingFixedOptionOrderTypeResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<ShippingFixedOptionOrderType>
+			Collection<ShippingFixedOptionOrderType>
 				shippingFixedOptionOrderTypes,
 			Map<String, Serializable> parameters)
 		throws Exception {
@@ -274,7 +287,7 @@ public abstract class BaseShippingFixedOptionOrderTypeResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<ShippingFixedOptionOrderType>
+			Collection<ShippingFixedOptionOrderType>
 				shippingFixedOptionOrderTypes,
 			Map<String, Serializable> parameters)
 		throws Exception {
@@ -349,7 +362,7 @@ public abstract class BaseShippingFixedOptionOrderTypeResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<ShippingFixedOptionOrderType>
+			Collection<ShippingFixedOptionOrderType>
 				shippingFixedOptionOrderTypes,
 			Map<String, Serializable> parameters)
 		throws Exception {
@@ -364,7 +377,7 @@ public abstract class BaseShippingFixedOptionOrderTypeResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<ShippingFixedOptionOrderType>,
+			<Collection<ShippingFixedOptionOrderType>,
 			 UnsafeConsumer<ShippingFixedOptionOrderType, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -543,8 +556,7 @@ public abstract class BaseShippingFixedOptionOrderTypeResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -556,8 +568,8 @@ public abstract class BaseShippingFixedOptionOrderTypeResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -570,8 +582,7 @@ public abstract class BaseShippingFixedOptionOrderTypeResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -585,8 +596,8 @@ public abstract class BaseShippingFixedOptionOrderTypeResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -602,7 +613,7 @@ public abstract class BaseShippingFixedOptionOrderTypeResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<ShippingFixedOptionOrderType>,
+		<Collection<ShippingFixedOptionOrderType>,
 		 UnsafeConsumer<ShippingFixedOptionOrderType, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -620,6 +631,115 @@ public abstract class BaseShippingFixedOptionOrderTypeResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseShippingFixedOptionTermResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseShippingFixedOptionTermResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.channel.resource.v1_0.ShippingFixedOp
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -262,8 +275,7 @@ public abstract class BaseShippingFixedOptionTermResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<ShippingFixedOptionTerm>
-				shippingFixedOptionTerms,
+			Collection<ShippingFixedOptionTerm> shippingFixedOptionTerms,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -273,8 +285,7 @@ public abstract class BaseShippingFixedOptionTermResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<ShippingFixedOptionTerm>
-				shippingFixedOptionTerms,
+			Collection<ShippingFixedOptionTerm> shippingFixedOptionTerms,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -347,8 +358,7 @@ public abstract class BaseShippingFixedOptionTermResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<ShippingFixedOptionTerm>
-				shippingFixedOptionTerms,
+			Collection<ShippingFixedOptionTerm> shippingFixedOptionTerms,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -362,7 +372,7 @@ public abstract class BaseShippingFixedOptionTermResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<ShippingFixedOptionTerm>,
+			<Collection<ShippingFixedOptionTerm>,
 			 UnsafeConsumer<ShippingFixedOptionTerm, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -541,8 +551,7 @@ public abstract class BaseShippingFixedOptionTermResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -554,8 +563,8 @@ public abstract class BaseShippingFixedOptionTermResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -568,8 +577,7 @@ public abstract class BaseShippingFixedOptionTermResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -583,8 +591,8 @@ public abstract class BaseShippingFixedOptionTermResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -600,7 +608,7 @@ public abstract class BaseShippingFixedOptionTermResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<ShippingFixedOptionTerm>,
+		<Collection<ShippingFixedOptionTerm>,
 		 UnsafeConsumer<ShippingFixedOptionTerm, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -618,6 +626,115 @@ public abstract class BaseShippingFixedOptionTermResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseShippingFixedOptionTermResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseShippingMethodResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseShippingMethodResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.channel.resource.v1_0.ShippingMethodR
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -122,7 +135,7 @@ public abstract class BaseShippingMethodResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<ShippingMethod> shippingMethods,
+			Collection<ShippingMethod> shippingMethods,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -132,7 +145,7 @@ public abstract class BaseShippingMethodResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<ShippingMethod> shippingMethods,
+			Collection<ShippingMethod> shippingMethods,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -208,7 +221,7 @@ public abstract class BaseShippingMethodResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<ShippingMethod> shippingMethods,
+			Collection<ShippingMethod> shippingMethods,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -222,7 +235,7 @@ public abstract class BaseShippingMethodResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<ShippingMethod>,
+			<Collection<ShippingMethod>,
 			 UnsafeConsumer<ShippingMethod, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -401,8 +414,7 @@ public abstract class BaseShippingMethodResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -414,8 +426,8 @@ public abstract class BaseShippingMethodResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -428,8 +440,7 @@ public abstract class BaseShippingMethodResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -443,8 +454,8 @@ public abstract class BaseShippingMethodResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -460,9 +471,8 @@ public abstract class BaseShippingMethodResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<ShippingMethod>,
-		 UnsafeConsumer<ShippingMethod, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<ShippingMethod>, UnsafeConsumer<ShippingMethod, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -478,6 +488,115 @@ public abstract class BaseShippingMethodResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseShippingMethodResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseTaxCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseTaxCategoryResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.channel.resource.v1_0.TaxCategoryReso
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -144,7 +157,7 @@ public abstract class BaseTaxCategoryResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<TaxCategory> taxCategories,
+			Collection<TaxCategory> taxCategories,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -154,7 +167,7 @@ public abstract class BaseTaxCategoryResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<TaxCategory> taxCategories,
+			Collection<TaxCategory> taxCategories,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -223,7 +236,7 @@ public abstract class BaseTaxCategoryResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<TaxCategory> taxCategories,
+			Collection<TaxCategory> taxCategories,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -237,9 +250,8 @@ public abstract class BaseTaxCategoryResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<TaxCategory>,
-			 UnsafeConsumer<TaxCategory, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<TaxCategory>, UnsafeConsumer<TaxCategory, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -416,8 +428,7 @@ public abstract class BaseTaxCategoryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -429,8 +440,8 @@ public abstract class BaseTaxCategoryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -443,8 +454,7 @@ public abstract class BaseTaxCategoryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -458,8 +468,8 @@ public abstract class BaseTaxCategoryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -475,9 +485,8 @@ public abstract class BaseTaxCategoryResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<TaxCategory>,
-		 UnsafeConsumer<TaxCategory, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<TaxCategory>, UnsafeConsumer<TaxCategory, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -493,6 +502,115 @@ public abstract class BaseTaxCategoryResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseTaxCategoryResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseTermResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseTermResourceImpl.java
@@ -17,23 +17,38 @@ package com.liferay.headless.commerce.admin.channel.internal.resource.v1_0;
 import com.liferay.headless.commerce.admin.channel.dto.v1_0.Term;
 import com.liferay.headless.commerce.admin.channel.resource.v1_0.TermResource;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -217,8 +232,7 @@ public abstract class BaseTermResourceImpl implements TermResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -230,8 +244,8 @@ public abstract class BaseTermResourceImpl implements TermResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -244,8 +258,7 @@ public abstract class BaseTermResourceImpl implements TermResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -259,8 +272,8 @@ public abstract class BaseTermResourceImpl implements TermResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -288,6 +301,115 @@ public abstract class BaseTermResourceImpl implements TermResource {
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseTermResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/BaseChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/BaseChannelResourceImpl.java
@@ -17,23 +17,38 @@ package com.liferay.headless.commerce.admin.inventory.internal.resource.v1_0;
 import com.liferay.headless.commerce.admin.inventory.dto.v1_0.Channel;
 import com.liferay.headless.commerce.admin.inventory.resource.v1_0.ChannelResource;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -183,8 +198,7 @@ public abstract class BaseChannelResourceImpl implements ChannelResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -196,8 +210,8 @@ public abstract class BaseChannelResourceImpl implements ChannelResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -210,8 +224,7 @@ public abstract class BaseChannelResourceImpl implements ChannelResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -225,8 +238,8 @@ public abstract class BaseChannelResourceImpl implements ChannelResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -254,6 +267,115 @@ public abstract class BaseChannelResourceImpl implements ChannelResource {
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseChannelResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/BaseOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/BaseOrderTypeResourceImpl.java
@@ -17,23 +17,38 @@ package com.liferay.headless.commerce.admin.inventory.internal.resource.v1_0;
 import com.liferay.headless.commerce.admin.inventory.dto.v1_0.OrderType;
 import com.liferay.headless.commerce.admin.inventory.resource.v1_0.OrderTypeResource;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -185,8 +200,7 @@ public abstract class BaseOrderTypeResourceImpl implements OrderTypeResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -198,8 +212,8 @@ public abstract class BaseOrderTypeResourceImpl implements OrderTypeResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -212,8 +226,7 @@ public abstract class BaseOrderTypeResourceImpl implements OrderTypeResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -227,8 +240,8 @@ public abstract class BaseOrderTypeResourceImpl implements OrderTypeResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -256,6 +269,115 @@ public abstract class BaseOrderTypeResourceImpl implements OrderTypeResource {
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseOrderTypeResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/BaseReplenishmentItemResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/BaseReplenishmentItemResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.inventory.resource.v1_0.Replenishment
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -510,7 +523,7 @@ public abstract class BaseReplenishmentItemResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<ReplenishmentItem> replenishmentItems,
+			Collection<ReplenishmentItem> replenishmentItems,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -546,7 +559,7 @@ public abstract class BaseReplenishmentItemResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<ReplenishmentItem> replenishmentItems,
+			Collection<ReplenishmentItem> replenishmentItems,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -616,7 +629,7 @@ public abstract class BaseReplenishmentItemResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<ReplenishmentItem> replenishmentItems,
+			Collection<ReplenishmentItem> replenishmentItems,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -659,7 +672,7 @@ public abstract class BaseReplenishmentItemResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<ReplenishmentItem>,
+			<Collection<ReplenishmentItem>,
 			 UnsafeConsumer<ReplenishmentItem, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -838,8 +851,7 @@ public abstract class BaseReplenishmentItemResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -851,8 +863,8 @@ public abstract class BaseReplenishmentItemResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -865,8 +877,7 @@ public abstract class BaseReplenishmentItemResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -880,8 +891,8 @@ public abstract class BaseReplenishmentItemResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -897,7 +908,7 @@ public abstract class BaseReplenishmentItemResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<ReplenishmentItem>,
+		<Collection<ReplenishmentItem>,
 		 UnsafeConsumer<ReplenishmentItem, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -915,6 +926,115 @@ public abstract class BaseReplenishmentItemResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseReplenishmentItemResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/BaseWarehouseChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/BaseWarehouseChannelResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.inventory.resource.v1_0.WarehouseChan
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -379,7 +392,7 @@ public abstract class BaseWarehouseChannelResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<WarehouseChannel> warehouseChannels,
+			Collection<WarehouseChannel> warehouseChannels,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -389,7 +402,7 @@ public abstract class BaseWarehouseChannelResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<WarehouseChannel> warehouseChannels,
+			Collection<WarehouseChannel> warehouseChannels,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -459,7 +472,7 @@ public abstract class BaseWarehouseChannelResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<WarehouseChannel> warehouseChannels,
+			Collection<WarehouseChannel> warehouseChannels,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -473,7 +486,7 @@ public abstract class BaseWarehouseChannelResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<WarehouseChannel>,
+			<Collection<WarehouseChannel>,
 			 UnsafeConsumer<WarehouseChannel, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -652,8 +665,7 @@ public abstract class BaseWarehouseChannelResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -665,8 +677,8 @@ public abstract class BaseWarehouseChannelResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -679,8 +691,7 @@ public abstract class BaseWarehouseChannelResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -694,8 +705,8 @@ public abstract class BaseWarehouseChannelResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -711,7 +722,7 @@ public abstract class BaseWarehouseChannelResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<WarehouseChannel>,
+		<Collection<WarehouseChannel>,
 		 UnsafeConsumer<WarehouseChannel, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -729,6 +740,115 @@ public abstract class BaseWarehouseChannelResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseWarehouseChannelResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/BaseWarehouseItemResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/BaseWarehouseItemResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.inventory.resource.v1_0.WarehouseItem
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -629,7 +642,7 @@ public abstract class BaseWarehouseItemResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<WarehouseItem> warehouseItems,
+			Collection<WarehouseItem> warehouseItems,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -639,7 +652,7 @@ public abstract class BaseWarehouseItemResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<WarehouseItem> warehouseItems,
+			Collection<WarehouseItem> warehouseItems,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -709,7 +722,7 @@ public abstract class BaseWarehouseItemResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<WarehouseItem> warehouseItems,
+			Collection<WarehouseItem> warehouseItems,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -749,7 +762,7 @@ public abstract class BaseWarehouseItemResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<WarehouseItem>,
+			<Collection<WarehouseItem>,
 			 UnsafeConsumer<WarehouseItem, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -928,8 +941,7 @@ public abstract class BaseWarehouseItemResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -941,8 +953,8 @@ public abstract class BaseWarehouseItemResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -955,8 +967,7 @@ public abstract class BaseWarehouseItemResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -970,8 +981,8 @@ public abstract class BaseWarehouseItemResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -987,9 +998,8 @@ public abstract class BaseWarehouseItemResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<WarehouseItem>,
-		 UnsafeConsumer<WarehouseItem, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<WarehouseItem>, UnsafeConsumer<WarehouseItem, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -1005,6 +1015,115 @@ public abstract class BaseWarehouseItemResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseWarehouseItemResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/BaseWarehouseOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/BaseWarehouseOrderTypeResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.inventory.resource.v1_0.WarehouseOrde
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -379,7 +392,7 @@ public abstract class BaseWarehouseOrderTypeResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<WarehouseOrderType> warehouseOrderTypes,
+			Collection<WarehouseOrderType> warehouseOrderTypes,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -389,7 +402,7 @@ public abstract class BaseWarehouseOrderTypeResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<WarehouseOrderType> warehouseOrderTypes,
+			Collection<WarehouseOrderType> warehouseOrderTypes,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -460,7 +473,7 @@ public abstract class BaseWarehouseOrderTypeResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<WarehouseOrderType> warehouseOrderTypes,
+			Collection<WarehouseOrderType> warehouseOrderTypes,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -474,7 +487,7 @@ public abstract class BaseWarehouseOrderTypeResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<WarehouseOrderType>,
+			<Collection<WarehouseOrderType>,
 			 UnsafeConsumer<WarehouseOrderType, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -653,8 +666,7 @@ public abstract class BaseWarehouseOrderTypeResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -666,8 +678,8 @@ public abstract class BaseWarehouseOrderTypeResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -680,8 +692,7 @@ public abstract class BaseWarehouseOrderTypeResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -695,8 +706,8 @@ public abstract class BaseWarehouseOrderTypeResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -712,7 +723,7 @@ public abstract class BaseWarehouseOrderTypeResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<WarehouseOrderType>,
+		<Collection<WarehouseOrderType>,
 		 UnsafeConsumer<WarehouseOrderType, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -730,6 +741,115 @@ public abstract class BaseWarehouseOrderTypeResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseWarehouseOrderTypeResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/BaseWarehouseResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/BaseWarehouseResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.inventory.resource.v1_0.WarehouseReso
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -368,7 +381,7 @@ public abstract class BaseWarehouseResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<Warehouse> warehouses,
+			Collection<Warehouse> warehouses,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -400,7 +413,7 @@ public abstract class BaseWarehouseResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<Warehouse> warehouses,
+			Collection<Warehouse> warehouses,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -468,7 +481,7 @@ public abstract class BaseWarehouseResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<Warehouse> warehouses,
+			Collection<Warehouse> warehouses,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -482,9 +495,8 @@ public abstract class BaseWarehouseResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<Warehouse>,
-			 UnsafeConsumer<Warehouse, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<Warehouse>, UnsafeConsumer<Warehouse, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -661,8 +673,7 @@ public abstract class BaseWarehouseResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -674,8 +685,8 @@ public abstract class BaseWarehouseResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -688,8 +699,7 @@ public abstract class BaseWarehouseResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -703,8 +713,8 @@ public abstract class BaseWarehouseResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -720,8 +730,8 @@ public abstract class BaseWarehouseResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<Warehouse>, UnsafeConsumer<Warehouse, Exception>,
-		 Exception> contextBatchUnsafeConsumer;
+		<Collection<Warehouse>, UnsafeConsumer<Warehouse, Exception>, Exception>
+			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -737,6 +747,115 @@ public abstract class BaseWarehouseResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseWarehouseResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseAccountGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseAccountGroupResourceImpl.java
@@ -17,23 +17,38 @@ package com.liferay.headless.commerce.admin.order.internal.resource.v1_0;
 import com.liferay.headless.commerce.admin.order.dto.v1_0.AccountGroup;
 import com.liferay.headless.commerce.admin.order.resource.v1_0.AccountGroupResource;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -186,8 +201,7 @@ public abstract class BaseAccountGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -199,8 +213,8 @@ public abstract class BaseAccountGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -213,8 +227,7 @@ public abstract class BaseAccountGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -228,8 +241,8 @@ public abstract class BaseAccountGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -257,6 +270,115 @@ public abstract class BaseAccountGroupResourceImpl
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseAccountGroupResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseAccountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseAccountResourceImpl.java
@@ -17,23 +17,38 @@ package com.liferay.headless.commerce.admin.order.internal.resource.v1_0;
 import com.liferay.headless.commerce.admin.order.dto.v1_0.Account;
 import com.liferay.headless.commerce.admin.order.resource.v1_0.AccountResource;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -244,8 +259,7 @@ public abstract class BaseAccountResourceImpl implements AccountResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -257,8 +271,8 @@ public abstract class BaseAccountResourceImpl implements AccountResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -271,8 +285,7 @@ public abstract class BaseAccountResourceImpl implements AccountResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -286,8 +299,8 @@ public abstract class BaseAccountResourceImpl implements AccountResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -315,6 +328,115 @@ public abstract class BaseAccountResourceImpl implements AccountResource {
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseAccountResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseBillingAddressResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseBillingAddressResourceImpl.java
@@ -17,23 +17,38 @@ package com.liferay.headless.commerce.admin.order.internal.resource.v1_0;
 import com.liferay.headless.commerce.admin.order.dto.v1_0.BillingAddress;
 import com.liferay.headless.commerce.admin.order.resource.v1_0.BillingAddressResource;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -293,8 +308,7 @@ public abstract class BaseBillingAddressResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -306,8 +320,8 @@ public abstract class BaseBillingAddressResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -320,8 +334,7 @@ public abstract class BaseBillingAddressResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -335,8 +348,8 @@ public abstract class BaseBillingAddressResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -364,6 +377,115 @@ public abstract class BaseBillingAddressResourceImpl
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseBillingAddressResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseChannelResourceImpl.java
@@ -17,23 +17,38 @@ package com.liferay.headless.commerce.admin.order.internal.resource.v1_0;
 import com.liferay.headless.commerce.admin.order.dto.v1_0.Channel;
 import com.liferay.headless.commerce.admin.order.resource.v1_0.ChannelResource;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -274,8 +289,7 @@ public abstract class BaseChannelResourceImpl implements ChannelResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -287,8 +301,8 @@ public abstract class BaseChannelResourceImpl implements ChannelResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -301,8 +315,7 @@ public abstract class BaseChannelResourceImpl implements ChannelResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -316,8 +329,8 @@ public abstract class BaseChannelResourceImpl implements ChannelResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -345,6 +358,115 @@ public abstract class BaseChannelResourceImpl implements ChannelResource {
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseChannelResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderItemResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderItemResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.order.resource.v1_0.OrderItemResource
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -684,7 +697,7 @@ public abstract class BaseOrderItemResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<OrderItem> orderItems,
+			Collection<OrderItem> orderItems,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -718,7 +731,7 @@ public abstract class BaseOrderItemResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<OrderItem> orderItems,
+			Collection<OrderItem> orderItems,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -787,7 +800,7 @@ public abstract class BaseOrderItemResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<OrderItem> orderItems,
+			Collection<OrderItem> orderItems,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -833,9 +846,8 @@ public abstract class BaseOrderItemResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<OrderItem>,
-			 UnsafeConsumer<OrderItem, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<OrderItem>, UnsafeConsumer<OrderItem, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -1012,8 +1024,7 @@ public abstract class BaseOrderItemResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -1025,8 +1036,8 @@ public abstract class BaseOrderItemResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -1039,8 +1050,7 @@ public abstract class BaseOrderItemResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -1054,8 +1064,8 @@ public abstract class BaseOrderItemResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -1071,8 +1081,8 @@ public abstract class BaseOrderItemResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<OrderItem>, UnsafeConsumer<OrderItem, Exception>,
-		 Exception> contextBatchUnsafeConsumer;
+		<Collection<OrderItem>, UnsafeConsumer<OrderItem, Exception>, Exception>
+			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -1088,6 +1098,115 @@ public abstract class BaseOrderItemResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseOrderItemResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderNoteResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderNoteResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.order.resource.v1_0.OrderNoteResource
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -520,7 +533,7 @@ public abstract class BaseOrderNoteResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<OrderNote> orderNotes,
+			Collection<OrderNote> orderNotes,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -530,7 +543,7 @@ public abstract class BaseOrderNoteResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<OrderNote> orderNotes,
+			Collection<OrderNote> orderNotes,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -600,7 +613,7 @@ public abstract class BaseOrderNoteResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<OrderNote> orderNotes,
+			Collection<OrderNote> orderNotes,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -639,9 +652,8 @@ public abstract class BaseOrderNoteResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<OrderNote>,
-			 UnsafeConsumer<OrderNote, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<OrderNote>, UnsafeConsumer<OrderNote, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -818,8 +830,7 @@ public abstract class BaseOrderNoteResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -831,8 +842,8 @@ public abstract class BaseOrderNoteResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -845,8 +856,7 @@ public abstract class BaseOrderNoteResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -860,8 +870,8 @@ public abstract class BaseOrderNoteResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -877,8 +887,8 @@ public abstract class BaseOrderNoteResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<OrderNote>, UnsafeConsumer<OrderNote, Exception>,
-		 Exception> contextBatchUnsafeConsumer;
+		<Collection<OrderNote>, UnsafeConsumer<OrderNote, Exception>, Exception>
+			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -894,6 +904,115 @@ public abstract class BaseOrderNoteResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseOrderNoteResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.order.resource.v1_0.OrderResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -434,8 +447,7 @@ public abstract class BaseOrderResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<Order> orders,
-			Map<String, Serializable> parameters)
+			Collection<Order> orders, Map<String, Serializable> parameters)
 		throws Exception {
 
 		UnsafeConsumer<Order, Exception> orderUnsafeConsumer = null;
@@ -465,8 +477,7 @@ public abstract class BaseOrderResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<Order> orders,
-			Map<String, Serializable> parameters)
+			Collection<Order> orders, Map<String, Serializable> parameters)
 		throws Exception {
 
 		for (Order order : orders) {
@@ -534,8 +545,7 @@ public abstract class BaseOrderResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<Order> orders,
-			Map<String, Serializable> parameters)
+			Collection<Order> orders, Map<String, Serializable> parameters)
 		throws Exception {
 
 		UnsafeConsumer<Order, Exception> orderUnsafeConsumer = null;
@@ -572,8 +582,8 @@ public abstract class BaseOrderResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<Order>, UnsafeConsumer<Order, Exception>,
-			 Exception> contextBatchUnsafeConsumer) {
+			<Collection<Order>, UnsafeConsumer<Order, Exception>, Exception>
+				contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -750,8 +760,7 @@ public abstract class BaseOrderResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -763,8 +772,8 @@ public abstract class BaseOrderResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -777,8 +786,7 @@ public abstract class BaseOrderResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -792,8 +800,8 @@ public abstract class BaseOrderResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -809,8 +817,8 @@ public abstract class BaseOrderResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<Order>, UnsafeConsumer<Order, Exception>,
-		 Exception> contextBatchUnsafeConsumer;
+		<Collection<Order>, UnsafeConsumer<Order, Exception>, Exception>
+			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -826,6 +834,115 @@ public abstract class BaseOrderResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseOrderResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleAccountGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleAccountGroupResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.order.resource.v1_0.OrderRuleAccountG
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -381,7 +394,7 @@ public abstract class BaseOrderRuleAccountGroupResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<OrderRuleAccountGroup> orderRuleAccountGroups,
+			Collection<OrderRuleAccountGroup> orderRuleAccountGroups,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -391,7 +404,7 @@ public abstract class BaseOrderRuleAccountGroupResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<OrderRuleAccountGroup> orderRuleAccountGroups,
+			Collection<OrderRuleAccountGroup> orderRuleAccountGroups,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -464,7 +477,7 @@ public abstract class BaseOrderRuleAccountGroupResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<OrderRuleAccountGroup> orderRuleAccountGroups,
+			Collection<OrderRuleAccountGroup> orderRuleAccountGroups,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -478,7 +491,7 @@ public abstract class BaseOrderRuleAccountGroupResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<OrderRuleAccountGroup>,
+			<Collection<OrderRuleAccountGroup>,
 			 UnsafeConsumer<OrderRuleAccountGroup, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -657,8 +670,7 @@ public abstract class BaseOrderRuleAccountGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -670,8 +682,8 @@ public abstract class BaseOrderRuleAccountGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -684,8 +696,7 @@ public abstract class BaseOrderRuleAccountGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -699,8 +710,8 @@ public abstract class BaseOrderRuleAccountGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -716,7 +727,7 @@ public abstract class BaseOrderRuleAccountGroupResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<OrderRuleAccountGroup>,
+		<Collection<OrderRuleAccountGroup>,
 		 UnsafeConsumer<OrderRuleAccountGroup, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -734,6 +745,115 @@ public abstract class BaseOrderRuleAccountGroupResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseOrderRuleAccountGroupResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleAccountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleAccountResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.order.resource.v1_0.OrderRuleAccountR
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -370,7 +383,7 @@ public abstract class BaseOrderRuleAccountResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<OrderRuleAccount> orderRuleAccounts,
+			Collection<OrderRuleAccount> orderRuleAccounts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -380,7 +393,7 @@ public abstract class BaseOrderRuleAccountResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<OrderRuleAccount> orderRuleAccounts,
+			Collection<OrderRuleAccount> orderRuleAccounts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -450,7 +463,7 @@ public abstract class BaseOrderRuleAccountResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<OrderRuleAccount> orderRuleAccounts,
+			Collection<OrderRuleAccount> orderRuleAccounts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -464,7 +477,7 @@ public abstract class BaseOrderRuleAccountResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<OrderRuleAccount>,
+			<Collection<OrderRuleAccount>,
 			 UnsafeConsumer<OrderRuleAccount, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -643,8 +656,7 @@ public abstract class BaseOrderRuleAccountResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -656,8 +668,8 @@ public abstract class BaseOrderRuleAccountResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -670,8 +682,7 @@ public abstract class BaseOrderRuleAccountResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -685,8 +696,8 @@ public abstract class BaseOrderRuleAccountResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -702,7 +713,7 @@ public abstract class BaseOrderRuleAccountResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<OrderRuleAccount>,
+		<Collection<OrderRuleAccount>,
 		 UnsafeConsumer<OrderRuleAccount, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -720,6 +731,115 @@ public abstract class BaseOrderRuleAccountResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseOrderRuleAccountResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleChannelResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.order.resource.v1_0.OrderRuleChannelR
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -378,7 +391,7 @@ public abstract class BaseOrderRuleChannelResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<OrderRuleChannel> orderRuleChannels,
+			Collection<OrderRuleChannel> orderRuleChannels,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -388,7 +401,7 @@ public abstract class BaseOrderRuleChannelResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<OrderRuleChannel> orderRuleChannels,
+			Collection<OrderRuleChannel> orderRuleChannels,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -458,7 +471,7 @@ public abstract class BaseOrderRuleChannelResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<OrderRuleChannel> orderRuleChannels,
+			Collection<OrderRuleChannel> orderRuleChannels,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -472,7 +485,7 @@ public abstract class BaseOrderRuleChannelResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<OrderRuleChannel>,
+			<Collection<OrderRuleChannel>,
 			 UnsafeConsumer<OrderRuleChannel, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -651,8 +664,7 @@ public abstract class BaseOrderRuleChannelResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -664,8 +676,8 @@ public abstract class BaseOrderRuleChannelResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -678,8 +690,7 @@ public abstract class BaseOrderRuleChannelResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -693,8 +704,8 @@ public abstract class BaseOrderRuleChannelResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -710,7 +721,7 @@ public abstract class BaseOrderRuleChannelResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<OrderRuleChannel>,
+		<Collection<OrderRuleChannel>,
 		 UnsafeConsumer<OrderRuleChannel, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -728,6 +739,115 @@ public abstract class BaseOrderRuleChannelResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseOrderRuleChannelResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleOrderTypeResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.order.resource.v1_0.OrderRuleOrderTyp
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -368,7 +381,7 @@ public abstract class BaseOrderRuleOrderTypeResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<OrderRuleOrderType> orderRuleOrderTypes,
+			Collection<OrderRuleOrderType> orderRuleOrderTypes,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -378,7 +391,7 @@ public abstract class BaseOrderRuleOrderTypeResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<OrderRuleOrderType> orderRuleOrderTypes,
+			Collection<OrderRuleOrderType> orderRuleOrderTypes,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -449,7 +462,7 @@ public abstract class BaseOrderRuleOrderTypeResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<OrderRuleOrderType> orderRuleOrderTypes,
+			Collection<OrderRuleOrderType> orderRuleOrderTypes,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -463,7 +476,7 @@ public abstract class BaseOrderRuleOrderTypeResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<OrderRuleOrderType>,
+			<Collection<OrderRuleOrderType>,
 			 UnsafeConsumer<OrderRuleOrderType, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -642,8 +655,7 @@ public abstract class BaseOrderRuleOrderTypeResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -655,8 +667,8 @@ public abstract class BaseOrderRuleOrderTypeResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -669,8 +681,7 @@ public abstract class BaseOrderRuleOrderTypeResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -684,8 +695,8 @@ public abstract class BaseOrderRuleOrderTypeResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -701,7 +712,7 @@ public abstract class BaseOrderRuleOrderTypeResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<OrderRuleOrderType>,
+		<Collection<OrderRuleOrderType>,
 		 UnsafeConsumer<OrderRuleOrderType, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -719,6 +730,115 @@ public abstract class BaseOrderRuleOrderTypeResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseOrderRuleOrderTypeResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.order.resource.v1_0.OrderRuleResource
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -422,7 +435,7 @@ public abstract class BaseOrderRuleResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<OrderRule> orderRules,
+			Collection<OrderRule> orderRules,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -454,7 +467,7 @@ public abstract class BaseOrderRuleResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<OrderRule> orderRules,
+			Collection<OrderRule> orderRules,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -523,7 +536,7 @@ public abstract class BaseOrderRuleResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<OrderRule> orderRules,
+			Collection<OrderRule> orderRules,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -562,9 +575,8 @@ public abstract class BaseOrderRuleResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<OrderRule>,
-			 UnsafeConsumer<OrderRule, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<OrderRule>, UnsafeConsumer<OrderRule, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -741,8 +753,7 @@ public abstract class BaseOrderRuleResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -754,8 +765,8 @@ public abstract class BaseOrderRuleResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -768,8 +779,7 @@ public abstract class BaseOrderRuleResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -783,8 +793,8 @@ public abstract class BaseOrderRuleResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -800,8 +810,8 @@ public abstract class BaseOrderRuleResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<OrderRule>, UnsafeConsumer<OrderRule, Exception>,
-		 Exception> contextBatchUnsafeConsumer;
+		<Collection<OrderRule>, UnsafeConsumer<OrderRule, Exception>, Exception>
+			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -817,6 +827,115 @@ public abstract class BaseOrderRuleResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseOrderRuleResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderTypeChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderTypeChannelResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.order.resource.v1_0.OrderTypeChannelR
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -373,7 +386,7 @@ public abstract class BaseOrderTypeChannelResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<OrderTypeChannel> orderTypeChannels,
+			Collection<OrderTypeChannel> orderTypeChannels,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -383,7 +396,7 @@ public abstract class BaseOrderTypeChannelResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<OrderTypeChannel> orderTypeChannels,
+			Collection<OrderTypeChannel> orderTypeChannels,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -453,7 +466,7 @@ public abstract class BaseOrderTypeChannelResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<OrderTypeChannel> orderTypeChannels,
+			Collection<OrderTypeChannel> orderTypeChannels,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -467,7 +480,7 @@ public abstract class BaseOrderTypeChannelResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<OrderTypeChannel>,
+			<Collection<OrderTypeChannel>,
 			 UnsafeConsumer<OrderTypeChannel, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -646,8 +659,7 @@ public abstract class BaseOrderTypeChannelResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -659,8 +671,8 @@ public abstract class BaseOrderTypeChannelResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -673,8 +685,7 @@ public abstract class BaseOrderTypeChannelResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -688,8 +699,8 @@ public abstract class BaseOrderTypeChannelResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -705,7 +716,7 @@ public abstract class BaseOrderTypeChannelResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<OrderTypeChannel>,
+		<Collection<OrderTypeChannel>,
 		 UnsafeConsumer<OrderTypeChannel, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -723,6 +734,115 @@ public abstract class BaseOrderTypeChannelResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseOrderTypeChannelResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderTypeResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.order.resource.v1_0.OrderTypeResource
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -484,7 +497,7 @@ public abstract class BaseOrderTypeResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<OrderType> orderTypes,
+			Collection<OrderType> orderTypes,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -516,7 +529,7 @@ public abstract class BaseOrderTypeResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<OrderType> orderTypes,
+			Collection<OrderType> orderTypes,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -585,7 +598,7 @@ public abstract class BaseOrderTypeResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<OrderType> orderTypes,
+			Collection<OrderType> orderTypes,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -624,9 +637,8 @@ public abstract class BaseOrderTypeResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<OrderType>,
-			 UnsafeConsumer<OrderType, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<OrderType>, UnsafeConsumer<OrderType, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -803,8 +815,7 @@ public abstract class BaseOrderTypeResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -816,8 +827,8 @@ public abstract class BaseOrderTypeResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -830,8 +841,7 @@ public abstract class BaseOrderTypeResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -845,8 +855,8 @@ public abstract class BaseOrderTypeResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -862,8 +872,8 @@ public abstract class BaseOrderTypeResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<OrderType>, UnsafeConsumer<OrderType, Exception>,
-		 Exception> contextBatchUnsafeConsumer;
+		<Collection<OrderType>, UnsafeConsumer<OrderType, Exception>, Exception>
+			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -879,6 +889,115 @@ public abstract class BaseOrderTypeResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseOrderTypeResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseShippingAddressResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseShippingAddressResourceImpl.java
@@ -17,23 +17,38 @@ package com.liferay.headless.commerce.admin.order.internal.resource.v1_0;
 import com.liferay.headless.commerce.admin.order.dto.v1_0.ShippingAddress;
 import com.liferay.headless.commerce.admin.order.resource.v1_0.ShippingAddressResource;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -324,8 +339,7 @@ public abstract class BaseShippingAddressResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -337,8 +351,8 @@ public abstract class BaseShippingAddressResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -351,8 +365,7 @@ public abstract class BaseShippingAddressResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -366,8 +379,8 @@ public abstract class BaseShippingAddressResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -395,6 +408,115 @@ public abstract class BaseShippingAddressResourceImpl
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseShippingAddressResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseTermOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseTermOrderTypeResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.order.resource.v1_0.TermOrderTypeReso
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -366,7 +379,7 @@ public abstract class BaseTermOrderTypeResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<TermOrderType> termOrderTypes,
+			Collection<TermOrderType> termOrderTypes,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -376,7 +389,7 @@ public abstract class BaseTermOrderTypeResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<TermOrderType> termOrderTypes,
+			Collection<TermOrderType> termOrderTypes,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -446,7 +459,7 @@ public abstract class BaseTermOrderTypeResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<TermOrderType> termOrderTypes,
+			Collection<TermOrderType> termOrderTypes,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -460,7 +473,7 @@ public abstract class BaseTermOrderTypeResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<TermOrderType>,
+			<Collection<TermOrderType>,
 			 UnsafeConsumer<TermOrderType, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -639,8 +652,7 @@ public abstract class BaseTermOrderTypeResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -652,8 +664,8 @@ public abstract class BaseTermOrderTypeResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -666,8 +678,7 @@ public abstract class BaseTermOrderTypeResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -681,8 +692,8 @@ public abstract class BaseTermOrderTypeResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -698,9 +709,8 @@ public abstract class BaseTermOrderTypeResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<TermOrderType>,
-		 UnsafeConsumer<TermOrderType, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<TermOrderType>, UnsafeConsumer<TermOrderType, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -716,6 +726,115 @@ public abstract class BaseTermOrderTypeResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseTermOrderTypeResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseTermResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseTermResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.order.resource.v1_0.TermResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -416,8 +429,7 @@ public abstract class BaseTermResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<Term> terms,
-			Map<String, Serializable> parameters)
+			Collection<Term> terms, Map<String, Serializable> parameters)
 		throws Exception {
 
 		UnsafeConsumer<Term, Exception> termUnsafeConsumer = null;
@@ -447,8 +459,7 @@ public abstract class BaseTermResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<Term> terms,
-			Map<String, Serializable> parameters)
+			Collection<Term> terms, Map<String, Serializable> parameters)
 		throws Exception {
 
 		for (Term term : terms) {
@@ -516,8 +527,7 @@ public abstract class BaseTermResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<Term> terms,
-			Map<String, Serializable> parameters)
+			Collection<Term> terms, Map<String, Serializable> parameters)
 		throws Exception {
 
 		UnsafeConsumer<Term, Exception> termUnsafeConsumer = null;
@@ -554,8 +564,8 @@ public abstract class BaseTermResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<Term>, UnsafeConsumer<Term, Exception>,
-			 Exception> contextBatchUnsafeConsumer) {
+			<Collection<Term>, UnsafeConsumer<Term, Exception>, Exception>
+				contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -732,8 +742,7 @@ public abstract class BaseTermResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -745,8 +754,8 @@ public abstract class BaseTermResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -759,8 +768,7 @@ public abstract class BaseTermResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -774,8 +782,8 @@ public abstract class BaseTermResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -791,7 +799,7 @@ public abstract class BaseTermResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<Term>, UnsafeConsumer<Term, Exception>, Exception>
+		<Collection<Term>, UnsafeConsumer<Term, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
@@ -808,6 +816,115 @@ public abstract class BaseTermResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseTermResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountAccountGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountAccountGroupResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.pricing.resource.v1_0.DiscountAccount
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -385,7 +398,7 @@ public abstract class BaseDiscountAccountGroupResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<DiscountAccountGroup> discountAccountGroups,
+			Collection<DiscountAccountGroup> discountAccountGroups,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -395,7 +408,7 @@ public abstract class BaseDiscountAccountGroupResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<DiscountAccountGroup> discountAccountGroups,
+			Collection<DiscountAccountGroup> discountAccountGroups,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -467,7 +480,7 @@ public abstract class BaseDiscountAccountGroupResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<DiscountAccountGroup> discountAccountGroups,
+			Collection<DiscountAccountGroup> discountAccountGroups,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -481,7 +494,7 @@ public abstract class BaseDiscountAccountGroupResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<DiscountAccountGroup>,
+			<Collection<DiscountAccountGroup>,
 			 UnsafeConsumer<DiscountAccountGroup, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -660,8 +673,7 @@ public abstract class BaseDiscountAccountGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -673,8 +685,8 @@ public abstract class BaseDiscountAccountGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -687,8 +699,7 @@ public abstract class BaseDiscountAccountGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -702,8 +713,8 @@ public abstract class BaseDiscountAccountGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -719,7 +730,7 @@ public abstract class BaseDiscountAccountGroupResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<DiscountAccountGroup>,
+		<Collection<DiscountAccountGroup>,
 		 UnsafeConsumer<DiscountAccountGroup, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -737,6 +748,115 @@ public abstract class BaseDiscountAccountGroupResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseDiscountAccountGroupResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountCategoryResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.pricing.resource.v1_0.DiscountCategor
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -370,7 +383,7 @@ public abstract class BaseDiscountCategoryResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<DiscountCategory> discountCategories,
+			Collection<DiscountCategory> discountCategories,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -380,7 +393,7 @@ public abstract class BaseDiscountCategoryResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<DiscountCategory> discountCategories,
+			Collection<DiscountCategory> discountCategories,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -450,7 +463,7 @@ public abstract class BaseDiscountCategoryResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<DiscountCategory> discountCategories,
+			Collection<DiscountCategory> discountCategories,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -464,7 +477,7 @@ public abstract class BaseDiscountCategoryResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<DiscountCategory>,
+			<Collection<DiscountCategory>,
 			 UnsafeConsumer<DiscountCategory, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -643,8 +656,7 @@ public abstract class BaseDiscountCategoryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -656,8 +668,8 @@ public abstract class BaseDiscountCategoryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -670,8 +682,7 @@ public abstract class BaseDiscountCategoryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -685,8 +696,8 @@ public abstract class BaseDiscountCategoryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -702,7 +713,7 @@ public abstract class BaseDiscountCategoryResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<DiscountCategory>,
+		<Collection<DiscountCategory>,
 		 UnsafeConsumer<DiscountCategory, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -720,6 +731,115 @@ public abstract class BaseDiscountCategoryResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseDiscountCategoryResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountProductResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.pricing.resource.v1_0.DiscountProduct
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -370,7 +383,7 @@ public abstract class BaseDiscountProductResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<DiscountProduct> discountProducts,
+			Collection<DiscountProduct> discountProducts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -380,7 +393,7 @@ public abstract class BaseDiscountProductResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<DiscountProduct> discountProducts,
+			Collection<DiscountProduct> discountProducts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -450,7 +463,7 @@ public abstract class BaseDiscountProductResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<DiscountProduct> discountProducts,
+			Collection<DiscountProduct> discountProducts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -464,7 +477,7 @@ public abstract class BaseDiscountProductResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<DiscountProduct>,
+			<Collection<DiscountProduct>,
 			 UnsafeConsumer<DiscountProduct, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -643,8 +656,7 @@ public abstract class BaseDiscountProductResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -656,8 +668,8 @@ public abstract class BaseDiscountProductResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -670,8 +682,7 @@ public abstract class BaseDiscountProductResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -685,8 +696,8 @@ public abstract class BaseDiscountProductResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -702,7 +713,7 @@ public abstract class BaseDiscountProductResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<DiscountProduct>,
+		<Collection<DiscountProduct>,
 		 UnsafeConsumer<DiscountProduct, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -720,6 +731,115 @@ public abstract class BaseDiscountProductResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseDiscountProductResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.pricing.resource.v1_0.DiscountResourc
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -417,7 +430,7 @@ public abstract class BaseDiscountResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<Discount> discounts,
+			Collection<Discount> discounts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -449,7 +462,7 @@ public abstract class BaseDiscountResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<Discount> discounts,
+			Collection<Discount> discounts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -518,7 +531,7 @@ public abstract class BaseDiscountResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<Discount> discounts,
+			Collection<Discount> discounts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -557,9 +570,8 @@ public abstract class BaseDiscountResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<Discount>,
-			 UnsafeConsumer<Discount, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<Discount>, UnsafeConsumer<Discount, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -736,8 +748,7 @@ public abstract class BaseDiscountResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -749,8 +760,8 @@ public abstract class BaseDiscountResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -763,8 +774,7 @@ public abstract class BaseDiscountResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -778,8 +788,8 @@ public abstract class BaseDiscountResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -795,8 +805,8 @@ public abstract class BaseDiscountResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<Discount>, UnsafeConsumer<Discount, Exception>,
-		 Exception> contextBatchUnsafeConsumer;
+		<Collection<Discount>, UnsafeConsumer<Discount, Exception>, Exception>
+			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -812,6 +822,115 @@ public abstract class BaseDiscountResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseDiscountResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountRuleResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountRuleResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.pricing.resource.v1_0.DiscountRuleRes
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -419,7 +432,7 @@ public abstract class BaseDiscountRuleResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<DiscountRule> discountRules,
+			Collection<DiscountRule> discountRules,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -429,7 +442,7 @@ public abstract class BaseDiscountRuleResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<DiscountRule> discountRules,
+			Collection<DiscountRule> discountRules,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -499,7 +512,7 @@ public abstract class BaseDiscountRuleResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<DiscountRule> discountRules,
+			Collection<DiscountRule> discountRules,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -539,9 +552,8 @@ public abstract class BaseDiscountRuleResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<DiscountRule>,
-			 UnsafeConsumer<DiscountRule, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<DiscountRule>, UnsafeConsumer<DiscountRule, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -718,8 +730,7 @@ public abstract class BaseDiscountRuleResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -731,8 +742,8 @@ public abstract class BaseDiscountRuleResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -745,8 +756,7 @@ public abstract class BaseDiscountRuleResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -760,8 +770,8 @@ public abstract class BaseDiscountRuleResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -777,9 +787,8 @@ public abstract class BaseDiscountRuleResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<DiscountRule>,
-		 UnsafeConsumer<DiscountRule, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<DiscountRule>, UnsafeConsumer<DiscountRule, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -795,6 +804,115 @@ public abstract class BaseDiscountRuleResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseDiscountRuleResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BasePriceEntryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BasePriceEntryResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.pricing.resource.v1_0.PriceEntryResou
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -520,7 +533,7 @@ public abstract class BasePriceEntryResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<PriceEntry> priceEntries,
+			Collection<PriceEntry> priceEntries,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -530,7 +543,7 @@ public abstract class BasePriceEntryResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<PriceEntry> priceEntries,
+			Collection<PriceEntry> priceEntries,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -600,7 +613,7 @@ public abstract class BasePriceEntryResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<PriceEntry> priceEntries,
+			Collection<PriceEntry> priceEntries,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -639,9 +652,8 @@ public abstract class BasePriceEntryResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<PriceEntry>,
-			 UnsafeConsumer<PriceEntry, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<PriceEntry>, UnsafeConsumer<PriceEntry, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -818,8 +830,7 @@ public abstract class BasePriceEntryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -831,8 +842,8 @@ public abstract class BasePriceEntryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -845,8 +856,7 @@ public abstract class BasePriceEntryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -860,8 +870,8 @@ public abstract class BasePriceEntryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -877,9 +887,8 @@ public abstract class BasePriceEntryResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<PriceEntry>,
-		 UnsafeConsumer<PriceEntry, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<PriceEntry>, UnsafeConsumer<PriceEntry, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -895,6 +904,115 @@ public abstract class BasePriceEntryResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BasePriceEntryResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BasePriceListAccountGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BasePriceListAccountGroupResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.pricing.resource.v1_0.PriceListAccoun
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -386,7 +399,7 @@ public abstract class BasePriceListAccountGroupResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<PriceListAccountGroup> priceListAccountGroups,
+			Collection<PriceListAccountGroup> priceListAccountGroups,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -396,7 +409,7 @@ public abstract class BasePriceListAccountGroupResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<PriceListAccountGroup> priceListAccountGroups,
+			Collection<PriceListAccountGroup> priceListAccountGroups,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -468,7 +481,7 @@ public abstract class BasePriceListAccountGroupResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<PriceListAccountGroup> priceListAccountGroups,
+			Collection<PriceListAccountGroup> priceListAccountGroups,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -482,7 +495,7 @@ public abstract class BasePriceListAccountGroupResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<PriceListAccountGroup>,
+			<Collection<PriceListAccountGroup>,
 			 UnsafeConsumer<PriceListAccountGroup, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -661,8 +674,7 @@ public abstract class BasePriceListAccountGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -674,8 +686,8 @@ public abstract class BasePriceListAccountGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -688,8 +700,7 @@ public abstract class BasePriceListAccountGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -703,8 +714,8 @@ public abstract class BasePriceListAccountGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -720,7 +731,7 @@ public abstract class BasePriceListAccountGroupResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<PriceListAccountGroup>,
+		<Collection<PriceListAccountGroup>,
 		 UnsafeConsumer<PriceListAccountGroup, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -738,6 +749,115 @@ public abstract class BasePriceListAccountGroupResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BasePriceListAccountGroupResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BasePriceListResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BasePriceListResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.pricing.resource.v1_0.PriceListResour
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -427,7 +440,7 @@ public abstract class BasePriceListResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<PriceList> priceLists,
+			Collection<PriceList> priceLists,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -459,7 +472,7 @@ public abstract class BasePriceListResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<PriceList> priceLists,
+			Collection<PriceList> priceLists,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -528,7 +541,7 @@ public abstract class BasePriceListResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<PriceList> priceLists,
+			Collection<PriceList> priceLists,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -567,9 +580,8 @@ public abstract class BasePriceListResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<PriceList>,
-			 UnsafeConsumer<PriceList, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<PriceList>, UnsafeConsumer<PriceList, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -746,8 +758,7 @@ public abstract class BasePriceListResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -759,8 +770,8 @@ public abstract class BasePriceListResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -773,8 +784,7 @@ public abstract class BasePriceListResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -788,8 +798,8 @@ public abstract class BasePriceListResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -805,8 +815,8 @@ public abstract class BasePriceListResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<PriceList>, UnsafeConsumer<PriceList, Exception>,
-		 Exception> contextBatchUnsafeConsumer;
+		<Collection<PriceList>, UnsafeConsumer<PriceList, Exception>, Exception>
+			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -822,6 +832,115 @@ public abstract class BasePriceListResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BasePriceListResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseTierPriceResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseTierPriceResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.pricing.resource.v1_0.TierPriceResour
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -520,7 +533,7 @@ public abstract class BaseTierPriceResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<TierPrice> tierPrices,
+			Collection<TierPrice> tierPrices,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -530,7 +543,7 @@ public abstract class BaseTierPriceResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<TierPrice> tierPrices,
+			Collection<TierPrice> tierPrices,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -600,7 +613,7 @@ public abstract class BaseTierPriceResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<TierPrice> tierPrices,
+			Collection<TierPrice> tierPrices,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -639,9 +652,8 @@ public abstract class BaseTierPriceResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<TierPrice>,
-			 UnsafeConsumer<TierPrice, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<TierPrice>, UnsafeConsumer<TierPrice, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -818,8 +830,7 @@ public abstract class BaseTierPriceResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -831,8 +842,8 @@ public abstract class BaseTierPriceResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -845,8 +856,7 @@ public abstract class BaseTierPriceResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -860,8 +870,8 @@ public abstract class BaseTierPriceResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -877,8 +887,8 @@ public abstract class BaseTierPriceResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<TierPrice>, UnsafeConsumer<TierPrice, Exception>,
-		 Exception> contextBatchUnsafeConsumer;
+		<Collection<TierPrice>, UnsafeConsumer<TierPrice, Exception>, Exception>
+			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -894,6 +904,115 @@ public abstract class BaseTierPriceResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseTierPriceResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseAccountGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseAccountGroupResourceImpl.java
@@ -17,23 +17,38 @@ package com.liferay.headless.commerce.admin.pricing.internal.resource.v2_0;
 import com.liferay.headless.commerce.admin.pricing.dto.v2_0.AccountGroup;
 import com.liferay.headless.commerce.admin.pricing.resource.v2_0.AccountGroupResource;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -218,8 +233,7 @@ public abstract class BaseAccountGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -231,8 +245,8 @@ public abstract class BaseAccountGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -245,8 +259,7 @@ public abstract class BaseAccountGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -260,8 +273,8 @@ public abstract class BaseAccountGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -289,6 +302,115 @@ public abstract class BaseAccountGroupResourceImpl
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseAccountGroupResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseAccountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseAccountResourceImpl.java
@@ -17,23 +17,38 @@ package com.liferay.headless.commerce.admin.pricing.internal.resource.v2_0;
 import com.liferay.headless.commerce.admin.pricing.dto.v2_0.Account;
 import com.liferay.headless.commerce.admin.pricing.resource.v2_0.AccountResource;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -213,8 +228,7 @@ public abstract class BaseAccountResourceImpl implements AccountResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -226,8 +240,8 @@ public abstract class BaseAccountResourceImpl implements AccountResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -240,8 +254,7 @@ public abstract class BaseAccountResourceImpl implements AccountResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -255,8 +268,8 @@ public abstract class BaseAccountResourceImpl implements AccountResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -284,6 +297,115 @@ public abstract class BaseAccountResourceImpl implements AccountResource {
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseAccountResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseCategoryResourceImpl.java
@@ -17,23 +17,38 @@ package com.liferay.headless.commerce.admin.pricing.internal.resource.v2_0;
 import com.liferay.headless.commerce.admin.pricing.dto.v2_0.Category;
 import com.liferay.headless.commerce.admin.pricing.resource.v2_0.CategoryResource;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -215,8 +230,7 @@ public abstract class BaseCategoryResourceImpl implements CategoryResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -228,8 +242,8 @@ public abstract class BaseCategoryResourceImpl implements CategoryResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -242,8 +256,7 @@ public abstract class BaseCategoryResourceImpl implements CategoryResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -257,8 +270,8 @@ public abstract class BaseCategoryResourceImpl implements CategoryResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -286,6 +299,115 @@ public abstract class BaseCategoryResourceImpl implements CategoryResource {
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseCategoryResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseChannelResourceImpl.java
@@ -17,23 +17,38 @@ package com.liferay.headless.commerce.admin.pricing.internal.resource.v2_0;
 import com.liferay.headless.commerce.admin.pricing.dto.v2_0.Channel;
 import com.liferay.headless.commerce.admin.pricing.resource.v2_0.ChannelResource;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -213,8 +228,7 @@ public abstract class BaseChannelResourceImpl implements ChannelResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -226,8 +240,8 @@ public abstract class BaseChannelResourceImpl implements ChannelResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -240,8 +254,7 @@ public abstract class BaseChannelResourceImpl implements ChannelResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -255,8 +268,8 @@ public abstract class BaseChannelResourceImpl implements ChannelResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -284,6 +297,115 @@ public abstract class BaseChannelResourceImpl implements ChannelResource {
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseChannelResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountAccountGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountAccountGroupResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.pricing.resource.v2_0.DiscountAccount
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -392,7 +405,7 @@ public abstract class BaseDiscountAccountGroupResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<DiscountAccountGroup> discountAccountGroups,
+			Collection<DiscountAccountGroup> discountAccountGroups,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -402,7 +415,7 @@ public abstract class BaseDiscountAccountGroupResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<DiscountAccountGroup> discountAccountGroups,
+			Collection<DiscountAccountGroup> discountAccountGroups,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -475,7 +488,7 @@ public abstract class BaseDiscountAccountGroupResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<DiscountAccountGroup> discountAccountGroups,
+			Collection<DiscountAccountGroup> discountAccountGroups,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -489,7 +502,7 @@ public abstract class BaseDiscountAccountGroupResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<DiscountAccountGroup>,
+			<Collection<DiscountAccountGroup>,
 			 UnsafeConsumer<DiscountAccountGroup, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -668,8 +681,7 @@ public abstract class BaseDiscountAccountGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -681,8 +693,8 @@ public abstract class BaseDiscountAccountGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -695,8 +707,7 @@ public abstract class BaseDiscountAccountGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -710,8 +721,8 @@ public abstract class BaseDiscountAccountGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -727,7 +738,7 @@ public abstract class BaseDiscountAccountGroupResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<DiscountAccountGroup>,
+		<Collection<DiscountAccountGroup>,
 		 UnsafeConsumer<DiscountAccountGroup, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -745,6 +756,115 @@ public abstract class BaseDiscountAccountGroupResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseDiscountAccountGroupResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountAccountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountAccountResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.pricing.resource.v2_0.DiscountAccount
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -377,7 +390,7 @@ public abstract class BaseDiscountAccountResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<DiscountAccount> discountAccounts,
+			Collection<DiscountAccount> discountAccounts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -387,7 +400,7 @@ public abstract class BaseDiscountAccountResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<DiscountAccount> discountAccounts,
+			Collection<DiscountAccount> discountAccounts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -457,7 +470,7 @@ public abstract class BaseDiscountAccountResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<DiscountAccount> discountAccounts,
+			Collection<DiscountAccount> discountAccounts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -471,7 +484,7 @@ public abstract class BaseDiscountAccountResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<DiscountAccount>,
+			<Collection<DiscountAccount>,
 			 UnsafeConsumer<DiscountAccount, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -650,8 +663,7 @@ public abstract class BaseDiscountAccountResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -663,8 +675,8 @@ public abstract class BaseDiscountAccountResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -677,8 +689,7 @@ public abstract class BaseDiscountAccountResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -692,8 +703,8 @@ public abstract class BaseDiscountAccountResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -709,7 +720,7 @@ public abstract class BaseDiscountAccountResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<DiscountAccount>,
+		<Collection<DiscountAccount>,
 		 UnsafeConsumer<DiscountAccount, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -727,6 +738,115 @@ public abstract class BaseDiscountAccountResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseDiscountAccountResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountCategoryResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.pricing.resource.v2_0.DiscountCategor
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -377,7 +390,7 @@ public abstract class BaseDiscountCategoryResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<DiscountCategory> discountCategories,
+			Collection<DiscountCategory> discountCategories,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -387,7 +400,7 @@ public abstract class BaseDiscountCategoryResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<DiscountCategory> discountCategories,
+			Collection<DiscountCategory> discountCategories,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -457,7 +470,7 @@ public abstract class BaseDiscountCategoryResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<DiscountCategory> discountCategories,
+			Collection<DiscountCategory> discountCategories,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -471,7 +484,7 @@ public abstract class BaseDiscountCategoryResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<DiscountCategory>,
+			<Collection<DiscountCategory>,
 			 UnsafeConsumer<DiscountCategory, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -650,8 +663,7 @@ public abstract class BaseDiscountCategoryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -663,8 +675,8 @@ public abstract class BaseDiscountCategoryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -677,8 +689,7 @@ public abstract class BaseDiscountCategoryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -692,8 +703,8 @@ public abstract class BaseDiscountCategoryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -709,7 +720,7 @@ public abstract class BaseDiscountCategoryResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<DiscountCategory>,
+		<Collection<DiscountCategory>,
 		 UnsafeConsumer<DiscountCategory, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -727,6 +738,115 @@ public abstract class BaseDiscountCategoryResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseDiscountCategoryResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountChannelResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.pricing.resource.v2_0.DiscountChannel
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -377,7 +390,7 @@ public abstract class BaseDiscountChannelResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<DiscountChannel> discountChannels,
+			Collection<DiscountChannel> discountChannels,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -387,7 +400,7 @@ public abstract class BaseDiscountChannelResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<DiscountChannel> discountChannels,
+			Collection<DiscountChannel> discountChannels,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -457,7 +470,7 @@ public abstract class BaseDiscountChannelResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<DiscountChannel> discountChannels,
+			Collection<DiscountChannel> discountChannels,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -471,7 +484,7 @@ public abstract class BaseDiscountChannelResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<DiscountChannel>,
+			<Collection<DiscountChannel>,
 			 UnsafeConsumer<DiscountChannel, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -650,8 +663,7 @@ public abstract class BaseDiscountChannelResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -663,8 +675,8 @@ public abstract class BaseDiscountChannelResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -677,8 +689,7 @@ public abstract class BaseDiscountChannelResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -692,8 +703,8 @@ public abstract class BaseDiscountChannelResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -709,7 +720,7 @@ public abstract class BaseDiscountChannelResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<DiscountChannel>,
+		<Collection<DiscountChannel>,
 		 UnsafeConsumer<DiscountChannel, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -727,6 +738,115 @@ public abstract class BaseDiscountChannelResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseDiscountChannelResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountOrderTypeResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.pricing.resource.v2_0.DiscountOrderTy
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -378,7 +391,7 @@ public abstract class BaseDiscountOrderTypeResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<DiscountOrderType> discountOrderTypes,
+			Collection<DiscountOrderType> discountOrderTypes,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -388,7 +401,7 @@ public abstract class BaseDiscountOrderTypeResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<DiscountOrderType> discountOrderTypes,
+			Collection<DiscountOrderType> discountOrderTypes,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -458,7 +471,7 @@ public abstract class BaseDiscountOrderTypeResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<DiscountOrderType> discountOrderTypes,
+			Collection<DiscountOrderType> discountOrderTypes,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -472,7 +485,7 @@ public abstract class BaseDiscountOrderTypeResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<DiscountOrderType>,
+			<Collection<DiscountOrderType>,
 			 UnsafeConsumer<DiscountOrderType, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -651,8 +664,7 @@ public abstract class BaseDiscountOrderTypeResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -664,8 +676,8 @@ public abstract class BaseDiscountOrderTypeResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -678,8 +690,7 @@ public abstract class BaseDiscountOrderTypeResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -693,8 +704,8 @@ public abstract class BaseDiscountOrderTypeResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -710,7 +721,7 @@ public abstract class BaseDiscountOrderTypeResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<DiscountOrderType>,
+		<Collection<DiscountOrderType>,
 		 UnsafeConsumer<DiscountOrderType, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -728,6 +739,115 @@ public abstract class BaseDiscountOrderTypeResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseDiscountOrderTypeResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountProductGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountProductGroupResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.pricing.resource.v2_0.DiscountProduct
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -392,7 +405,7 @@ public abstract class BaseDiscountProductGroupResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<DiscountProductGroup> discountProductGroups,
+			Collection<DiscountProductGroup> discountProductGroups,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -402,7 +415,7 @@ public abstract class BaseDiscountProductGroupResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<DiscountProductGroup> discountProductGroups,
+			Collection<DiscountProductGroup> discountProductGroups,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -475,7 +488,7 @@ public abstract class BaseDiscountProductGroupResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<DiscountProductGroup> discountProductGroups,
+			Collection<DiscountProductGroup> discountProductGroups,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -489,7 +502,7 @@ public abstract class BaseDiscountProductGroupResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<DiscountProductGroup>,
+			<Collection<DiscountProductGroup>,
 			 UnsafeConsumer<DiscountProductGroup, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -668,8 +681,7 @@ public abstract class BaseDiscountProductGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -681,8 +693,8 @@ public abstract class BaseDiscountProductGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -695,8 +707,7 @@ public abstract class BaseDiscountProductGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -710,8 +721,8 @@ public abstract class BaseDiscountProductGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -727,7 +738,7 @@ public abstract class BaseDiscountProductGroupResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<DiscountProductGroup>,
+		<Collection<DiscountProductGroup>,
 		 UnsafeConsumer<DiscountProductGroup, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -745,6 +756,115 @@ public abstract class BaseDiscountProductGroupResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseDiscountProductGroupResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountProductResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.pricing.resource.v2_0.DiscountProduct
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -377,7 +390,7 @@ public abstract class BaseDiscountProductResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<DiscountProduct> discountProducts,
+			Collection<DiscountProduct> discountProducts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -387,7 +400,7 @@ public abstract class BaseDiscountProductResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<DiscountProduct> discountProducts,
+			Collection<DiscountProduct> discountProducts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -457,7 +470,7 @@ public abstract class BaseDiscountProductResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<DiscountProduct> discountProducts,
+			Collection<DiscountProduct> discountProducts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -471,7 +484,7 @@ public abstract class BaseDiscountProductResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<DiscountProduct>,
+			<Collection<DiscountProduct>,
 			 UnsafeConsumer<DiscountProduct, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -650,8 +663,7 @@ public abstract class BaseDiscountProductResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -663,8 +675,8 @@ public abstract class BaseDiscountProductResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -677,8 +689,7 @@ public abstract class BaseDiscountProductResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -692,8 +703,8 @@ public abstract class BaseDiscountProductResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -709,7 +720,7 @@ public abstract class BaseDiscountProductResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<DiscountProduct>,
+		<Collection<DiscountProduct>,
 		 UnsafeConsumer<DiscountProduct, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -727,6 +738,115 @@ public abstract class BaseDiscountProductResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseDiscountProductResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.pricing.resource.v2_0.DiscountResourc
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -422,7 +435,7 @@ public abstract class BaseDiscountResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<Discount> discounts,
+			Collection<Discount> discounts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -454,7 +467,7 @@ public abstract class BaseDiscountResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<Discount> discounts,
+			Collection<Discount> discounts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -523,7 +536,7 @@ public abstract class BaseDiscountResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<Discount> discounts,
+			Collection<Discount> discounts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -562,9 +575,8 @@ public abstract class BaseDiscountResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<Discount>,
-			 UnsafeConsumer<Discount, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<Discount>, UnsafeConsumer<Discount, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -741,8 +753,7 @@ public abstract class BaseDiscountResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -754,8 +765,8 @@ public abstract class BaseDiscountResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -768,8 +779,7 @@ public abstract class BaseDiscountResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -783,8 +793,8 @@ public abstract class BaseDiscountResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -800,8 +810,8 @@ public abstract class BaseDiscountResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<Discount>, UnsafeConsumer<Discount, Exception>,
-		 Exception> contextBatchUnsafeConsumer;
+		<Collection<Discount>, UnsafeConsumer<Discount, Exception>, Exception>
+			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -817,6 +827,115 @@ public abstract class BaseDiscountResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseDiscountResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountRuleResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountRuleResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.pricing.resource.v2_0.DiscountRuleRes
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -430,7 +443,7 @@ public abstract class BaseDiscountRuleResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<DiscountRule> discountRules,
+			Collection<DiscountRule> discountRules,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -440,7 +453,7 @@ public abstract class BaseDiscountRuleResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<DiscountRule> discountRules,
+			Collection<DiscountRule> discountRules,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -510,7 +523,7 @@ public abstract class BaseDiscountRuleResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<DiscountRule> discountRules,
+			Collection<DiscountRule> discountRules,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -550,9 +563,8 @@ public abstract class BaseDiscountRuleResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<DiscountRule>,
-			 UnsafeConsumer<DiscountRule, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<DiscountRule>, UnsafeConsumer<DiscountRule, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -729,8 +741,7 @@ public abstract class BaseDiscountRuleResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -742,8 +753,8 @@ public abstract class BaseDiscountRuleResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -756,8 +767,7 @@ public abstract class BaseDiscountRuleResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -771,8 +781,8 @@ public abstract class BaseDiscountRuleResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -788,9 +798,8 @@ public abstract class BaseDiscountRuleResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<DiscountRule>,
-		 UnsafeConsumer<DiscountRule, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<DiscountRule>, UnsafeConsumer<DiscountRule, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -806,6 +815,115 @@ public abstract class BaseDiscountRuleResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseDiscountRuleResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountSkuResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountSkuResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.pricing.resource.v2_0.DiscountSkuReso
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -362,7 +375,7 @@ public abstract class BaseDiscountSkuResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<DiscountSku> discountSkus,
+			Collection<DiscountSku> discountSkus,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -372,7 +385,7 @@ public abstract class BaseDiscountSkuResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<DiscountSku> discountSkus,
+			Collection<DiscountSku> discountSkus,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -442,7 +455,7 @@ public abstract class BaseDiscountSkuResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<DiscountSku> discountSkus,
+			Collection<DiscountSku> discountSkus,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -456,9 +469,8 @@ public abstract class BaseDiscountSkuResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<DiscountSku>,
-			 UnsafeConsumer<DiscountSku, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<DiscountSku>, UnsafeConsumer<DiscountSku, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -635,8 +647,7 @@ public abstract class BaseDiscountSkuResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -648,8 +659,8 @@ public abstract class BaseDiscountSkuResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -662,8 +673,7 @@ public abstract class BaseDiscountSkuResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -677,8 +687,8 @@ public abstract class BaseDiscountSkuResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -694,9 +704,8 @@ public abstract class BaseDiscountSkuResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<DiscountSku>,
-		 UnsafeConsumer<DiscountSku, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<DiscountSku>, UnsafeConsumer<DiscountSku, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -712,6 +721,115 @@ public abstract class BaseDiscountSkuResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseDiscountSkuResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseOrderTypeResourceImpl.java
@@ -17,23 +17,38 @@ package com.liferay.headless.commerce.admin.pricing.internal.resource.v2_0;
 import com.liferay.headless.commerce.admin.pricing.dto.v2_0.OrderType;
 import com.liferay.headless.commerce.admin.pricing.resource.v2_0.OrderTypeResource;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -215,8 +230,7 @@ public abstract class BaseOrderTypeResourceImpl implements OrderTypeResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -228,8 +242,8 @@ public abstract class BaseOrderTypeResourceImpl implements OrderTypeResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -242,8 +256,7 @@ public abstract class BaseOrderTypeResourceImpl implements OrderTypeResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -257,8 +270,8 @@ public abstract class BaseOrderTypeResourceImpl implements OrderTypeResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -286,6 +299,115 @@ public abstract class BaseOrderTypeResourceImpl implements OrderTypeResource {
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseOrderTypeResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceEntryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceEntryResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.pricing.resource.v2_0.PriceEntryResou
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -538,7 +551,7 @@ public abstract class BasePriceEntryResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<PriceEntry> priceEntries,
+			Collection<PriceEntry> priceEntries,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -548,7 +561,7 @@ public abstract class BasePriceEntryResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<PriceEntry> priceEntries,
+			Collection<PriceEntry> priceEntries,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -618,7 +631,7 @@ public abstract class BasePriceEntryResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<PriceEntry> priceEntries,
+			Collection<PriceEntry> priceEntries,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -658,9 +671,8 @@ public abstract class BasePriceEntryResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<PriceEntry>,
-			 UnsafeConsumer<PriceEntry, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<PriceEntry>, UnsafeConsumer<PriceEntry, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -837,8 +849,7 @@ public abstract class BasePriceEntryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -850,8 +861,8 @@ public abstract class BasePriceEntryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -864,8 +875,7 @@ public abstract class BasePriceEntryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -879,8 +889,8 @@ public abstract class BasePriceEntryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -896,9 +906,8 @@ public abstract class BasePriceEntryResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<PriceEntry>,
-		 UnsafeConsumer<PriceEntry, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<PriceEntry>, UnsafeConsumer<PriceEntry, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -914,6 +923,115 @@ public abstract class BasePriceEntryResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BasePriceEntryResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListAccountGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListAccountGroupResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.pricing.resource.v2_0.PriceListAccoun
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -381,7 +394,7 @@ public abstract class BasePriceListAccountGroupResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<PriceListAccountGroup> priceListAccountGroups,
+			Collection<PriceListAccountGroup> priceListAccountGroups,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -391,7 +404,7 @@ public abstract class BasePriceListAccountGroupResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<PriceListAccountGroup> priceListAccountGroups,
+			Collection<PriceListAccountGroup> priceListAccountGroups,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -464,7 +477,7 @@ public abstract class BasePriceListAccountGroupResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<PriceListAccountGroup> priceListAccountGroups,
+			Collection<PriceListAccountGroup> priceListAccountGroups,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -478,7 +491,7 @@ public abstract class BasePriceListAccountGroupResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<PriceListAccountGroup>,
+			<Collection<PriceListAccountGroup>,
 			 UnsafeConsumer<PriceListAccountGroup, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -657,8 +670,7 @@ public abstract class BasePriceListAccountGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -670,8 +682,8 @@ public abstract class BasePriceListAccountGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -684,8 +696,7 @@ public abstract class BasePriceListAccountGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -699,8 +710,8 @@ public abstract class BasePriceListAccountGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -716,7 +727,7 @@ public abstract class BasePriceListAccountGroupResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<PriceListAccountGroup>,
+		<Collection<PriceListAccountGroup>,
 		 UnsafeConsumer<PriceListAccountGroup, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -734,6 +745,115 @@ public abstract class BasePriceListAccountGroupResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BasePriceListAccountGroupResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListAccountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListAccountResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.pricing.resource.v2_0.PriceListAccoun
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -370,7 +383,7 @@ public abstract class BasePriceListAccountResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<PriceListAccount> priceListAccounts,
+			Collection<PriceListAccount> priceListAccounts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -380,7 +393,7 @@ public abstract class BasePriceListAccountResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<PriceListAccount> priceListAccounts,
+			Collection<PriceListAccount> priceListAccounts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -450,7 +463,7 @@ public abstract class BasePriceListAccountResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<PriceListAccount> priceListAccounts,
+			Collection<PriceListAccount> priceListAccounts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -464,7 +477,7 @@ public abstract class BasePriceListAccountResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<PriceListAccount>,
+			<Collection<PriceListAccount>,
 			 UnsafeConsumer<PriceListAccount, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -643,8 +656,7 @@ public abstract class BasePriceListAccountResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -656,8 +668,8 @@ public abstract class BasePriceListAccountResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -670,8 +682,7 @@ public abstract class BasePriceListAccountResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -685,8 +696,8 @@ public abstract class BasePriceListAccountResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -702,7 +713,7 @@ public abstract class BasePriceListAccountResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<PriceListAccount>,
+		<Collection<PriceListAccount>,
 		 UnsafeConsumer<PriceListAccount, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -720,6 +731,115 @@ public abstract class BasePriceListAccountResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BasePriceListAccountResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListChannelResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.pricing.resource.v2_0.PriceListChanne
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -378,7 +391,7 @@ public abstract class BasePriceListChannelResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<PriceListChannel> priceListChannels,
+			Collection<PriceListChannel> priceListChannels,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -388,7 +401,7 @@ public abstract class BasePriceListChannelResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<PriceListChannel> priceListChannels,
+			Collection<PriceListChannel> priceListChannels,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -458,7 +471,7 @@ public abstract class BasePriceListChannelResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<PriceListChannel> priceListChannels,
+			Collection<PriceListChannel> priceListChannels,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -472,7 +485,7 @@ public abstract class BasePriceListChannelResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<PriceListChannel>,
+			<Collection<PriceListChannel>,
 			 UnsafeConsumer<PriceListChannel, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -651,8 +664,7 @@ public abstract class BasePriceListChannelResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -664,8 +676,8 @@ public abstract class BasePriceListChannelResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -678,8 +690,7 @@ public abstract class BasePriceListChannelResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -693,8 +704,8 @@ public abstract class BasePriceListChannelResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -710,7 +721,7 @@ public abstract class BasePriceListChannelResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<PriceListChannel>,
+		<Collection<PriceListChannel>,
 		 UnsafeConsumer<PriceListChannel, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -728,6 +739,115 @@ public abstract class BasePriceListChannelResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BasePriceListChannelResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListDiscountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListDiscountResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.pricing.resource.v2_0.PriceListDiscou
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -361,7 +374,7 @@ public abstract class BasePriceListDiscountResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<PriceListDiscount> priceListDiscounts,
+			Collection<PriceListDiscount> priceListDiscounts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -371,7 +384,7 @@ public abstract class BasePriceListDiscountResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<PriceListDiscount> priceListDiscounts,
+			Collection<PriceListDiscount> priceListDiscounts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -441,7 +454,7 @@ public abstract class BasePriceListDiscountResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<PriceListDiscount> priceListDiscounts,
+			Collection<PriceListDiscount> priceListDiscounts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -455,7 +468,7 @@ public abstract class BasePriceListDiscountResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<PriceListDiscount>,
+			<Collection<PriceListDiscount>,
 			 UnsafeConsumer<PriceListDiscount, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -634,8 +647,7 @@ public abstract class BasePriceListDiscountResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -647,8 +659,8 @@ public abstract class BasePriceListDiscountResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -661,8 +673,7 @@ public abstract class BasePriceListDiscountResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -676,8 +687,8 @@ public abstract class BasePriceListDiscountResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -693,7 +704,7 @@ public abstract class BasePriceListDiscountResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<PriceListDiscount>,
+		<Collection<PriceListDiscount>,
 		 UnsafeConsumer<PriceListDiscount, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -711,6 +722,115 @@ public abstract class BasePriceListDiscountResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BasePriceListDiscountResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListOrderTypeResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.pricing.resource.v2_0.PriceListOrderT
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -360,7 +373,7 @@ public abstract class BasePriceListOrderTypeResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<PriceListOrderType> priceListOrderTypes,
+			Collection<PriceListOrderType> priceListOrderTypes,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -370,7 +383,7 @@ public abstract class BasePriceListOrderTypeResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<PriceListOrderType> priceListOrderTypes,
+			Collection<PriceListOrderType> priceListOrderTypes,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -441,7 +454,7 @@ public abstract class BasePriceListOrderTypeResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<PriceListOrderType> priceListOrderTypes,
+			Collection<PriceListOrderType> priceListOrderTypes,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -455,7 +468,7 @@ public abstract class BasePriceListOrderTypeResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<PriceListOrderType>,
+			<Collection<PriceListOrderType>,
 			 UnsafeConsumer<PriceListOrderType, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -634,8 +647,7 @@ public abstract class BasePriceListOrderTypeResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -647,8 +659,8 @@ public abstract class BasePriceListOrderTypeResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -661,8 +673,7 @@ public abstract class BasePriceListOrderTypeResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -676,8 +687,8 @@ public abstract class BasePriceListOrderTypeResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -693,7 +704,7 @@ public abstract class BasePriceListOrderTypeResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<PriceListOrderType>,
+		<Collection<PriceListOrderType>,
 		 UnsafeConsumer<PriceListOrderType, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -711,6 +722,115 @@ public abstract class BasePriceListOrderTypeResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BasePriceListOrderTypeResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.pricing.resource.v2_0.PriceListResour
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -422,7 +435,7 @@ public abstract class BasePriceListResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<PriceList> priceLists,
+			Collection<PriceList> priceLists,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -454,7 +467,7 @@ public abstract class BasePriceListResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<PriceList> priceLists,
+			Collection<PriceList> priceLists,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -523,7 +536,7 @@ public abstract class BasePriceListResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<PriceList> priceLists,
+			Collection<PriceList> priceLists,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -562,9 +575,8 @@ public abstract class BasePriceListResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<PriceList>,
-			 UnsafeConsumer<PriceList, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<PriceList>, UnsafeConsumer<PriceList, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -741,8 +753,7 @@ public abstract class BasePriceListResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -754,8 +765,8 @@ public abstract class BasePriceListResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -768,8 +779,7 @@ public abstract class BasePriceListResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -783,8 +793,8 @@ public abstract class BasePriceListResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -800,8 +810,8 @@ public abstract class BasePriceListResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<PriceList>, UnsafeConsumer<PriceList, Exception>,
-		 Exception> contextBatchUnsafeConsumer;
+		<Collection<PriceList>, UnsafeConsumer<PriceList, Exception>, Exception>
+			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -817,6 +827,115 @@ public abstract class BasePriceListResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BasePriceListResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceModifierCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceModifierCategoryResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.pricing.resource.v2_0.PriceModifierCa
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -395,7 +408,7 @@ public abstract class BasePriceModifierCategoryResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<PriceModifierCategory> priceModifierCategories,
+			Collection<PriceModifierCategory> priceModifierCategories,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -405,7 +418,7 @@ public abstract class BasePriceModifierCategoryResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<PriceModifierCategory> priceModifierCategories,
+			Collection<PriceModifierCategory> priceModifierCategories,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -478,7 +491,7 @@ public abstract class BasePriceModifierCategoryResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<PriceModifierCategory> priceModifierCategories,
+			Collection<PriceModifierCategory> priceModifierCategories,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -492,7 +505,7 @@ public abstract class BasePriceModifierCategoryResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<PriceModifierCategory>,
+			<Collection<PriceModifierCategory>,
 			 UnsafeConsumer<PriceModifierCategory, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -671,8 +684,7 @@ public abstract class BasePriceModifierCategoryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -684,8 +696,8 @@ public abstract class BasePriceModifierCategoryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -698,8 +710,7 @@ public abstract class BasePriceModifierCategoryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -713,8 +724,8 @@ public abstract class BasePriceModifierCategoryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -730,7 +741,7 @@ public abstract class BasePriceModifierCategoryResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<PriceModifierCategory>,
+		<Collection<PriceModifierCategory>,
 		 UnsafeConsumer<PriceModifierCategory, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -748,6 +759,115 @@ public abstract class BasePriceModifierCategoryResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BasePriceModifierCategoryResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceModifierProductGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceModifierProductGroupResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.pricing.resource.v2_0.PriceModifierPr
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -399,8 +412,7 @@ public abstract class BasePriceModifierProductGroupResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<PriceModifierProductGroup>
-				priceModifierProductGroups,
+			Collection<PriceModifierProductGroup> priceModifierProductGroups,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -410,8 +422,7 @@ public abstract class BasePriceModifierProductGroupResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<PriceModifierProductGroup>
-				priceModifierProductGroups,
+			Collection<PriceModifierProductGroup> priceModifierProductGroups,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -484,8 +495,7 @@ public abstract class BasePriceModifierProductGroupResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<PriceModifierProductGroup>
-				priceModifierProductGroups,
+			Collection<PriceModifierProductGroup> priceModifierProductGroups,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -499,7 +509,7 @@ public abstract class BasePriceModifierProductGroupResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<PriceModifierProductGroup>,
+			<Collection<PriceModifierProductGroup>,
 			 UnsafeConsumer<PriceModifierProductGroup, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -678,8 +688,7 @@ public abstract class BasePriceModifierProductGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -691,8 +700,8 @@ public abstract class BasePriceModifierProductGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -705,8 +714,7 @@ public abstract class BasePriceModifierProductGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -720,8 +728,8 @@ public abstract class BasePriceModifierProductGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -737,7 +745,7 @@ public abstract class BasePriceModifierProductGroupResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<PriceModifierProductGroup>,
+		<Collection<PriceModifierProductGroup>,
 		 UnsafeConsumer<PriceModifierProductGroup, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -755,6 +763,115 @@ public abstract class BasePriceModifierProductGroupResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BasePriceModifierProductGroupResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceModifierProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceModifierProductResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.pricing.resource.v2_0.PriceModifierPr
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -394,7 +407,7 @@ public abstract class BasePriceModifierProductResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<PriceModifierProduct> priceModifierProducts,
+			Collection<PriceModifierProduct> priceModifierProducts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -404,7 +417,7 @@ public abstract class BasePriceModifierProductResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<PriceModifierProduct> priceModifierProducts,
+			Collection<PriceModifierProduct> priceModifierProducts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -477,7 +490,7 @@ public abstract class BasePriceModifierProductResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<PriceModifierProduct> priceModifierProducts,
+			Collection<PriceModifierProduct> priceModifierProducts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -491,7 +504,7 @@ public abstract class BasePriceModifierProductResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<PriceModifierProduct>,
+			<Collection<PriceModifierProduct>,
 			 UnsafeConsumer<PriceModifierProduct, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -670,8 +683,7 @@ public abstract class BasePriceModifierProductResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -683,8 +695,8 @@ public abstract class BasePriceModifierProductResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -697,8 +709,7 @@ public abstract class BasePriceModifierProductResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -712,8 +723,8 @@ public abstract class BasePriceModifierProductResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -729,7 +740,7 @@ public abstract class BasePriceModifierProductResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<PriceModifierProduct>,
+		<Collection<PriceModifierProduct>,
 		 UnsafeConsumer<PriceModifierProduct, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -747,6 +758,115 @@ public abstract class BasePriceModifierProductResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BasePriceModifierProductResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceModifierResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceModifierResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.pricing.resource.v2_0.PriceModifierRe
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -554,7 +567,7 @@ public abstract class BasePriceModifierResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<PriceModifier> priceModifiers,
+			Collection<PriceModifier> priceModifiers,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -564,7 +577,7 @@ public abstract class BasePriceModifierResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<PriceModifier> priceModifiers,
+			Collection<PriceModifier> priceModifiers,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -634,7 +647,7 @@ public abstract class BasePriceModifierResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<PriceModifier> priceModifiers,
+			Collection<PriceModifier> priceModifiers,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -674,7 +687,7 @@ public abstract class BasePriceModifierResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<PriceModifier>,
+			<Collection<PriceModifier>,
 			 UnsafeConsumer<PriceModifier, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -853,8 +866,7 @@ public abstract class BasePriceModifierResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -866,8 +878,8 @@ public abstract class BasePriceModifierResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -880,8 +892,7 @@ public abstract class BasePriceModifierResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -895,8 +906,8 @@ public abstract class BasePriceModifierResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -912,9 +923,8 @@ public abstract class BasePriceModifierResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<PriceModifier>,
-		 UnsafeConsumer<PriceModifier, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<PriceModifier>, UnsafeConsumer<PriceModifier, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -930,6 +940,115 @@ public abstract class BasePriceModifierResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BasePriceModifierResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseProductGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseProductGroupResourceImpl.java
@@ -17,23 +17,38 @@ package com.liferay.headless.commerce.admin.pricing.internal.resource.v2_0;
 import com.liferay.headless.commerce.admin.pricing.dto.v2_0.ProductGroup;
 import com.liferay.headless.commerce.admin.pricing.resource.v2_0.ProductGroupResource;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -218,8 +233,7 @@ public abstract class BaseProductGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -231,8 +245,8 @@ public abstract class BaseProductGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -245,8 +259,7 @@ public abstract class BaseProductGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -260,8 +273,8 @@ public abstract class BaseProductGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -289,6 +302,115 @@ public abstract class BaseProductGroupResourceImpl
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseProductGroupResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseProductResourceImpl.java
@@ -17,23 +17,38 @@ package com.liferay.headless.commerce.admin.pricing.internal.resource.v2_0;
 import com.liferay.headless.commerce.admin.pricing.dto.v2_0.Product;
 import com.liferay.headless.commerce.admin.pricing.resource.v2_0.ProductResource;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -245,8 +260,7 @@ public abstract class BaseProductResourceImpl implements ProductResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -258,8 +272,8 @@ public abstract class BaseProductResourceImpl implements ProductResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -272,8 +286,7 @@ public abstract class BaseProductResourceImpl implements ProductResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -287,8 +300,8 @@ public abstract class BaseProductResourceImpl implements ProductResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -316,6 +329,115 @@ public abstract class BaseProductResourceImpl implements ProductResource {
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseProductResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseSkuResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseSkuResourceImpl.java
@@ -17,23 +17,38 @@ package com.liferay.headless.commerce.admin.pricing.internal.resource.v2_0;
 import com.liferay.headless.commerce.admin.pricing.dto.v2_0.Sku;
 import com.liferay.headless.commerce.admin.pricing.resource.v2_0.SkuResource;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -213,8 +228,7 @@ public abstract class BaseSkuResourceImpl implements SkuResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -226,8 +240,8 @@ public abstract class BaseSkuResourceImpl implements SkuResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -240,8 +254,7 @@ public abstract class BaseSkuResourceImpl implements SkuResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -255,8 +268,8 @@ public abstract class BaseSkuResourceImpl implements SkuResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -284,6 +297,115 @@ public abstract class BaseSkuResourceImpl implements SkuResource {
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseSkuResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseTierPriceResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseTierPriceResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.pricing.resource.v2_0.TierPriceResour
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -515,7 +528,7 @@ public abstract class BaseTierPriceResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<TierPrice> tierPrices,
+			Collection<TierPrice> tierPrices,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -525,7 +538,7 @@ public abstract class BaseTierPriceResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<TierPrice> tierPrices,
+			Collection<TierPrice> tierPrices,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -595,7 +608,7 @@ public abstract class BaseTierPriceResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<TierPrice> tierPrices,
+			Collection<TierPrice> tierPrices,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -634,9 +647,8 @@ public abstract class BaseTierPriceResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<TierPrice>,
-			 UnsafeConsumer<TierPrice, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<TierPrice>, UnsafeConsumer<TierPrice, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -813,8 +825,7 @@ public abstract class BaseTierPriceResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -826,8 +837,8 @@ public abstract class BaseTierPriceResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -840,8 +851,7 @@ public abstract class BaseTierPriceResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -855,8 +865,8 @@ public abstract class BaseTierPriceResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -872,8 +882,8 @@ public abstract class BaseTierPriceResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<TierPrice>, UnsafeConsumer<TierPrice, Exception>,
-		 Exception> contextBatchUnsafeConsumer;
+		<Collection<TierPrice>, UnsafeConsumer<TierPrice, Exception>, Exception>
+			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -889,6 +899,115 @@ public abstract class BaseTierPriceResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseTierPriceResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/BaseShipmentItemResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/BaseShipmentItemResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.shipment.resource.v1_0.ShipmentItemRe
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -455,7 +468,7 @@ public abstract class BaseShipmentItemResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<ShipmentItem> shipmentItems,
+			Collection<ShipmentItem> shipmentItems,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -465,7 +478,7 @@ public abstract class BaseShipmentItemResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<ShipmentItem> shipmentItems,
+			Collection<ShipmentItem> shipmentItems,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -535,7 +548,7 @@ public abstract class BaseShipmentItemResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<ShipmentItem> shipmentItems,
+			Collection<ShipmentItem> shipmentItems,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -575,9 +588,8 @@ public abstract class BaseShipmentItemResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<ShipmentItem>,
-			 UnsafeConsumer<ShipmentItem, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<ShipmentItem>, UnsafeConsumer<ShipmentItem, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -754,8 +766,7 @@ public abstract class BaseShipmentItemResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -767,8 +778,8 @@ public abstract class BaseShipmentItemResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -781,8 +792,7 @@ public abstract class BaseShipmentItemResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -796,8 +806,8 @@ public abstract class BaseShipmentItemResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -813,9 +823,8 @@ public abstract class BaseShipmentItemResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<ShipmentItem>,
-		 UnsafeConsumer<ShipmentItem, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<ShipmentItem>, UnsafeConsumer<ShipmentItem, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -831,6 +840,115 @@ public abstract class BaseShipmentItemResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseShipmentItemResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/BaseShipmentResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/BaseShipmentResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.shipment.resource.v1_0.ShipmentResour
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -711,7 +724,7 @@ public abstract class BaseShipmentResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<Shipment> shipments,
+			Collection<Shipment> shipments,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -749,7 +762,7 @@ public abstract class BaseShipmentResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<Shipment> shipments,
+			Collection<Shipment> shipments,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -818,7 +831,7 @@ public abstract class BaseShipmentResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<Shipment> shipments,
+			Collection<Shipment> shipments,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -857,9 +870,8 @@ public abstract class BaseShipmentResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<Shipment>,
-			 UnsafeConsumer<Shipment, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<Shipment>, UnsafeConsumer<Shipment, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -1039,8 +1051,7 @@ public abstract class BaseShipmentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -1052,8 +1063,8 @@ public abstract class BaseShipmentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -1066,8 +1077,7 @@ public abstract class BaseShipmentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -1081,8 +1091,8 @@ public abstract class BaseShipmentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -1098,8 +1108,8 @@ public abstract class BaseShipmentResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<Shipment>, UnsafeConsumer<Shipment, Exception>,
-		 Exception> contextBatchUnsafeConsumer;
+		<Collection<Shipment>, UnsafeConsumer<Shipment, Exception>, Exception>
+			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -1115,6 +1125,115 @@ public abstract class BaseShipmentResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseShipmentResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/BaseShippingAddressResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/BaseShippingAddressResourceImpl.java
@@ -17,23 +17,38 @@ package com.liferay.headless.commerce.admin.shipment.internal.resource.v1_0;
 import com.liferay.headless.commerce.admin.shipment.dto.v1_0.ShippingAddress;
 import com.liferay.headless.commerce.admin.shipment.resource.v1_0.ShippingAddressResource;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -290,8 +305,7 @@ public abstract class BaseShippingAddressResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -303,8 +317,8 @@ public abstract class BaseShippingAddressResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -317,8 +331,7 @@ public abstract class BaseShippingAddressResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -332,8 +345,8 @@ public abstract class BaseShippingAddressResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -361,6 +374,115 @@ public abstract class BaseShippingAddressResourceImpl
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseShippingAddressResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseAvailabilityEstimateResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseAvailabilityEstimateResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.site.setting.resource.v1_0.Availabili
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -379,7 +392,7 @@ public abstract class BaseAvailabilityEstimateResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<AvailabilityEstimate> availabilityEstimates,
+			Collection<AvailabilityEstimate> availabilityEstimates,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -389,7 +402,7 @@ public abstract class BaseAvailabilityEstimateResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<AvailabilityEstimate> availabilityEstimates,
+			Collection<AvailabilityEstimate> availabilityEstimates,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -461,7 +474,7 @@ public abstract class BaseAvailabilityEstimateResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<AvailabilityEstimate> availabilityEstimates,
+			Collection<AvailabilityEstimate> availabilityEstimates,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -507,7 +520,7 @@ public abstract class BaseAvailabilityEstimateResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<AvailabilityEstimate>,
+			<Collection<AvailabilityEstimate>,
 			 UnsafeConsumer<AvailabilityEstimate, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -686,8 +699,7 @@ public abstract class BaseAvailabilityEstimateResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -699,8 +711,8 @@ public abstract class BaseAvailabilityEstimateResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -713,8 +725,7 @@ public abstract class BaseAvailabilityEstimateResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -728,8 +739,8 @@ public abstract class BaseAvailabilityEstimateResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -745,7 +756,7 @@ public abstract class BaseAvailabilityEstimateResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<AvailabilityEstimate>,
+		<Collection<AvailabilityEstimate>,
 		 UnsafeConsumer<AvailabilityEstimate, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -763,6 +774,115 @@ public abstract class BaseAvailabilityEstimateResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseAvailabilityEstimateResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseMeasurementUnitResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseMeasurementUnitResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.site.setting.resource.v1_0.Measuremen
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -582,7 +595,7 @@ public abstract class BaseMeasurementUnitResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<MeasurementUnit> measurementUnits,
+			Collection<MeasurementUnit> measurementUnits,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -616,7 +629,7 @@ public abstract class BaseMeasurementUnitResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<MeasurementUnit> measurementUnits,
+			Collection<MeasurementUnit> measurementUnits,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -685,7 +698,7 @@ public abstract class BaseMeasurementUnitResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<MeasurementUnit> measurementUnits,
+			Collection<MeasurementUnit> measurementUnits,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -727,7 +740,7 @@ public abstract class BaseMeasurementUnitResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<MeasurementUnit>,
+			<Collection<MeasurementUnit>,
 			 UnsafeConsumer<MeasurementUnit, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -906,8 +919,7 @@ public abstract class BaseMeasurementUnitResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -919,8 +931,8 @@ public abstract class BaseMeasurementUnitResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -933,8 +945,7 @@ public abstract class BaseMeasurementUnitResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -948,8 +959,8 @@ public abstract class BaseMeasurementUnitResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -965,7 +976,7 @@ public abstract class BaseMeasurementUnitResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<MeasurementUnit>,
+		<Collection<MeasurementUnit>,
 		 UnsafeConsumer<MeasurementUnit, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -983,6 +994,115 @@ public abstract class BaseMeasurementUnitResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseMeasurementUnitResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseTaxCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseTaxCategoryResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.site.setting.resource.v1_0.TaxCategor
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -345,7 +358,7 @@ public abstract class BaseTaxCategoryResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<TaxCategory> taxCategories,
+			Collection<TaxCategory> taxCategories,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -355,7 +368,7 @@ public abstract class BaseTaxCategoryResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<TaxCategory> taxCategories,
+			Collection<TaxCategory> taxCategories,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -425,7 +438,7 @@ public abstract class BaseTaxCategoryResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<TaxCategory> taxCategories,
+			Collection<TaxCategory> taxCategories,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -464,9 +477,8 @@ public abstract class BaseTaxCategoryResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<TaxCategory>,
-			 UnsafeConsumer<TaxCategory, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<TaxCategory>, UnsafeConsumer<TaxCategory, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -643,8 +655,7 @@ public abstract class BaseTaxCategoryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -656,8 +667,8 @@ public abstract class BaseTaxCategoryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -670,8 +681,7 @@ public abstract class BaseTaxCategoryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -685,8 +695,8 @@ public abstract class BaseTaxCategoryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -702,9 +712,8 @@ public abstract class BaseTaxCategoryResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<TaxCategory>,
-		 UnsafeConsumer<TaxCategory, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<TaxCategory>, UnsafeConsumer<TaxCategory, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -720,6 +729,115 @@ public abstract class BaseTaxCategoryResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseTaxCategoryResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseWarehouseResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseWarehouseResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.admin.site.setting.resource.v1_0.WarehouseR
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -352,7 +365,7 @@ public abstract class BaseWarehouseResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<Warehouse> warehouses,
+			Collection<Warehouse> warehouses,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -362,7 +375,7 @@ public abstract class BaseWarehouseResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<Warehouse> warehouses,
+			Collection<Warehouse> warehouses,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -432,7 +445,7 @@ public abstract class BaseWarehouseResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<Warehouse> warehouses,
+			Collection<Warehouse> warehouses,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -471,9 +484,8 @@ public abstract class BaseWarehouseResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<Warehouse>,
-			 UnsafeConsumer<Warehouse, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<Warehouse>, UnsafeConsumer<Warehouse, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -650,8 +662,7 @@ public abstract class BaseWarehouseResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -663,8 +674,8 @@ public abstract class BaseWarehouseResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -677,8 +688,7 @@ public abstract class BaseWarehouseResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -692,8 +702,8 @@ public abstract class BaseWarehouseResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -709,8 +719,8 @@ public abstract class BaseWarehouseResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<Warehouse>, UnsafeConsumer<Warehouse, Exception>,
-		 Exception> contextBatchUnsafeConsumer;
+		<Collection<Warehouse>, UnsafeConsumer<Warehouse, Exception>, Exception>
+			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -726,6 +736,115 @@ public abstract class BaseWarehouseResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseWarehouseResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseAddressResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseAddressResourceImpl.java
@@ -17,23 +17,38 @@ package com.liferay.headless.commerce.delivery.cart.internal.resource.v1_0;
 import com.liferay.headless.commerce.delivery.cart.dto.v1_0.Address;
 import com.liferay.headless.commerce.delivery.cart.resource.v1_0.AddressResource;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -219,8 +234,7 @@ public abstract class BaseAddressResourceImpl implements AddressResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -232,8 +246,8 @@ public abstract class BaseAddressResourceImpl implements AddressResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -246,8 +260,7 @@ public abstract class BaseAddressResourceImpl implements AddressResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -261,8 +274,8 @@ public abstract class BaseAddressResourceImpl implements AddressResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -290,6 +303,115 @@ public abstract class BaseAddressResourceImpl implements AddressResource {
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseAddressResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartCommentResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartCommentResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.delivery.cart.resource.v1_0.CartCommentReso
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -380,7 +393,7 @@ public abstract class BaseCartCommentResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<CartComment> cartComments,
+			Collection<CartComment> cartComments,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -390,7 +403,7 @@ public abstract class BaseCartCommentResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<CartComment> cartComments,
+			Collection<CartComment> cartComments,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -460,7 +473,7 @@ public abstract class BaseCartCommentResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<CartComment> cartComments,
+			Collection<CartComment> cartComments,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -506,9 +519,8 @@ public abstract class BaseCartCommentResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<CartComment>,
-			 UnsafeConsumer<CartComment, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<CartComment>, UnsafeConsumer<CartComment, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -689,8 +701,7 @@ public abstract class BaseCartCommentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -702,8 +713,8 @@ public abstract class BaseCartCommentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -716,8 +727,7 @@ public abstract class BaseCartCommentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -731,8 +741,8 @@ public abstract class BaseCartCommentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -748,9 +758,8 @@ public abstract class BaseCartCommentResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<CartComment>,
-		 UnsafeConsumer<CartComment, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<CartComment>, UnsafeConsumer<CartComment, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -766,6 +775,115 @@ public abstract class BaseCartCommentResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseCartCommentResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartItemResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartItemResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.delivery.cart.resource.v1_0.CartItemResourc
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -451,7 +464,7 @@ public abstract class BaseCartItemResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<CartItem> cartItems,
+			Collection<CartItem> cartItems,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -461,7 +474,7 @@ public abstract class BaseCartItemResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<CartItem> cartItems,
+			Collection<CartItem> cartItems,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -531,7 +544,7 @@ public abstract class BaseCartItemResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<CartItem> cartItems,
+			Collection<CartItem> cartItems,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -577,9 +590,8 @@ public abstract class BaseCartItemResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<CartItem>,
-			 UnsafeConsumer<CartItem, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<CartItem>, UnsafeConsumer<CartItem, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -759,8 +771,7 @@ public abstract class BaseCartItemResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -772,8 +783,8 @@ public abstract class BaseCartItemResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -786,8 +797,7 @@ public abstract class BaseCartItemResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -801,8 +811,8 @@ public abstract class BaseCartItemResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -818,8 +828,8 @@ public abstract class BaseCartItemResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<CartItem>, UnsafeConsumer<CartItem, Exception>,
-		 Exception> contextBatchUnsafeConsumer;
+		<Collection<CartItem>, UnsafeConsumer<CartItem, Exception>, Exception>
+			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -835,6 +845,115 @@ public abstract class BaseCartItemResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseCartItemResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartResourceImpl.java
@@ -21,15 +21,21 @@ import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -45,13 +51,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -595,8 +608,7 @@ public abstract class BaseCartResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<Cart> carts,
-			Map<String, Serializable> parameters)
+			Collection<Cart> carts, Map<String, Serializable> parameters)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -605,8 +617,7 @@ public abstract class BaseCartResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<Cart> carts,
-			Map<String, Serializable> parameters)
+			Collection<Cart> carts, Map<String, Serializable> parameters)
 		throws Exception {
 
 		for (Cart cart : carts) {
@@ -675,8 +686,7 @@ public abstract class BaseCartResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<Cart> carts,
-			Map<String, Serializable> parameters)
+			Collection<Cart> carts, Map<String, Serializable> parameters)
 		throws Exception {
 
 		UnsafeConsumer<Cart, Exception> cartUnsafeConsumer = null;
@@ -720,8 +730,8 @@ public abstract class BaseCartResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<Cart>, UnsafeConsumer<Cart, Exception>,
-			 Exception> contextBatchUnsafeConsumer) {
+			<Collection<Cart>, UnsafeConsumer<Cart, Exception>, Exception>
+				contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -901,8 +911,7 @@ public abstract class BaseCartResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -914,8 +923,8 @@ public abstract class BaseCartResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -928,8 +937,7 @@ public abstract class BaseCartResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -943,8 +951,8 @@ public abstract class BaseCartResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -960,7 +968,7 @@ public abstract class BaseCartResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<Cart>, UnsafeConsumer<Cart, Exception>, Exception>
+		<Collection<Cart>, UnsafeConsumer<Cart, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
@@ -977,6 +985,115 @@ public abstract class BaseCartResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseCartResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BasePaymentMethodResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BasePaymentMethodResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.delivery.cart.resource.v1_0.PaymentMethodRe
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -113,7 +126,7 @@ public abstract class BasePaymentMethodResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<PaymentMethod> paymentMethods,
+			Collection<PaymentMethod> paymentMethods,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -123,7 +136,7 @@ public abstract class BasePaymentMethodResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<PaymentMethod> paymentMethods,
+			Collection<PaymentMethod> paymentMethods,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -198,7 +211,7 @@ public abstract class BasePaymentMethodResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<PaymentMethod> paymentMethods,
+			Collection<PaymentMethod> paymentMethods,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -212,7 +225,7 @@ public abstract class BasePaymentMethodResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<PaymentMethod>,
+			<Collection<PaymentMethod>,
 			 UnsafeConsumer<PaymentMethod, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -391,8 +404,7 @@ public abstract class BasePaymentMethodResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -404,8 +416,8 @@ public abstract class BasePaymentMethodResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -418,8 +430,7 @@ public abstract class BasePaymentMethodResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -433,8 +444,8 @@ public abstract class BasePaymentMethodResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -450,9 +461,8 @@ public abstract class BasePaymentMethodResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<PaymentMethod>,
-		 UnsafeConsumer<PaymentMethod, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<PaymentMethod>, UnsafeConsumer<PaymentMethod, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -468,6 +478,115 @@ public abstract class BasePaymentMethodResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BasePaymentMethodResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseShippingMethodResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseShippingMethodResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.delivery.cart.resource.v1_0.ShippingMethodR
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -113,7 +126,7 @@ public abstract class BaseShippingMethodResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<ShippingMethod> shippingMethods,
+			Collection<ShippingMethod> shippingMethods,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -123,7 +136,7 @@ public abstract class BaseShippingMethodResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<ShippingMethod> shippingMethods,
+			Collection<ShippingMethod> shippingMethods,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -198,7 +211,7 @@ public abstract class BaseShippingMethodResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<ShippingMethod> shippingMethods,
+			Collection<ShippingMethod> shippingMethods,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -212,7 +225,7 @@ public abstract class BaseShippingMethodResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<ShippingMethod>,
+			<Collection<ShippingMethod>,
 			 UnsafeConsumer<ShippingMethod, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -391,8 +404,7 @@ public abstract class BaseShippingMethodResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -404,8 +416,8 @@ public abstract class BaseShippingMethodResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -418,8 +430,7 @@ public abstract class BaseShippingMethodResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -433,8 +444,8 @@ public abstract class BaseShippingMethodResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -450,9 +461,8 @@ public abstract class BaseShippingMethodResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<ShippingMethod>,
-		 UnsafeConsumer<ShippingMethod, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<ShippingMethod>, UnsafeConsumer<ShippingMethod, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -468,6 +478,115 @@ public abstract class BaseShippingMethodResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseShippingMethodResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseAttachmentResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseAttachmentResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.delivery.catalog.resource.v1_0.AttachmentRe
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -185,7 +198,7 @@ public abstract class BaseAttachmentResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<Attachment> attachments,
+			Collection<Attachment> attachments,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -195,7 +208,7 @@ public abstract class BaseAttachmentResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<Attachment> attachments,
+			Collection<Attachment> attachments,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -264,7 +277,7 @@ public abstract class BaseAttachmentResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<Attachment> attachments,
+			Collection<Attachment> attachments,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -278,9 +291,8 @@ public abstract class BaseAttachmentResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<Attachment>,
-			 UnsafeConsumer<Attachment, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<Attachment>, UnsafeConsumer<Attachment, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -457,8 +469,7 @@ public abstract class BaseAttachmentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -470,8 +481,8 @@ public abstract class BaseAttachmentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -484,8 +495,7 @@ public abstract class BaseAttachmentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -499,8 +509,8 @@ public abstract class BaseAttachmentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -516,9 +526,8 @@ public abstract class BaseAttachmentResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<Attachment>,
-		 UnsafeConsumer<Attachment, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<Attachment>, UnsafeConsumer<Attachment, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -534,6 +543,115 @@ public abstract class BaseAttachmentResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseAttachmentResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseCategoryResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.delivery.catalog.resource.v1_0.CategoryReso
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -127,7 +140,7 @@ public abstract class BaseCategoryResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<Category> categories,
+			Collection<Category> categories,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -137,7 +150,7 @@ public abstract class BaseCategoryResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<Category> categories,
+			Collection<Category> categories,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -206,7 +219,7 @@ public abstract class BaseCategoryResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<Category> categories,
+			Collection<Category> categories,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -220,9 +233,8 @@ public abstract class BaseCategoryResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<Category>,
-			 UnsafeConsumer<Category, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<Category>, UnsafeConsumer<Category, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -399,8 +411,7 @@ public abstract class BaseCategoryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -412,8 +423,8 @@ public abstract class BaseCategoryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -426,8 +437,7 @@ public abstract class BaseCategoryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -441,8 +451,8 @@ public abstract class BaseCategoryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -458,8 +468,8 @@ public abstract class BaseCategoryResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<Category>, UnsafeConsumer<Category, Exception>,
-		 Exception> contextBatchUnsafeConsumer;
+		<Collection<Category>, UnsafeConsumer<Category, Exception>, Exception>
+			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -475,6 +485,115 @@ public abstract class BaseCategoryResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseCategoryResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseChannelResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.delivery.catalog.resource.v1_0.ChannelResou
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -125,8 +138,7 @@ public abstract class BaseChannelResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<Channel> channels,
-			Map<String, Serializable> parameters)
+			Collection<Channel> channels, Map<String, Serializable> parameters)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -135,8 +147,7 @@ public abstract class BaseChannelResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<Channel> channels,
-			Map<String, Serializable> parameters)
+			Collection<Channel> channels, Map<String, Serializable> parameters)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -203,8 +214,7 @@ public abstract class BaseChannelResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<Channel> channels,
-			Map<String, Serializable> parameters)
+			Collection<Channel> channels, Map<String, Serializable> parameters)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -217,8 +227,8 @@ public abstract class BaseChannelResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<Channel>, UnsafeConsumer<Channel, Exception>,
-			 Exception> contextBatchUnsafeConsumer) {
+			<Collection<Channel>, UnsafeConsumer<Channel, Exception>, Exception>
+				contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -395,8 +405,7 @@ public abstract class BaseChannelResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -408,8 +417,8 @@ public abstract class BaseChannelResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -422,8 +431,7 @@ public abstract class BaseChannelResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -437,8 +445,8 @@ public abstract class BaseChannelResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -454,8 +462,8 @@ public abstract class BaseChannelResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<Channel>, UnsafeConsumer<Channel, Exception>,
-		 Exception> contextBatchUnsafeConsumer;
+		<Collection<Channel>, UnsafeConsumer<Channel, Exception>, Exception>
+			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -471,6 +479,115 @@ public abstract class BaseChannelResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseChannelResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseMappedProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseMappedProductResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.delivery.catalog.resource.v1_0.MappedProduc
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -147,7 +160,7 @@ public abstract class BaseMappedProductResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<MappedProduct> mappedProducts,
+			Collection<MappedProduct> mappedProducts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -157,7 +170,7 @@ public abstract class BaseMappedProductResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<MappedProduct> mappedProducts,
+			Collection<MappedProduct> mappedProducts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -226,7 +239,7 @@ public abstract class BaseMappedProductResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<MappedProduct> mappedProducts,
+			Collection<MappedProduct> mappedProducts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -240,7 +253,7 @@ public abstract class BaseMappedProductResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<MappedProduct>,
+			<Collection<MappedProduct>,
 			 UnsafeConsumer<MappedProduct, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -419,8 +432,7 @@ public abstract class BaseMappedProductResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -432,8 +444,8 @@ public abstract class BaseMappedProductResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -446,8 +458,7 @@ public abstract class BaseMappedProductResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -461,8 +472,8 @@ public abstract class BaseMappedProductResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -478,9 +489,8 @@ public abstract class BaseMappedProductResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<MappedProduct>,
-		 UnsafeConsumer<MappedProduct, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<MappedProduct>, UnsafeConsumer<MappedProduct, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -496,6 +506,115 @@ public abstract class BaseMappedProductResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseMappedProductResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BasePinResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BasePinResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.delivery.catalog.resource.v1_0.PinResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -143,8 +156,7 @@ public abstract class BasePinResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<Pin> pins,
-			Map<String, Serializable> parameters)
+			Collection<Pin> pins, Map<String, Serializable> parameters)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -153,8 +165,7 @@ public abstract class BasePinResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<Pin> pins,
-			Map<String, Serializable> parameters)
+			Collection<Pin> pins, Map<String, Serializable> parameters)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -222,8 +233,7 @@ public abstract class BasePinResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<Pin> pins,
-			Map<String, Serializable> parameters)
+			Collection<Pin> pins, Map<String, Serializable> parameters)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -236,8 +246,8 @@ public abstract class BasePinResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<Pin>, UnsafeConsumer<Pin, Exception>,
-			 Exception> contextBatchUnsafeConsumer) {
+			<Collection<Pin>, UnsafeConsumer<Pin, Exception>, Exception>
+				contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -414,8 +424,7 @@ public abstract class BasePinResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -427,8 +436,8 @@ public abstract class BasePinResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -441,8 +450,7 @@ public abstract class BasePinResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -456,8 +464,8 @@ public abstract class BasePinResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -473,7 +481,7 @@ public abstract class BasePinResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<Pin>, UnsafeConsumer<Pin, Exception>, Exception>
+		<Collection<Pin>, UnsafeConsumer<Pin, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
@@ -490,6 +498,115 @@ public abstract class BasePinResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BasePinResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseProductOptionResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseProductOptionResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.delivery.catalog.resource.v1_0.ProductOptio
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -128,7 +141,7 @@ public abstract class BaseProductOptionResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<ProductOption> productOptions,
+			Collection<ProductOption> productOptions,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -138,7 +151,7 @@ public abstract class BaseProductOptionResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<ProductOption> productOptions,
+			Collection<ProductOption> productOptions,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -207,7 +220,7 @@ public abstract class BaseProductOptionResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<ProductOption> productOptions,
+			Collection<ProductOption> productOptions,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -221,7 +234,7 @@ public abstract class BaseProductOptionResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<ProductOption>,
+			<Collection<ProductOption>,
 			 UnsafeConsumer<ProductOption, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -400,8 +413,7 @@ public abstract class BaseProductOptionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -413,8 +425,8 @@ public abstract class BaseProductOptionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -427,8 +439,7 @@ public abstract class BaseProductOptionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -442,8 +453,8 @@ public abstract class BaseProductOptionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -459,9 +470,8 @@ public abstract class BaseProductOptionResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<ProductOption>,
-		 UnsafeConsumer<ProductOption, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<ProductOption>, UnsafeConsumer<ProductOption, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -477,6 +487,115 @@ public abstract class BaseProductOptionResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseProductOptionResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseProductResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.delivery.catalog.resource.v1_0.ProductResou
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -191,8 +204,7 @@ public abstract class BaseProductResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<Product> products,
-			Map<String, Serializable> parameters)
+			Collection<Product> products, Map<String, Serializable> parameters)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -201,8 +213,7 @@ public abstract class BaseProductResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<Product> products,
-			Map<String, Serializable> parameters)
+			Collection<Product> products, Map<String, Serializable> parameters)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -270,8 +281,7 @@ public abstract class BaseProductResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<Product> products,
-			Map<String, Serializable> parameters)
+			Collection<Product> products, Map<String, Serializable> parameters)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -284,8 +294,8 @@ public abstract class BaseProductResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<Product>, UnsafeConsumer<Product, Exception>,
-			 Exception> contextBatchUnsafeConsumer) {
+			<Collection<Product>, UnsafeConsumer<Product, Exception>, Exception>
+				contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -462,8 +472,7 @@ public abstract class BaseProductResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -475,8 +484,8 @@ public abstract class BaseProductResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -489,8 +498,7 @@ public abstract class BaseProductResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -504,8 +512,8 @@ public abstract class BaseProductResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -521,8 +529,8 @@ public abstract class BaseProductResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<Product>, UnsafeConsumer<Product, Exception>,
-		 Exception> contextBatchUnsafeConsumer;
+		<Collection<Product>, UnsafeConsumer<Product, Exception>, Exception>
+			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -538,6 +546,115 @@ public abstract class BaseProductResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseProductResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseProductSpecificationResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseProductSpecificationResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.delivery.catalog.resource.v1_0.ProductSpeci
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -131,7 +144,7 @@ public abstract class BaseProductSpecificationResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<ProductSpecification> productSpecifications,
+			Collection<ProductSpecification> productSpecifications,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -141,7 +154,7 @@ public abstract class BaseProductSpecificationResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<ProductSpecification> productSpecifications,
+			Collection<ProductSpecification> productSpecifications,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -210,7 +223,7 @@ public abstract class BaseProductSpecificationResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<ProductSpecification> productSpecifications,
+			Collection<ProductSpecification> productSpecifications,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -224,7 +237,7 @@ public abstract class BaseProductSpecificationResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<ProductSpecification>,
+			<Collection<ProductSpecification>,
 			 UnsafeConsumer<ProductSpecification, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -403,8 +416,7 @@ public abstract class BaseProductSpecificationResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -416,8 +428,8 @@ public abstract class BaseProductSpecificationResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -430,8 +442,7 @@ public abstract class BaseProductSpecificationResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -445,8 +456,8 @@ public abstract class BaseProductSpecificationResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -462,7 +473,7 @@ public abstract class BaseProductSpecificationResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<ProductSpecification>,
+		<Collection<ProductSpecification>,
 		 UnsafeConsumer<ProductSpecification, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -480,6 +491,115 @@ public abstract class BaseProductSpecificationResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseProductSpecificationResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseRelatedProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseRelatedProductResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.delivery.catalog.resource.v1_0.RelatedProdu
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -138,7 +151,7 @@ public abstract class BaseRelatedProductResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<RelatedProduct> relatedProducts,
+			Collection<RelatedProduct> relatedProducts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -148,7 +161,7 @@ public abstract class BaseRelatedProductResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<RelatedProduct> relatedProducts,
+			Collection<RelatedProduct> relatedProducts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -217,7 +230,7 @@ public abstract class BaseRelatedProductResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<RelatedProduct> relatedProducts,
+			Collection<RelatedProduct> relatedProducts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -231,7 +244,7 @@ public abstract class BaseRelatedProductResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<RelatedProduct>,
+			<Collection<RelatedProduct>,
 			 UnsafeConsumer<RelatedProduct, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -410,8 +423,7 @@ public abstract class BaseRelatedProductResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -423,8 +435,8 @@ public abstract class BaseRelatedProductResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -437,8 +449,7 @@ public abstract class BaseRelatedProductResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -452,8 +463,8 @@ public abstract class BaseRelatedProductResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -469,9 +480,8 @@ public abstract class BaseRelatedProductResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<RelatedProduct>,
-		 UnsafeConsumer<RelatedProduct, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<RelatedProduct>, UnsafeConsumer<RelatedProduct, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -487,6 +497,115 @@ public abstract class BaseRelatedProductResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseRelatedProductResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseSkuResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseSkuResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.delivery.catalog.resource.v1_0.SkuResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -134,8 +147,7 @@ public abstract class BaseSkuResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<Sku> skus,
-			Map<String, Serializable> parameters)
+			Collection<Sku> skus, Map<String, Serializable> parameters)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -144,8 +156,7 @@ public abstract class BaseSkuResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<Sku> skus,
-			Map<String, Serializable> parameters)
+			Collection<Sku> skus, Map<String, Serializable> parameters)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -213,8 +224,7 @@ public abstract class BaseSkuResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<Sku> skus,
-			Map<String, Serializable> parameters)
+			Collection<Sku> skus, Map<String, Serializable> parameters)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -227,8 +237,8 @@ public abstract class BaseSkuResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<Sku>, UnsafeConsumer<Sku, Exception>,
-			 Exception> contextBatchUnsafeConsumer) {
+			<Collection<Sku>, UnsafeConsumer<Sku, Exception>, Exception>
+				contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -405,8 +415,7 @@ public abstract class BaseSkuResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -418,8 +427,8 @@ public abstract class BaseSkuResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -432,8 +441,7 @@ public abstract class BaseSkuResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -447,8 +455,8 @@ public abstract class BaseSkuResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -464,7 +472,7 @@ public abstract class BaseSkuResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<Sku>, UnsafeConsumer<Sku, Exception>, Exception>
+		<Collection<Sku>, UnsafeConsumer<Sku, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
@@ -481,6 +489,115 @@ public abstract class BaseSkuResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseSkuResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseWishListItemResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseWishListItemResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.delivery.catalog.resource.v1_0.WishListItem
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -282,7 +295,7 @@ public abstract class BaseWishListItemResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<WishListItem> wishListItems,
+			Collection<WishListItem> wishListItems,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -292,7 +305,7 @@ public abstract class BaseWishListItemResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<WishListItem> wishListItems,
+			Collection<WishListItem> wishListItems,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -362,7 +375,7 @@ public abstract class BaseWishListItemResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<WishListItem> wishListItems,
+			Collection<WishListItem> wishListItems,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -376,9 +389,8 @@ public abstract class BaseWishListItemResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<WishListItem>,
-			 UnsafeConsumer<WishListItem, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<WishListItem>, UnsafeConsumer<WishListItem, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -555,8 +567,7 @@ public abstract class BaseWishListItemResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -568,8 +579,8 @@ public abstract class BaseWishListItemResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -582,8 +593,7 @@ public abstract class BaseWishListItemResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -597,8 +607,8 @@ public abstract class BaseWishListItemResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -614,9 +624,8 @@ public abstract class BaseWishListItemResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<WishListItem>,
-		 UnsafeConsumer<WishListItem, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<WishListItem>, UnsafeConsumer<WishListItem, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -632,6 +641,115 @@ public abstract class BaseWishListItemResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseWishListItemResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseWishListResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseWishListResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.delivery.catalog.resource.v1_0.WishListReso
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -306,7 +319,7 @@ public abstract class BaseWishListResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<WishList> wishLists,
+			Collection<WishList> wishLists,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -316,7 +329,7 @@ public abstract class BaseWishListResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<WishList> wishLists,
+			Collection<WishList> wishLists,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -386,7 +399,7 @@ public abstract class BaseWishListResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<WishList> wishLists,
+			Collection<WishList> wishLists,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -400,9 +413,8 @@ public abstract class BaseWishListResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<WishList>,
-			 UnsafeConsumer<WishList, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<WishList>, UnsafeConsumer<WishList, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -579,8 +591,7 @@ public abstract class BaseWishListResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -592,8 +603,8 @@ public abstract class BaseWishListResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -606,8 +617,7 @@ public abstract class BaseWishListResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -621,8 +631,8 @@ public abstract class BaseWishListResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -638,8 +648,8 @@ public abstract class BaseWishListResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<WishList>, UnsafeConsumer<WishList, Exception>,
-		 Exception> contextBatchUnsafeConsumer;
+		<Collection<WishList>, UnsafeConsumer<WishList, Exception>, Exception>
+			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -655,6 +665,115 @@ public abstract class BaseWishListResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseWishListResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/BasePlacedOrderAddressResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/BasePlacedOrderAddressResourceImpl.java
@@ -17,23 +17,38 @@ package com.liferay.headless.commerce.delivery.order.internal.resource.v1_0;
 import com.liferay.headless.commerce.delivery.order.dto.v1_0.PlacedOrderAddress;
 import com.liferay.headless.commerce.delivery.order.resource.v1_0.PlacedOrderAddressResource;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -228,8 +243,7 @@ public abstract class BasePlacedOrderAddressResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -241,8 +255,8 @@ public abstract class BasePlacedOrderAddressResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -255,8 +269,7 @@ public abstract class BasePlacedOrderAddressResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -270,8 +283,8 @@ public abstract class BasePlacedOrderAddressResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -299,6 +312,115 @@ public abstract class BasePlacedOrderAddressResourceImpl
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BasePlacedOrderAddressResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/BasePlacedOrderCommentResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/BasePlacedOrderCommentResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.delivery.order.resource.v1_0.PlacedOrderCom
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -151,7 +164,7 @@ public abstract class BasePlacedOrderCommentResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<PlacedOrderComment> placedOrderComments,
+			Collection<PlacedOrderComment> placedOrderComments,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -161,7 +174,7 @@ public abstract class BasePlacedOrderCommentResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<PlacedOrderComment> placedOrderComments,
+			Collection<PlacedOrderComment> placedOrderComments,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -237,7 +250,7 @@ public abstract class BasePlacedOrderCommentResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<PlacedOrderComment> placedOrderComments,
+			Collection<PlacedOrderComment> placedOrderComments,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -251,7 +264,7 @@ public abstract class BasePlacedOrderCommentResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<PlacedOrderComment>,
+			<Collection<PlacedOrderComment>,
 			 UnsafeConsumer<PlacedOrderComment, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -430,8 +443,7 @@ public abstract class BasePlacedOrderCommentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -443,8 +455,8 @@ public abstract class BasePlacedOrderCommentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -457,8 +469,7 @@ public abstract class BasePlacedOrderCommentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -472,8 +483,8 @@ public abstract class BasePlacedOrderCommentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -489,7 +500,7 @@ public abstract class BasePlacedOrderCommentResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<PlacedOrderComment>,
+		<Collection<PlacedOrderComment>,
 		 UnsafeConsumer<PlacedOrderComment, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -507,6 +518,115 @@ public abstract class BasePlacedOrderCommentResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BasePlacedOrderCommentResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/BasePlacedOrderItemResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/BasePlacedOrderItemResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.delivery.order.resource.v1_0.PlacedOrderIte
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -164,7 +177,7 @@ public abstract class BasePlacedOrderItemResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<PlacedOrderItem> placedOrderItems,
+			Collection<PlacedOrderItem> placedOrderItems,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -174,7 +187,7 @@ public abstract class BasePlacedOrderItemResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<PlacedOrderItem> placedOrderItems,
+			Collection<PlacedOrderItem> placedOrderItems,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -250,7 +263,7 @@ public abstract class BasePlacedOrderItemResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<PlacedOrderItem> placedOrderItems,
+			Collection<PlacedOrderItem> placedOrderItems,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -264,7 +277,7 @@ public abstract class BasePlacedOrderItemResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<PlacedOrderItem>,
+			<Collection<PlacedOrderItem>,
 			 UnsafeConsumer<PlacedOrderItem, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -443,8 +456,7 @@ public abstract class BasePlacedOrderItemResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -456,8 +468,8 @@ public abstract class BasePlacedOrderItemResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -470,8 +482,7 @@ public abstract class BasePlacedOrderItemResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -485,8 +496,8 @@ public abstract class BasePlacedOrderItemResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -502,7 +513,7 @@ public abstract class BasePlacedOrderItemResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<PlacedOrderItem>,
+		<Collection<PlacedOrderItem>,
 		 UnsafeConsumer<PlacedOrderItem, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -520,6 +531,115 @@ public abstract class BasePlacedOrderItemResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BasePlacedOrderItemResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/BasePlacedOrderItemShipmentResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/BasePlacedOrderItemShipmentResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.delivery.order.resource.v1_0.PlacedOrderIte
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -118,8 +131,7 @@ public abstract class BasePlacedOrderItemShipmentResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<PlacedOrderItemShipment>
-				placedOrderItemShipments,
+			Collection<PlacedOrderItemShipment> placedOrderItemShipments,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -129,8 +141,7 @@ public abstract class BasePlacedOrderItemShipmentResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<PlacedOrderItemShipment>
-				placedOrderItemShipments,
+			Collection<PlacedOrderItemShipment> placedOrderItemShipments,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -205,8 +216,7 @@ public abstract class BasePlacedOrderItemShipmentResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<PlacedOrderItemShipment>
-				placedOrderItemShipments,
+			Collection<PlacedOrderItemShipment> placedOrderItemShipments,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -220,7 +230,7 @@ public abstract class BasePlacedOrderItemShipmentResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<PlacedOrderItemShipment>,
+			<Collection<PlacedOrderItemShipment>,
 			 UnsafeConsumer<PlacedOrderItemShipment, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -399,8 +409,7 @@ public abstract class BasePlacedOrderItemShipmentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -412,8 +421,8 @@ public abstract class BasePlacedOrderItemShipmentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -426,8 +435,7 @@ public abstract class BasePlacedOrderItemShipmentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -441,8 +449,8 @@ public abstract class BasePlacedOrderItemShipmentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -458,7 +466,7 @@ public abstract class BasePlacedOrderItemShipmentResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<PlacedOrderItemShipment>,
+		<Collection<PlacedOrderItemShipment>,
 		 UnsafeConsumer<PlacedOrderItemShipment, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -476,6 +484,115 @@ public abstract class BasePlacedOrderItemShipmentResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BasePlacedOrderItemShipmentResourceImpl.class);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/BasePlacedOrderResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/BasePlacedOrderResourceImpl.java
@@ -20,15 +20,21 @@ import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -44,13 +50,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -200,7 +213,7 @@ public abstract class BasePlacedOrderResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<PlacedOrder> placedOrders,
+			Collection<PlacedOrder> placedOrders,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -210,7 +223,7 @@ public abstract class BasePlacedOrderResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<PlacedOrder> placedOrders,
+			Collection<PlacedOrder> placedOrders,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -279,7 +292,7 @@ public abstract class BasePlacedOrderResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<PlacedOrder> placedOrders,
+			Collection<PlacedOrder> placedOrders,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -293,9 +306,8 @@ public abstract class BasePlacedOrderResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<PlacedOrder>,
-			 UnsafeConsumer<PlacedOrder, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<PlacedOrder>, UnsafeConsumer<PlacedOrder, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -472,8 +484,7 @@ public abstract class BasePlacedOrderResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -485,8 +496,8 @@ public abstract class BasePlacedOrderResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -499,8 +510,7 @@ public abstract class BasePlacedOrderResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -514,8 +524,8 @@ public abstract class BasePlacedOrderResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -531,9 +541,8 @@ public abstract class BasePlacedOrderResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<PlacedOrder>,
-		 UnsafeConsumer<PlacedOrder, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<PlacedOrder>, UnsafeConsumer<PlacedOrder, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -549,6 +558,115 @@ public abstract class BasePlacedOrderResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BasePlacedOrderResourceImpl.class);

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataDefinitionFieldLinkResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataDefinitionFieldLinkResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.data.engine.rest.resource.v2_0.DataDefinitionFieldLinkResourc
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -122,8 +135,7 @@ public abstract class BaseDataDefinitionFieldLinkResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<DataDefinitionFieldLink>
-				dataDefinitionFieldLinks,
+			Collection<DataDefinitionFieldLink> dataDefinitionFieldLinks,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -133,8 +145,7 @@ public abstract class BaseDataDefinitionFieldLinkResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<DataDefinitionFieldLink>
-				dataDefinitionFieldLinks,
+			Collection<DataDefinitionFieldLink> dataDefinitionFieldLinks,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -210,8 +221,7 @@ public abstract class BaseDataDefinitionFieldLinkResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<DataDefinitionFieldLink>
-				dataDefinitionFieldLinks,
+			Collection<DataDefinitionFieldLink> dataDefinitionFieldLinks,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -225,7 +235,7 @@ public abstract class BaseDataDefinitionFieldLinkResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<DataDefinitionFieldLink>,
+			<Collection<DataDefinitionFieldLink>,
 			 UnsafeConsumer<DataDefinitionFieldLink, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -404,8 +414,7 @@ public abstract class BaseDataDefinitionFieldLinkResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -417,8 +426,8 @@ public abstract class BaseDataDefinitionFieldLinkResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -431,8 +440,7 @@ public abstract class BaseDataDefinitionFieldLinkResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -446,8 +454,8 @@ public abstract class BaseDataDefinitionFieldLinkResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -463,7 +471,7 @@ public abstract class BaseDataDefinitionFieldLinkResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<DataDefinitionFieldLink>,
+		<Collection<DataDefinitionFieldLink>,
 		 UnsafeConsumer<DataDefinitionFieldLink, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -481,6 +489,115 @@ public abstract class BaseDataDefinitionFieldLinkResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseDataDefinitionFieldLinkResourceImpl.class);

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataDefinitionResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataDefinitionResourceImpl.java
@@ -20,17 +20,22 @@ import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -50,6 +55,7 @@ import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTa
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.permission.ModelPermissionsUtil;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.permission.PermissionUtil;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
@@ -57,7 +63,13 @@ import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -528,15 +540,14 @@ public abstract class BaseDataDefinitionResourceImpl
 	@javax.ws.rs.Path("/data-definitions/{dataDefinitionId}/permissions")
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			getDataDefinitionPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("dataDefinitionId")
-				Long dataDefinitionId,
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.ws.rs.QueryParam("roleNames")
-				String roleNames)
+	public Page<Permission> getDataDefinitionPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("dataDefinitionId")
+			Long dataDefinitionId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("roleNames")
+			String roleNames)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(
@@ -584,13 +595,12 @@ public abstract class BaseDataDefinitionResourceImpl
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@javax.ws.rs.PUT
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putDataDefinitionPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("dataDefinitionId")
-				Long dataDefinitionId,
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<Permission> putDataDefinitionPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("dataDefinitionId")
+			Long dataDefinitionId,
+			Permission[] permissions)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(
@@ -786,7 +796,7 @@ public abstract class BaseDataDefinitionResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<DataDefinition> dataDefinitions,
+			Collection<DataDefinition> dataDefinitions,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -796,7 +806,7 @@ public abstract class BaseDataDefinitionResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<DataDefinition> dataDefinitions,
+			Collection<DataDefinition> dataDefinitions,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -866,7 +876,7 @@ public abstract class BaseDataDefinitionResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<DataDefinition> dataDefinitions,
+			Collection<DataDefinition> dataDefinitions,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -938,10 +948,9 @@ public abstract class BaseDataDefinitionResourceImpl
 			"This method needs to be implemented");
 	}
 
-	protected Page<com.liferay.portal.vulcan.permission.Permission>
-			toPermissionPage(
-				Map<String, Map<String, String>> actions, long id,
-				String resourceName, String roleNames)
+	protected Page<Permission> toPermissionPage(
+			Map<String, Map<String, String>> actions, long id,
+			String resourceName, String roleNames)
 		throws Exception {
 
 		List<ResourceAction> resourceActions =
@@ -950,24 +959,16 @@ public abstract class BaseDataDefinitionResourceImpl
 		if (Validator.isNotNull(roleNames)) {
 			return Page.of(
 				actions,
-				transform(
-					PermissionUtil.getRoles(
-						contextCompany, roleLocalService,
-						StringUtil.split(roleNames)),
-					role -> PermissionUtil.toPermission(
-						contextCompany.getCompanyId(), id, resourceActions,
-						resourceName, resourcePermissionLocalService, role)));
+				_getPermissions(
+					contextCompany.getCompanyId(), resourceActions, id,
+					resourceName, StringUtil.split(roleNames)));
 		}
 
 		return Page.of(
 			actions,
-			transform(
-				PermissionUtil.getResourcePermissions(
-					contextCompany.getCompanyId(), id, resourceName,
-					resourcePermissionLocalService),
-				resourcePermission -> PermissionUtil.toPermission(
-					resourceActions, resourcePermission,
-					roleLocalService.getRole(resourcePermission.getRoleId()))));
+			_getPermissions(
+				contextCompany.getCompanyId(), resourceActions, id,
+				resourceName, null));
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
@@ -976,7 +977,7 @@ public abstract class BaseDataDefinitionResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<DataDefinition>,
+			<Collection<DataDefinition>,
 			 UnsafeConsumer<DataDefinition, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -1159,8 +1160,7 @@ public abstract class BaseDataDefinitionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -1172,8 +1172,8 @@ public abstract class BaseDataDefinitionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -1186,8 +1186,7 @@ public abstract class BaseDataDefinitionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -1201,8 +1200,8 @@ public abstract class BaseDataDefinitionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -1218,9 +1217,8 @@ public abstract class BaseDataDefinitionResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<DataDefinition>,
-		 UnsafeConsumer<DataDefinition, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<DataDefinition>, UnsafeConsumer<DataDefinition, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -1236,6 +1234,115 @@ public abstract class BaseDataDefinitionResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseDataDefinitionResourceImpl.class);

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataLayoutResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataLayoutResourceImpl.java
@@ -20,15 +20,21 @@ import com.liferay.data.engine.rest.resource.v2_0.DataLayoutResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -44,13 +50,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -503,7 +516,7 @@ public abstract class BaseDataLayoutResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<DataLayout> dataLayouts,
+			Collection<DataLayout> dataLayouts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -545,7 +558,7 @@ public abstract class BaseDataLayoutResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<DataLayout> dataLayouts,
+			Collection<DataLayout> dataLayouts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -622,7 +635,7 @@ public abstract class BaseDataLayoutResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<DataLayout> dataLayouts,
+			Collection<DataLayout> dataLayouts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -661,9 +674,8 @@ public abstract class BaseDataLayoutResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<DataLayout>,
-			 UnsafeConsumer<DataLayout, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<DataLayout>, UnsafeConsumer<DataLayout, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -840,8 +852,7 @@ public abstract class BaseDataLayoutResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -853,8 +864,8 @@ public abstract class BaseDataLayoutResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -867,8 +878,7 @@ public abstract class BaseDataLayoutResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -882,8 +892,8 @@ public abstract class BaseDataLayoutResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -899,9 +909,8 @@ public abstract class BaseDataLayoutResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<DataLayout>,
-		 UnsafeConsumer<DataLayout, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<DataLayout>, UnsafeConsumer<DataLayout, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -917,6 +926,115 @@ public abstract class BaseDataLayoutResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseDataLayoutResourceImpl.class);

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataListViewResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataListViewResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.data.engine.rest.resource.v2_0.DataListViewResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -422,7 +435,7 @@ public abstract class BaseDataListViewResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<DataListView> dataListViews,
+			Collection<DataListView> dataListViews,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -465,7 +478,7 @@ public abstract class BaseDataListViewResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<DataListView> dataListViews,
+			Collection<DataListView> dataListViews,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -542,7 +555,7 @@ public abstract class BaseDataListViewResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<DataListView> dataListViews,
+			Collection<DataListView> dataListViews,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -582,9 +595,8 @@ public abstract class BaseDataListViewResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<DataListView>,
-			 UnsafeConsumer<DataListView, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<DataListView>, UnsafeConsumer<DataListView, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -761,8 +773,7 @@ public abstract class BaseDataListViewResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -774,8 +785,8 @@ public abstract class BaseDataListViewResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -788,8 +799,7 @@ public abstract class BaseDataListViewResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -803,8 +813,8 @@ public abstract class BaseDataListViewResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -820,9 +830,8 @@ public abstract class BaseDataListViewResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<DataListView>,
-		 UnsafeConsumer<DataListView, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<DataListView>, UnsafeConsumer<DataListView, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -838,6 +847,115 @@ public abstract class BaseDataListViewResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseDataListViewResourceImpl.class);

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataRecordCollectionResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataRecordCollectionResourceImpl.java
@@ -20,17 +20,22 @@ import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -50,6 +55,7 @@ import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTa
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.permission.ModelPermissionsUtil;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.permission.PermissionUtil;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
@@ -57,7 +63,13 @@ import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -497,15 +509,14 @@ public abstract class BaseDataRecordCollectionResourceImpl
 	)
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			getDataRecordCollectionPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("dataRecordCollectionId")
-				Long dataRecordCollectionId,
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.ws.rs.QueryParam("roleNames")
-				String roleNames)
+	public Page<Permission> getDataRecordCollectionPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("dataRecordCollectionId")
+			Long dataRecordCollectionId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("roleNames")
+			String roleNames)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(
@@ -560,13 +571,12 @@ public abstract class BaseDataRecordCollectionResourceImpl
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@javax.ws.rs.PUT
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putDataRecordCollectionPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("dataRecordCollectionId")
-				Long dataRecordCollectionId,
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<Permission> putDataRecordCollectionPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("dataRecordCollectionId")
+			Long dataRecordCollectionId,
+			Permission[] permissions)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(
@@ -688,7 +698,7 @@ public abstract class BaseDataRecordCollectionResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<DataRecordCollection> dataRecordCollections,
+			Collection<DataRecordCollection> dataRecordCollections,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -734,7 +744,7 @@ public abstract class BaseDataRecordCollectionResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<DataRecordCollection> dataRecordCollections,
+			Collection<DataRecordCollection> dataRecordCollections,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -813,7 +823,7 @@ public abstract class BaseDataRecordCollectionResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<DataRecordCollection> dataRecordCollections,
+			Collection<DataRecordCollection> dataRecordCollections,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -882,10 +892,9 @@ public abstract class BaseDataRecordCollectionResourceImpl
 			"This method needs to be implemented");
 	}
 
-	protected Page<com.liferay.portal.vulcan.permission.Permission>
-			toPermissionPage(
-				Map<String, Map<String, String>> actions, long id,
-				String resourceName, String roleNames)
+	protected Page<Permission> toPermissionPage(
+			Map<String, Map<String, String>> actions, long id,
+			String resourceName, String roleNames)
 		throws Exception {
 
 		List<ResourceAction> resourceActions =
@@ -894,24 +903,16 @@ public abstract class BaseDataRecordCollectionResourceImpl
 		if (Validator.isNotNull(roleNames)) {
 			return Page.of(
 				actions,
-				transform(
-					PermissionUtil.getRoles(
-						contextCompany, roleLocalService,
-						StringUtil.split(roleNames)),
-					role -> PermissionUtil.toPermission(
-						contextCompany.getCompanyId(), id, resourceActions,
-						resourceName, resourcePermissionLocalService, role)));
+				_getPermissions(
+					contextCompany.getCompanyId(), resourceActions, id,
+					resourceName, StringUtil.split(roleNames)));
 		}
 
 		return Page.of(
 			actions,
-			transform(
-				PermissionUtil.getResourcePermissions(
-					contextCompany.getCompanyId(), id, resourceName,
-					resourcePermissionLocalService),
-				resourcePermission -> PermissionUtil.toPermission(
-					resourceActions, resourcePermission,
-					roleLocalService.getRole(resourcePermission.getRoleId()))));
+			_getPermissions(
+				contextCompany.getCompanyId(), resourceActions, id,
+				resourceName, null));
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
@@ -920,7 +921,7 @@ public abstract class BaseDataRecordCollectionResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<DataRecordCollection>,
+			<Collection<DataRecordCollection>,
 			 UnsafeConsumer<DataRecordCollection, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -1099,8 +1100,7 @@ public abstract class BaseDataRecordCollectionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -1112,8 +1112,8 @@ public abstract class BaseDataRecordCollectionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -1126,8 +1126,7 @@ public abstract class BaseDataRecordCollectionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -1141,8 +1140,8 @@ public abstract class BaseDataRecordCollectionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -1158,7 +1157,7 @@ public abstract class BaseDataRecordCollectionResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<DataRecordCollection>,
+		<Collection<DataRecordCollection>,
 		 UnsafeConsumer<DataRecordCollection, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -1176,6 +1175,115 @@ public abstract class BaseDataRecordCollectionResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseDataRecordCollectionResourceImpl.class);

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataRecordResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataRecordResourceImpl.java
@@ -20,15 +20,21 @@ import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -44,13 +50,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -639,7 +652,7 @@ public abstract class BaseDataRecordResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<DataRecord> dataRecords,
+			Collection<DataRecord> dataRecords,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -688,7 +701,7 @@ public abstract class BaseDataRecordResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<DataRecord> dataRecords,
+			Collection<DataRecord> dataRecords,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -773,7 +786,7 @@ public abstract class BaseDataRecordResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<DataRecord> dataRecords,
+			Collection<DataRecord> dataRecords,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -819,9 +832,8 @@ public abstract class BaseDataRecordResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<DataRecord>,
-			 UnsafeConsumer<DataRecord, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<DataRecord>, UnsafeConsumer<DataRecord, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -1002,8 +1014,7 @@ public abstract class BaseDataRecordResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -1015,8 +1026,8 @@ public abstract class BaseDataRecordResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -1029,8 +1040,7 @@ public abstract class BaseDataRecordResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -1044,8 +1054,8 @@ public abstract class BaseDataRecordResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -1061,9 +1071,8 @@ public abstract class BaseDataRecordResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<DataRecord>,
-		 UnsafeConsumer<DataRecord, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<DataRecord>, UnsafeConsumer<DataRecord, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -1079,6 +1088,115 @@ public abstract class BaseDataRecordResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseDataRecordResourceImpl.class);

--- a/modules/apps/digital-signature/digital-signature-rest-impl/src/main/java/com/liferay/digital/signature/rest/internal/resource/v1_0/BaseDSEnvelopeResourceImpl.java
+++ b/modules/apps/digital-signature/digital-signature-rest-impl/src/main/java/com/liferay/digital/signature/rest/internal/resource/v1_0/BaseDSEnvelopeResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.digital.signature.rest.resource.v1_0.DSEnvelopeResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -241,7 +254,7 @@ public abstract class BaseDSEnvelopeResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<DSEnvelope> dsEnvelopes,
+			Collection<DSEnvelope> dsEnvelopes,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -280,7 +293,7 @@ public abstract class BaseDSEnvelopeResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<DSEnvelope> dsEnvelopes,
+			Collection<DSEnvelope> dsEnvelopes,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -355,7 +368,7 @@ public abstract class BaseDSEnvelopeResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<DSEnvelope> dsEnvelopes,
+			Collection<DSEnvelope> dsEnvelopes,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -369,9 +382,8 @@ public abstract class BaseDSEnvelopeResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<DSEnvelope>,
-			 UnsafeConsumer<DSEnvelope, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<DSEnvelope>, UnsafeConsumer<DSEnvelope, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -548,8 +560,7 @@ public abstract class BaseDSEnvelopeResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -561,8 +572,8 @@ public abstract class BaseDSEnvelopeResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -575,8 +586,7 @@ public abstract class BaseDSEnvelopeResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -590,8 +600,8 @@ public abstract class BaseDSEnvelopeResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -607,9 +617,8 @@ public abstract class BaseDSEnvelopeResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<DSEnvelope>,
-		 UnsafeConsumer<DSEnvelope, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<DSEnvelope>, UnsafeConsumer<DSEnvelope, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -625,6 +634,115 @@ public abstract class BaseDSEnvelopeResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseDSEnvelopeResourceImpl.class);

--- a/modules/apps/dispatch/dispatch-rest-impl/src/main/java/com/liferay/dispatch/rest/internal/resource/v1_0/BaseDispatchTriggerResourceImpl.java
+++ b/modules/apps/dispatch/dispatch-rest-impl/src/main/java/com/liferay/dispatch/rest/internal/resource/v1_0/BaseDispatchTriggerResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.dispatch.rest.resource.v1_0.DispatchTriggerResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -194,7 +207,7 @@ public abstract class BaseDispatchTriggerResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<DispatchTrigger> dispatchTriggers,
+			Collection<DispatchTrigger> dispatchTriggers,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -228,7 +241,7 @@ public abstract class BaseDispatchTriggerResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<DispatchTrigger> dispatchTriggers,
+			Collection<DispatchTrigger> dispatchTriggers,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -296,7 +309,7 @@ public abstract class BaseDispatchTriggerResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<DispatchTrigger> dispatchTriggers,
+			Collection<DispatchTrigger> dispatchTriggers,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -310,7 +323,7 @@ public abstract class BaseDispatchTriggerResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<DispatchTrigger>,
+			<Collection<DispatchTrigger>,
 			 UnsafeConsumer<DispatchTrigger, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -489,8 +502,7 @@ public abstract class BaseDispatchTriggerResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -502,8 +514,8 @@ public abstract class BaseDispatchTriggerResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -516,8 +528,7 @@ public abstract class BaseDispatchTriggerResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -531,8 +542,8 @@ public abstract class BaseDispatchTriggerResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -548,7 +559,7 @@ public abstract class BaseDispatchTriggerResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<DispatchTrigger>,
+		<Collection<DispatchTrigger>,
 		 UnsafeConsumer<DispatchTrigger, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -566,6 +577,115 @@ public abstract class BaseDispatchTriggerResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseDispatchTriggerResourceImpl.class);

--- a/modules/apps/frontend-view-state/frontend-view-state-rest-impl/src/main/java/com/liferay/frontend/view/state/rest/internal/resource/v1_0/BaseActiveViewResourceImpl.java
+++ b/modules/apps/frontend-view-state/frontend-view-state-rest-impl/src/main/java/com/liferay/frontend/view/state/rest/internal/resource/v1_0/BaseActiveViewResourceImpl.java
@@ -16,23 +16,38 @@ package com.liferay.frontend.view.state.rest.internal.resource.v1_0;
 
 import com.liferay.frontend.view.state.rest.resource.v1_0.ActiveViewResource;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -249,8 +264,7 @@ public abstract class BaseActiveViewResourceImpl implements ActiveViewResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -262,8 +276,8 @@ public abstract class BaseActiveViewResourceImpl implements ActiveViewResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -276,8 +290,7 @@ public abstract class BaseActiveViewResourceImpl implements ActiveViewResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -291,8 +304,8 @@ public abstract class BaseActiveViewResourceImpl implements ActiveViewResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -320,6 +333,115 @@ public abstract class BaseActiveViewResourceImpl implements ActiveViewResource {
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseActiveViewResourceImpl.class);

--- a/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/java/com/liferay/headless/admin/address/internal/resource/v1_0/BaseCountryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/java/com/liferay/headless/admin/address/internal/resource/v1_0/BaseCountryResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.admin.address.resource.v1_0.CountryResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -574,8 +587,7 @@ public abstract class BaseCountryResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<Country> countries,
-			Map<String, Serializable> parameters)
+			Collection<Country> countries, Map<String, Serializable> parameters)
 		throws Exception {
 
 		UnsafeConsumer<Country, Exception> countryUnsafeConsumer = null;
@@ -605,8 +617,7 @@ public abstract class BaseCountryResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<Country> countries,
-			Map<String, Serializable> parameters)
+			Collection<Country> countries, Map<String, Serializable> parameters)
 		throws Exception {
 
 		for (Country country : countries) {
@@ -675,8 +686,7 @@ public abstract class BaseCountryResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<Country> countries,
-			Map<String, Serializable> parameters)
+			Collection<Country> countries, Map<String, Serializable> parameters)
 		throws Exception {
 
 		UnsafeConsumer<Country, Exception> countryUnsafeConsumer = null;
@@ -720,8 +730,8 @@ public abstract class BaseCountryResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<Country>, UnsafeConsumer<Country, Exception>,
-			 Exception> contextBatchUnsafeConsumer) {
+			<Collection<Country>, UnsafeConsumer<Country, Exception>, Exception>
+				contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -901,8 +911,7 @@ public abstract class BaseCountryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -914,8 +923,8 @@ public abstract class BaseCountryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -928,8 +937,7 @@ public abstract class BaseCountryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -943,8 +951,8 @@ public abstract class BaseCountryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -960,8 +968,8 @@ public abstract class BaseCountryResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<Country>, UnsafeConsumer<Country, Exception>,
-		 Exception> contextBatchUnsafeConsumer;
+		<Collection<Country>, UnsafeConsumer<Country, Exception>, Exception>
+			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -977,6 +985,115 @@ public abstract class BaseCountryResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseCountryResourceImpl.class);

--- a/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/java/com/liferay/headless/admin/address/internal/resource/v1_0/BaseRegionResourceImpl.java
+++ b/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/java/com/liferay/headless/admin/address/internal/resource/v1_0/BaseRegionResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.admin.address.resource.v1_0.RegionResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -549,8 +562,7 @@ public abstract class BaseRegionResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<Region> regions,
-			Map<String, Serializable> parameters)
+			Collection<Region> regions, Map<String, Serializable> parameters)
 		throws Exception {
 
 		UnsafeConsumer<Region, Exception> regionUnsafeConsumer = null;
@@ -588,8 +600,7 @@ public abstract class BaseRegionResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<Region> regions,
-			Map<String, Serializable> parameters)
+			Collection<Region> regions, Map<String, Serializable> parameters)
 		throws Exception {
 
 		for (Region region : regions) {
@@ -667,8 +678,7 @@ public abstract class BaseRegionResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<Region> regions,
-			Map<String, Serializable> parameters)
+			Collection<Region> regions, Map<String, Serializable> parameters)
 		throws Exception {
 
 		UnsafeConsumer<Region, Exception> regionUnsafeConsumer = null;
@@ -712,8 +722,8 @@ public abstract class BaseRegionResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<Region>, UnsafeConsumer<Region, Exception>,
-			 Exception> contextBatchUnsafeConsumer) {
+			<Collection<Region>, UnsafeConsumer<Region, Exception>, Exception>
+				contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -893,8 +903,7 @@ public abstract class BaseRegionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -906,8 +915,8 @@ public abstract class BaseRegionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -920,8 +929,7 @@ public abstract class BaseRegionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -935,8 +943,8 @@ public abstract class BaseRegionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -952,8 +960,8 @@ public abstract class BaseRegionResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<Region>, UnsafeConsumer<Region, Exception>,
-		 Exception> contextBatchUnsafeConsumer;
+		<Collection<Region>, UnsafeConsumer<Region, Exception>, Exception>
+			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -969,6 +977,115 @@ public abstract class BaseRegionResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseRegionResourceImpl.class);

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/resource/v1_0/BaseDisplayPageTemplateResourceImpl.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/resource/v1_0/BaseDisplayPageTemplateResourceImpl.java
@@ -17,27 +17,41 @@ package com.liferay.headless.admin.content.internal.resource.v1_0;
 import com.liferay.headless.admin.content.dto.v1_0.DisplayPageTemplate;
 import com.liferay.headless.admin.content.resource.v1_0.DisplayPageTemplateResource;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -280,8 +294,7 @@ public abstract class BaseDisplayPageTemplateResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -293,8 +306,8 @@ public abstract class BaseDisplayPageTemplateResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -307,8 +320,7 @@ public abstract class BaseDisplayPageTemplateResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -322,8 +334,8 @@ public abstract class BaseDisplayPageTemplateResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -351,6 +363,115 @@ public abstract class BaseDisplayPageTemplateResourceImpl
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseDisplayPageTemplateResourceImpl.class);

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/resource/v1_0/BasePageDefinitionResourceImpl.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/resource/v1_0/BasePageDefinitionResourceImpl.java
@@ -16,23 +16,38 @@ package com.liferay.headless.admin.content.internal.resource.v1_0;
 
 import com.liferay.headless.admin.content.resource.v1_0.PageDefinitionResource;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -194,8 +209,7 @@ public abstract class BasePageDefinitionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -207,8 +221,8 @@ public abstract class BasePageDefinitionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -221,8 +235,7 @@ public abstract class BasePageDefinitionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -236,8 +249,8 @@ public abstract class BasePageDefinitionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -265,6 +278,115 @@ public abstract class BasePageDefinitionResourceImpl
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BasePageDefinitionResourceImpl.class);

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/resource/v1_0/BaseStructuredContentResourceImpl.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/resource/v1_0/BaseStructuredContentResourceImpl.java
@@ -16,27 +16,41 @@ package com.liferay.headless.admin.content.internal.resource.v1_0;
 
 import com.liferay.headless.admin.content.resource.v1_0.StructuredContentResource;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -433,8 +447,7 @@ public abstract class BaseStructuredContentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -446,8 +459,8 @@ public abstract class BaseStructuredContentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -460,8 +473,7 @@ public abstract class BaseStructuredContentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -475,8 +487,8 @@ public abstract class BaseStructuredContentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -504,6 +516,115 @@ public abstract class BaseStructuredContentResourceImpl
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseStructuredContentResourceImpl.class);

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/resource/v1_0/BaseListTypeDefinitionResourceImpl.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/resource/v1_0/BaseListTypeDefinitionResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.admin.list.type.resource.v1_0.ListTypeDefinitionReso
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -460,7 +473,7 @@ public abstract class BaseListTypeDefinitionResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<ListTypeDefinition> listTypeDefinitions,
+			Collection<ListTypeDefinition> listTypeDefinitions,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -495,7 +508,7 @@ public abstract class BaseListTypeDefinitionResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<ListTypeDefinition> listTypeDefinitions,
+			Collection<ListTypeDefinition> listTypeDefinitions,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -565,7 +578,7 @@ public abstract class BaseListTypeDefinitionResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<ListTypeDefinition> listTypeDefinitions,
+			Collection<ListTypeDefinition> listTypeDefinitions,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -618,7 +631,7 @@ public abstract class BaseListTypeDefinitionResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<ListTypeDefinition>,
+			<Collection<ListTypeDefinition>,
 			 UnsafeConsumer<ListTypeDefinition, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -802,8 +815,7 @@ public abstract class BaseListTypeDefinitionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -815,8 +827,8 @@ public abstract class BaseListTypeDefinitionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -829,8 +841,7 @@ public abstract class BaseListTypeDefinitionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -844,8 +855,8 @@ public abstract class BaseListTypeDefinitionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -861,7 +872,7 @@ public abstract class BaseListTypeDefinitionResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<ListTypeDefinition>,
+		<Collection<ListTypeDefinition>,
 		 UnsafeConsumer<ListTypeDefinition, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -879,6 +890,115 @@ public abstract class BaseListTypeDefinitionResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseListTypeDefinitionResourceImpl.class);

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/resource/v1_0/BaseListTypeEntryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/resource/v1_0/BaseListTypeEntryResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.admin.list.type.resource.v1_0.ListTypeEntryResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -425,7 +438,7 @@ public abstract class BaseListTypeEntryResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<ListTypeEntry> listTypeEntries,
+			Collection<ListTypeEntry> listTypeEntries,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -468,7 +481,7 @@ public abstract class BaseListTypeEntryResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<ListTypeEntry> listTypeEntries,
+			Collection<ListTypeEntry> listTypeEntries,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -538,7 +551,7 @@ public abstract class BaseListTypeEntryResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<ListTypeEntry> listTypeEntries,
+			Collection<ListTypeEntry> listTypeEntries,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -578,7 +591,7 @@ public abstract class BaseListTypeEntryResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<ListTypeEntry>,
+			<Collection<ListTypeEntry>,
 			 UnsafeConsumer<ListTypeEntry, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -757,8 +770,7 @@ public abstract class BaseListTypeEntryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -770,8 +782,8 @@ public abstract class BaseListTypeEntryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -784,8 +796,7 @@ public abstract class BaseListTypeEntryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -799,8 +810,8 @@ public abstract class BaseListTypeEntryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -816,9 +827,8 @@ public abstract class BaseListTypeEntryResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<ListTypeEntry>,
-		 UnsafeConsumer<ListTypeEntry, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<ListTypeEntry>, UnsafeConsumer<ListTypeEntry, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -834,6 +844,115 @@ public abstract class BaseListTypeEntryResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseListTypeEntryResourceImpl.class);

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseKeywordResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseKeywordResourceImpl.java
@@ -19,17 +19,22 @@ import com.liferay.headless.admin.taxonomy.resource.v1_0.KeywordResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -49,6 +54,7 @@ import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTa
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.permission.ModelPermissionsUtil;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.permission.PermissionUtil;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
@@ -56,7 +62,13 @@ import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -269,15 +281,14 @@ public abstract class BaseKeywordResourceImpl
 	@javax.ws.rs.Path("/asset-libraries/{assetLibraryId}/keywords/permissions")
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			getAssetLibraryKeywordPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("assetLibraryId")
-				Long assetLibraryId,
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.ws.rs.QueryParam("roleNames")
-				String roleNames)
+	public Page<Permission> getAssetLibraryKeywordPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("assetLibraryId")
+			Long assetLibraryId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("roleNames")
+			String roleNames)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(assetLibraryId);
@@ -323,13 +334,12 @@ public abstract class BaseKeywordResourceImpl
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@javax.ws.rs.PUT
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putAssetLibraryKeywordPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("assetLibraryId")
-				Long assetLibraryId,
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<Permission> putAssetLibraryKeywordPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("assetLibraryId")
+			Long assetLibraryId,
+			Permission[] permissions)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(assetLibraryId);
@@ -859,15 +869,14 @@ public abstract class BaseKeywordResourceImpl
 	@javax.ws.rs.Path("/sites/{siteId}/keywords/permissions")
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			getSiteKeywordPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("siteId")
-				Long siteId,
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.ws.rs.QueryParam("roleNames")
-				String roleNames)
+	public Page<Permission> getSiteKeywordPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("siteId")
+			Long siteId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("roleNames")
+			String roleNames)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(siteId);
@@ -911,13 +920,12 @@ public abstract class BaseKeywordResourceImpl
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@javax.ws.rs.PUT
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putSiteKeywordPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("siteId")
-				Long siteId,
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<Permission> putSiteKeywordPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("siteId")
+			Long siteId,
+			Permission[] permissions)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(siteId);
@@ -952,8 +960,7 @@ public abstract class BaseKeywordResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<Keyword> keywords,
-			Map<String, Serializable> parameters)
+			Collection<Keyword> keywords, Map<String, Serializable> parameters)
 		throws Exception {
 
 		UnsafeConsumer<Keyword, Exception> keywordUnsafeConsumer = null;
@@ -994,8 +1001,7 @@ public abstract class BaseKeywordResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<Keyword> keywords,
-			Map<String, Serializable> parameters)
+			Collection<Keyword> keywords, Map<String, Serializable> parameters)
 		throws Exception {
 
 		for (Keyword keyword : keywords) {
@@ -1076,8 +1082,7 @@ public abstract class BaseKeywordResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<Keyword> keywords,
-			Map<String, Serializable> parameters)
+			Collection<Keyword> keywords, Map<String, Serializable> parameters)
 		throws Exception {
 
 		UnsafeConsumer<Keyword, Exception> keywordUnsafeConsumer = null;
@@ -1137,10 +1142,9 @@ public abstract class BaseKeywordResourceImpl
 			"This method needs to be implemented");
 	}
 
-	protected Page<com.liferay.portal.vulcan.permission.Permission>
-			toPermissionPage(
-				Map<String, Map<String, String>> actions, long id,
-				String resourceName, String roleNames)
+	protected Page<Permission> toPermissionPage(
+			Map<String, Map<String, String>> actions, long id,
+			String resourceName, String roleNames)
 		throws Exception {
 
 		List<ResourceAction> resourceActions =
@@ -1149,24 +1153,16 @@ public abstract class BaseKeywordResourceImpl
 		if (Validator.isNotNull(roleNames)) {
 			return Page.of(
 				actions,
-				transform(
-					PermissionUtil.getRoles(
-						contextCompany, roleLocalService,
-						StringUtil.split(roleNames)),
-					role -> PermissionUtil.toPermission(
-						contextCompany.getCompanyId(), id, resourceActions,
-						resourceName, resourcePermissionLocalService, role)));
+				_getPermissions(
+					contextCompany.getCompanyId(), resourceActions, id,
+					resourceName, StringUtil.split(roleNames)));
 		}
 
 		return Page.of(
 			actions,
-			transform(
-				PermissionUtil.getResourcePermissions(
-					contextCompany.getCompanyId(), id, resourceName,
-					resourcePermissionLocalService),
-				resourcePermission -> PermissionUtil.toPermission(
-					resourceActions, resourcePermission,
-					roleLocalService.getRole(resourcePermission.getRoleId()))));
+			_getPermissions(
+				contextCompany.getCompanyId(), resourceActions, id,
+				resourceName, null));
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
@@ -1175,8 +1171,8 @@ public abstract class BaseKeywordResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<Keyword>, UnsafeConsumer<Keyword, Exception>,
-			 Exception> contextBatchUnsafeConsumer) {
+			<Collection<Keyword>, UnsafeConsumer<Keyword, Exception>, Exception>
+				contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -1353,8 +1349,7 @@ public abstract class BaseKeywordResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -1366,8 +1361,8 @@ public abstract class BaseKeywordResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -1380,8 +1375,7 @@ public abstract class BaseKeywordResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -1395,8 +1389,8 @@ public abstract class BaseKeywordResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -1412,8 +1406,8 @@ public abstract class BaseKeywordResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<Keyword>, UnsafeConsumer<Keyword, Exception>,
-		 Exception> contextBatchUnsafeConsumer;
+		<Collection<Keyword>, UnsafeConsumer<Keyword, Exception>, Exception>
+			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -1429,6 +1423,115 @@ public abstract class BaseKeywordResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseKeywordResourceImpl.class);

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyCategoryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyCategoryResourceImpl.java
@@ -19,17 +19,22 @@ import com.liferay.headless.admin.taxonomy.resource.v1_0.TaxonomyCategoryResourc
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -49,6 +54,7 @@ import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTa
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.permission.ModelPermissionsUtil;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.permission.PermissionUtil;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
@@ -56,7 +62,13 @@ import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -596,15 +608,14 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 	@javax.ws.rs.Path("/taxonomy-categories/{taxonomyCategoryId}/permissions")
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			getTaxonomyCategoryPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("taxonomyCategoryId")
-				String taxonomyCategoryId,
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.ws.rs.QueryParam("roleNames")
-				String roleNames)
+	public Page<Permission> getTaxonomyCategoryPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("taxonomyCategoryId")
+			String taxonomyCategoryId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("roleNames")
+			String roleNames)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(
@@ -654,13 +665,12 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@javax.ws.rs.PUT
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putTaxonomyCategoryPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("taxonomyCategoryId")
-				String taxonomyCategoryId,
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<Permission> putTaxonomyCategoryPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("taxonomyCategoryId")
+			String taxonomyCategoryId,
+			Permission[] permissions)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(
@@ -1017,7 +1027,7 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<TaxonomyCategory> taxonomyCategories,
+			Collection<TaxonomyCategory> taxonomyCategories,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -1071,7 +1081,7 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<TaxonomyCategory> taxonomyCategories,
+			Collection<TaxonomyCategory> taxonomyCategories,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -1141,7 +1151,7 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<TaxonomyCategory> taxonomyCategories,
+			Collection<TaxonomyCategory> taxonomyCategories,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -1215,10 +1225,9 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 			"This method needs to be implemented");
 	}
 
-	protected Page<com.liferay.portal.vulcan.permission.Permission>
-			toPermissionPage(
-				Map<String, Map<String, String>> actions, long id,
-				String resourceName, String roleNames)
+	protected Page<Permission> toPermissionPage(
+			Map<String, Map<String, String>> actions, long id,
+			String resourceName, String roleNames)
 		throws Exception {
 
 		List<ResourceAction> resourceActions =
@@ -1227,24 +1236,16 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 		if (Validator.isNotNull(roleNames)) {
 			return Page.of(
 				actions,
-				transform(
-					PermissionUtil.getRoles(
-						contextCompany, roleLocalService,
-						StringUtil.split(roleNames)),
-					role -> PermissionUtil.toPermission(
-						contextCompany.getCompanyId(), id, resourceActions,
-						resourceName, resourcePermissionLocalService, role)));
+				_getPermissions(
+					contextCompany.getCompanyId(), resourceActions, id,
+					resourceName, StringUtil.split(roleNames)));
 		}
 
 		return Page.of(
 			actions,
-			transform(
-				PermissionUtil.getResourcePermissions(
-					contextCompany.getCompanyId(), id, resourceName,
-					resourcePermissionLocalService),
-				resourcePermission -> PermissionUtil.toPermission(
-					resourceActions, resourcePermission,
-					roleLocalService.getRole(resourcePermission.getRoleId()))));
+			_getPermissions(
+				contextCompany.getCompanyId(), resourceActions, id,
+				resourceName, null));
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
@@ -1253,7 +1254,7 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<TaxonomyCategory>,
+			<Collection<TaxonomyCategory>,
 			 UnsafeConsumer<TaxonomyCategory, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -1437,8 +1438,7 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -1450,8 +1450,8 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -1464,8 +1464,7 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -1479,8 +1478,8 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -1496,7 +1495,7 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<TaxonomyCategory>,
+		<Collection<TaxonomyCategory>,
 		 UnsafeConsumer<TaxonomyCategory, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -1514,6 +1513,115 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseTaxonomyCategoryResourceImpl.class);

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyVocabularyResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyVocabularyResourceImpl.java
@@ -19,17 +19,22 @@ import com.liferay.headless.admin.taxonomy.resource.v1_0.TaxonomyVocabularyResou
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -49,6 +54,7 @@ import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTa
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.permission.ModelPermissionsUtil;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.permission.PermissionUtil;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
@@ -56,7 +62,13 @@ import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -426,15 +438,14 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 	)
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			getAssetLibraryTaxonomyVocabularyPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("assetLibraryId")
-				Long assetLibraryId,
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.ws.rs.QueryParam("roleNames")
-				String roleNames)
+	public Page<Permission> getAssetLibraryTaxonomyVocabularyPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("assetLibraryId")
+			Long assetLibraryId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("roleNames")
+			String roleNames)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(assetLibraryId);
@@ -484,13 +495,12 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@javax.ws.rs.PUT
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putAssetLibraryTaxonomyVocabularyPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("assetLibraryId")
-				Long assetLibraryId,
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<Permission> putAssetLibraryTaxonomyVocabularyPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("assetLibraryId")
+			Long assetLibraryId,
+			Permission[] permissions)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(assetLibraryId);
@@ -867,15 +877,14 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 	@javax.ws.rs.Path("/sites/{siteId}/taxonomy-vocabularies/permissions")
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			getSiteTaxonomyVocabularyPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("siteId")
-				Long siteId,
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.ws.rs.QueryParam("roleNames")
-				String roleNames)
+	public Page<Permission> getSiteTaxonomyVocabularyPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("siteId")
+			Long siteId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("roleNames")
+			String roleNames)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(siteId);
@@ -923,13 +932,12 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@javax.ws.rs.PUT
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putSiteTaxonomyVocabularyPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("siteId")
-				Long siteId,
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<Permission> putSiteTaxonomyVocabularyPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("siteId")
+			Long siteId,
+			Permission[] permissions)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(siteId);
@@ -1311,15 +1319,14 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 	)
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			getTaxonomyVocabularyPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("taxonomyVocabularyId")
-				Long taxonomyVocabularyId,
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.ws.rs.QueryParam("roleNames")
-				String roleNames)
+	public Page<Permission> getTaxonomyVocabularyPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("taxonomyVocabularyId")
+			Long taxonomyVocabularyId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("roleNames")
+			String roleNames)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(
@@ -1371,13 +1378,12 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@javax.ws.rs.PUT
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putTaxonomyVocabularyPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("taxonomyVocabularyId")
-				Long taxonomyVocabularyId,
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<Permission> putTaxonomyVocabularyPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("taxonomyVocabularyId")
+			Long taxonomyVocabularyId,
+			Permission[] permissions)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(
@@ -1417,7 +1423,7 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<TaxonomyVocabulary> taxonomyVocabularies,
+			Collection<TaxonomyVocabulary> taxonomyVocabularies,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -1474,7 +1480,7 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<TaxonomyVocabulary> taxonomyVocabularies,
+			Collection<TaxonomyVocabulary> taxonomyVocabularies,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -1544,7 +1550,7 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<TaxonomyVocabulary> taxonomyVocabularies,
+			Collection<TaxonomyVocabulary> taxonomyVocabularies,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -1620,10 +1626,9 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 			"This method needs to be implemented");
 	}
 
-	protected Page<com.liferay.portal.vulcan.permission.Permission>
-			toPermissionPage(
-				Map<String, Map<String, String>> actions, long id,
-				String resourceName, String roleNames)
+	protected Page<Permission> toPermissionPage(
+			Map<String, Map<String, String>> actions, long id,
+			String resourceName, String roleNames)
 		throws Exception {
 
 		List<ResourceAction> resourceActions =
@@ -1632,24 +1637,16 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 		if (Validator.isNotNull(roleNames)) {
 			return Page.of(
 				actions,
-				transform(
-					PermissionUtil.getRoles(
-						contextCompany, roleLocalService,
-						StringUtil.split(roleNames)),
-					role -> PermissionUtil.toPermission(
-						contextCompany.getCompanyId(), id, resourceActions,
-						resourceName, resourcePermissionLocalService, role)));
+				_getPermissions(
+					contextCompany.getCompanyId(), resourceActions, id,
+					resourceName, StringUtil.split(roleNames)));
 		}
 
 		return Page.of(
 			actions,
-			transform(
-				PermissionUtil.getResourcePermissions(
-					contextCompany.getCompanyId(), id, resourceName,
-					resourcePermissionLocalService),
-				resourcePermission -> PermissionUtil.toPermission(
-					resourceActions, resourcePermission,
-					roleLocalService.getRole(resourcePermission.getRoleId()))));
+			_getPermissions(
+				contextCompany.getCompanyId(), resourceActions, id,
+				resourceName, null));
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
@@ -1658,7 +1655,7 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<TaxonomyVocabulary>,
+			<Collection<TaxonomyVocabulary>,
 			 UnsafeConsumer<TaxonomyVocabulary, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -1842,8 +1839,7 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -1855,8 +1851,8 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -1869,8 +1865,7 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -1884,8 +1879,8 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -1901,7 +1896,7 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<TaxonomyVocabulary>,
+		<Collection<TaxonomyVocabulary>,
 		 UnsafeConsumer<TaxonomyVocabulary, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -1919,6 +1914,115 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseTaxonomyVocabularyResourceImpl.class);

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseAccountResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseAccountResourceImpl.java
@@ -15,19 +15,26 @@
 package com.liferay.headless.admin.user.internal.resource.v1_0;
 
 import com.liferay.headless.admin.user.dto.v1_0.Account;
+import com.liferay.headless.admin.user.dto.v1_0.Role;
 import com.liferay.headless.admin.user.resource.v1_0.AccountResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +50,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -907,8 +921,7 @@ public abstract class BaseAccountResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<Account> accounts,
-			Map<String, Serializable> parameters)
+			Collection<Account> accounts, Map<String, Serializable> parameters)
 		throws Exception {
 
 		UnsafeConsumer<Account, Exception> accountUnsafeConsumer = null;
@@ -944,8 +957,7 @@ public abstract class BaseAccountResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<Account> accounts,
-			Map<String, Serializable> parameters)
+			Collection<Account> accounts, Map<String, Serializable> parameters)
 		throws Exception {
 
 		for (Account account : accounts) {
@@ -1020,8 +1032,7 @@ public abstract class BaseAccountResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<Account> accounts,
-			Map<String, Serializable> parameters)
+			Collection<Account> accounts, Map<String, Serializable> parameters)
 		throws Exception {
 
 		UnsafeConsumer<Account, Exception> accountUnsafeConsumer = null;
@@ -1065,8 +1076,8 @@ public abstract class BaseAccountResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<Account>, UnsafeConsumer<Account, Exception>,
-			 Exception> contextBatchUnsafeConsumer) {
+			<Collection<Account>, UnsafeConsumer<Account, Exception>, Exception>
+				contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -1246,8 +1257,7 @@ public abstract class BaseAccountResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -1259,8 +1269,8 @@ public abstract class BaseAccountResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -1273,8 +1283,7 @@ public abstract class BaseAccountResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -1288,8 +1297,8 @@ public abstract class BaseAccountResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -1305,8 +1314,8 @@ public abstract class BaseAccountResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<Account>, UnsafeConsumer<Account, Exception>,
-		 Exception> contextBatchUnsafeConsumer;
+		<Collection<Account>, UnsafeConsumer<Account, Exception>, Exception>
+			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -1322,6 +1331,115 @@ public abstract class BaseAccountResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseAccountResourceImpl.class);

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseAccountRoleResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseAccountRoleResourceImpl.java
@@ -15,19 +15,26 @@
 package com.liferay.headless.admin.user.internal.resource.v1_0;
 
 import com.liferay.headless.admin.user.dto.v1_0.AccountRole;
+import com.liferay.headless.admin.user.dto.v1_0.Role;
 import com.liferay.headless.admin.user.resource.v1_0.AccountRoleResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +50,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -709,7 +723,7 @@ public abstract class BaseAccountRoleResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<AccountRole> accountRoles,
+			Collection<AccountRole> accountRoles,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -750,7 +764,7 @@ public abstract class BaseAccountRoleResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<AccountRole> accountRoles,
+			Collection<AccountRole> accountRoles,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -826,7 +840,7 @@ public abstract class BaseAccountRoleResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<AccountRole> accountRoles,
+			Collection<AccountRole> accountRoles,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -840,9 +854,8 @@ public abstract class BaseAccountRoleResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<AccountRole>,
-			 UnsafeConsumer<AccountRole, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<AccountRole>, UnsafeConsumer<AccountRole, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -1019,8 +1032,7 @@ public abstract class BaseAccountRoleResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -1032,8 +1044,8 @@ public abstract class BaseAccountRoleResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -1046,8 +1058,7 @@ public abstract class BaseAccountRoleResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -1061,8 +1072,8 @@ public abstract class BaseAccountRoleResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -1078,9 +1089,8 @@ public abstract class BaseAccountRoleResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<AccountRole>,
-		 UnsafeConsumer<AccountRole, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<AccountRole>, UnsafeConsumer<AccountRole, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -1096,6 +1106,115 @@ public abstract class BaseAccountRoleResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseAccountRoleResourceImpl.class);

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseEmailAddressResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseEmailAddressResourceImpl.java
@@ -15,19 +15,26 @@
 package com.liferay.headless.admin.user.internal.resource.v1_0;
 
 import com.liferay.headless.admin.user.dto.v1_0.EmailAddress;
+import com.liferay.headless.admin.user.dto.v1_0.Role;
 import com.liferay.headless.admin.user.resource.v1_0.EmailAddressResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +50,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -176,7 +190,7 @@ public abstract class BaseEmailAddressResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<EmailAddress> emailAddresses,
+			Collection<EmailAddress> emailAddresses,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -186,7 +200,7 @@ public abstract class BaseEmailAddressResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<EmailAddress> emailAddresses,
+			Collection<EmailAddress> emailAddresses,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -255,7 +269,7 @@ public abstract class BaseEmailAddressResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<EmailAddress> emailAddresses,
+			Collection<EmailAddress> emailAddresses,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -269,9 +283,8 @@ public abstract class BaseEmailAddressResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<EmailAddress>,
-			 UnsafeConsumer<EmailAddress, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<EmailAddress>, UnsafeConsumer<EmailAddress, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -448,8 +461,7 @@ public abstract class BaseEmailAddressResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -461,8 +473,8 @@ public abstract class BaseEmailAddressResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -475,8 +487,7 @@ public abstract class BaseEmailAddressResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -490,8 +501,8 @@ public abstract class BaseEmailAddressResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -507,9 +518,8 @@ public abstract class BaseEmailAddressResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<EmailAddress>,
-		 UnsafeConsumer<EmailAddress, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<EmailAddress>, UnsafeConsumer<EmailAddress, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -525,6 +535,115 @@ public abstract class BaseEmailAddressResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseEmailAddressResourceImpl.class);

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseOrganizationResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseOrganizationResourceImpl.java
@@ -15,20 +15,27 @@
 package com.liferay.headless.admin.user.internal.resource.v1_0;
 
 import com.liferay.headless.admin.user.dto.v1_0.Organization;
+import com.liferay.headless.admin.user.dto.v1_0.Role;
 import com.liferay.headless.admin.user.dto.v1_0.UserAccount;
 import com.liferay.headless.admin.user.resource.v1_0.OrganizationResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -44,13 +51,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -1237,7 +1251,7 @@ public abstract class BaseOrganizationResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<Organization> organizations,
+			Collection<Organization> organizations,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -1277,7 +1291,7 @@ public abstract class BaseOrganizationResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<Organization> organizations,
+			Collection<Organization> organizations,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -1355,7 +1369,7 @@ public abstract class BaseOrganizationResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<Organization> organizations,
+			Collection<Organization> organizations,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -1402,9 +1416,8 @@ public abstract class BaseOrganizationResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<Organization>,
-			 UnsafeConsumer<Organization, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<Organization>, UnsafeConsumer<Organization, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -1585,8 +1598,7 @@ public abstract class BaseOrganizationResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -1598,8 +1610,8 @@ public abstract class BaseOrganizationResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -1612,8 +1624,7 @@ public abstract class BaseOrganizationResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -1627,8 +1638,8 @@ public abstract class BaseOrganizationResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -1644,9 +1655,8 @@ public abstract class BaseOrganizationResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<Organization>,
-		 UnsafeConsumer<Organization, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<Organization>, UnsafeConsumer<Organization, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -1662,6 +1672,115 @@ public abstract class BaseOrganizationResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseOrganizationResourceImpl.class);

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BasePhoneResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BasePhoneResourceImpl.java
@@ -15,19 +15,26 @@
 package com.liferay.headless.admin.user.internal.resource.v1_0;
 
 import com.liferay.headless.admin.user.dto.v1_0.Phone;
+import com.liferay.headless.admin.user.dto.v1_0.Role;
 import com.liferay.headless.admin.user.resource.v1_0.PhoneResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +50,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -177,8 +191,7 @@ public abstract class BasePhoneResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<Phone> phones,
-			Map<String, Serializable> parameters)
+			Collection<Phone> phones, Map<String, Serializable> parameters)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -187,8 +200,7 @@ public abstract class BasePhoneResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<Phone> phones,
-			Map<String, Serializable> parameters)
+			Collection<Phone> phones, Map<String, Serializable> parameters)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -266,8 +278,7 @@ public abstract class BasePhoneResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<Phone> phones,
-			Map<String, Serializable> parameters)
+			Collection<Phone> phones, Map<String, Serializable> parameters)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -280,8 +291,8 @@ public abstract class BasePhoneResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<Phone>, UnsafeConsumer<Phone, Exception>,
-			 Exception> contextBatchUnsafeConsumer) {
+			<Collection<Phone>, UnsafeConsumer<Phone, Exception>, Exception>
+				contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -458,8 +469,7 @@ public abstract class BasePhoneResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -471,8 +481,8 @@ public abstract class BasePhoneResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -485,8 +495,7 @@ public abstract class BasePhoneResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -500,8 +509,8 @@ public abstract class BasePhoneResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -517,8 +526,8 @@ public abstract class BasePhoneResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<Phone>, UnsafeConsumer<Phone, Exception>,
-		 Exception> contextBatchUnsafeConsumer;
+		<Collection<Phone>, UnsafeConsumer<Phone, Exception>, Exception>
+			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -534,6 +543,115 @@ public abstract class BasePhoneResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BasePhoneResourceImpl.class);

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BasePostalAddressResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BasePostalAddressResourceImpl.java
@@ -15,19 +15,26 @@
 package com.liferay.headless.admin.user.internal.resource.v1_0;
 
 import com.liferay.headless.admin.user.dto.v1_0.PostalAddress;
+import com.liferay.headless.admin.user.dto.v1_0.Role;
 import com.liferay.headless.admin.user.resource.v1_0.PostalAddressResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +50,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -217,7 +231,7 @@ public abstract class BasePostalAddressResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<PostalAddress> postalAddresses,
+			Collection<PostalAddress> postalAddresses,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -227,7 +241,7 @@ public abstract class BasePostalAddressResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<PostalAddress> postalAddresses,
+			Collection<PostalAddress> postalAddresses,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -296,7 +310,7 @@ public abstract class BasePostalAddressResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<PostalAddress> postalAddresses,
+			Collection<PostalAddress> postalAddresses,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -310,7 +324,7 @@ public abstract class BasePostalAddressResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<PostalAddress>,
+			<Collection<PostalAddress>,
 			 UnsafeConsumer<PostalAddress, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -489,8 +503,7 @@ public abstract class BasePostalAddressResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -502,8 +515,8 @@ public abstract class BasePostalAddressResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -516,8 +529,7 @@ public abstract class BasePostalAddressResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -531,8 +543,8 @@ public abstract class BasePostalAddressResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -548,9 +560,8 @@ public abstract class BasePostalAddressResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<PostalAddress>,
-		 UnsafeConsumer<PostalAddress, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<PostalAddress>, UnsafeConsumer<PostalAddress, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -566,6 +577,115 @@ public abstract class BasePostalAddressResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BasePostalAddressResourceImpl.class);

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseRoleResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseRoleResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.admin.user.resource.v1_0.RoleResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -436,8 +449,7 @@ public abstract class BaseRoleResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<Role> roles,
-			Map<String, Serializable> parameters)
+			Collection<Role> roles, Map<String, Serializable> parameters)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -446,8 +458,7 @@ public abstract class BaseRoleResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<Role> roles,
-			Map<String, Serializable> parameters)
+			Collection<Role> roles, Map<String, Serializable> parameters)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -515,8 +526,7 @@ public abstract class BaseRoleResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<Role> roles,
-			Map<String, Serializable> parameters)
+			Collection<Role> roles, Map<String, Serializable> parameters)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -529,8 +539,8 @@ public abstract class BaseRoleResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<Role>, UnsafeConsumer<Role, Exception>,
-			 Exception> contextBatchUnsafeConsumer) {
+			<Collection<Role>, UnsafeConsumer<Role, Exception>, Exception>
+				contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -707,8 +717,7 @@ public abstract class BaseRoleResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -720,8 +729,8 @@ public abstract class BaseRoleResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -734,8 +743,7 @@ public abstract class BaseRoleResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -749,8 +757,8 @@ public abstract class BaseRoleResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -766,7 +774,7 @@ public abstract class BaseRoleResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<Role>, UnsafeConsumer<Role, Exception>, Exception>
+		<Collection<Role>, UnsafeConsumer<Role, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
@@ -783,6 +791,115 @@ public abstract class BaseRoleResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseRoleResourceImpl.class);

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSegmentResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSegmentResourceImpl.java
@@ -14,20 +14,27 @@
 
 package com.liferay.headless.admin.user.internal.resource.v1_0;
 
+import com.liferay.headless.admin.user.dto.v1_0.Role;
 import com.liferay.headless.admin.user.dto.v1_0.Segment;
 import com.liferay.headless.admin.user.resource.v1_0.SegmentResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +50,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -161,8 +175,7 @@ public abstract class BaseSegmentResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<Segment> segments,
-			Map<String, Serializable> parameters)
+			Collection<Segment> segments, Map<String, Serializable> parameters)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -171,8 +184,7 @@ public abstract class BaseSegmentResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<Segment> segments,
-			Map<String, Serializable> parameters)
+			Collection<Segment> segments, Map<String, Serializable> parameters)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -246,8 +258,7 @@ public abstract class BaseSegmentResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<Segment> segments,
-			Map<String, Serializable> parameters)
+			Collection<Segment> segments, Map<String, Serializable> parameters)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -260,8 +271,8 @@ public abstract class BaseSegmentResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<Segment>, UnsafeConsumer<Segment, Exception>,
-			 Exception> contextBatchUnsafeConsumer) {
+			<Collection<Segment>, UnsafeConsumer<Segment, Exception>, Exception>
+				contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -438,8 +449,7 @@ public abstract class BaseSegmentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -451,8 +461,8 @@ public abstract class BaseSegmentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -465,8 +475,7 @@ public abstract class BaseSegmentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -480,8 +489,8 @@ public abstract class BaseSegmentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -497,8 +506,8 @@ public abstract class BaseSegmentResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<Segment>, UnsafeConsumer<Segment, Exception>,
-		 Exception> contextBatchUnsafeConsumer;
+		<Collection<Segment>, UnsafeConsumer<Segment, Exception>, Exception>
+			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -514,6 +523,115 @@ public abstract class BaseSegmentResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseSegmentResourceImpl.class);

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSegmentUserResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSegmentUserResourceImpl.java
@@ -14,20 +14,27 @@
 
 package com.liferay.headless.admin.user.internal.resource.v1_0;
 
+import com.liferay.headless.admin.user.dto.v1_0.Role;
 import com.liferay.headless.admin.user.dto.v1_0.SegmentUser;
 import com.liferay.headless.admin.user.resource.v1_0.SegmentUserResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +50,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -119,7 +133,7 @@ public abstract class BaseSegmentUserResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<SegmentUser> segmentUsers,
+			Collection<SegmentUser> segmentUsers,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -129,7 +143,7 @@ public abstract class BaseSegmentUserResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<SegmentUser> segmentUsers,
+			Collection<SegmentUser> segmentUsers,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -198,7 +212,7 @@ public abstract class BaseSegmentUserResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<SegmentUser> segmentUsers,
+			Collection<SegmentUser> segmentUsers,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -212,9 +226,8 @@ public abstract class BaseSegmentUserResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<SegmentUser>,
-			 UnsafeConsumer<SegmentUser, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<SegmentUser>, UnsafeConsumer<SegmentUser, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -391,8 +404,7 @@ public abstract class BaseSegmentUserResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -404,8 +416,8 @@ public abstract class BaseSegmentUserResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -418,8 +430,7 @@ public abstract class BaseSegmentUserResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -433,8 +444,8 @@ public abstract class BaseSegmentUserResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -450,9 +461,8 @@ public abstract class BaseSegmentUserResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<SegmentUser>,
-		 UnsafeConsumer<SegmentUser, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<SegmentUser>, UnsafeConsumer<SegmentUser, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -468,6 +478,115 @@ public abstract class BaseSegmentUserResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseSegmentUserResourceImpl.class);

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSiteResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSiteResourceImpl.java
@@ -14,20 +14,27 @@
 
 package com.liferay.headless.admin.user.internal.resource.v1_0;
 
+import com.liferay.headless.admin.user.dto.v1_0.Role;
 import com.liferay.headless.admin.user.dto.v1_0.Site;
 import com.liferay.headless.admin.user.resource.v1_0.SiteResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +50,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -168,8 +182,7 @@ public abstract class BaseSiteResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<Site> sites,
-			Map<String, Serializable> parameters)
+			Collection<Site> sites, Map<String, Serializable> parameters)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -178,8 +191,7 @@ public abstract class BaseSiteResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<Site> sites,
-			Map<String, Serializable> parameters)
+			Collection<Site> sites, Map<String, Serializable> parameters)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -247,8 +259,7 @@ public abstract class BaseSiteResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<Site> sites,
-			Map<String, Serializable> parameters)
+			Collection<Site> sites, Map<String, Serializable> parameters)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -261,8 +272,8 @@ public abstract class BaseSiteResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<Site>, UnsafeConsumer<Site, Exception>,
-			 Exception> contextBatchUnsafeConsumer) {
+			<Collection<Site>, UnsafeConsumer<Site, Exception>, Exception>
+				contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -439,8 +450,7 @@ public abstract class BaseSiteResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -452,8 +462,8 @@ public abstract class BaseSiteResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -466,8 +476,7 @@ public abstract class BaseSiteResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -481,8 +490,8 @@ public abstract class BaseSiteResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -498,7 +507,7 @@ public abstract class BaseSiteResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<Site>, UnsafeConsumer<Site, Exception>, Exception>
+		<Collection<Site>, UnsafeConsumer<Site, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
@@ -515,6 +524,115 @@ public abstract class BaseSiteResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseSiteResourceImpl.class);

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSubscriptionResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSubscriptionResourceImpl.java
@@ -14,20 +14,27 @@
 
 package com.liferay.headless.admin.user.internal.resource.v1_0;
 
+import com.liferay.headless.admin.user.dto.v1_0.Role;
 import com.liferay.headless.admin.user.dto.v1_0.Subscription;
 import com.liferay.headless.admin.user.resource.v1_0.SubscriptionResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +50,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -173,7 +187,7 @@ public abstract class BaseSubscriptionResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<Subscription> subscriptions,
+			Collection<Subscription> subscriptions,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -183,7 +197,7 @@ public abstract class BaseSubscriptionResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<Subscription> subscriptions,
+			Collection<Subscription> subscriptions,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -252,7 +266,7 @@ public abstract class BaseSubscriptionResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<Subscription> subscriptions,
+			Collection<Subscription> subscriptions,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -266,9 +280,8 @@ public abstract class BaseSubscriptionResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<Subscription>,
-			 UnsafeConsumer<Subscription, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<Subscription>, UnsafeConsumer<Subscription, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -445,8 +458,7 @@ public abstract class BaseSubscriptionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -458,8 +470,8 @@ public abstract class BaseSubscriptionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -472,8 +484,7 @@ public abstract class BaseSubscriptionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -487,8 +498,8 @@ public abstract class BaseSubscriptionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -504,9 +515,8 @@ public abstract class BaseSubscriptionResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<Subscription>,
-		 UnsafeConsumer<Subscription, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<Subscription>, UnsafeConsumer<Subscription, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -522,6 +532,115 @@ public abstract class BaseSubscriptionResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseSubscriptionResourceImpl.class);

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseUserAccountResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseUserAccountResourceImpl.java
@@ -14,20 +14,27 @@
 
 package com.liferay.headless.admin.user.internal.resource.v1_0;
 
+import com.liferay.headless.admin.user.dto.v1_0.Role;
 import com.liferay.headless.admin.user.dto.v1_0.UserAccount;
 import com.liferay.headless.admin.user.resource.v1_0.UserAccountResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +50,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -1385,7 +1399,7 @@ public abstract class BaseUserAccountResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<UserAccount> userAccounts,
+			Collection<UserAccount> userAccounts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -1431,7 +1445,7 @@ public abstract class BaseUserAccountResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<UserAccount> userAccounts,
+			Collection<UserAccount> userAccounts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -1517,7 +1531,7 @@ public abstract class BaseUserAccountResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<UserAccount> userAccounts,
+			Collection<UserAccount> userAccounts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -1563,9 +1577,8 @@ public abstract class BaseUserAccountResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<UserAccount>,
-			 UnsafeConsumer<UserAccount, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<UserAccount>, UnsafeConsumer<UserAccount, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -1746,8 +1759,7 @@ public abstract class BaseUserAccountResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -1759,8 +1771,8 @@ public abstract class BaseUserAccountResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -1773,8 +1785,7 @@ public abstract class BaseUserAccountResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -1788,8 +1799,8 @@ public abstract class BaseUserAccountResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -1805,9 +1816,8 @@ public abstract class BaseUserAccountResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<UserAccount>,
-		 UnsafeConsumer<UserAccount, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<UserAccount>, UnsafeConsumer<UserAccount, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -1823,6 +1833,115 @@ public abstract class BaseUserAccountResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseUserAccountResourceImpl.class);

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseUserGroupResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseUserGroupResourceImpl.java
@@ -14,20 +14,27 @@
 
 package com.liferay.headless.admin.user.internal.resource.v1_0;
 
+import com.liferay.headless.admin.user.dto.v1_0.Role;
 import com.liferay.headless.admin.user.dto.v1_0.UserGroup;
 import com.liferay.headless.admin.user.resource.v1_0.UserGroupResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +50,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -673,7 +687,7 @@ public abstract class BaseUserGroupResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<UserGroup> userGroups,
+			Collection<UserGroup> userGroups,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -711,7 +725,7 @@ public abstract class BaseUserGroupResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<UserGroup> userGroups,
+			Collection<UserGroup> userGroups,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -780,7 +794,7 @@ public abstract class BaseUserGroupResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<UserGroup> userGroups,
+			Collection<UserGroup> userGroups,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -826,9 +840,8 @@ public abstract class BaseUserGroupResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<UserGroup>,
-			 UnsafeConsumer<UserGroup, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<UserGroup>, UnsafeConsumer<UserGroup, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -1009,8 +1022,7 @@ public abstract class BaseUserGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -1022,8 +1034,8 @@ public abstract class BaseUserGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -1036,8 +1048,7 @@ public abstract class BaseUserGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -1051,8 +1062,8 @@ public abstract class BaseUserGroupResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -1068,8 +1079,8 @@ public abstract class BaseUserGroupResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<UserGroup>, UnsafeConsumer<UserGroup, Exception>,
-		 Exception> contextBatchUnsafeConsumer;
+		<Collection<UserGroup>, UnsafeConsumer<UserGroup, Exception>, Exception>
+			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -1085,6 +1096,115 @@ public abstract class BaseUserGroupResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseUserGroupResourceImpl.class);

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseWebUrlResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseWebUrlResourceImpl.java
@@ -14,20 +14,27 @@
 
 package com.liferay.headless.admin.user.internal.resource.v1_0;
 
+import com.liferay.headless.admin.user.dto.v1_0.Role;
 import com.liferay.headless.admin.user.dto.v1_0.WebUrl;
 import com.liferay.headless.admin.user.resource.v1_0.WebUrlResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +50,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -177,8 +191,7 @@ public abstract class BaseWebUrlResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<WebUrl> webUrls,
-			Map<String, Serializable> parameters)
+			Collection<WebUrl> webUrls, Map<String, Serializable> parameters)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -187,8 +200,7 @@ public abstract class BaseWebUrlResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<WebUrl> webUrls,
-			Map<String, Serializable> parameters)
+			Collection<WebUrl> webUrls, Map<String, Serializable> parameters)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -266,8 +278,7 @@ public abstract class BaseWebUrlResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<WebUrl> webUrls,
-			Map<String, Serializable> parameters)
+			Collection<WebUrl> webUrls, Map<String, Serializable> parameters)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -280,8 +291,8 @@ public abstract class BaseWebUrlResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<WebUrl>, UnsafeConsumer<WebUrl, Exception>,
-			 Exception> contextBatchUnsafeConsumer) {
+			<Collection<WebUrl>, UnsafeConsumer<WebUrl, Exception>, Exception>
+				contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -458,8 +469,7 @@ public abstract class BaseWebUrlResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -471,8 +481,8 @@ public abstract class BaseWebUrlResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -485,8 +495,7 @@ public abstract class BaseWebUrlResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -500,8 +509,8 @@ public abstract class BaseWebUrlResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -517,8 +526,8 @@ public abstract class BaseWebUrlResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<WebUrl>, UnsafeConsumer<WebUrl, Exception>,
-		 Exception> contextBatchUnsafeConsumer;
+		<Collection<WebUrl>, UnsafeConsumer<WebUrl, Exception>, Exception>
+			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -534,6 +543,115 @@ public abstract class BaseWebUrlResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseWebUrlResourceImpl.class);

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -116,8 +116,6 @@ public class OpenAPIResourceImpl {
 
 			add(SubscriptionResourceImpl.class);
 
-			add(TicketResourceImpl.class);
-
 			add(UserAccountResourceImpl.class);
 
 			add(UserGroupResourceImpl.class);

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/BaseAssigneeResourceImpl.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/BaseAssigneeResourceImpl.java
@@ -15,19 +15,26 @@
 package com.liferay.headless.admin.workflow.internal.resource.v1_0;
 
 import com.liferay.headless.admin.workflow.dto.v1_0.Assignee;
+import com.liferay.headless.admin.workflow.dto.v1_0.Role;
 import com.liferay.headless.admin.workflow.resource.v1_0.AssigneeResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +50,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -116,7 +130,7 @@ public abstract class BaseAssigneeResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<Assignee> assignees,
+			Collection<Assignee> assignees,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -126,7 +140,7 @@ public abstract class BaseAssigneeResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<Assignee> assignees,
+			Collection<Assignee> assignees,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -195,7 +209,7 @@ public abstract class BaseAssigneeResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<Assignee> assignees,
+			Collection<Assignee> assignees,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -209,9 +223,8 @@ public abstract class BaseAssigneeResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<Assignee>,
-			 UnsafeConsumer<Assignee, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<Assignee>, UnsafeConsumer<Assignee, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -388,8 +401,7 @@ public abstract class BaseAssigneeResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -401,8 +413,8 @@ public abstract class BaseAssigneeResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -415,8 +427,7 @@ public abstract class BaseAssigneeResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -430,8 +441,8 @@ public abstract class BaseAssigneeResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -447,8 +458,8 @@ public abstract class BaseAssigneeResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<Assignee>, UnsafeConsumer<Assignee, Exception>,
-		 Exception> contextBatchUnsafeConsumer;
+		<Collection<Assignee>, UnsafeConsumer<Assignee, Exception>, Exception>
+			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -464,6 +475,115 @@ public abstract class BaseAssigneeResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseAssigneeResourceImpl.class);

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/BaseTransitionResourceImpl.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/BaseTransitionResourceImpl.java
@@ -14,20 +14,27 @@
 
 package com.liferay.headless.admin.workflow.internal.resource.v1_0;
 
+import com.liferay.headless.admin.workflow.dto.v1_0.Role;
 import com.liferay.headless.admin.workflow.dto.v1_0.Transition;
 import com.liferay.headless.admin.workflow.resource.v1_0.TransitionResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +50,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -157,7 +171,7 @@ public abstract class BaseTransitionResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<Transition> transitions,
+			Collection<Transition> transitions,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -167,7 +181,7 @@ public abstract class BaseTransitionResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<Transition> transitions,
+			Collection<Transition> transitions,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -236,7 +250,7 @@ public abstract class BaseTransitionResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<Transition> transitions,
+			Collection<Transition> transitions,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -250,9 +264,8 @@ public abstract class BaseTransitionResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<Transition>,
-			 UnsafeConsumer<Transition, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<Transition>, UnsafeConsumer<Transition, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -429,8 +442,7 @@ public abstract class BaseTransitionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -442,8 +454,8 @@ public abstract class BaseTransitionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -456,8 +468,7 @@ public abstract class BaseTransitionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -471,8 +482,8 @@ public abstract class BaseTransitionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -488,9 +499,8 @@ public abstract class BaseTransitionResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<Transition>,
-		 UnsafeConsumer<Transition, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<Transition>, UnsafeConsumer<Transition, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -506,6 +516,115 @@ public abstract class BaseTransitionResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseTransitionResourceImpl.class);

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/BaseWorkflowDefinitionResourceImpl.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/BaseWorkflowDefinitionResourceImpl.java
@@ -14,20 +14,27 @@
 
 package com.liferay.headless.admin.workflow.internal.resource.v1_0;
 
+import com.liferay.headless.admin.workflow.dto.v1_0.Role;
 import com.liferay.headless.admin.workflow.dto.v1_0.WorkflowDefinition;
 import com.liferay.headless.admin.workflow.resource.v1_0.WorkflowDefinitionResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +50,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -549,7 +563,7 @@ public abstract class BaseWorkflowDefinitionResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<WorkflowDefinition> workflowDefinitions,
+			Collection<WorkflowDefinition> workflowDefinitions,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -584,7 +598,7 @@ public abstract class BaseWorkflowDefinitionResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<WorkflowDefinition> workflowDefinitions,
+			Collection<WorkflowDefinition> workflowDefinitions,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -655,7 +669,7 @@ public abstract class BaseWorkflowDefinitionResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<WorkflowDefinition> workflowDefinitions,
+			Collection<WorkflowDefinition> workflowDefinitions,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -698,7 +712,7 @@ public abstract class BaseWorkflowDefinitionResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<WorkflowDefinition>,
+			<Collection<WorkflowDefinition>,
 			 UnsafeConsumer<WorkflowDefinition, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -877,8 +891,7 @@ public abstract class BaseWorkflowDefinitionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -890,8 +903,8 @@ public abstract class BaseWorkflowDefinitionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -904,8 +917,7 @@ public abstract class BaseWorkflowDefinitionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -919,8 +931,8 @@ public abstract class BaseWorkflowDefinitionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -936,7 +948,7 @@ public abstract class BaseWorkflowDefinitionResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<WorkflowDefinition>,
+		<Collection<WorkflowDefinition>,
 		 UnsafeConsumer<WorkflowDefinition, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -954,6 +966,115 @@ public abstract class BaseWorkflowDefinitionResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseWorkflowDefinitionResourceImpl.class);

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/BaseWorkflowInstanceResourceImpl.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/BaseWorkflowInstanceResourceImpl.java
@@ -15,21 +15,28 @@
 package com.liferay.headless.admin.workflow.internal.resource.v1_0;
 
 import com.liferay.headless.admin.workflow.dto.v1_0.ChangeTransition;
+import com.liferay.headless.admin.workflow.dto.v1_0.Role;
 import com.liferay.headless.admin.workflow.dto.v1_0.WorkflowInstance;
 import com.liferay.headless.admin.workflow.dto.v1_0.WorkflowInstanceSubmit;
 import com.liferay.headless.admin.workflow.resource.v1_0.WorkflowInstanceResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -45,13 +52,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -301,7 +315,7 @@ public abstract class BaseWorkflowInstanceResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<WorkflowInstance> workflowInstances,
+			Collection<WorkflowInstance> workflowInstances,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -311,7 +325,7 @@ public abstract class BaseWorkflowInstanceResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<WorkflowInstance> workflowInstances,
+			Collection<WorkflowInstance> workflowInstances,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -384,7 +398,7 @@ public abstract class BaseWorkflowInstanceResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<WorkflowInstance> workflowInstances,
+			Collection<WorkflowInstance> workflowInstances,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -398,7 +412,7 @@ public abstract class BaseWorkflowInstanceResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<WorkflowInstance>,
+			<Collection<WorkflowInstance>,
 			 UnsafeConsumer<WorkflowInstance, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -577,8 +591,7 @@ public abstract class BaseWorkflowInstanceResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -590,8 +603,8 @@ public abstract class BaseWorkflowInstanceResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -604,8 +617,7 @@ public abstract class BaseWorkflowInstanceResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -619,8 +631,8 @@ public abstract class BaseWorkflowInstanceResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -636,7 +648,7 @@ public abstract class BaseWorkflowInstanceResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<WorkflowInstance>,
+		<Collection<WorkflowInstance>,
 		 UnsafeConsumer<WorkflowInstance, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -654,6 +666,115 @@ public abstract class BaseWorkflowInstanceResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseWorkflowInstanceResourceImpl.class);

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/BaseWorkflowLogResourceImpl.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/BaseWorkflowLogResourceImpl.java
@@ -14,20 +14,27 @@
 
 package com.liferay.headless.admin.workflow.internal.resource.v1_0;
 
+import com.liferay.headless.admin.workflow.dto.v1_0.Role;
 import com.liferay.headless.admin.workflow.dto.v1_0.WorkflowLog;
 import com.liferay.headless.admin.workflow.resource.v1_0.WorkflowLogResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +50,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -201,7 +215,7 @@ public abstract class BaseWorkflowLogResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<WorkflowLog> workflowLogs,
+			Collection<WorkflowLog> workflowLogs,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -211,7 +225,7 @@ public abstract class BaseWorkflowLogResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<WorkflowLog> workflowLogs,
+			Collection<WorkflowLog> workflowLogs,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -292,7 +306,7 @@ public abstract class BaseWorkflowLogResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<WorkflowLog> workflowLogs,
+			Collection<WorkflowLog> workflowLogs,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -306,9 +320,8 @@ public abstract class BaseWorkflowLogResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<WorkflowLog>,
-			 UnsafeConsumer<WorkflowLog, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<WorkflowLog>, UnsafeConsumer<WorkflowLog, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -485,8 +498,7 @@ public abstract class BaseWorkflowLogResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -498,8 +510,8 @@ public abstract class BaseWorkflowLogResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -512,8 +524,7 @@ public abstract class BaseWorkflowLogResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -527,8 +538,8 @@ public abstract class BaseWorkflowLogResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -544,9 +555,8 @@ public abstract class BaseWorkflowLogResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<WorkflowLog>,
-		 UnsafeConsumer<WorkflowLog, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<WorkflowLog>, UnsafeConsumer<WorkflowLog, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -562,6 +572,115 @@ public abstract class BaseWorkflowLogResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseWorkflowLogResourceImpl.class);

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/BaseWorkflowTaskAssignableUsersResourceImpl.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/BaseWorkflowTaskAssignableUsersResourceImpl.java
@@ -14,27 +14,43 @@
 
 package com.liferay.headless.admin.workflow.internal.resource.v1_0;
 
+import com.liferay.headless.admin.workflow.dto.v1_0.Role;
 import com.liferay.headless.admin.workflow.dto.v1_0.WorkflowTaskAssignableUsers;
 import com.liferay.headless.admin.workflow.dto.v1_0.WorkflowTaskIds;
 import com.liferay.headless.admin.workflow.resource.v1_0.WorkflowTaskAssignableUsersResource;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -179,8 +195,7 @@ public abstract class BaseWorkflowTaskAssignableUsersResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -192,8 +207,8 @@ public abstract class BaseWorkflowTaskAssignableUsersResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -206,8 +221,7 @@ public abstract class BaseWorkflowTaskAssignableUsersResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -221,8 +235,8 @@ public abstract class BaseWorkflowTaskAssignableUsersResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -250,6 +264,115 @@ public abstract class BaseWorkflowTaskAssignableUsersResourceImpl
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/BaseWorkflowTaskResourceImpl.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/BaseWorkflowTaskResourceImpl.java
@@ -15,6 +15,7 @@
 package com.liferay.headless.admin.workflow.internal.resource.v1_0;
 
 import com.liferay.headless.admin.workflow.dto.v1_0.ChangeTransition;
+import com.liferay.headless.admin.workflow.dto.v1_0.Role;
 import com.liferay.headless.admin.workflow.dto.v1_0.WorkflowTask;
 import com.liferay.headless.admin.workflow.dto.v1_0.WorkflowTaskAssignToMe;
 import com.liferay.headless.admin.workflow.dto.v1_0.WorkflowTaskAssignToRole;
@@ -24,15 +25,21 @@ import com.liferay.headless.admin.workflow.resource.v1_0.WorkflowTaskResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -48,13 +55,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -761,7 +775,7 @@ public abstract class BaseWorkflowTaskResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<WorkflowTask> workflowTasks,
+			Collection<WorkflowTask> workflowTasks,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -771,7 +785,7 @@ public abstract class BaseWorkflowTaskResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<WorkflowTask> workflowTasks,
+			Collection<WorkflowTask> workflowTasks,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -848,7 +862,7 @@ public abstract class BaseWorkflowTaskResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<WorkflowTask> workflowTasks,
+			Collection<WorkflowTask> workflowTasks,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -862,9 +876,8 @@ public abstract class BaseWorkflowTaskResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<WorkflowTask>,
-			 UnsafeConsumer<WorkflowTask, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<WorkflowTask>, UnsafeConsumer<WorkflowTask, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -1041,8 +1054,7 @@ public abstract class BaseWorkflowTaskResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -1054,8 +1066,8 @@ public abstract class BaseWorkflowTaskResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -1068,8 +1080,7 @@ public abstract class BaseWorkflowTaskResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -1083,8 +1094,8 @@ public abstract class BaseWorkflowTaskResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -1100,9 +1111,8 @@ public abstract class BaseWorkflowTaskResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<WorkflowTask>,
-		 UnsafeConsumer<WorkflowTask, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<WorkflowTask>, UnsafeConsumer<WorkflowTask, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -1118,6 +1128,115 @@ public abstract class BaseWorkflowTaskResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseWorkflowTaskResourceImpl.class);

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/BaseWorkflowTaskTransitionsResourceImpl.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/BaseWorkflowTaskTransitionsResourceImpl.java
@@ -14,27 +14,43 @@
 
 package com.liferay.headless.admin.workflow.internal.resource.v1_0;
 
+import com.liferay.headless.admin.workflow.dto.v1_0.Role;
 import com.liferay.headless.admin.workflow.dto.v1_0.WorkflowTaskIds;
 import com.liferay.headless.admin.workflow.dto.v1_0.WorkflowTaskTransitions;
 import com.liferay.headless.admin.workflow.resource.v1_0.WorkflowTaskTransitionsResource;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -179,8 +195,7 @@ public abstract class BaseWorkflowTaskTransitionsResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -192,8 +207,8 @@ public abstract class BaseWorkflowTaskTransitionsResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -206,8 +221,7 @@ public abstract class BaseWorkflowTaskTransitionsResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -221,8 +235,8 @@ public abstract class BaseWorkflowTaskTransitionsResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -250,6 +264,115 @@ public abstract class BaseWorkflowTaskTransitionsResourceImpl
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseWorkflowTaskTransitionsResourceImpl.class);

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/src/main/java/com/liferay/headless/batch/engine/internal/resource/v1_0/BaseExportTaskResourceImpl.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/src/main/java/com/liferay/headless/batch/engine/internal/resource/v1_0/BaseExportTaskResourceImpl.java
@@ -17,23 +17,38 @@ package com.liferay.headless.batch.engine.internal.resource.v1_0;
 import com.liferay.headless.batch.engine.dto.v1_0.ExportTask;
 import com.liferay.headless.batch.engine.resource.v1_0.ExportTaskResource;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -363,8 +378,7 @@ public abstract class BaseExportTaskResourceImpl implements ExportTaskResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -376,8 +390,8 @@ public abstract class BaseExportTaskResourceImpl implements ExportTaskResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -390,8 +404,7 @@ public abstract class BaseExportTaskResourceImpl implements ExportTaskResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -405,8 +418,8 @@ public abstract class BaseExportTaskResourceImpl implements ExportTaskResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -434,6 +447,115 @@ public abstract class BaseExportTaskResourceImpl implements ExportTaskResource {
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseExportTaskResourceImpl.class);

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/src/main/java/com/liferay/headless/batch/engine/internal/resource/v1_0/BaseImportTaskResourceImpl.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/src/main/java/com/liferay/headless/batch/engine/internal/resource/v1_0/BaseImportTaskResourceImpl.java
@@ -17,24 +17,39 @@ package com.liferay.headless.batch.engine.internal.resource.v1_0;
 import com.liferay.headless.batch.engine.dto.v1_0.ImportTask;
 import com.liferay.headless.batch.engine.resource.v1_0.ImportTaskResource;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.multipart.MultipartBody;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -796,8 +811,7 @@ public abstract class BaseImportTaskResourceImpl implements ImportTaskResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -809,8 +823,8 @@ public abstract class BaseImportTaskResourceImpl implements ImportTaskResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -823,8 +837,7 @@ public abstract class BaseImportTaskResourceImpl implements ImportTaskResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -838,8 +851,8 @@ public abstract class BaseImportTaskResourceImpl implements ImportTaskResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -867,6 +880,115 @@ public abstract class BaseImportTaskResourceImpl implements ImportTaskResource {
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseImportTaskResourceImpl.class);

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingImageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingImageResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.delivery.resource.v1_0.BlogPostingImageResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -44,13 +50,20 @@ import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTa
 import com.liferay.portal.vulcan.multipart.MultipartBody;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -377,7 +390,7 @@ public abstract class BaseBlogPostingImageResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<BlogPostingImage> blogPostingImages,
+			Collection<BlogPostingImage> blogPostingImages,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -419,7 +432,7 @@ public abstract class BaseBlogPostingImageResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<BlogPostingImage> blogPostingImages,
+			Collection<BlogPostingImage> blogPostingImages,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -496,7 +509,7 @@ public abstract class BaseBlogPostingImageResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<BlogPostingImage> blogPostingImages,
+			Collection<BlogPostingImage> blogPostingImages,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -510,7 +523,7 @@ public abstract class BaseBlogPostingImageResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<BlogPostingImage>,
+			<Collection<BlogPostingImage>,
 			 UnsafeConsumer<BlogPostingImage, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -689,8 +702,7 @@ public abstract class BaseBlogPostingImageResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -702,8 +714,8 @@ public abstract class BaseBlogPostingImageResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -716,8 +728,7 @@ public abstract class BaseBlogPostingImageResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -731,8 +742,8 @@ public abstract class BaseBlogPostingImageResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -748,7 +759,7 @@ public abstract class BaseBlogPostingImageResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<BlogPostingImage>,
+		<Collection<BlogPostingImage>,
 		 UnsafeConsumer<BlogPostingImage, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -766,6 +777,115 @@ public abstract class BaseBlogPostingImageResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseBlogPostingImageResourceImpl.class);

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingResourceImpl.java
@@ -21,17 +21,22 @@ import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -51,6 +56,7 @@ import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTa
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.permission.ModelPermissionsUtil;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.permission.PermissionUtil;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
@@ -58,7 +64,13 @@ import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -572,15 +584,14 @@ public abstract class BaseBlogPostingResourceImpl
 	@javax.ws.rs.Path("/blog-postings/{blogPostingId}/permissions")
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			getBlogPostingPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("blogPostingId")
-				Long blogPostingId,
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.ws.rs.QueryParam("roleNames")
-				String roleNames)
+	public Page<Permission> getBlogPostingPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("blogPostingId")
+			Long blogPostingId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("roleNames")
+			String roleNames)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(blogPostingId);
@@ -625,13 +636,12 @@ public abstract class BaseBlogPostingResourceImpl
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@javax.ws.rs.PUT
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putBlogPostingPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("blogPostingId")
-				Long blogPostingId,
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<Permission> putBlogPostingPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("blogPostingId")
+			Long blogPostingId,
+			Permission[] permissions)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(blogPostingId);
@@ -1061,15 +1071,14 @@ public abstract class BaseBlogPostingResourceImpl
 	@javax.ws.rs.Path("/sites/{siteId}/blog-postings/permissions")
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			getSiteBlogPostingPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("siteId")
-				Long siteId,
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.ws.rs.QueryParam("roleNames")
-				String roleNames)
+	public Page<Permission> getSiteBlogPostingPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("siteId")
+			Long siteId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("roleNames")
+			String roleNames)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(siteId);
@@ -1113,13 +1122,12 @@ public abstract class BaseBlogPostingResourceImpl
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@javax.ws.rs.PUT
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putSiteBlogPostingPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("siteId")
-				Long siteId,
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<Permission> putSiteBlogPostingPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("siteId")
+			Long siteId,
+			Permission[] permissions)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(siteId);
@@ -1210,7 +1218,7 @@ public abstract class BaseBlogPostingResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<BlogPosting> blogPostings,
+			Collection<BlogPosting> blogPostings,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -1257,7 +1265,7 @@ public abstract class BaseBlogPostingResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<BlogPosting> blogPostings,
+			Collection<BlogPosting> blogPostings,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -1334,7 +1342,7 @@ public abstract class BaseBlogPostingResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<BlogPosting> blogPostings,
+			Collection<BlogPosting> blogPostings,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -1403,10 +1411,9 @@ public abstract class BaseBlogPostingResourceImpl
 			"This method needs to be implemented");
 	}
 
-	protected Page<com.liferay.portal.vulcan.permission.Permission>
-			toPermissionPage(
-				Map<String, Map<String, String>> actions, long id,
-				String resourceName, String roleNames)
+	protected Page<Permission> toPermissionPage(
+			Map<String, Map<String, String>> actions, long id,
+			String resourceName, String roleNames)
 		throws Exception {
 
 		List<ResourceAction> resourceActions =
@@ -1415,24 +1422,16 @@ public abstract class BaseBlogPostingResourceImpl
 		if (Validator.isNotNull(roleNames)) {
 			return Page.of(
 				actions,
-				transform(
-					PermissionUtil.getRoles(
-						contextCompany, roleLocalService,
-						StringUtil.split(roleNames)),
-					role -> PermissionUtil.toPermission(
-						contextCompany.getCompanyId(), id, resourceActions,
-						resourceName, resourcePermissionLocalService, role)));
+				_getPermissions(
+					contextCompany.getCompanyId(), resourceActions, id,
+					resourceName, StringUtil.split(roleNames)));
 		}
 
 		return Page.of(
 			actions,
-			transform(
-				PermissionUtil.getResourcePermissions(
-					contextCompany.getCompanyId(), id, resourceName,
-					resourcePermissionLocalService),
-				resourcePermission -> PermissionUtil.toPermission(
-					resourceActions, resourcePermission,
-					roleLocalService.getRole(resourcePermission.getRoleId()))));
+			_getPermissions(
+				contextCompany.getCompanyId(), resourceActions, id,
+				resourceName, null));
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
@@ -1441,9 +1440,8 @@ public abstract class BaseBlogPostingResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<BlogPosting>,
-			 UnsafeConsumer<BlogPosting, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<BlogPosting>, UnsafeConsumer<BlogPosting, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -1624,8 +1622,7 @@ public abstract class BaseBlogPostingResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -1637,8 +1634,8 @@ public abstract class BaseBlogPostingResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -1651,8 +1648,7 @@ public abstract class BaseBlogPostingResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -1666,8 +1662,8 @@ public abstract class BaseBlogPostingResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -1683,9 +1679,8 @@ public abstract class BaseBlogPostingResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<BlogPosting>,
-		 UnsafeConsumer<BlogPosting, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<BlogPosting>, UnsafeConsumer<BlogPosting, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -1701,6 +1696,115 @@ public abstract class BaseBlogPostingResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseBlogPostingResourceImpl.class);

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseCommentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseCommentResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.delivery.resource.v1_0.CommentResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -1556,8 +1569,7 @@ public abstract class BaseCommentResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<Comment> comments,
-			Map<String, Serializable> parameters)
+			Collection<Comment> comments, Map<String, Serializable> parameters)
 		throws Exception {
 
 		UnsafeConsumer<Comment, Exception> commentUnsafeConsumer = null;
@@ -1606,8 +1618,7 @@ public abstract class BaseCommentResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<Comment> comments,
-			Map<String, Serializable> parameters)
+			Collection<Comment> comments, Map<String, Serializable> parameters)
 		throws Exception {
 
 		for (Comment comment : comments) {
@@ -1693,8 +1704,7 @@ public abstract class BaseCommentResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<Comment> comments,
-			Map<String, Serializable> parameters)
+			Collection<Comment> comments, Map<String, Serializable> parameters)
 		throws Exception {
 
 		UnsafeConsumer<Comment, Exception> commentUnsafeConsumer = null;
@@ -1731,8 +1741,8 @@ public abstract class BaseCommentResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<Comment>, UnsafeConsumer<Comment, Exception>,
-			 Exception> contextBatchUnsafeConsumer) {
+			<Collection<Comment>, UnsafeConsumer<Comment, Exception>, Exception>
+				contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -1909,8 +1919,7 @@ public abstract class BaseCommentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -1922,8 +1931,8 @@ public abstract class BaseCommentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -1936,8 +1945,7 @@ public abstract class BaseCommentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -1951,8 +1959,8 @@ public abstract class BaseCommentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -1968,8 +1976,8 @@ public abstract class BaseCommentResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<Comment>, UnsafeConsumer<Comment, Exception>,
-		 Exception> contextBatchUnsafeConsumer;
+		<Collection<Comment>, UnsafeConsumer<Comment, Exception>, Exception>
+			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -1985,6 +1993,115 @@ public abstract class BaseCommentResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseCommentResourceImpl.class);

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentElementResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentElementResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.delivery.resource.v1_0.ContentElementResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -222,7 +235,7 @@ public abstract class BaseContentElementResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<ContentElement> contentElements,
+			Collection<ContentElement> contentElements,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -232,7 +245,7 @@ public abstract class BaseContentElementResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<ContentElement> contentElements,
+			Collection<ContentElement> contentElements,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -313,7 +326,7 @@ public abstract class BaseContentElementResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<ContentElement> contentElements,
+			Collection<ContentElement> contentElements,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -327,7 +340,7 @@ public abstract class BaseContentElementResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<ContentElement>,
+			<Collection<ContentElement>,
 			 UnsafeConsumer<ContentElement, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -506,8 +519,7 @@ public abstract class BaseContentElementResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -519,8 +531,8 @@ public abstract class BaseContentElementResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -533,8 +545,7 @@ public abstract class BaseContentElementResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -548,8 +559,8 @@ public abstract class BaseContentElementResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -565,9 +576,8 @@ public abstract class BaseContentElementResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<ContentElement>,
-		 UnsafeConsumer<ContentElement, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<ContentElement>, UnsafeConsumer<ContentElement, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -583,6 +593,115 @@ public abstract class BaseContentElementResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseContentElementResourceImpl.class);

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentSetElementResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentSetElementResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.delivery.resource.v1_0.ContentSetElementResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -373,7 +386,7 @@ public abstract class BaseContentSetElementResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<ContentSetElement> contentSetElements,
+			Collection<ContentSetElement> contentSetElements,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -383,7 +396,7 @@ public abstract class BaseContentSetElementResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<ContentSetElement> contentSetElements,
+			Collection<ContentSetElement> contentSetElements,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -452,7 +465,7 @@ public abstract class BaseContentSetElementResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<ContentSetElement> contentSetElements,
+			Collection<ContentSetElement> contentSetElements,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -466,7 +479,7 @@ public abstract class BaseContentSetElementResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<ContentSetElement>,
+			<Collection<ContentSetElement>,
 			 UnsafeConsumer<ContentSetElement, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -645,8 +658,7 @@ public abstract class BaseContentSetElementResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -658,8 +670,8 @@ public abstract class BaseContentSetElementResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -672,8 +684,7 @@ public abstract class BaseContentSetElementResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -687,8 +698,8 @@ public abstract class BaseContentSetElementResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -704,7 +715,7 @@ public abstract class BaseContentSetElementResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<ContentSetElement>,
+		<Collection<ContentSetElement>,
 		 UnsafeConsumer<ContentSetElement, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -722,6 +733,115 @@ public abstract class BaseContentSetElementResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseContentSetElementResourceImpl.class);

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentStructureResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentStructureResourceImpl.java
@@ -19,17 +19,22 @@ import com.liferay.headless.delivery.resource.v1_0.ContentStructureResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -49,6 +54,7 @@ import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTa
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.permission.ModelPermissionsUtil;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.permission.PermissionUtil;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
@@ -56,7 +62,13 @@ import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -198,15 +210,14 @@ public abstract class BaseContentStructureResourceImpl
 	)
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			getAssetLibraryContentStructurePermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("assetLibraryId")
-				Long assetLibraryId,
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.ws.rs.QueryParam("roleNames")
-				String roleNames)
+	public Page<Permission> getAssetLibraryContentStructurePermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("assetLibraryId")
+			Long assetLibraryId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("roleNames")
+			String roleNames)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(assetLibraryId);
@@ -256,13 +267,12 @@ public abstract class BaseContentStructureResourceImpl
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@javax.ws.rs.PUT
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putAssetLibraryContentStructurePermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("assetLibraryId")
-				Long assetLibraryId,
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<Permission> putAssetLibraryContentStructurePermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("assetLibraryId")
+			Long assetLibraryId,
+			Permission[] permissions)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(assetLibraryId);
@@ -381,15 +391,14 @@ public abstract class BaseContentStructureResourceImpl
 	@javax.ws.rs.Path("/content-structures/{contentStructureId}/permissions")
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			getContentStructurePermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("contentStructureId")
-				Long contentStructureId,
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.ws.rs.QueryParam("roleNames")
-				String roleNames)
+	public Page<Permission> getContentStructurePermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("contentStructureId")
+			Long contentStructureId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("roleNames")
+			String roleNames)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(
@@ -439,13 +448,12 @@ public abstract class BaseContentStructureResourceImpl
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@javax.ws.rs.PUT
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putContentStructurePermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("contentStructureId")
-				Long contentStructureId,
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<Permission> putContentStructurePermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("contentStructureId")
+			Long contentStructureId,
+			Permission[] permissions)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(
@@ -599,15 +607,14 @@ public abstract class BaseContentStructureResourceImpl
 	@javax.ws.rs.Path("/sites/{siteId}/content-structures/permissions")
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			getSiteContentStructurePermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("siteId")
-				Long siteId,
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.ws.rs.QueryParam("roleNames")
-				String roleNames)
+	public Page<Permission> getSiteContentStructurePermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("siteId")
+			Long siteId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("roleNames")
+			String roleNames)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(siteId);
@@ -655,13 +662,12 @@ public abstract class BaseContentStructureResourceImpl
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@javax.ws.rs.PUT
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putSiteContentStructurePermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("siteId")
-				Long siteId,
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<Permission> putSiteContentStructurePermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("siteId")
+			Long siteId,
+			Permission[] permissions)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(siteId);
@@ -698,7 +704,7 @@ public abstract class BaseContentStructureResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<ContentStructure> contentStructures,
+			Collection<ContentStructure> contentStructures,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -708,7 +714,7 @@ public abstract class BaseContentStructureResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<ContentStructure> contentStructures,
+			Collection<ContentStructure> contentStructures,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -789,7 +795,7 @@ public abstract class BaseContentStructureResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<ContentStructure> contentStructures,
+			Collection<ContentStructure> contentStructures,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -826,10 +832,9 @@ public abstract class BaseContentStructureResourceImpl
 			"This method needs to be implemented");
 	}
 
-	protected Page<com.liferay.portal.vulcan.permission.Permission>
-			toPermissionPage(
-				Map<String, Map<String, String>> actions, long id,
-				String resourceName, String roleNames)
+	protected Page<Permission> toPermissionPage(
+			Map<String, Map<String, String>> actions, long id,
+			String resourceName, String roleNames)
 		throws Exception {
 
 		List<ResourceAction> resourceActions =
@@ -838,24 +843,16 @@ public abstract class BaseContentStructureResourceImpl
 		if (Validator.isNotNull(roleNames)) {
 			return Page.of(
 				actions,
-				transform(
-					PermissionUtil.getRoles(
-						contextCompany, roleLocalService,
-						StringUtil.split(roleNames)),
-					role -> PermissionUtil.toPermission(
-						contextCompany.getCompanyId(), id, resourceActions,
-						resourceName, resourcePermissionLocalService, role)));
+				_getPermissions(
+					contextCompany.getCompanyId(), resourceActions, id,
+					resourceName, StringUtil.split(roleNames)));
 		}
 
 		return Page.of(
 			actions,
-			transform(
-				PermissionUtil.getResourcePermissions(
-					contextCompany.getCompanyId(), id, resourceName,
-					resourcePermissionLocalService),
-				resourcePermission -> PermissionUtil.toPermission(
-					resourceActions, resourcePermission,
-					roleLocalService.getRole(resourcePermission.getRoleId()))));
+			_getPermissions(
+				contextCompany.getCompanyId(), resourceActions, id,
+				resourceName, null));
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
@@ -864,7 +861,7 @@ public abstract class BaseContentStructureResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<ContentStructure>,
+			<Collection<ContentStructure>,
 			 UnsafeConsumer<ContentStructure, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -1043,8 +1040,7 @@ public abstract class BaseContentStructureResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -1056,8 +1052,8 @@ public abstract class BaseContentStructureResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -1070,8 +1066,7 @@ public abstract class BaseContentStructureResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -1085,8 +1080,8 @@ public abstract class BaseContentStructureResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -1102,7 +1097,7 @@ public abstract class BaseContentStructureResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<ContentStructure>,
+		<Collection<ContentStructure>,
 		 UnsafeConsumer<ContentStructure, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -1120,6 +1115,115 @@ public abstract class BaseContentStructureResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseContentStructureResourceImpl.class);

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentTemplateResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentTemplateResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.delivery.resource.v1_0.ContentTemplateResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -286,7 +299,7 @@ public abstract class BaseContentTemplateResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<ContentTemplate> contentTemplates,
+			Collection<ContentTemplate> contentTemplates,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -296,7 +309,7 @@ public abstract class BaseContentTemplateResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<ContentTemplate> contentTemplates,
+			Collection<ContentTemplate> contentTemplates,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -377,7 +390,7 @@ public abstract class BaseContentTemplateResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<ContentTemplate> contentTemplates,
+			Collection<ContentTemplate> contentTemplates,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -391,7 +404,7 @@ public abstract class BaseContentTemplateResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<ContentTemplate>,
+			<Collection<ContentTemplate>,
 			 UnsafeConsumer<ContentTemplate, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -570,8 +583,7 @@ public abstract class BaseContentTemplateResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -583,8 +595,8 @@ public abstract class BaseContentTemplateResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -597,8 +609,7 @@ public abstract class BaseContentTemplateResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -612,8 +623,8 @@ public abstract class BaseContentTemplateResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -629,7 +640,7 @@ public abstract class BaseContentTemplateResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<ContentTemplate>,
+		<Collection<ContentTemplate>,
 		 UnsafeConsumer<ContentTemplate, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -647,6 +658,115 @@ public abstract class BaseContentTemplateResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseContentTemplateResourceImpl.class);

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentFolderResourceImpl.java
@@ -19,17 +19,22 @@ import com.liferay.headless.delivery.resource.v1_0.DocumentFolderResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -49,6 +54,7 @@ import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTa
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.permission.ModelPermissionsUtil;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.permission.PermissionUtil;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
@@ -56,7 +62,13 @@ import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -296,15 +308,14 @@ public abstract class BaseDocumentFolderResourceImpl
 	)
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			getAssetLibraryDocumentFolderPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("assetLibraryId")
-				Long assetLibraryId,
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.ws.rs.QueryParam("roleNames")
-				String roleNames)
+	public Page<Permission> getAssetLibraryDocumentFolderPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("assetLibraryId")
+			Long assetLibraryId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("roleNames")
+			String roleNames)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(assetLibraryId);
@@ -354,13 +365,12 @@ public abstract class BaseDocumentFolderResourceImpl
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@javax.ws.rs.PUT
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putAssetLibraryDocumentFolderPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("assetLibraryId")
-				Long assetLibraryId,
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<Permission> putAssetLibraryDocumentFolderPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("assetLibraryId")
+			Long assetLibraryId,
+			Permission[] permissions)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(assetLibraryId);
@@ -740,15 +750,14 @@ public abstract class BaseDocumentFolderResourceImpl
 	@javax.ws.rs.Path("/document-folders/{documentFolderId}/permissions")
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			getDocumentFolderPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("documentFolderId")
-				Long documentFolderId,
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.ws.rs.QueryParam("roleNames")
-				String roleNames)
+	public Page<Permission> getDocumentFolderPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("documentFolderId")
+			Long documentFolderId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("roleNames")
+			String roleNames)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(
@@ -796,13 +805,12 @@ public abstract class BaseDocumentFolderResourceImpl
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@javax.ws.rs.PUT
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putDocumentFolderPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("documentFolderId")
-				Long documentFolderId,
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<Permission> putDocumentFolderPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("documentFolderId")
+			Long documentFolderId,
+			Permission[] permissions)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(
@@ -1239,15 +1247,14 @@ public abstract class BaseDocumentFolderResourceImpl
 	@javax.ws.rs.Path("/sites/{siteId}/document-folders/permissions")
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			getSiteDocumentFolderPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("siteId")
-				Long siteId,
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.ws.rs.QueryParam("roleNames")
-				String roleNames)
+	public Page<Permission> getSiteDocumentFolderPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("siteId")
+			Long siteId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("roleNames")
+			String roleNames)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(siteId);
@@ -1293,13 +1300,12 @@ public abstract class BaseDocumentFolderResourceImpl
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@javax.ws.rs.PUT
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putSiteDocumentFolderPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("siteId")
-				Long siteId,
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<Permission> putSiteDocumentFolderPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("siteId")
+			Long siteId,
+			Permission[] permissions)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(siteId);
@@ -1334,7 +1340,7 @@ public abstract class BaseDocumentFolderResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<DocumentFolder> documentFolders,
+			Collection<DocumentFolder> documentFolders,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -1380,7 +1386,7 @@ public abstract class BaseDocumentFolderResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<DocumentFolder> documentFolders,
+			Collection<DocumentFolder> documentFolders,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -1464,7 +1470,7 @@ public abstract class BaseDocumentFolderResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<DocumentFolder> documentFolders,
+			Collection<DocumentFolder> documentFolders,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -1536,10 +1542,9 @@ public abstract class BaseDocumentFolderResourceImpl
 			"This method needs to be implemented");
 	}
 
-	protected Page<com.liferay.portal.vulcan.permission.Permission>
-			toPermissionPage(
-				Map<String, Map<String, String>> actions, long id,
-				String resourceName, String roleNames)
+	protected Page<Permission> toPermissionPage(
+			Map<String, Map<String, String>> actions, long id,
+			String resourceName, String roleNames)
 		throws Exception {
 
 		List<ResourceAction> resourceActions =
@@ -1548,24 +1553,16 @@ public abstract class BaseDocumentFolderResourceImpl
 		if (Validator.isNotNull(roleNames)) {
 			return Page.of(
 				actions,
-				transform(
-					PermissionUtil.getRoles(
-						contextCompany, roleLocalService,
-						StringUtil.split(roleNames)),
-					role -> PermissionUtil.toPermission(
-						contextCompany.getCompanyId(), id, resourceActions,
-						resourceName, resourcePermissionLocalService, role)));
+				_getPermissions(
+					contextCompany.getCompanyId(), resourceActions, id,
+					resourceName, StringUtil.split(roleNames)));
 		}
 
 		return Page.of(
 			actions,
-			transform(
-				PermissionUtil.getResourcePermissions(
-					contextCompany.getCompanyId(), id, resourceName,
-					resourcePermissionLocalService),
-				resourcePermission -> PermissionUtil.toPermission(
-					resourceActions, resourcePermission,
-					roleLocalService.getRole(resourcePermission.getRoleId()))));
+			_getPermissions(
+				contextCompany.getCompanyId(), resourceActions, id,
+				resourceName, null));
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
@@ -1574,7 +1571,7 @@ public abstract class BaseDocumentFolderResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<DocumentFolder>,
+			<Collection<DocumentFolder>,
 			 UnsafeConsumer<DocumentFolder, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -1757,8 +1754,7 @@ public abstract class BaseDocumentFolderResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -1770,8 +1766,8 @@ public abstract class BaseDocumentFolderResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -1784,8 +1780,7 @@ public abstract class BaseDocumentFolderResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -1799,8 +1794,8 @@ public abstract class BaseDocumentFolderResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -1816,9 +1811,8 @@ public abstract class BaseDocumentFolderResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<DocumentFolder>,
-		 UnsafeConsumer<DocumentFolder, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<DocumentFolder>, UnsafeConsumer<DocumentFolder, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -1834,6 +1828,115 @@ public abstract class BaseDocumentFolderResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseDocumentFolderResourceImpl.class);

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentResourceImpl.java
@@ -21,17 +21,22 @@ import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -52,6 +57,7 @@ import com.liferay.portal.vulcan.multipart.MultipartBody;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.permission.ModelPermissionsUtil;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.permission.PermissionUtil;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
@@ -59,7 +65,13 @@ import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -429,15 +441,14 @@ public abstract class BaseDocumentResourceImpl
 	@javax.ws.rs.Path("/asset-libraries/{assetLibraryId}/documents/permissions")
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			getAssetLibraryDocumentPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("assetLibraryId")
-				Long assetLibraryId,
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.ws.rs.QueryParam("roleNames")
-				String roleNames)
+	public Page<Permission> getAssetLibraryDocumentPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("assetLibraryId")
+			Long assetLibraryId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("roleNames")
+			String roleNames)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(assetLibraryId);
@@ -483,13 +494,12 @@ public abstract class BaseDocumentResourceImpl
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@javax.ws.rs.PUT
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putAssetLibraryDocumentPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("assetLibraryId")
-				Long assetLibraryId,
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<Permission> putAssetLibraryDocumentPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("assetLibraryId")
+			Long assetLibraryId,
+			Permission[] permissions)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(assetLibraryId);
@@ -1108,15 +1118,14 @@ public abstract class BaseDocumentResourceImpl
 	@javax.ws.rs.Path("/documents/{documentId}/permissions")
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			getDocumentPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("documentId")
-				Long documentId,
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.ws.rs.QueryParam("roleNames")
-				String roleNames)
+	public Page<Permission> getDocumentPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("documentId")
+			Long documentId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("roleNames")
+			String roleNames)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(documentId);
@@ -1161,13 +1170,12 @@ public abstract class BaseDocumentResourceImpl
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@javax.ws.rs.PUT
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putDocumentPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("documentId")
-				Long documentId,
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<Permission> putDocumentPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("documentId")
+			Long documentId,
+			Permission[] permissions)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(documentId);
@@ -1605,15 +1613,14 @@ public abstract class BaseDocumentResourceImpl
 	@javax.ws.rs.Path("/sites/{siteId}/documents/permissions")
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			getSiteDocumentPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("siteId")
-				Long siteId,
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.ws.rs.QueryParam("roleNames")
-				String roleNames)
+	public Page<Permission> getSiteDocumentPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("siteId")
+			Long siteId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("roleNames")
+			String roleNames)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(siteId);
@@ -1657,13 +1664,12 @@ public abstract class BaseDocumentResourceImpl
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@javax.ws.rs.PUT
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putSiteDocumentPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("siteId")
-				Long siteId,
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<Permission> putSiteDocumentPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("siteId")
+			Long siteId,
+			Permission[] permissions)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(siteId);
@@ -1698,7 +1704,7 @@ public abstract class BaseDocumentResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<Document> documents,
+			Collection<Document> documents,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -1756,7 +1762,7 @@ public abstract class BaseDocumentResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<Document> documents,
+			Collection<Document> documents,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -1846,7 +1852,7 @@ public abstract class BaseDocumentResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<Document> documents,
+			Collection<Document> documents,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -1915,10 +1921,9 @@ public abstract class BaseDocumentResourceImpl
 			"This method needs to be implemented");
 	}
 
-	protected Page<com.liferay.portal.vulcan.permission.Permission>
-			toPermissionPage(
-				Map<String, Map<String, String>> actions, long id,
-				String resourceName, String roleNames)
+	protected Page<Permission> toPermissionPage(
+			Map<String, Map<String, String>> actions, long id,
+			String resourceName, String roleNames)
 		throws Exception {
 
 		List<ResourceAction> resourceActions =
@@ -1927,24 +1932,16 @@ public abstract class BaseDocumentResourceImpl
 		if (Validator.isNotNull(roleNames)) {
 			return Page.of(
 				actions,
-				transform(
-					PermissionUtil.getRoles(
-						contextCompany, roleLocalService,
-						StringUtil.split(roleNames)),
-					role -> PermissionUtil.toPermission(
-						contextCompany.getCompanyId(), id, resourceActions,
-						resourceName, resourcePermissionLocalService, role)));
+				_getPermissions(
+					contextCompany.getCompanyId(), resourceActions, id,
+					resourceName, StringUtil.split(roleNames)));
 		}
 
 		return Page.of(
 			actions,
-			transform(
-				PermissionUtil.getResourcePermissions(
-					contextCompany.getCompanyId(), id, resourceName,
-					resourcePermissionLocalService),
-				resourcePermission -> PermissionUtil.toPermission(
-					resourceActions, resourcePermission,
-					roleLocalService.getRole(resourcePermission.getRoleId()))));
+			_getPermissions(
+				contextCompany.getCompanyId(), resourceActions, id,
+				resourceName, null));
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
@@ -1953,9 +1950,8 @@ public abstract class BaseDocumentResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<Document>,
-			 UnsafeConsumer<Document, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<Document>, UnsafeConsumer<Document, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -2132,8 +2128,7 @@ public abstract class BaseDocumentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -2145,8 +2140,8 @@ public abstract class BaseDocumentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -2159,8 +2154,7 @@ public abstract class BaseDocumentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -2174,8 +2168,8 @@ public abstract class BaseDocumentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -2191,8 +2185,8 @@ public abstract class BaseDocumentResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<Document>, UnsafeConsumer<Document, Exception>,
-		 Exception> contextBatchUnsafeConsumer;
+		<Collection<Document>, UnsafeConsumer<Document, Exception>, Exception>
+			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -2208,6 +2202,115 @@ public abstract class BaseDocumentResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseDocumentResourceImpl.class);

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseArticleResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseArticleResourceImpl.java
@@ -20,17 +20,22 @@ import com.liferay.headless.delivery.resource.v1_0.KnowledgeBaseArticleResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -50,6 +55,7 @@ import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTa
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.permission.ModelPermissionsUtil;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.permission.PermissionUtil;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
@@ -57,7 +63,13 @@ import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -646,15 +658,14 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 	)
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			getKnowledgeBaseArticlePermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("knowledgeBaseArticleId")
-				Long knowledgeBaseArticleId,
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.ws.rs.QueryParam("roleNames")
-				String roleNames)
+	public Page<Permission> getKnowledgeBaseArticlePermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("knowledgeBaseArticleId")
+			Long knowledgeBaseArticleId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("roleNames")
+			String roleNames)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(
@@ -709,13 +720,12 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@javax.ws.rs.PUT
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putKnowledgeBaseArticlePermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("knowledgeBaseArticleId")
-				Long knowledgeBaseArticleId,
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<Permission> putKnowledgeBaseArticlePermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("knowledgeBaseArticleId")
+			Long knowledgeBaseArticleId,
+			Permission[] permissions)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(
@@ -1523,15 +1533,14 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 	@javax.ws.rs.Path("/sites/{siteId}/knowledge-base-articles/permissions")
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			getSiteKnowledgeBaseArticlePermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("siteId")
-				Long siteId,
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.ws.rs.QueryParam("roleNames")
-				String roleNames)
+	public Page<Permission> getSiteKnowledgeBaseArticlePermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("siteId")
+			Long siteId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("roleNames")
+			String roleNames)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(siteId);
@@ -1581,13 +1590,12 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@javax.ws.rs.PUT
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putSiteKnowledgeBaseArticlePermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("siteId")
-				Long siteId,
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<Permission> putSiteKnowledgeBaseArticlePermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("siteId")
+			Long siteId,
+			Permission[] permissions)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(siteId);
@@ -1688,7 +1696,7 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<KnowledgeBaseArticle> knowledgeBaseArticles,
+			Collection<KnowledgeBaseArticle> knowledgeBaseArticles,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -1748,7 +1756,7 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<KnowledgeBaseArticle> knowledgeBaseArticles,
+			Collection<KnowledgeBaseArticle> knowledgeBaseArticles,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -1834,7 +1842,7 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<KnowledgeBaseArticle> knowledgeBaseArticles,
+			Collection<KnowledgeBaseArticle> knowledgeBaseArticles,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -1914,10 +1922,9 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 			"This method needs to be implemented");
 	}
 
-	protected Page<com.liferay.portal.vulcan.permission.Permission>
-			toPermissionPage(
-				Map<String, Map<String, String>> actions, long id,
-				String resourceName, String roleNames)
+	protected Page<Permission> toPermissionPage(
+			Map<String, Map<String, String>> actions, long id,
+			String resourceName, String roleNames)
 		throws Exception {
 
 		List<ResourceAction> resourceActions =
@@ -1926,24 +1933,16 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 		if (Validator.isNotNull(roleNames)) {
 			return Page.of(
 				actions,
-				transform(
-					PermissionUtil.getRoles(
-						contextCompany, roleLocalService,
-						StringUtil.split(roleNames)),
-					role -> PermissionUtil.toPermission(
-						contextCompany.getCompanyId(), id, resourceActions,
-						resourceName, resourcePermissionLocalService, role)));
+				_getPermissions(
+					contextCompany.getCompanyId(), resourceActions, id,
+					resourceName, StringUtil.split(roleNames)));
 		}
 
 		return Page.of(
 			actions,
-			transform(
-				PermissionUtil.getResourcePermissions(
-					contextCompany.getCompanyId(), id, resourceName,
-					resourcePermissionLocalService),
-				resourcePermission -> PermissionUtil.toPermission(
-					resourceActions, resourcePermission,
-					roleLocalService.getRole(resourcePermission.getRoleId()))));
+			_getPermissions(
+				contextCompany.getCompanyId(), resourceActions, id,
+				resourceName, null));
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
@@ -1952,7 +1951,7 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<KnowledgeBaseArticle>,
+			<Collection<KnowledgeBaseArticle>,
 			 UnsafeConsumer<KnowledgeBaseArticle, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -2136,8 +2135,7 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -2149,8 +2147,8 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -2163,8 +2161,7 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -2178,8 +2175,8 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -2195,7 +2192,7 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<KnowledgeBaseArticle>,
+		<Collection<KnowledgeBaseArticle>,
 		 UnsafeConsumer<KnowledgeBaseArticle, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -2213,6 +2210,115 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseKnowledgeBaseArticleResourceImpl.class);

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseAttachmentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseAttachmentResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.delivery.resource.v1_0.KnowledgeBaseAttachmentResour
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -44,13 +50,20 @@ import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTa
 import com.liferay.portal.vulcan.multipart.MultipartBody;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -366,8 +379,7 @@ public abstract class BaseKnowledgeBaseAttachmentResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<KnowledgeBaseAttachment>
-				knowledgeBaseAttachments,
+			Collection<KnowledgeBaseAttachment> knowledgeBaseAttachments,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -416,8 +428,7 @@ public abstract class BaseKnowledgeBaseAttachmentResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<KnowledgeBaseAttachment>
-				knowledgeBaseAttachments,
+			Collection<KnowledgeBaseAttachment> knowledgeBaseAttachments,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -496,8 +507,7 @@ public abstract class BaseKnowledgeBaseAttachmentResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<KnowledgeBaseAttachment>
-				knowledgeBaseAttachments,
+			Collection<KnowledgeBaseAttachment> knowledgeBaseAttachments,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -511,7 +521,7 @@ public abstract class BaseKnowledgeBaseAttachmentResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<KnowledgeBaseAttachment>,
+			<Collection<KnowledgeBaseAttachment>,
 			 UnsafeConsumer<KnowledgeBaseAttachment, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -690,8 +700,7 @@ public abstract class BaseKnowledgeBaseAttachmentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -703,8 +712,8 @@ public abstract class BaseKnowledgeBaseAttachmentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -717,8 +726,7 @@ public abstract class BaseKnowledgeBaseAttachmentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -732,8 +740,8 @@ public abstract class BaseKnowledgeBaseAttachmentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -749,7 +757,7 @@ public abstract class BaseKnowledgeBaseAttachmentResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<KnowledgeBaseAttachment>,
+		<Collection<KnowledgeBaseAttachment>,
 		 UnsafeConsumer<KnowledgeBaseAttachment, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -767,6 +775,115 @@ public abstract class BaseKnowledgeBaseAttachmentResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseKnowledgeBaseAttachmentResourceImpl.class);

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseFolderResourceImpl.java
@@ -19,17 +19,22 @@ import com.liferay.headless.delivery.resource.v1_0.KnowledgeBaseFolderResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -49,6 +54,7 @@ import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTa
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.permission.ModelPermissionsUtil;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.permission.PermissionUtil;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
@@ -56,7 +62,13 @@ import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -443,15 +455,14 @@ public abstract class BaseKnowledgeBaseFolderResourceImpl
 	)
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			getKnowledgeBaseFolderPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("knowledgeBaseFolderId")
-				Long knowledgeBaseFolderId,
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.ws.rs.QueryParam("roleNames")
-				String roleNames)
+	public Page<Permission> getKnowledgeBaseFolderPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("knowledgeBaseFolderId")
+			Long knowledgeBaseFolderId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("roleNames")
+			String roleNames)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(
@@ -505,13 +516,12 @@ public abstract class BaseKnowledgeBaseFolderResourceImpl
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@javax.ws.rs.PUT
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putKnowledgeBaseFolderPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("knowledgeBaseFolderId")
-				Long knowledgeBaseFolderId,
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<Permission> putKnowledgeBaseFolderPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("knowledgeBaseFolderId")
+			Long knowledgeBaseFolderId,
+			Permission[] permissions)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(
@@ -998,15 +1008,14 @@ public abstract class BaseKnowledgeBaseFolderResourceImpl
 	@javax.ws.rs.Path("/sites/{siteId}/knowledge-base-folders/permissions")
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			getSiteKnowledgeBaseFolderPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("siteId")
-				Long siteId,
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.ws.rs.QueryParam("roleNames")
-				String roleNames)
+	public Page<Permission> getSiteKnowledgeBaseFolderPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("siteId")
+			Long siteId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("roleNames")
+			String roleNames)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(siteId);
@@ -1056,13 +1065,12 @@ public abstract class BaseKnowledgeBaseFolderResourceImpl
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@javax.ws.rs.PUT
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putSiteKnowledgeBaseFolderPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("siteId")
-				Long siteId,
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<Permission> putSiteKnowledgeBaseFolderPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("siteId")
+			Long siteId,
+			Permission[] permissions)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(siteId);
@@ -1099,7 +1107,7 @@ public abstract class BaseKnowledgeBaseFolderResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<KnowledgeBaseFolder> knowledgeBaseFolders,
+			Collection<KnowledgeBaseFolder> knowledgeBaseFolders,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -1152,7 +1160,7 @@ public abstract class BaseKnowledgeBaseFolderResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<KnowledgeBaseFolder> knowledgeBaseFolders,
+			Collection<KnowledgeBaseFolder> knowledgeBaseFolders,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -1228,7 +1236,7 @@ public abstract class BaseKnowledgeBaseFolderResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<KnowledgeBaseFolder> knowledgeBaseFolders,
+			Collection<KnowledgeBaseFolder> knowledgeBaseFolders,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -1308,10 +1316,9 @@ public abstract class BaseKnowledgeBaseFolderResourceImpl
 			"This method needs to be implemented");
 	}
 
-	protected Page<com.liferay.portal.vulcan.permission.Permission>
-			toPermissionPage(
-				Map<String, Map<String, String>> actions, long id,
-				String resourceName, String roleNames)
+	protected Page<Permission> toPermissionPage(
+			Map<String, Map<String, String>> actions, long id,
+			String resourceName, String roleNames)
 		throws Exception {
 
 		List<ResourceAction> resourceActions =
@@ -1320,24 +1327,16 @@ public abstract class BaseKnowledgeBaseFolderResourceImpl
 		if (Validator.isNotNull(roleNames)) {
 			return Page.of(
 				actions,
-				transform(
-					PermissionUtil.getRoles(
-						contextCompany, roleLocalService,
-						StringUtil.split(roleNames)),
-					role -> PermissionUtil.toPermission(
-						contextCompany.getCompanyId(), id, resourceActions,
-						resourceName, resourcePermissionLocalService, role)));
+				_getPermissions(
+					contextCompany.getCompanyId(), resourceActions, id,
+					resourceName, StringUtil.split(roleNames)));
 		}
 
 		return Page.of(
 			actions,
-			transform(
-				PermissionUtil.getResourcePermissions(
-					contextCompany.getCompanyId(), id, resourceName,
-					resourcePermissionLocalService),
-				resourcePermission -> PermissionUtil.toPermission(
-					resourceActions, resourcePermission,
-					roleLocalService.getRole(resourcePermission.getRoleId()))));
+			_getPermissions(
+				contextCompany.getCompanyId(), resourceActions, id,
+				resourceName, null));
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
@@ -1346,7 +1345,7 @@ public abstract class BaseKnowledgeBaseFolderResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<KnowledgeBaseFolder>,
+			<Collection<KnowledgeBaseFolder>,
 			 UnsafeConsumer<KnowledgeBaseFolder, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -1530,8 +1529,7 @@ public abstract class BaseKnowledgeBaseFolderResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -1543,8 +1541,8 @@ public abstract class BaseKnowledgeBaseFolderResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -1557,8 +1555,7 @@ public abstract class BaseKnowledgeBaseFolderResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -1572,8 +1569,8 @@ public abstract class BaseKnowledgeBaseFolderResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -1589,7 +1586,7 @@ public abstract class BaseKnowledgeBaseFolderResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<KnowledgeBaseFolder>,
+		<Collection<KnowledgeBaseFolder>,
 		 UnsafeConsumer<KnowledgeBaseFolder, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -1607,6 +1604,115 @@ public abstract class BaseKnowledgeBaseFolderResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseKnowledgeBaseFolderResourceImpl.class);

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseLanguageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseLanguageResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.delivery.resource.v1_0.LanguageResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -160,7 +173,7 @@ public abstract class BaseLanguageResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<Language> languages,
+			Collection<Language> languages,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -170,7 +183,7 @@ public abstract class BaseLanguageResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<Language> languages,
+			Collection<Language> languages,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -248,7 +261,7 @@ public abstract class BaseLanguageResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<Language> languages,
+			Collection<Language> languages,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -262,9 +275,8 @@ public abstract class BaseLanguageResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<Language>,
-			 UnsafeConsumer<Language, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<Language>, UnsafeConsumer<Language, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -441,8 +453,7 @@ public abstract class BaseLanguageResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -454,8 +465,8 @@ public abstract class BaseLanguageResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -468,8 +479,7 @@ public abstract class BaseLanguageResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -483,8 +493,8 @@ public abstract class BaseLanguageResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -500,8 +510,8 @@ public abstract class BaseLanguageResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<Language>, UnsafeConsumer<Language, Exception>,
-		 Exception> contextBatchUnsafeConsumer;
+		<Collection<Language>, UnsafeConsumer<Language, Exception>, Exception>
+			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -517,6 +527,115 @@ public abstract class BaseLanguageResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseLanguageResourceImpl.class);

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardAttachmentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardAttachmentResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.delivery.resource.v1_0.MessageBoardAttachmentResourc
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -44,13 +50,20 @@ import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTa
 import com.liferay.portal.vulcan.multipart.MultipartBody;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -640,8 +653,7 @@ public abstract class BaseMessageBoardAttachmentResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<MessageBoardAttachment>
-				messageBoardAttachments,
+			Collection<MessageBoardAttachment> messageBoardAttachments,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -694,8 +706,7 @@ public abstract class BaseMessageBoardAttachmentResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<MessageBoardAttachment>
-				messageBoardAttachments,
+			Collection<MessageBoardAttachment> messageBoardAttachments,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -778,8 +789,7 @@ public abstract class BaseMessageBoardAttachmentResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<MessageBoardAttachment>
-				messageBoardAttachments,
+			Collection<MessageBoardAttachment> messageBoardAttachments,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -793,7 +803,7 @@ public abstract class BaseMessageBoardAttachmentResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<MessageBoardAttachment>,
+			<Collection<MessageBoardAttachment>,
 			 UnsafeConsumer<MessageBoardAttachment, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -972,8 +982,7 @@ public abstract class BaseMessageBoardAttachmentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -985,8 +994,8 @@ public abstract class BaseMessageBoardAttachmentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -999,8 +1008,7 @@ public abstract class BaseMessageBoardAttachmentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -1014,8 +1022,8 @@ public abstract class BaseMessageBoardAttachmentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -1031,7 +1039,7 @@ public abstract class BaseMessageBoardAttachmentResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<MessageBoardAttachment>,
+		<Collection<MessageBoardAttachment>,
 		 UnsafeConsumer<MessageBoardAttachment, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -1049,6 +1057,115 @@ public abstract class BaseMessageBoardAttachmentResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseMessageBoardAttachmentResourceImpl.class);

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardMessageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardMessageResourceImpl.java
@@ -20,17 +20,22 @@ import com.liferay.headless.delivery.resource.v1_0.MessageBoardMessageResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -50,6 +55,7 @@ import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTa
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.permission.ModelPermissionsUtil;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.permission.PermissionUtil;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
@@ -57,7 +63,13 @@ import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -666,15 +678,14 @@ public abstract class BaseMessageBoardMessageResourceImpl
 	)
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			getMessageBoardMessagePermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("messageBoardMessageId")
-				Long messageBoardMessageId,
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.ws.rs.QueryParam("roleNames")
-				String roleNames)
+	public Page<Permission> getMessageBoardMessagePermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("messageBoardMessageId")
+			Long messageBoardMessageId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("roleNames")
+			String roleNames)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(
@@ -728,13 +739,12 @@ public abstract class BaseMessageBoardMessageResourceImpl
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@javax.ws.rs.PUT
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putMessageBoardMessagePermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("messageBoardMessageId")
-				Long messageBoardMessageId,
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<Permission> putMessageBoardMessagePermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("messageBoardMessageId")
+			Long messageBoardMessageId,
+			Permission[] permissions)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(
@@ -1495,15 +1505,14 @@ public abstract class BaseMessageBoardMessageResourceImpl
 	@javax.ws.rs.Path("/sites/{siteId}/message-board-messages/permissions")
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			getSiteMessageBoardMessagePermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("siteId")
-				Long siteId,
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.ws.rs.QueryParam("roleNames")
-				String roleNames)
+	public Page<Permission> getSiteMessageBoardMessagePermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("siteId")
+			Long siteId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("roleNames")
+			String roleNames)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(siteId);
@@ -1553,13 +1562,12 @@ public abstract class BaseMessageBoardMessageResourceImpl
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@javax.ws.rs.PUT
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putSiteMessageBoardMessagePermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("siteId")
-				Long siteId,
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<Permission> putSiteMessageBoardMessagePermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("siteId")
+			Long siteId,
+			Permission[] permissions)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(siteId);
@@ -1596,7 +1604,7 @@ public abstract class BaseMessageBoardMessageResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<MessageBoardMessage> messageBoardMessages,
+			Collection<MessageBoardMessage> messageBoardMessages,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -1651,7 +1659,7 @@ public abstract class BaseMessageBoardMessageResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<MessageBoardMessage> messageBoardMessages,
+			Collection<MessageBoardMessage> messageBoardMessages,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -1734,7 +1742,7 @@ public abstract class BaseMessageBoardMessageResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<MessageBoardMessage> messageBoardMessages,
+			Collection<MessageBoardMessage> messageBoardMessages,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -1814,10 +1822,9 @@ public abstract class BaseMessageBoardMessageResourceImpl
 			"This method needs to be implemented");
 	}
 
-	protected Page<com.liferay.portal.vulcan.permission.Permission>
-			toPermissionPage(
-				Map<String, Map<String, String>> actions, long id,
-				String resourceName, String roleNames)
+	protected Page<Permission> toPermissionPage(
+			Map<String, Map<String, String>> actions, long id,
+			String resourceName, String roleNames)
 		throws Exception {
 
 		List<ResourceAction> resourceActions =
@@ -1826,24 +1833,16 @@ public abstract class BaseMessageBoardMessageResourceImpl
 		if (Validator.isNotNull(roleNames)) {
 			return Page.of(
 				actions,
-				transform(
-					PermissionUtil.getRoles(
-						contextCompany, roleLocalService,
-						StringUtil.split(roleNames)),
-					role -> PermissionUtil.toPermission(
-						contextCompany.getCompanyId(), id, resourceActions,
-						resourceName, resourcePermissionLocalService, role)));
+				_getPermissions(
+					contextCompany.getCompanyId(), resourceActions, id,
+					resourceName, StringUtil.split(roleNames)));
 		}
 
 		return Page.of(
 			actions,
-			transform(
-				PermissionUtil.getResourcePermissions(
-					contextCompany.getCompanyId(), id, resourceName,
-					resourcePermissionLocalService),
-				resourcePermission -> PermissionUtil.toPermission(
-					resourceActions, resourcePermission,
-					roleLocalService.getRole(resourcePermission.getRoleId()))));
+			_getPermissions(
+				contextCompany.getCompanyId(), resourceActions, id,
+				resourceName, null));
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
@@ -1852,7 +1851,7 @@ public abstract class BaseMessageBoardMessageResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<MessageBoardMessage>,
+			<Collection<MessageBoardMessage>,
 			 UnsafeConsumer<MessageBoardMessage, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -2036,8 +2035,7 @@ public abstract class BaseMessageBoardMessageResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -2049,8 +2047,8 @@ public abstract class BaseMessageBoardMessageResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -2063,8 +2061,7 @@ public abstract class BaseMessageBoardMessageResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -2078,8 +2075,8 @@ public abstract class BaseMessageBoardMessageResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -2095,7 +2092,7 @@ public abstract class BaseMessageBoardMessageResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<MessageBoardMessage>,
+		<Collection<MessageBoardMessage>,
 		 UnsafeConsumer<MessageBoardMessage, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -2113,6 +2110,115 @@ public abstract class BaseMessageBoardMessageResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseMessageBoardMessageResourceImpl.class);

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardSectionResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardSectionResourceImpl.java
@@ -19,17 +19,22 @@ import com.liferay.headless.delivery.resource.v1_0.MessageBoardSectionResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -49,6 +54,7 @@ import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTa
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.permission.ModelPermissionsUtil;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.permission.PermissionUtil;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
@@ -56,7 +62,13 @@ import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -444,15 +456,14 @@ public abstract class BaseMessageBoardSectionResourceImpl
 	)
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			getMessageBoardSectionPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("messageBoardSectionId")
-				Long messageBoardSectionId,
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.ws.rs.QueryParam("roleNames")
-				String roleNames)
+	public Page<Permission> getMessageBoardSectionPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("messageBoardSectionId")
+			Long messageBoardSectionId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("roleNames")
+			String roleNames)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(
@@ -506,13 +517,12 @@ public abstract class BaseMessageBoardSectionResourceImpl
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@javax.ws.rs.PUT
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putMessageBoardSectionPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("messageBoardSectionId")
-				Long messageBoardSectionId,
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<Permission> putMessageBoardSectionPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("messageBoardSectionId")
+			Long messageBoardSectionId,
+			Permission[] permissions)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(
@@ -966,15 +976,14 @@ public abstract class BaseMessageBoardSectionResourceImpl
 	@javax.ws.rs.Path("/sites/{siteId}/message-board-sections/permissions")
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			getSiteMessageBoardSectionPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("siteId")
-				Long siteId,
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.ws.rs.QueryParam("roleNames")
-				String roleNames)
+	public Page<Permission> getSiteMessageBoardSectionPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("siteId")
+			Long siteId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("roleNames")
+			String roleNames)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(siteId);
@@ -1024,13 +1033,12 @@ public abstract class BaseMessageBoardSectionResourceImpl
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@javax.ws.rs.PUT
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putSiteMessageBoardSectionPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("siteId")
-				Long siteId,
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<Permission> putSiteMessageBoardSectionPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("siteId")
+			Long siteId,
+			Permission[] permissions)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(siteId);
@@ -1067,7 +1075,7 @@ public abstract class BaseMessageBoardSectionResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<MessageBoardSection> messageBoardSections,
+			Collection<MessageBoardSection> messageBoardSections,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -1110,7 +1118,7 @@ public abstract class BaseMessageBoardSectionResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<MessageBoardSection> messageBoardSections,
+			Collection<MessageBoardSection> messageBoardSections,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -1188,7 +1196,7 @@ public abstract class BaseMessageBoardSectionResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<MessageBoardSection> messageBoardSections,
+			Collection<MessageBoardSection> messageBoardSections,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -1268,10 +1276,9 @@ public abstract class BaseMessageBoardSectionResourceImpl
 			"This method needs to be implemented");
 	}
 
-	protected Page<com.liferay.portal.vulcan.permission.Permission>
-			toPermissionPage(
-				Map<String, Map<String, String>> actions, long id,
-				String resourceName, String roleNames)
+	protected Page<Permission> toPermissionPage(
+			Map<String, Map<String, String>> actions, long id,
+			String resourceName, String roleNames)
 		throws Exception {
 
 		List<ResourceAction> resourceActions =
@@ -1280,24 +1287,16 @@ public abstract class BaseMessageBoardSectionResourceImpl
 		if (Validator.isNotNull(roleNames)) {
 			return Page.of(
 				actions,
-				transform(
-					PermissionUtil.getRoles(
-						contextCompany, roleLocalService,
-						StringUtil.split(roleNames)),
-					role -> PermissionUtil.toPermission(
-						contextCompany.getCompanyId(), id, resourceActions,
-						resourceName, resourcePermissionLocalService, role)));
+				_getPermissions(
+					contextCompany.getCompanyId(), resourceActions, id,
+					resourceName, StringUtil.split(roleNames)));
 		}
 
 		return Page.of(
 			actions,
-			transform(
-				PermissionUtil.getResourcePermissions(
-					contextCompany.getCompanyId(), id, resourceName,
-					resourcePermissionLocalService),
-				resourcePermission -> PermissionUtil.toPermission(
-					resourceActions, resourcePermission,
-					roleLocalService.getRole(resourcePermission.getRoleId()))));
+			_getPermissions(
+				contextCompany.getCompanyId(), resourceActions, id,
+				resourceName, null));
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
@@ -1306,7 +1305,7 @@ public abstract class BaseMessageBoardSectionResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<MessageBoardSection>,
+			<Collection<MessageBoardSection>,
 			 UnsafeConsumer<MessageBoardSection, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -1490,8 +1489,7 @@ public abstract class BaseMessageBoardSectionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -1503,8 +1501,8 @@ public abstract class BaseMessageBoardSectionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -1517,8 +1515,7 @@ public abstract class BaseMessageBoardSectionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -1532,8 +1529,8 @@ public abstract class BaseMessageBoardSectionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -1549,7 +1546,7 @@ public abstract class BaseMessageBoardSectionResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<MessageBoardSection>,
+		<Collection<MessageBoardSection>,
 		 UnsafeConsumer<MessageBoardSection, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -1567,6 +1564,115 @@ public abstract class BaseMessageBoardSectionResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseMessageBoardSectionResourceImpl.class);

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardThreadResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardThreadResourceImpl.java
@@ -20,17 +20,22 @@ import com.liferay.headless.delivery.resource.v1_0.MessageBoardThreadResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -50,6 +55,7 @@ import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTa
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.permission.ModelPermissionsUtil;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.permission.PermissionUtil;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
@@ -57,7 +63,13 @@ import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -894,15 +906,14 @@ public abstract class BaseMessageBoardThreadResourceImpl
 	)
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			getMessageBoardThreadPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("messageBoardThreadId")
-				Long messageBoardThreadId,
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.ws.rs.QueryParam("roleNames")
-				String roleNames)
+	public Page<Permission> getMessageBoardThreadPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("messageBoardThreadId")
+			Long messageBoardThreadId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("roleNames")
+			String roleNames)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(
@@ -954,13 +965,12 @@ public abstract class BaseMessageBoardThreadResourceImpl
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@javax.ws.rs.PUT
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putMessageBoardThreadPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("messageBoardThreadId")
-				Long messageBoardThreadId,
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<Permission> putMessageBoardThreadPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("messageBoardThreadId")
+			Long messageBoardThreadId,
+			Permission[] permissions)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(
@@ -1328,15 +1338,14 @@ public abstract class BaseMessageBoardThreadResourceImpl
 	@javax.ws.rs.Path("/sites/{siteId}/message-board-threads/permissions")
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			getSiteMessageBoardThreadPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("siteId")
-				Long siteId,
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.ws.rs.QueryParam("roleNames")
-				String roleNames)
+	public Page<Permission> getSiteMessageBoardThreadPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("siteId")
+			Long siteId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("roleNames")
+			String roleNames)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(siteId);
@@ -1384,13 +1393,12 @@ public abstract class BaseMessageBoardThreadResourceImpl
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@javax.ws.rs.PUT
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putSiteMessageBoardThreadPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("siteId")
-				Long siteId,
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<Permission> putSiteMessageBoardThreadPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("siteId")
+			Long siteId,
+			Permission[] permissions)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(siteId);
@@ -1427,7 +1435,7 @@ public abstract class BaseMessageBoardThreadResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<MessageBoardThread> messageBoardThreads,
+			Collection<MessageBoardThread> messageBoardThreads,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -1477,7 +1485,7 @@ public abstract class BaseMessageBoardThreadResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<MessageBoardThread> messageBoardThreads,
+			Collection<MessageBoardThread> messageBoardThreads,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -1560,7 +1568,7 @@ public abstract class BaseMessageBoardThreadResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<MessageBoardThread> messageBoardThreads,
+			Collection<MessageBoardThread> messageBoardThreads,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -1636,10 +1644,9 @@ public abstract class BaseMessageBoardThreadResourceImpl
 			"This method needs to be implemented");
 	}
 
-	protected Page<com.liferay.portal.vulcan.permission.Permission>
-			toPermissionPage(
-				Map<String, Map<String, String>> actions, long id,
-				String resourceName, String roleNames)
+	protected Page<Permission> toPermissionPage(
+			Map<String, Map<String, String>> actions, long id,
+			String resourceName, String roleNames)
 		throws Exception {
 
 		List<ResourceAction> resourceActions =
@@ -1648,24 +1655,16 @@ public abstract class BaseMessageBoardThreadResourceImpl
 		if (Validator.isNotNull(roleNames)) {
 			return Page.of(
 				actions,
-				transform(
-					PermissionUtil.getRoles(
-						contextCompany, roleLocalService,
-						StringUtil.split(roleNames)),
-					role -> PermissionUtil.toPermission(
-						contextCompany.getCompanyId(), id, resourceActions,
-						resourceName, resourcePermissionLocalService, role)));
+				_getPermissions(
+					contextCompany.getCompanyId(), resourceActions, id,
+					resourceName, StringUtil.split(roleNames)));
 		}
 
 		return Page.of(
 			actions,
-			transform(
-				PermissionUtil.getResourcePermissions(
-					contextCompany.getCompanyId(), id, resourceName,
-					resourcePermissionLocalService),
-				resourcePermission -> PermissionUtil.toPermission(
-					resourceActions, resourcePermission,
-					roleLocalService.getRole(resourcePermission.getRoleId()))));
+			_getPermissions(
+				contextCompany.getCompanyId(), resourceActions, id,
+				resourceName, null));
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
@@ -1674,7 +1673,7 @@ public abstract class BaseMessageBoardThreadResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<MessageBoardThread>,
+			<Collection<MessageBoardThread>,
 			 UnsafeConsumer<MessageBoardThread, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -1858,8 +1857,7 @@ public abstract class BaseMessageBoardThreadResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -1871,8 +1869,8 @@ public abstract class BaseMessageBoardThreadResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -1885,8 +1883,7 @@ public abstract class BaseMessageBoardThreadResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -1900,8 +1897,8 @@ public abstract class BaseMessageBoardThreadResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -1917,7 +1914,7 @@ public abstract class BaseMessageBoardThreadResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<MessageBoardThread>,
+		<Collection<MessageBoardThread>,
 		 UnsafeConsumer<MessageBoardThread, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -1935,6 +1932,115 @@ public abstract class BaseMessageBoardThreadResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseMessageBoardThreadResourceImpl.class);

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseNavigationMenuResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseNavigationMenuResourceImpl.java
@@ -19,17 +19,22 @@ import com.liferay.headless.delivery.resource.v1_0.NavigationMenuResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -49,6 +54,7 @@ import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTa
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.permission.ModelPermissionsUtil;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.permission.PermissionUtil;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
@@ -56,7 +62,13 @@ import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -327,15 +339,14 @@ public abstract class BaseNavigationMenuResourceImpl
 	@javax.ws.rs.Path("/navigation-menus/{navigationMenuId}/permissions")
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			getNavigationMenuPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("navigationMenuId")
-				Long navigationMenuId,
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.ws.rs.QueryParam("roleNames")
-				String roleNames)
+	public Page<Permission> getNavigationMenuPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("navigationMenuId")
+			Long navigationMenuId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("roleNames")
+			String roleNames)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(
@@ -383,13 +394,12 @@ public abstract class BaseNavigationMenuResourceImpl
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@javax.ws.rs.PUT
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putNavigationMenuPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("navigationMenuId")
-				Long navigationMenuId,
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<Permission> putNavigationMenuPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("navigationMenuId")
+			Long navigationMenuId,
+			Permission[] permissions)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(
@@ -606,15 +616,14 @@ public abstract class BaseNavigationMenuResourceImpl
 	@javax.ws.rs.Path("/sites/{siteId}/navigation-menus/permissions")
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			getSiteNavigationMenuPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("siteId")
-				Long siteId,
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.ws.rs.QueryParam("roleNames")
-				String roleNames)
+	public Page<Permission> getSiteNavigationMenuPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("siteId")
+			Long siteId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("roleNames")
+			String roleNames)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(siteId);
@@ -660,13 +669,12 @@ public abstract class BaseNavigationMenuResourceImpl
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@javax.ws.rs.PUT
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putSiteNavigationMenuPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("siteId")
-				Long siteId,
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<Permission> putSiteNavigationMenuPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("siteId")
+			Long siteId,
+			Permission[] permissions)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(siteId);
@@ -701,7 +709,7 @@ public abstract class BaseNavigationMenuResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<NavigationMenu> navigationMenus,
+			Collection<NavigationMenu> navigationMenus,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -742,7 +750,7 @@ public abstract class BaseNavigationMenuResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<NavigationMenu> navigationMenus,
+			Collection<NavigationMenu> navigationMenus,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -818,7 +826,7 @@ public abstract class BaseNavigationMenuResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<NavigationMenu> navigationMenus,
+			Collection<NavigationMenu> navigationMenus,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -881,10 +889,9 @@ public abstract class BaseNavigationMenuResourceImpl
 			"This method needs to be implemented");
 	}
 
-	protected Page<com.liferay.portal.vulcan.permission.Permission>
-			toPermissionPage(
-				Map<String, Map<String, String>> actions, long id,
-				String resourceName, String roleNames)
+	protected Page<Permission> toPermissionPage(
+			Map<String, Map<String, String>> actions, long id,
+			String resourceName, String roleNames)
 		throws Exception {
 
 		List<ResourceAction> resourceActions =
@@ -893,24 +900,16 @@ public abstract class BaseNavigationMenuResourceImpl
 		if (Validator.isNotNull(roleNames)) {
 			return Page.of(
 				actions,
-				transform(
-					PermissionUtil.getRoles(
-						contextCompany, roleLocalService,
-						StringUtil.split(roleNames)),
-					role -> PermissionUtil.toPermission(
-						contextCompany.getCompanyId(), id, resourceActions,
-						resourceName, resourcePermissionLocalService, role)));
+				_getPermissions(
+					contextCompany.getCompanyId(), resourceActions, id,
+					resourceName, StringUtil.split(roleNames)));
 		}
 
 		return Page.of(
 			actions,
-			transform(
-				PermissionUtil.getResourcePermissions(
-					contextCompany.getCompanyId(), id, resourceName,
-					resourcePermissionLocalService),
-				resourcePermission -> PermissionUtil.toPermission(
-					resourceActions, resourcePermission,
-					roleLocalService.getRole(resourcePermission.getRoleId()))));
+			_getPermissions(
+				contextCompany.getCompanyId(), resourceActions, id,
+				resourceName, null));
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
@@ -919,7 +918,7 @@ public abstract class BaseNavigationMenuResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<NavigationMenu>,
+			<Collection<NavigationMenu>,
 			 UnsafeConsumer<NavigationMenu, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -1098,8 +1097,7 @@ public abstract class BaseNavigationMenuResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -1111,8 +1109,8 @@ public abstract class BaseNavigationMenuResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -1125,8 +1123,7 @@ public abstract class BaseNavigationMenuResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -1140,8 +1137,8 @@ public abstract class BaseNavigationMenuResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -1157,9 +1154,8 @@ public abstract class BaseNavigationMenuResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<NavigationMenu>,
-		 UnsafeConsumer<NavigationMenu, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<NavigationMenu>, UnsafeConsumer<NavigationMenu, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -1175,6 +1171,115 @@ public abstract class BaseNavigationMenuResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseNavigationMenuResourceImpl.class);

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseSitePageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseSitePageResourceImpl.java
@@ -20,15 +20,21 @@ import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -44,13 +50,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -445,7 +458,7 @@ public abstract class BaseSitePageResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<SitePage> sitePages,
+			Collection<SitePage> sitePages,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -455,7 +468,7 @@ public abstract class BaseSitePageResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<SitePage> sitePages,
+			Collection<SitePage> sitePages,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -531,7 +544,7 @@ public abstract class BaseSitePageResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<SitePage> sitePages,
+			Collection<SitePage> sitePages,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -545,9 +558,8 @@ public abstract class BaseSitePageResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<SitePage>,
-			 UnsafeConsumer<SitePage, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<SitePage>, UnsafeConsumer<SitePage, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -724,8 +736,7 @@ public abstract class BaseSitePageResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -737,8 +748,8 @@ public abstract class BaseSitePageResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -751,8 +762,7 @@ public abstract class BaseSitePageResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -766,8 +776,8 @@ public abstract class BaseSitePageResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -783,8 +793,8 @@ public abstract class BaseSitePageResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<SitePage>, UnsafeConsumer<SitePage, Exception>,
-		 Exception> contextBatchUnsafeConsumer;
+		<Collection<SitePage>, UnsafeConsumer<SitePage, Exception>, Exception>
+			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -800,6 +810,115 @@ public abstract class BaseSitePageResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseSitePageResourceImpl.class);

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentFolderResourceImpl.java
@@ -19,17 +19,22 @@ import com.liferay.headless.delivery.resource.v1_0.StructuredContentFolderResour
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -49,6 +54,7 @@ import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTa
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.permission.ModelPermissionsUtil;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.permission.PermissionUtil;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
@@ -56,7 +62,13 @@ import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -467,7 +479,7 @@ public abstract class BaseStructuredContentFolderResourceImpl
 	)
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
+	public Page<Permission>
 			getAssetLibraryStructuredContentFolderPermissionsPage(
 				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 				@javax.validation.constraints.NotNull
@@ -527,13 +539,13 @@ public abstract class BaseStructuredContentFolderResourceImpl
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@javax.ws.rs.PUT
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
+	public Page<Permission>
 			putAssetLibraryStructuredContentFolderPermissionsPage(
 				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 				@javax.validation.constraints.NotNull
 				@javax.ws.rs.PathParam("assetLibraryId")
 				Long assetLibraryId,
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+				Permission[] permissions)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(assetLibraryId);
@@ -937,15 +949,14 @@ public abstract class BaseStructuredContentFolderResourceImpl
 	@javax.ws.rs.Path("/sites/{siteId}/structured-content-folders/permissions")
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			getSiteStructuredContentFolderPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("siteId")
-				Long siteId,
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.ws.rs.QueryParam("roleNames")
-				String roleNames)
+	public Page<Permission> getSiteStructuredContentFolderPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("siteId")
+			Long siteId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("roleNames")
+			String roleNames)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(siteId);
@@ -995,13 +1006,12 @@ public abstract class BaseStructuredContentFolderResourceImpl
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@javax.ws.rs.PUT
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putSiteStructuredContentFolderPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("siteId")
-				Long siteId,
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<Permission> putSiteStructuredContentFolderPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("siteId")
+			Long siteId,
+			Permission[] permissions)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(siteId);
@@ -1077,15 +1087,14 @@ public abstract class BaseStructuredContentFolderResourceImpl
 	)
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			getStructuredContentFolderPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("structuredContentFolderId")
-				Long structuredContentFolderId,
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.ws.rs.QueryParam("roleNames")
-				String roleNames)
+	public Page<Permission> getStructuredContentFolderPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("structuredContentFolderId")
+			Long structuredContentFolderId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("roleNames")
+			String roleNames)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(
@@ -1140,13 +1149,12 @@ public abstract class BaseStructuredContentFolderResourceImpl
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@javax.ws.rs.PUT
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putStructuredContentFolderPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("structuredContentFolderId")
-				Long structuredContentFolderId,
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<Permission> putStructuredContentFolderPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("structuredContentFolderId")
+			Long structuredContentFolderId,
+			Permission[] permissions)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(
@@ -1715,8 +1723,7 @@ public abstract class BaseStructuredContentFolderResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<StructuredContentFolder>
-				structuredContentFolders,
+			Collection<StructuredContentFolder> structuredContentFolders,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -1779,8 +1786,7 @@ public abstract class BaseStructuredContentFolderResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<StructuredContentFolder>
-				structuredContentFolders,
+			Collection<StructuredContentFolder> structuredContentFolders,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -1866,8 +1872,7 @@ public abstract class BaseStructuredContentFolderResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<StructuredContentFolder>
-				structuredContentFolders,
+			Collection<StructuredContentFolder> structuredContentFolders,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -1949,10 +1954,9 @@ public abstract class BaseStructuredContentFolderResourceImpl
 			"This method needs to be implemented");
 	}
 
-	protected Page<com.liferay.portal.vulcan.permission.Permission>
-			toPermissionPage(
-				Map<String, Map<String, String>> actions, long id,
-				String resourceName, String roleNames)
+	protected Page<Permission> toPermissionPage(
+			Map<String, Map<String, String>> actions, long id,
+			String resourceName, String roleNames)
 		throws Exception {
 
 		List<ResourceAction> resourceActions =
@@ -1961,24 +1965,16 @@ public abstract class BaseStructuredContentFolderResourceImpl
 		if (Validator.isNotNull(roleNames)) {
 			return Page.of(
 				actions,
-				transform(
-					PermissionUtil.getRoles(
-						contextCompany, roleLocalService,
-						StringUtil.split(roleNames)),
-					role -> PermissionUtil.toPermission(
-						contextCompany.getCompanyId(), id, resourceActions,
-						resourceName, resourcePermissionLocalService, role)));
+				_getPermissions(
+					contextCompany.getCompanyId(), resourceActions, id,
+					resourceName, StringUtil.split(roleNames)));
 		}
 
 		return Page.of(
 			actions,
-			transform(
-				PermissionUtil.getResourcePermissions(
-					contextCompany.getCompanyId(), id, resourceName,
-					resourcePermissionLocalService),
-				resourcePermission -> PermissionUtil.toPermission(
-					resourceActions, resourcePermission,
-					roleLocalService.getRole(resourcePermission.getRoleId()))));
+			_getPermissions(
+				contextCompany.getCompanyId(), resourceActions, id,
+				resourceName, null));
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
@@ -1987,7 +1983,7 @@ public abstract class BaseStructuredContentFolderResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<StructuredContentFolder>,
+			<Collection<StructuredContentFolder>,
 			 UnsafeConsumer<StructuredContentFolder, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -2171,8 +2167,7 @@ public abstract class BaseStructuredContentFolderResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -2184,8 +2179,8 @@ public abstract class BaseStructuredContentFolderResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -2198,8 +2193,7 @@ public abstract class BaseStructuredContentFolderResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -2213,8 +2207,8 @@ public abstract class BaseStructuredContentFolderResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -2230,7 +2224,7 @@ public abstract class BaseStructuredContentFolderResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<StructuredContentFolder>,
+		<Collection<StructuredContentFolder>,
 		 UnsafeConsumer<StructuredContentFolder, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -2248,6 +2242,115 @@ public abstract class BaseStructuredContentFolderResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseStructuredContentFolderResourceImpl.class);

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentResourceImpl.java
@@ -21,17 +21,22 @@ import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -51,6 +56,7 @@ import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTa
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.permission.ModelPermissionsUtil;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.permission.PermissionUtil;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
@@ -58,7 +64,13 @@ import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -444,15 +456,14 @@ public abstract class BaseStructuredContentResourceImpl
 	)
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			getAssetLibraryStructuredContentPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("assetLibraryId")
-				Long assetLibraryId,
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.ws.rs.QueryParam("roleNames")
-				String roleNames)
+	public Page<Permission> getAssetLibraryStructuredContentPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("assetLibraryId")
+			Long assetLibraryId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("roleNames")
+			String roleNames)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(assetLibraryId);
@@ -502,13 +513,12 @@ public abstract class BaseStructuredContentResourceImpl
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@javax.ws.rs.PUT
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putAssetLibraryStructuredContentPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("assetLibraryId")
-				Long assetLibraryId,
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<Permission> putAssetLibraryStructuredContentPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("assetLibraryId")
+			Long assetLibraryId,
+			Permission[] permissions)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(assetLibraryId);
@@ -1093,15 +1103,14 @@ public abstract class BaseStructuredContentResourceImpl
 	@javax.ws.rs.Path("/sites/{siteId}/structured-contents/permissions")
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			getSiteStructuredContentPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("siteId")
-				Long siteId,
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.ws.rs.QueryParam("roleNames")
-				String roleNames)
+	public Page<Permission> getSiteStructuredContentPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("siteId")
+			Long siteId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("roleNames")
+			String roleNames)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(siteId);
@@ -1149,13 +1158,12 @@ public abstract class BaseStructuredContentResourceImpl
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@javax.ws.rs.PUT
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putSiteStructuredContentPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("siteId")
-				Long siteId,
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<Permission> putSiteStructuredContentPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("siteId")
+			Long siteId,
+			Permission[] permissions)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(siteId);
@@ -1930,15 +1938,14 @@ public abstract class BaseStructuredContentResourceImpl
 	@javax.ws.rs.Path("/structured-contents/{structuredContentId}/permissions")
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			getStructuredContentPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("structuredContentId")
-				Long structuredContentId,
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.ws.rs.QueryParam("roleNames")
-				String roleNames)
+	public Page<Permission> getStructuredContentPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("structuredContentId")
+			Long structuredContentId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("roleNames")
+			String roleNames)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(
@@ -1988,13 +1995,12 @@ public abstract class BaseStructuredContentResourceImpl
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@javax.ws.rs.PUT
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putStructuredContentPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("structuredContentId")
-				Long structuredContentId,
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<Permission> putStructuredContentPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("structuredContentId")
+			Long structuredContentId,
+			Permission[] permissions)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(
@@ -2209,7 +2215,7 @@ public abstract class BaseStructuredContentResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<StructuredContent> structuredContents,
+			Collection<StructuredContent> structuredContents,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -2274,7 +2280,7 @@ public abstract class BaseStructuredContentResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<StructuredContent> structuredContents,
+			Collection<StructuredContent> structuredContents,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -2370,7 +2376,7 @@ public abstract class BaseStructuredContentResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<StructuredContent> structuredContents,
+			Collection<StructuredContent> structuredContents,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -2446,10 +2452,9 @@ public abstract class BaseStructuredContentResourceImpl
 			"This method needs to be implemented");
 	}
 
-	protected Page<com.liferay.portal.vulcan.permission.Permission>
-			toPermissionPage(
-				Map<String, Map<String, String>> actions, long id,
-				String resourceName, String roleNames)
+	protected Page<Permission> toPermissionPage(
+			Map<String, Map<String, String>> actions, long id,
+			String resourceName, String roleNames)
 		throws Exception {
 
 		List<ResourceAction> resourceActions =
@@ -2458,24 +2463,16 @@ public abstract class BaseStructuredContentResourceImpl
 		if (Validator.isNotNull(roleNames)) {
 			return Page.of(
 				actions,
-				transform(
-					PermissionUtil.getRoles(
-						contextCompany, roleLocalService,
-						StringUtil.split(roleNames)),
-					role -> PermissionUtil.toPermission(
-						contextCompany.getCompanyId(), id, resourceActions,
-						resourceName, resourcePermissionLocalService, role)));
+				_getPermissions(
+					contextCompany.getCompanyId(), resourceActions, id,
+					resourceName, StringUtil.split(roleNames)));
 		}
 
 		return Page.of(
 			actions,
-			transform(
-				PermissionUtil.getResourcePermissions(
-					contextCompany.getCompanyId(), id, resourceName,
-					resourcePermissionLocalService),
-				resourcePermission -> PermissionUtil.toPermission(
-					resourceActions, resourcePermission,
-					roleLocalService.getRole(resourcePermission.getRoleId()))));
+			_getPermissions(
+				contextCompany.getCompanyId(), resourceActions, id,
+				resourceName, null));
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
@@ -2484,7 +2481,7 @@ public abstract class BaseStructuredContentResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<StructuredContent>,
+			<Collection<StructuredContent>,
 			 UnsafeConsumer<StructuredContent, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -2668,8 +2665,7 @@ public abstract class BaseStructuredContentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -2681,8 +2677,8 @@ public abstract class BaseStructuredContentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -2695,8 +2691,7 @@ public abstract class BaseStructuredContentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -2710,8 +2705,8 @@ public abstract class BaseStructuredContentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -2727,7 +2722,7 @@ public abstract class BaseStructuredContentResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<StructuredContent>,
+		<Collection<StructuredContent>,
 		 UnsafeConsumer<StructuredContent, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -2745,6 +2740,115 @@ public abstract class BaseStructuredContentResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseStructuredContentResourceImpl.class);

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiNodeResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiNodeResourceImpl.java
@@ -19,17 +19,22 @@ import com.liferay.headless.delivery.resource.v1_0.WikiNodeResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -49,6 +54,7 @@ import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTa
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.permission.ModelPermissionsUtil;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.permission.PermissionUtil;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
@@ -56,7 +62,13 @@ import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -424,15 +436,14 @@ public abstract class BaseWikiNodeResourceImpl
 	@javax.ws.rs.Path("/sites/{siteId}/wiki-nodes/permissions")
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			getSiteWikiNodePermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("siteId")
-				Long siteId,
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.ws.rs.QueryParam("roleNames")
-				String roleNames)
+	public Page<Permission> getSiteWikiNodePermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("siteId")
+			Long siteId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("roleNames")
+			String roleNames)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(siteId);
@@ -476,13 +487,12 @@ public abstract class BaseWikiNodeResourceImpl
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@javax.ws.rs.PUT
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putSiteWikiNodePermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("siteId")
-				Long siteId,
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<Permission> putSiteWikiNodePermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("siteId")
+			Long siteId,
+			Permission[] permissions)
 		throws Exception {
 
 		String portletName = getPermissionCheckerPortletName(siteId);
@@ -749,15 +759,14 @@ public abstract class BaseWikiNodeResourceImpl
 	@javax.ws.rs.Path("/wiki-nodes/{wikiNodeId}/permissions")
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			getWikiNodePermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("wikiNodeId")
-				Long wikiNodeId,
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.ws.rs.QueryParam("roleNames")
-				String roleNames)
+	public Page<Permission> getWikiNodePermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("wikiNodeId")
+			Long wikiNodeId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("roleNames")
+			String roleNames)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(wikiNodeId);
@@ -802,13 +811,12 @@ public abstract class BaseWikiNodeResourceImpl
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@javax.ws.rs.PUT
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putWikiNodePermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("wikiNodeId")
-				Long wikiNodeId,
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<Permission> putWikiNodePermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("wikiNodeId")
+			Long wikiNodeId,
+			Permission[] permissions)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(wikiNodeId);
@@ -901,7 +909,7 @@ public abstract class BaseWikiNodeResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<WikiNode> wikiNodes,
+			Collection<WikiNode> wikiNodes,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -948,7 +956,7 @@ public abstract class BaseWikiNodeResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<WikiNode> wikiNodes,
+			Collection<WikiNode> wikiNodes,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -1025,7 +1033,7 @@ public abstract class BaseWikiNodeResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<WikiNode> wikiNodes,
+			Collection<WikiNode> wikiNodes,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -1087,10 +1095,9 @@ public abstract class BaseWikiNodeResourceImpl
 			"This method needs to be implemented");
 	}
 
-	protected Page<com.liferay.portal.vulcan.permission.Permission>
-			toPermissionPage(
-				Map<String, Map<String, String>> actions, long id,
-				String resourceName, String roleNames)
+	protected Page<Permission> toPermissionPage(
+			Map<String, Map<String, String>> actions, long id,
+			String resourceName, String roleNames)
 		throws Exception {
 
 		List<ResourceAction> resourceActions =
@@ -1099,24 +1106,16 @@ public abstract class BaseWikiNodeResourceImpl
 		if (Validator.isNotNull(roleNames)) {
 			return Page.of(
 				actions,
-				transform(
-					PermissionUtil.getRoles(
-						contextCompany, roleLocalService,
-						StringUtil.split(roleNames)),
-					role -> PermissionUtil.toPermission(
-						contextCompany.getCompanyId(), id, resourceActions,
-						resourceName, resourcePermissionLocalService, role)));
+				_getPermissions(
+					contextCompany.getCompanyId(), resourceActions, id,
+					resourceName, StringUtil.split(roleNames)));
 		}
 
 		return Page.of(
 			actions,
-			transform(
-				PermissionUtil.getResourcePermissions(
-					contextCompany.getCompanyId(), id, resourceName,
-					resourcePermissionLocalService),
-				resourcePermission -> PermissionUtil.toPermission(
-					resourceActions, resourcePermission,
-					roleLocalService.getRole(resourcePermission.getRoleId()))));
+			_getPermissions(
+				contextCompany.getCompanyId(), resourceActions, id,
+				resourceName, null));
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
@@ -1125,9 +1124,8 @@ public abstract class BaseWikiNodeResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<WikiNode>,
-			 UnsafeConsumer<WikiNode, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<WikiNode>, UnsafeConsumer<WikiNode, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -1304,8 +1302,7 @@ public abstract class BaseWikiNodeResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -1317,8 +1314,8 @@ public abstract class BaseWikiNodeResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -1331,8 +1328,7 @@ public abstract class BaseWikiNodeResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -1346,8 +1342,8 @@ public abstract class BaseWikiNodeResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -1363,8 +1359,8 @@ public abstract class BaseWikiNodeResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<WikiNode>, UnsafeConsumer<WikiNode, Exception>,
-		 Exception> contextBatchUnsafeConsumer;
+		<Collection<WikiNode>, UnsafeConsumer<WikiNode, Exception>, Exception>
+			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -1380,6 +1376,115 @@ public abstract class BaseWikiNodeResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseWikiNodeResourceImpl.class);

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiPageAttachmentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiPageAttachmentResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.delivery.resource.v1_0.WikiPageAttachmentResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -44,13 +50,20 @@ import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTa
 import com.liferay.portal.vulcan.multipart.MultipartBody;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -460,7 +473,7 @@ public abstract class BaseWikiPageAttachmentResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<WikiPageAttachment> wikiPageAttachments,
+			Collection<WikiPageAttachment> wikiPageAttachments,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -502,7 +515,7 @@ public abstract class BaseWikiPageAttachmentResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<WikiPageAttachment> wikiPageAttachments,
+			Collection<WikiPageAttachment> wikiPageAttachments,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -578,7 +591,7 @@ public abstract class BaseWikiPageAttachmentResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<WikiPageAttachment> wikiPageAttachments,
+			Collection<WikiPageAttachment> wikiPageAttachments,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -592,7 +605,7 @@ public abstract class BaseWikiPageAttachmentResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<WikiPageAttachment>,
+			<Collection<WikiPageAttachment>,
 			 UnsafeConsumer<WikiPageAttachment, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -771,8 +784,7 @@ public abstract class BaseWikiPageAttachmentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -784,8 +796,8 @@ public abstract class BaseWikiPageAttachmentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -798,8 +810,7 @@ public abstract class BaseWikiPageAttachmentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -813,8 +824,8 @@ public abstract class BaseWikiPageAttachmentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -830,7 +841,7 @@ public abstract class BaseWikiPageAttachmentResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<WikiPageAttachment>,
+		<Collection<WikiPageAttachment>,
 		 UnsafeConsumer<WikiPageAttachment, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -848,6 +859,115 @@ public abstract class BaseWikiPageAttachmentResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseWikiPageAttachmentResourceImpl.class);

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiPageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiPageResourceImpl.java
@@ -19,17 +19,22 @@ import com.liferay.headless.delivery.resource.v1_0.WikiPageResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -49,6 +54,7 @@ import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTa
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.permission.ModelPermissionsUtil;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.permission.PermissionUtil;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
@@ -56,7 +62,13 @@ import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -703,15 +715,14 @@ public abstract class BaseWikiPageResourceImpl
 	@javax.ws.rs.Path("/wiki-pages/{wikiPageId}/permissions")
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			getWikiPagePermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("wikiPageId")
-				Long wikiPageId,
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.ws.rs.QueryParam("roleNames")
-				String roleNames)
+	public Page<Permission> getWikiPagePermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("wikiPageId")
+			Long wikiPageId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("roleNames")
+			String roleNames)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(wikiPageId);
@@ -756,13 +767,12 @@ public abstract class BaseWikiPageResourceImpl
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@javax.ws.rs.PUT
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putWikiPagePermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("wikiPageId")
-				Long wikiPageId,
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<Permission> putWikiPagePermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("wikiPageId")
+			Long wikiPageId,
+			Permission[] permissions)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(wikiPageId);
@@ -855,7 +865,7 @@ public abstract class BaseWikiPageResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<WikiPage> wikiPages,
+			Collection<WikiPage> wikiPages,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -903,7 +913,7 @@ public abstract class BaseWikiPageResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<WikiPage> wikiPages,
+			Collection<WikiPage> wikiPages,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -980,7 +990,7 @@ public abstract class BaseWikiPageResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<WikiPage> wikiPages,
+			Collection<WikiPage> wikiPages,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -1042,10 +1052,9 @@ public abstract class BaseWikiPageResourceImpl
 			"This method needs to be implemented");
 	}
 
-	protected Page<com.liferay.portal.vulcan.permission.Permission>
-			toPermissionPage(
-				Map<String, Map<String, String>> actions, long id,
-				String resourceName, String roleNames)
+	protected Page<Permission> toPermissionPage(
+			Map<String, Map<String, String>> actions, long id,
+			String resourceName, String roleNames)
 		throws Exception {
 
 		List<ResourceAction> resourceActions =
@@ -1054,24 +1063,16 @@ public abstract class BaseWikiPageResourceImpl
 		if (Validator.isNotNull(roleNames)) {
 			return Page.of(
 				actions,
-				transform(
-					PermissionUtil.getRoles(
-						contextCompany, roleLocalService,
-						StringUtil.split(roleNames)),
-					role -> PermissionUtil.toPermission(
-						contextCompany.getCompanyId(), id, resourceActions,
-						resourceName, resourcePermissionLocalService, role)));
+				_getPermissions(
+					contextCompany.getCompanyId(), resourceActions, id,
+					resourceName, StringUtil.split(roleNames)));
 		}
 
 		return Page.of(
 			actions,
-			transform(
-				PermissionUtil.getResourcePermissions(
-					contextCompany.getCompanyId(), id, resourceName,
-					resourcePermissionLocalService),
-				resourcePermission -> PermissionUtil.toPermission(
-					resourceActions, resourcePermission,
-					roleLocalService.getRole(resourcePermission.getRoleId()))));
+			_getPermissions(
+				contextCompany.getCompanyId(), resourceActions, id,
+				resourceName, null));
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
@@ -1080,9 +1081,8 @@ public abstract class BaseWikiPageResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<WikiPage>,
-			 UnsafeConsumer<WikiPage, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<WikiPage>, UnsafeConsumer<WikiPage, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -1259,8 +1259,7 @@ public abstract class BaseWikiPageResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -1272,8 +1271,8 @@ public abstract class BaseWikiPageResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -1286,8 +1285,7 @@ public abstract class BaseWikiPageResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -1301,8 +1299,8 @@ public abstract class BaseWikiPageResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -1318,8 +1316,8 @@ public abstract class BaseWikiPageResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<WikiPage>, UnsafeConsumer<WikiPage, Exception>,
-		 Exception> contextBatchUnsafeConsumer;
+		<Collection<WikiPage>, UnsafeConsumer<WikiPage, Exception>, Exception>
+			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -1335,6 +1333,115 @@ public abstract class BaseWikiPageResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseWikiPageResourceImpl.class);

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormDocumentResourceImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormDocumentResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.form.resource.v1_0.FormDocumentResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -186,7 +199,7 @@ public abstract class BaseFormDocumentResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<FormDocument> formDocuments,
+			Collection<FormDocument> formDocuments,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -196,7 +209,7 @@ public abstract class BaseFormDocumentResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<FormDocument> formDocuments,
+			Collection<FormDocument> formDocuments,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -266,7 +279,7 @@ public abstract class BaseFormDocumentResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<FormDocument> formDocuments,
+			Collection<FormDocument> formDocuments,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -280,9 +293,8 @@ public abstract class BaseFormDocumentResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<FormDocument>,
-			 UnsafeConsumer<FormDocument, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<FormDocument>, UnsafeConsumer<FormDocument, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -459,8 +471,7 @@ public abstract class BaseFormDocumentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -472,8 +483,8 @@ public abstract class BaseFormDocumentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -486,8 +497,7 @@ public abstract class BaseFormDocumentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -501,8 +511,8 @@ public abstract class BaseFormDocumentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -518,9 +528,8 @@ public abstract class BaseFormDocumentResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<FormDocument>,
-		 UnsafeConsumer<FormDocument, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<FormDocument>, UnsafeConsumer<FormDocument, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -536,6 +545,115 @@ public abstract class BaseFormDocumentResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseFormDocumentResourceImpl.class);

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormRecordResourceImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormRecordResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.form.resource.v1_0.FormRecordResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -352,7 +365,7 @@ public abstract class BaseFormRecordResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<FormRecord> formRecords,
+			Collection<FormRecord> formRecords,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -392,7 +405,7 @@ public abstract class BaseFormRecordResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<FormRecord> formRecords,
+			Collection<FormRecord> formRecords,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -467,7 +480,7 @@ public abstract class BaseFormRecordResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<FormRecord> formRecords,
+			Collection<FormRecord> formRecords,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -506,9 +519,8 @@ public abstract class BaseFormRecordResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<FormRecord>,
-			 UnsafeConsumer<FormRecord, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<FormRecord>, UnsafeConsumer<FormRecord, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -685,8 +697,7 @@ public abstract class BaseFormRecordResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -698,8 +709,8 @@ public abstract class BaseFormRecordResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -712,8 +723,7 @@ public abstract class BaseFormRecordResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -727,8 +737,8 @@ public abstract class BaseFormRecordResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -744,9 +754,8 @@ public abstract class BaseFormRecordResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<FormRecord>,
-		 UnsafeConsumer<FormRecord, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<FormRecord>, UnsafeConsumer<FormRecord, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -762,6 +771,115 @@ public abstract class BaseFormRecordResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseFormRecordResourceImpl.class);

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormResourceImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormResourceImpl.java
@@ -21,15 +21,21 @@ import com.liferay.headless.form.resource.v1_0.FormResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -46,13 +52,20 @@ import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTa
 import com.liferay.portal.vulcan.multipart.MultipartBody;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -222,8 +235,7 @@ public abstract class BaseFormResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<Form> forms,
-			Map<String, Serializable> parameters)
+			Collection<Form> forms, Map<String, Serializable> parameters)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -232,8 +244,7 @@ public abstract class BaseFormResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<Form> forms,
-			Map<String, Serializable> parameters)
+			Collection<Form> forms, Map<String, Serializable> parameters)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -306,8 +317,7 @@ public abstract class BaseFormResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<Form> forms,
-			Map<String, Serializable> parameters)
+			Collection<Form> forms, Map<String, Serializable> parameters)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -320,8 +330,8 @@ public abstract class BaseFormResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<Form>, UnsafeConsumer<Form, Exception>,
-			 Exception> contextBatchUnsafeConsumer) {
+			<Collection<Form>, UnsafeConsumer<Form, Exception>, Exception>
+				contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -498,8 +508,7 @@ public abstract class BaseFormResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -511,8 +520,8 @@ public abstract class BaseFormResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -525,8 +534,7 @@ public abstract class BaseFormResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -540,8 +548,8 @@ public abstract class BaseFormResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -557,7 +565,7 @@ public abstract class BaseFormResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<Form>, UnsafeConsumer<Form, Exception>, Exception>
+		<Collection<Form>, UnsafeConsumer<Form, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
@@ -574,6 +582,115 @@ public abstract class BaseFormResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseFormResourceImpl.class);

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormStructureResourceImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormStructureResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.form.resource.v1_0.FormStructureResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -155,7 +168,7 @@ public abstract class BaseFormStructureResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<FormStructure> formStructures,
+			Collection<FormStructure> formStructures,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -165,7 +178,7 @@ public abstract class BaseFormStructureResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<FormStructure> formStructures,
+			Collection<FormStructure> formStructures,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -240,7 +253,7 @@ public abstract class BaseFormStructureResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<FormStructure> formStructures,
+			Collection<FormStructure> formStructures,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -254,7 +267,7 @@ public abstract class BaseFormStructureResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<FormStructure>,
+			<Collection<FormStructure>,
 			 UnsafeConsumer<FormStructure, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -433,8 +446,7 @@ public abstract class BaseFormStructureResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -446,8 +458,8 @@ public abstract class BaseFormStructureResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -460,8 +472,7 @@ public abstract class BaseFormStructureResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -475,8 +486,8 @@ public abstract class BaseFormStructureResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -492,9 +503,8 @@ public abstract class BaseFormStructureResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<FormStructure>,
-		 UnsafeConsumer<FormStructure, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<FormStructure>, UnsafeConsumer<FormStructure, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -510,6 +520,115 @@ public abstract class BaseFormStructureResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseFormStructureResourceImpl.class);

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/src/main/java/com/liferay/headless/portal/instances/internal/resource/v1_0/BasePortalInstanceResourceImpl.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/src/main/java/com/liferay/headless/portal/instances/internal/resource/v1_0/BasePortalInstanceResourceImpl.java
@@ -17,25 +17,39 @@ package com.liferay.headless.portal.instances.internal.resource.v1_0;
 import com.liferay.headless.portal.instances.dto.v1_0.PortalInstance;
 import com.liferay.headless.portal.instances.resource.v1_0.PortalInstanceResource;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -385,8 +399,7 @@ public abstract class BasePortalInstanceResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -398,8 +411,8 @@ public abstract class BasePortalInstanceResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -412,8 +425,7 @@ public abstract class BasePortalInstanceResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -427,8 +439,8 @@ public abstract class BasePortalInstanceResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -456,6 +468,115 @@ public abstract class BasePortalInstanceResourceImpl
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BasePortalInstanceResourceImpl.class);

--- a/modules/apps/notification/notification-rest-impl/src/main/java/com/liferay/notification/rest/internal/resource/v1_0/BaseNotificationQueueEntryResourceImpl.java
+++ b/modules/apps/notification/notification-rest-impl/src/main/java/com/liferay/notification/rest/internal/resource/v1_0/BaseNotificationQueueEntryResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.notification.rest.resource.v1_0.NotificationQueueEntryResourc
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -278,8 +291,7 @@ public abstract class BaseNotificationQueueEntryResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<NotificationQueueEntry>
-				notificationQueueEntries,
+			Collection<NotificationQueueEntry> notificationQueueEntries,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -289,8 +301,7 @@ public abstract class BaseNotificationQueueEntryResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<NotificationQueueEntry>
-				notificationQueueEntries,
+			Collection<NotificationQueueEntry> notificationQueueEntries,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -362,8 +373,7 @@ public abstract class BaseNotificationQueueEntryResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<NotificationQueueEntry>
-				notificationQueueEntries,
+			Collection<NotificationQueueEntry> notificationQueueEntries,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -377,7 +387,7 @@ public abstract class BaseNotificationQueueEntryResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<NotificationQueueEntry>,
+			<Collection<NotificationQueueEntry>,
 			 UnsafeConsumer<NotificationQueueEntry, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -556,8 +566,7 @@ public abstract class BaseNotificationQueueEntryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -569,8 +578,8 @@ public abstract class BaseNotificationQueueEntryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -583,8 +592,7 @@ public abstract class BaseNotificationQueueEntryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -598,8 +606,8 @@ public abstract class BaseNotificationQueueEntryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -615,7 +623,7 @@ public abstract class BaseNotificationQueueEntryResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<NotificationQueueEntry>,
+		<Collection<NotificationQueueEntry>,
 		 UnsafeConsumer<NotificationQueueEntry, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -633,6 +641,115 @@ public abstract class BaseNotificationQueueEntryResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseNotificationQueueEntryResourceImpl.class);

--- a/modules/apps/notification/notification-rest-impl/src/main/java/com/liferay/notification/rest/internal/resource/v1_0/BaseNotificationTemplateResourceImpl.java
+++ b/modules/apps/notification/notification-rest-impl/src/main/java/com/liferay/notification/rest/internal/resource/v1_0/BaseNotificationTemplateResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.notification.rest.resource.v1_0.NotificationTemplateResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -650,7 +663,7 @@ public abstract class BaseNotificationTemplateResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<NotificationTemplate> notificationTemplates,
+			Collection<NotificationTemplate> notificationTemplates,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -694,7 +707,7 @@ public abstract class BaseNotificationTemplateResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<NotificationTemplate> notificationTemplates,
+			Collection<NotificationTemplate> notificationTemplates,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -766,7 +779,7 @@ public abstract class BaseNotificationTemplateResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<NotificationTemplate> notificationTemplates,
+			Collection<NotificationTemplate> notificationTemplates,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -823,7 +836,7 @@ public abstract class BaseNotificationTemplateResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<NotificationTemplate>,
+			<Collection<NotificationTemplate>,
 			 UnsafeConsumer<NotificationTemplate, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -1007,8 +1020,7 @@ public abstract class BaseNotificationTemplateResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -1020,8 +1032,8 @@ public abstract class BaseNotificationTemplateResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -1034,8 +1046,7 @@ public abstract class BaseNotificationTemplateResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -1049,8 +1060,8 @@ public abstract class BaseNotificationTemplateResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -1066,7 +1077,7 @@ public abstract class BaseNotificationTemplateResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<NotificationTemplate>,
+		<Collection<NotificationTemplate>,
 		 UnsafeConsumer<NotificationTemplate, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -1084,6 +1095,115 @@ public abstract class BaseNotificationTemplateResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseNotificationTemplateResourceImpl.class);

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectActionResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectActionResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.object.admin.rest.resource.v1_0.ObjectActionResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -566,7 +579,7 @@ public abstract class BaseObjectActionResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<ObjectAction> objectActions,
+			Collection<ObjectAction> objectActions,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -609,7 +622,7 @@ public abstract class BaseObjectActionResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<ObjectAction> objectActions,
+			Collection<ObjectAction> objectActions,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -686,7 +699,7 @@ public abstract class BaseObjectActionResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<ObjectAction> objectActions,
+			Collection<ObjectAction> objectActions,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -733,9 +746,8 @@ public abstract class BaseObjectActionResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<ObjectAction>,
-			 UnsafeConsumer<ObjectAction, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<ObjectAction>, UnsafeConsumer<ObjectAction, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -916,8 +928,7 @@ public abstract class BaseObjectActionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -929,8 +940,8 @@ public abstract class BaseObjectActionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -943,8 +954,7 @@ public abstract class BaseObjectActionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -958,8 +968,8 @@ public abstract class BaseObjectActionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -975,9 +985,8 @@ public abstract class BaseObjectActionResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<ObjectAction>,
-		 UnsafeConsumer<ObjectAction, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<ObjectAction>, UnsafeConsumer<ObjectAction, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -993,6 +1002,115 @@ public abstract class BaseObjectActionResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseObjectActionResourceImpl.class);

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectDefinitionResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectDefinitionResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.object.admin.rest.resource.v1_0.ObjectDefinitionResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -641,7 +654,7 @@ public abstract class BaseObjectDefinitionResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<ObjectDefinition> objectDefinitions,
+			Collection<ObjectDefinition> objectDefinitions,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -682,7 +695,7 @@ public abstract class BaseObjectDefinitionResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<ObjectDefinition> objectDefinitions,
+			Collection<ObjectDefinition> objectDefinitions,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -752,7 +765,7 @@ public abstract class BaseObjectDefinitionResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<ObjectDefinition> objectDefinitions,
+			Collection<ObjectDefinition> objectDefinitions,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -805,7 +818,7 @@ public abstract class BaseObjectDefinitionResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<ObjectDefinition>,
+			<Collection<ObjectDefinition>,
 			 UnsafeConsumer<ObjectDefinition, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -989,8 +1002,7 @@ public abstract class BaseObjectDefinitionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -1002,8 +1014,8 @@ public abstract class BaseObjectDefinitionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -1016,8 +1028,7 @@ public abstract class BaseObjectDefinitionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -1031,8 +1042,8 @@ public abstract class BaseObjectDefinitionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -1048,7 +1059,7 @@ public abstract class BaseObjectDefinitionResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<ObjectDefinition>,
+		<Collection<ObjectDefinition>,
 		 UnsafeConsumer<ObjectDefinition, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -1066,6 +1077,115 @@ public abstract class BaseObjectDefinitionResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseObjectDefinitionResourceImpl.class);

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectFieldResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectFieldResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.object.admin.rest.resource.v1_0.ObjectFieldResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -602,7 +615,7 @@ public abstract class BaseObjectFieldResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<ObjectField> objectFields,
+			Collection<ObjectField> objectFields,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -644,7 +657,7 @@ public abstract class BaseObjectFieldResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<ObjectField> objectFields,
+			Collection<ObjectField> objectFields,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -721,7 +734,7 @@ public abstract class BaseObjectFieldResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<ObjectField> objectFields,
+			Collection<ObjectField> objectFields,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -767,9 +780,8 @@ public abstract class BaseObjectFieldResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<ObjectField>,
-			 UnsafeConsumer<ObjectField, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<ObjectField>, UnsafeConsumer<ObjectField, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -950,8 +962,7 @@ public abstract class BaseObjectFieldResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -963,8 +974,8 @@ public abstract class BaseObjectFieldResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -977,8 +988,7 @@ public abstract class BaseObjectFieldResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -992,8 +1002,8 @@ public abstract class BaseObjectFieldResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -1009,9 +1019,8 @@ public abstract class BaseObjectFieldResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<ObjectField>,
-		 UnsafeConsumer<ObjectField, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<ObjectField>, UnsafeConsumer<ObjectField, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -1027,6 +1036,115 @@ public abstract class BaseObjectFieldResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseObjectFieldResourceImpl.class);

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectLayoutResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectLayoutResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.object.admin.rest.resource.v1_0.ObjectLayoutResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -472,7 +485,7 @@ public abstract class BaseObjectLayoutResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<ObjectLayout> objectLayouts,
+			Collection<ObjectLayout> objectLayouts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -515,7 +528,7 @@ public abstract class BaseObjectLayoutResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<ObjectLayout> objectLayouts,
+			Collection<ObjectLayout> objectLayouts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -592,7 +605,7 @@ public abstract class BaseObjectLayoutResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<ObjectLayout> objectLayouts,
+			Collection<ObjectLayout> objectLayouts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -632,9 +645,8 @@ public abstract class BaseObjectLayoutResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<ObjectLayout>,
-			 UnsafeConsumer<ObjectLayout, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<ObjectLayout>, UnsafeConsumer<ObjectLayout, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -811,8 +823,7 @@ public abstract class BaseObjectLayoutResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -824,8 +835,8 @@ public abstract class BaseObjectLayoutResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -838,8 +849,7 @@ public abstract class BaseObjectLayoutResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -853,8 +863,8 @@ public abstract class BaseObjectLayoutResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -870,9 +880,8 @@ public abstract class BaseObjectLayoutResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<ObjectLayout>,
-		 UnsafeConsumer<ObjectLayout, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<ObjectLayout>, UnsafeConsumer<ObjectLayout, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -888,6 +897,115 @@ public abstract class BaseObjectLayoutResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseObjectLayoutResourceImpl.class);

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectRelationshipResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectRelationshipResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.object.admin.rest.resource.v1_0.ObjectRelationshipResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -507,7 +520,7 @@ public abstract class BaseObjectRelationshipResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<ObjectRelationship> objectRelationships,
+			Collection<ObjectRelationship> objectRelationships,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -551,7 +564,7 @@ public abstract class BaseObjectRelationshipResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<ObjectRelationship> objectRelationships,
+			Collection<ObjectRelationship> objectRelationships,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -628,7 +641,7 @@ public abstract class BaseObjectRelationshipResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<ObjectRelationship> objectRelationships,
+			Collection<ObjectRelationship> objectRelationships,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -671,7 +684,7 @@ public abstract class BaseObjectRelationshipResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<ObjectRelationship>,
+			<Collection<ObjectRelationship>,
 			 UnsafeConsumer<ObjectRelationship, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -850,8 +863,7 @@ public abstract class BaseObjectRelationshipResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -863,8 +875,8 @@ public abstract class BaseObjectRelationshipResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -877,8 +889,7 @@ public abstract class BaseObjectRelationshipResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -892,8 +903,8 @@ public abstract class BaseObjectRelationshipResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -909,7 +920,7 @@ public abstract class BaseObjectRelationshipResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<ObjectRelationship>,
+		<Collection<ObjectRelationship>,
 		 UnsafeConsumer<ObjectRelationship, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -927,6 +938,115 @@ public abstract class BaseObjectRelationshipResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseObjectRelationshipResourceImpl.class);

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectValidationRuleResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectValidationRuleResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.object.admin.rest.resource.v1_0.ObjectValidationRuleResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -619,7 +632,7 @@ public abstract class BaseObjectValidationRuleResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<ObjectValidationRule> objectValidationRules,
+			Collection<ObjectValidationRule> objectValidationRules,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -664,7 +677,7 @@ public abstract class BaseObjectValidationRuleResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<ObjectValidationRule> objectValidationRules,
+			Collection<ObjectValidationRule> objectValidationRules,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -743,7 +756,7 @@ public abstract class BaseObjectValidationRuleResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<ObjectValidationRule> objectValidationRules,
+			Collection<ObjectValidationRule> objectValidationRules,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -800,7 +813,7 @@ public abstract class BaseObjectValidationRuleResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<ObjectValidationRule>,
+			<Collection<ObjectValidationRule>,
 			 UnsafeConsumer<ObjectValidationRule, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -984,8 +997,7 @@ public abstract class BaseObjectValidationRuleResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -997,8 +1009,8 @@ public abstract class BaseObjectValidationRuleResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -1011,8 +1023,7 @@ public abstract class BaseObjectValidationRuleResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -1026,8 +1037,8 @@ public abstract class BaseObjectValidationRuleResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -1043,7 +1054,7 @@ public abstract class BaseObjectValidationRuleResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<ObjectValidationRule>,
+		<Collection<ObjectValidationRule>,
 		 UnsafeConsumer<ObjectValidationRule, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -1061,6 +1072,115 @@ public abstract class BaseObjectValidationRuleResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseObjectValidationRuleResourceImpl.class);

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectViewResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectViewResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.object.admin.rest.resource.v1_0.ObjectViewResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -502,7 +515,7 @@ public abstract class BaseObjectViewResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<ObjectView> objectViews,
+			Collection<ObjectView> objectViews,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -544,7 +557,7 @@ public abstract class BaseObjectViewResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<ObjectView> objectViews,
+			Collection<ObjectView> objectViews,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -621,7 +634,7 @@ public abstract class BaseObjectViewResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<ObjectView> objectViews,
+			Collection<ObjectView> objectViews,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -660,9 +673,8 @@ public abstract class BaseObjectViewResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<ObjectView>,
-			 UnsafeConsumer<ObjectView, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<ObjectView>, UnsafeConsumer<ObjectView, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -839,8 +851,7 @@ public abstract class BaseObjectViewResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -852,8 +863,8 @@ public abstract class BaseObjectViewResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -866,8 +877,7 @@ public abstract class BaseObjectViewResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -881,8 +891,8 @@ public abstract class BaseObjectViewResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -898,9 +908,8 @@ public abstract class BaseObjectViewResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<ObjectView>,
-		 UnsafeConsumer<ObjectView, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<ObjectView>, UnsafeConsumer<ObjectView, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -916,6 +925,115 @@ public abstract class BaseObjectViewResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseObjectViewResourceImpl.class);

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseObjectEntryResourceImpl.java
@@ -19,17 +19,22 @@ import com.liferay.object.rest.resource.v1_0.ObjectEntryResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -49,6 +54,7 @@ import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTa
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.permission.ModelPermissionsUtil;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.permission.PermissionUtil;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
@@ -56,7 +62,13 @@ import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -873,15 +885,14 @@ public abstract class BaseObjectEntryResourceImpl
 	@javax.ws.rs.Path("/{objectEntryId}/permissions")
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			getObjectEntryPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("objectEntryId")
-				Long objectEntryId,
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.ws.rs.QueryParam("roleNames")
-				String roleNames)
+	public Page<Permission> getObjectEntryPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("objectEntryId")
+			Long objectEntryId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("roleNames")
+			String roleNames)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(objectEntryId);
@@ -921,13 +932,12 @@ public abstract class BaseObjectEntryResourceImpl
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@javax.ws.rs.PUT
 	@Override
-	public Page<com.liferay.portal.vulcan.permission.Permission>
-			putObjectEntryPermissionsPage(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("objectEntryId")
-				Long objectEntryId,
-				com.liferay.portal.vulcan.permission.Permission[] permissions)
+	public Page<Permission> putObjectEntryPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("objectEntryId")
+			Long objectEntryId,
+			Permission[] permissions)
 		throws Exception {
 
 		String resourceName = getPermissionCheckerResourceName(objectEntryId);
@@ -1053,7 +1063,7 @@ public abstract class BaseObjectEntryResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<ObjectEntry> objectEntries,
+			Collection<ObjectEntry> objectEntries,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -1092,7 +1102,7 @@ public abstract class BaseObjectEntryResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<ObjectEntry> objectEntries,
+			Collection<ObjectEntry> objectEntries,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -1162,7 +1172,7 @@ public abstract class BaseObjectEntryResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<ObjectEntry> objectEntries,
+			Collection<ObjectEntry> objectEntries,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -1231,10 +1241,9 @@ public abstract class BaseObjectEntryResourceImpl
 			"This method needs to be implemented");
 	}
 
-	protected Page<com.liferay.portal.vulcan.permission.Permission>
-			toPermissionPage(
-				Map<String, Map<String, String>> actions, long id,
-				String resourceName, String roleNames)
+	protected Page<Permission> toPermissionPage(
+			Map<String, Map<String, String>> actions, long id,
+			String resourceName, String roleNames)
 		throws Exception {
 
 		List<ResourceAction> resourceActions =
@@ -1243,24 +1252,16 @@ public abstract class BaseObjectEntryResourceImpl
 		if (Validator.isNotNull(roleNames)) {
 			return Page.of(
 				actions,
-				transform(
-					PermissionUtil.getRoles(
-						contextCompany, roleLocalService,
-						StringUtil.split(roleNames)),
-					role -> PermissionUtil.toPermission(
-						contextCompany.getCompanyId(), id, resourceActions,
-						resourceName, resourcePermissionLocalService, role)));
+				_getPermissions(
+					contextCompany.getCompanyId(), resourceActions, id,
+					resourceName, StringUtil.split(roleNames)));
 		}
 
 		return Page.of(
 			actions,
-			transform(
-				PermissionUtil.getResourcePermissions(
-					contextCompany.getCompanyId(), id, resourceName,
-					resourcePermissionLocalService),
-				resourcePermission -> PermissionUtil.toPermission(
-					resourceActions, resourcePermission,
-					roleLocalService.getRole(resourcePermission.getRoleId()))));
+			_getPermissions(
+				contextCompany.getCompanyId(), resourceActions, id,
+				resourceName, null));
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
@@ -1269,9 +1270,8 @@ public abstract class BaseObjectEntryResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<ObjectEntry>,
-			 UnsafeConsumer<ObjectEntry, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<ObjectEntry>, UnsafeConsumer<ObjectEntry, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -1452,8 +1452,7 @@ public abstract class BaseObjectEntryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -1465,8 +1464,8 @@ public abstract class BaseObjectEntryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -1479,8 +1478,7 @@ public abstract class BaseObjectEntryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -1494,8 +1492,8 @@ public abstract class BaseObjectEntryResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -1511,9 +1509,8 @@ public abstract class BaseObjectEntryResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<ObjectEntry>,
-		 UnsafeConsumer<ObjectEntry, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<ObjectEntry>, UnsafeConsumer<ObjectEntry, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -1529,6 +1526,115 @@ public abstract class BaseObjectEntryResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseObjectEntryResourceImpl.class);

--- a/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/resource/v1_0/BaseSuggestionResourceImpl.java
+++ b/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/resource/v1_0/BaseSuggestionResourceImpl.java
@@ -15,14 +15,20 @@
 package com.liferay.portal.search.rest.internal.resource.v1_0;
 
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
@@ -31,12 +37,20 @@ import com.liferay.portal.search.rest.dto.v1_0.SuggestionsContributorResults;
 import com.liferay.portal.search.rest.resource.v1_0.SuggestionResource;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -231,8 +245,7 @@ public abstract class BaseSuggestionResourceImpl implements SuggestionResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -244,8 +257,8 @@ public abstract class BaseSuggestionResourceImpl implements SuggestionResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -258,8 +271,7 @@ public abstract class BaseSuggestionResourceImpl implements SuggestionResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -273,8 +285,8 @@ public abstract class BaseSuggestionResourceImpl implements SuggestionResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -302,6 +314,115 @@ public abstract class BaseSuggestionResourceImpl implements SuggestionResource {
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseSuggestionResourceImpl.class);

--- a/modules/dxp/apps/commerce-punchout/headless/headless-commerce-punchout-impl/src/main/java/com/liferay/headless/commerce/punchout/internal/resource/v1_0/BasePunchOutSessionResourceImpl.java
+++ b/modules/dxp/apps/commerce-punchout/headless/headless-commerce-punchout-impl/src/main/java/com/liferay/headless/commerce/punchout/internal/resource/v1_0/BasePunchOutSessionResourceImpl.java
@@ -18,23 +18,38 @@ import com.liferay.headless.commerce.punchout.dto.v1_0.PunchOutSession;
 import com.liferay.headless.commerce.punchout.dto.v1_0.User;
 import com.liferay.headless.commerce.punchout.resource.v1_0.PunchOutSessionResource;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -180,8 +195,7 @@ public abstract class BasePunchOutSessionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -193,8 +207,8 @@ public abstract class BasePunchOutSessionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -207,8 +221,7 @@ public abstract class BasePunchOutSessionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -222,8 +235,8 @@ public abstract class BasePunchOutSessionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -251,6 +264,115 @@ public abstract class BasePunchOutSessionResourceImpl
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BasePunchOutSessionResourceImpl.class);

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/BaseAccountCategoryForecastResourceImpl.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/BaseAccountCategoryForecastResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.machine.learning.resource.v1_0.AccountCateg
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -151,8 +164,7 @@ public abstract class BaseAccountCategoryForecastResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<AccountCategoryForecast>
-				accountCategoryForecasts,
+			Collection<AccountCategoryForecast> accountCategoryForecasts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -162,8 +174,7 @@ public abstract class BaseAccountCategoryForecastResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<AccountCategoryForecast>
-				accountCategoryForecasts,
+			Collection<AccountCategoryForecast> accountCategoryForecasts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -232,8 +243,7 @@ public abstract class BaseAccountCategoryForecastResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<AccountCategoryForecast>
-				accountCategoryForecasts,
+			Collection<AccountCategoryForecast> accountCategoryForecasts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -247,7 +257,7 @@ public abstract class BaseAccountCategoryForecastResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<AccountCategoryForecast>,
+			<Collection<AccountCategoryForecast>,
 			 UnsafeConsumer<AccountCategoryForecast, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -426,8 +436,7 @@ public abstract class BaseAccountCategoryForecastResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -439,8 +448,8 @@ public abstract class BaseAccountCategoryForecastResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -453,8 +462,7 @@ public abstract class BaseAccountCategoryForecastResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -468,8 +476,8 @@ public abstract class BaseAccountCategoryForecastResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -485,7 +493,7 @@ public abstract class BaseAccountCategoryForecastResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<AccountCategoryForecast>,
+		<Collection<AccountCategoryForecast>,
 		 UnsafeConsumer<AccountCategoryForecast, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -503,6 +511,115 @@ public abstract class BaseAccountCategoryForecastResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseAccountCategoryForecastResourceImpl.class);

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/BaseAccountForecastResourceImpl.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/BaseAccountForecastResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.machine.learning.resource.v1_0.AccountForec
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -141,7 +154,7 @@ public abstract class BaseAccountForecastResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<AccountForecast> accountForecasts,
+			Collection<AccountForecast> accountForecasts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -151,7 +164,7 @@ public abstract class BaseAccountForecastResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<AccountForecast> accountForecasts,
+			Collection<AccountForecast> accountForecasts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -220,7 +233,7 @@ public abstract class BaseAccountForecastResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<AccountForecast> accountForecasts,
+			Collection<AccountForecast> accountForecasts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -234,7 +247,7 @@ public abstract class BaseAccountForecastResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<AccountForecast>,
+			<Collection<AccountForecast>,
 			 UnsafeConsumer<AccountForecast, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -413,8 +426,7 @@ public abstract class BaseAccountForecastResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -426,8 +438,8 @@ public abstract class BaseAccountForecastResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -440,8 +452,7 @@ public abstract class BaseAccountForecastResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -455,8 +466,8 @@ public abstract class BaseAccountForecastResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -472,7 +483,7 @@ public abstract class BaseAccountForecastResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<AccountForecast>,
+		<Collection<AccountForecast>,
 		 UnsafeConsumer<AccountForecast, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -490,6 +501,115 @@ public abstract class BaseAccountForecastResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseAccountForecastResourceImpl.class);

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/BaseSkuForecastResourceImpl.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/BaseSkuForecastResourceImpl.java
@@ -19,15 +19,21 @@ import com.liferay.headless.commerce.machine.learning.resource.v1_0.SkuForecastR
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -43,13 +49,20 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -139,7 +152,7 @@ public abstract class BaseSkuForecastResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<SkuForecast> skuForecasts,
+			Collection<SkuForecast> skuForecasts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -149,7 +162,7 @@ public abstract class BaseSkuForecastResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<SkuForecast> skuForecasts,
+			Collection<SkuForecast> skuForecasts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -218,7 +231,7 @@ public abstract class BaseSkuForecastResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<SkuForecast> skuForecasts,
+			Collection<SkuForecast> skuForecasts,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -232,9 +245,8 @@ public abstract class BaseSkuForecastResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<SkuForecast>,
-			 UnsafeConsumer<SkuForecast, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<SkuForecast>, UnsafeConsumer<SkuForecast, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -411,8 +423,7 @@ public abstract class BaseSkuForecastResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -424,8 +435,8 @@ public abstract class BaseSkuForecastResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -438,8 +449,7 @@ public abstract class BaseSkuForecastResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -453,8 +463,8 @@ public abstract class BaseSkuForecastResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -470,9 +480,8 @@ public abstract class BaseSkuForecastResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<SkuForecast>,
-		 UnsafeConsumer<SkuForecast, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<SkuForecast>, UnsafeConsumer<SkuForecast, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -488,6 +497,115 @@ public abstract class BaseSkuForecastResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseSkuForecastResourceImpl.class);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseAssigneeMetricResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseAssigneeMetricResourceImpl.java
@@ -17,15 +17,21 @@ package com.liferay.portal.workflow.metrics.rest.internal.resource.v1_0;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -41,16 +47,24 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 import com.liferay.portal.workflow.metrics.rest.dto.v1_0.AssigneeMetric;
 import com.liferay.portal.workflow.metrics.rest.dto.v1_0.AssigneeMetricBulkSelection;
+import com.liferay.portal.workflow.metrics.rest.dto.v1_0.Role;
 import com.liferay.portal.workflow.metrics.rest.resource.v1_0.AssigneeMetricResource;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -126,7 +140,7 @@ public abstract class BaseAssigneeMetricResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<AssigneeMetric> assigneeMetrics,
+			Collection<AssigneeMetric> assigneeMetrics,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -136,7 +150,7 @@ public abstract class BaseAssigneeMetricResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<AssigneeMetric> assigneeMetrics,
+			Collection<AssigneeMetric> assigneeMetrics,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -205,7 +219,7 @@ public abstract class BaseAssigneeMetricResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<AssigneeMetric> assigneeMetrics,
+			Collection<AssigneeMetric> assigneeMetrics,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -219,7 +233,7 @@ public abstract class BaseAssigneeMetricResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<AssigneeMetric>,
+			<Collection<AssigneeMetric>,
 			 UnsafeConsumer<AssigneeMetric, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -398,8 +412,7 @@ public abstract class BaseAssigneeMetricResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -411,8 +424,8 @@ public abstract class BaseAssigneeMetricResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -425,8 +438,7 @@ public abstract class BaseAssigneeMetricResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -440,8 +452,8 @@ public abstract class BaseAssigneeMetricResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -457,9 +469,8 @@ public abstract class BaseAssigneeMetricResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<AssigneeMetric>,
-		 UnsafeConsumer<AssigneeMetric, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<AssigneeMetric>, UnsafeConsumer<AssigneeMetric, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -475,6 +486,115 @@ public abstract class BaseAssigneeMetricResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseAssigneeMetricResourceImpl.class);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseAssigneeResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseAssigneeResourceImpl.java
@@ -17,15 +17,21 @@ package com.liferay.portal.workflow.metrics.rest.internal.resource.v1_0;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -41,16 +47,24 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 import com.liferay.portal.workflow.metrics.rest.dto.v1_0.Assignee;
 import com.liferay.portal.workflow.metrics.rest.dto.v1_0.AssigneeBulkSelection;
+import com.liferay.portal.workflow.metrics.rest.dto.v1_0.Role;
 import com.liferay.portal.workflow.metrics.rest.resource.v1_0.AssigneeResource;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -110,7 +124,7 @@ public abstract class BaseAssigneeResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<Assignee> assignees,
+			Collection<Assignee> assignees,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -120,7 +134,7 @@ public abstract class BaseAssigneeResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<Assignee> assignees,
+			Collection<Assignee> assignees,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -189,7 +203,7 @@ public abstract class BaseAssigneeResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<Assignee> assignees,
+			Collection<Assignee> assignees,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -203,9 +217,8 @@ public abstract class BaseAssigneeResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<Assignee>,
-			 UnsafeConsumer<Assignee, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<Assignee>, UnsafeConsumer<Assignee, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -382,8 +395,7 @@ public abstract class BaseAssigneeResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -395,8 +407,8 @@ public abstract class BaseAssigneeResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -409,8 +421,7 @@ public abstract class BaseAssigneeResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -424,8 +435,8 @@ public abstract class BaseAssigneeResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -441,8 +452,8 @@ public abstract class BaseAssigneeResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<Assignee>, UnsafeConsumer<Assignee, Exception>,
-		 Exception> contextBatchUnsafeConsumer;
+		<Collection<Assignee>, UnsafeConsumer<Assignee, Exception>, Exception>
+			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -458,6 +469,115 @@ public abstract class BaseAssigneeResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseAssigneeResourceImpl.class);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseCalendarResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseCalendarResourceImpl.java
@@ -17,15 +17,21 @@ package com.liferay.portal.workflow.metrics.rest.internal.resource.v1_0;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -41,15 +47,23 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 import com.liferay.portal.workflow.metrics.rest.dto.v1_0.Calendar;
+import com.liferay.portal.workflow.metrics.rest.dto.v1_0.Role;
 import com.liferay.portal.workflow.metrics.rest.resource.v1_0.CalendarResource;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -93,7 +107,7 @@ public abstract class BaseCalendarResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<Calendar> calendars,
+			Collection<Calendar> calendars,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -103,7 +117,7 @@ public abstract class BaseCalendarResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<Calendar> calendars,
+			Collection<Calendar> calendars,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -171,7 +185,7 @@ public abstract class BaseCalendarResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<Calendar> calendars,
+			Collection<Calendar> calendars,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -185,9 +199,8 @@ public abstract class BaseCalendarResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<Calendar>,
-			 UnsafeConsumer<Calendar, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<Calendar>, UnsafeConsumer<Calendar, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -364,8 +377,7 @@ public abstract class BaseCalendarResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -377,8 +389,8 @@ public abstract class BaseCalendarResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -391,8 +403,7 @@ public abstract class BaseCalendarResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -406,8 +417,8 @@ public abstract class BaseCalendarResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -423,8 +434,8 @@ public abstract class BaseCalendarResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<Calendar>, UnsafeConsumer<Calendar, Exception>,
-		 Exception> contextBatchUnsafeConsumer;
+		<Collection<Calendar>, UnsafeConsumer<Calendar, Exception>, Exception>
+			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -440,6 +451,115 @@ public abstract class BaseCalendarResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseCalendarResourceImpl.class);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseHistogramMetricResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseHistogramMetricResourceImpl.java
@@ -15,25 +15,41 @@
 package com.liferay.portal.workflow.metrics.rest.internal.resource.v1_0;
 
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 import com.liferay.portal.workflow.metrics.rest.dto.v1_0.HistogramMetric;
+import com.liferay.portal.workflow.metrics.rest.dto.v1_0.Role;
 import com.liferay.portal.workflow.metrics.rest.resource.v1_0.HistogramMetricResource;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -208,8 +224,7 @@ public abstract class BaseHistogramMetricResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -221,8 +236,8 @@ public abstract class BaseHistogramMetricResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -235,8 +250,7 @@ public abstract class BaseHistogramMetricResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -250,8 +264,8 @@ public abstract class BaseHistogramMetricResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -279,6 +293,115 @@ public abstract class BaseHistogramMetricResourceImpl
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseHistogramMetricResourceImpl.class);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseIndexResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseIndexResourceImpl.java
@@ -17,15 +17,21 @@ package com.liferay.portal.workflow.metrics.rest.internal.resource.v1_0;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -41,15 +47,23 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 import com.liferay.portal.workflow.metrics.rest.dto.v1_0.Index;
+import com.liferay.portal.workflow.metrics.rest.dto.v1_0.Role;
 import com.liferay.portal.workflow.metrics.rest.resource.v1_0.IndexResource;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -125,8 +139,7 @@ public abstract class BaseIndexResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<Index> indexes,
-			Map<String, Serializable> parameters)
+			Collection<Index> indexes, Map<String, Serializable> parameters)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -135,8 +148,7 @@ public abstract class BaseIndexResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<Index> indexes,
-			Map<String, Serializable> parameters)
+			Collection<Index> indexes, Map<String, Serializable> parameters)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -204,8 +216,7 @@ public abstract class BaseIndexResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<Index> indexes,
-			Map<String, Serializable> parameters)
+			Collection<Index> indexes, Map<String, Serializable> parameters)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -218,8 +229,8 @@ public abstract class BaseIndexResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<Index>, UnsafeConsumer<Index, Exception>,
-			 Exception> contextBatchUnsafeConsumer) {
+			<Collection<Index>, UnsafeConsumer<Index, Exception>, Exception>
+				contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -396,8 +407,7 @@ public abstract class BaseIndexResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -409,8 +419,8 @@ public abstract class BaseIndexResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -423,8 +433,7 @@ public abstract class BaseIndexResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -438,8 +447,8 @@ public abstract class BaseIndexResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -455,8 +464,8 @@ public abstract class BaseIndexResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<Index>, UnsafeConsumer<Index, Exception>,
-		 Exception> contextBatchUnsafeConsumer;
+		<Collection<Index>, UnsafeConsumer<Index, Exception>, Exception>
+			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -472,6 +481,115 @@ public abstract class BaseIndexResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseIndexResourceImpl.class);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseInstanceResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseInstanceResourceImpl.java
@@ -17,15 +17,21 @@ package com.liferay.portal.workflow.metrics.rest.internal.resource.v1_0;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -41,15 +47,23 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 import com.liferay.portal.workflow.metrics.rest.dto.v1_0.Instance;
+import com.liferay.portal.workflow.metrics.rest.dto.v1_0.Role;
 import com.liferay.portal.workflow.metrics.rest.resource.v1_0.InstanceResource;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -406,7 +420,7 @@ public abstract class BaseInstanceResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<Instance> instances,
+			Collection<Instance> instances,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -446,7 +460,7 @@ public abstract class BaseInstanceResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<Instance> instances,
+			Collection<Instance> instances,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -528,7 +542,7 @@ public abstract class BaseInstanceResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<Instance> instances,
+			Collection<Instance> instances,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -542,9 +556,8 @@ public abstract class BaseInstanceResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<Instance>,
-			 UnsafeConsumer<Instance, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<Instance>, UnsafeConsumer<Instance, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -721,8 +734,7 @@ public abstract class BaseInstanceResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -734,8 +746,8 @@ public abstract class BaseInstanceResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -748,8 +760,7 @@ public abstract class BaseInstanceResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -763,8 +774,8 @@ public abstract class BaseInstanceResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -780,8 +791,8 @@ public abstract class BaseInstanceResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<Instance>, UnsafeConsumer<Instance, Exception>,
-		 Exception> contextBatchUnsafeConsumer;
+		<Collection<Instance>, UnsafeConsumer<Instance, Exception>, Exception>
+			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -797,6 +808,115 @@ public abstract class BaseInstanceResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseInstanceResourceImpl.class);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseNodeMetricResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseNodeMetricResourceImpl.java
@@ -17,15 +17,21 @@ package com.liferay.portal.workflow.metrics.rest.internal.resource.v1_0;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -41,15 +47,23 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 import com.liferay.portal.workflow.metrics.rest.dto.v1_0.NodeMetric;
+import com.liferay.portal.workflow.metrics.rest.dto.v1_0.Role;
 import com.liferay.portal.workflow.metrics.rest.resource.v1_0.NodeMetricResource;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -156,7 +170,7 @@ public abstract class BaseNodeMetricResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<NodeMetric> nodeMetrics,
+			Collection<NodeMetric> nodeMetrics,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -166,7 +180,7 @@ public abstract class BaseNodeMetricResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<NodeMetric> nodeMetrics,
+			Collection<NodeMetric> nodeMetrics,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -235,7 +249,7 @@ public abstract class BaseNodeMetricResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<NodeMetric> nodeMetrics,
+			Collection<NodeMetric> nodeMetrics,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -249,9 +263,8 @@ public abstract class BaseNodeMetricResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<NodeMetric>,
-			 UnsafeConsumer<NodeMetric, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<NodeMetric>, UnsafeConsumer<NodeMetric, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -428,8 +441,7 @@ public abstract class BaseNodeMetricResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -441,8 +453,8 @@ public abstract class BaseNodeMetricResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -455,8 +467,7 @@ public abstract class BaseNodeMetricResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -470,8 +481,8 @@ public abstract class BaseNodeMetricResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -487,9 +498,8 @@ public abstract class BaseNodeMetricResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<NodeMetric>,
-		 UnsafeConsumer<NodeMetric, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<NodeMetric>, UnsafeConsumer<NodeMetric, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -505,6 +515,115 @@ public abstract class BaseNodeMetricResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseNodeMetricResourceImpl.class);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseNodeResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseNodeResourceImpl.java
@@ -17,15 +17,21 @@ package com.liferay.portal.workflow.metrics.rest.internal.resource.v1_0;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -41,15 +47,23 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 import com.liferay.portal.workflow.metrics.rest.dto.v1_0.Node;
+import com.liferay.portal.workflow.metrics.rest.dto.v1_0.Role;
 import com.liferay.portal.workflow.metrics.rest.resource.v1_0.NodeResource;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -229,8 +243,7 @@ public abstract class BaseNodeResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<Node> nodes,
-			Map<String, Serializable> parameters)
+			Collection<Node> nodes, Map<String, Serializable> parameters)
 		throws Exception {
 
 		UnsafeConsumer<Node, Exception> nodeUnsafeConsumer = null;
@@ -267,8 +280,7 @@ public abstract class BaseNodeResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<Node> nodes,
-			Map<String, Serializable> parameters)
+			Collection<Node> nodes, Map<String, Serializable> parameters)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -342,8 +354,7 @@ public abstract class BaseNodeResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<Node> nodes,
-			Map<String, Serializable> parameters)
+			Collection<Node> nodes, Map<String, Serializable> parameters)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -356,8 +367,8 @@ public abstract class BaseNodeResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<Node>, UnsafeConsumer<Node, Exception>,
-			 Exception> contextBatchUnsafeConsumer) {
+			<Collection<Node>, UnsafeConsumer<Node, Exception>, Exception>
+				contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -534,8 +545,7 @@ public abstract class BaseNodeResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -547,8 +557,8 @@ public abstract class BaseNodeResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -561,8 +571,7 @@ public abstract class BaseNodeResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -576,8 +585,8 @@ public abstract class BaseNodeResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -593,7 +602,7 @@ public abstract class BaseNodeResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<Node>, UnsafeConsumer<Node, Exception>, Exception>
+		<Collection<Node>, UnsafeConsumer<Node, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
@@ -610,6 +619,115 @@ public abstract class BaseNodeResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseNodeResourceImpl.class);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseProcessMetricResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseProcessMetricResourceImpl.java
@@ -17,15 +17,21 @@ package com.liferay.portal.workflow.metrics.rest.internal.resource.v1_0;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -41,15 +47,23 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 import com.liferay.portal.workflow.metrics.rest.dto.v1_0.ProcessMetric;
+import com.liferay.portal.workflow.metrics.rest.dto.v1_0.Role;
 import com.liferay.portal.workflow.metrics.rest.resource.v1_0.ProcessMetricResource;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -175,7 +189,7 @@ public abstract class BaseProcessMetricResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<ProcessMetric> processMetrics,
+			Collection<ProcessMetric> processMetrics,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -185,7 +199,7 @@ public abstract class BaseProcessMetricResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<ProcessMetric> processMetrics,
+			Collection<ProcessMetric> processMetrics,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -254,7 +268,7 @@ public abstract class BaseProcessMetricResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<ProcessMetric> processMetrics,
+			Collection<ProcessMetric> processMetrics,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -268,7 +282,7 @@ public abstract class BaseProcessMetricResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<ProcessMetric>,
+			<Collection<ProcessMetric>,
 			 UnsafeConsumer<ProcessMetric, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -447,8 +461,7 @@ public abstract class BaseProcessMetricResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -460,8 +473,8 @@ public abstract class BaseProcessMetricResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -474,8 +487,7 @@ public abstract class BaseProcessMetricResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -489,8 +501,8 @@ public abstract class BaseProcessMetricResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -506,9 +518,8 @@ public abstract class BaseProcessMetricResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<ProcessMetric>,
-		 UnsafeConsumer<ProcessMetric, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<ProcessMetric>, UnsafeConsumer<ProcessMetric, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -524,6 +535,115 @@ public abstract class BaseProcessMetricResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseProcessMetricResourceImpl.class);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseProcessResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseProcessResourceImpl.java
@@ -18,15 +18,21 @@ import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -42,15 +48,23 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 import com.liferay.portal.workflow.metrics.rest.dto.v1_0.Process;
+import com.liferay.portal.workflow.metrics.rest.dto.v1_0.Role;
 import com.liferay.portal.workflow.metrics.rest.resource.v1_0.ProcessResource;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -347,8 +361,7 @@ public abstract class BaseProcessResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<Process> processes,
-			Map<String, Serializable> parameters)
+			Collection<Process> processes, Map<String, Serializable> parameters)
 		throws Exception {
 
 		UnsafeConsumer<Process, Exception> processUnsafeConsumer = null;
@@ -378,8 +391,7 @@ public abstract class BaseProcessResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<Process> processes,
-			Map<String, Serializable> parameters)
+			Collection<Process> processes, Map<String, Serializable> parameters)
 		throws Exception {
 
 		for (Process process : processes) {
@@ -448,8 +460,7 @@ public abstract class BaseProcessResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<Process> processes,
-			Map<String, Serializable> parameters)
+			Collection<Process> processes, Map<String, Serializable> parameters)
 		throws Exception {
 
 		UnsafeConsumer<Process, Exception> processUnsafeConsumer = null;
@@ -486,8 +497,8 @@ public abstract class BaseProcessResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<Process>, UnsafeConsumer<Process, Exception>,
-			 Exception> contextBatchUnsafeConsumer) {
+			<Collection<Process>, UnsafeConsumer<Process, Exception>, Exception>
+				contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -664,8 +675,7 @@ public abstract class BaseProcessResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -677,8 +687,8 @@ public abstract class BaseProcessResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -691,8 +701,7 @@ public abstract class BaseProcessResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -706,8 +715,8 @@ public abstract class BaseProcessResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -723,8 +732,8 @@ public abstract class BaseProcessResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<Process>, UnsafeConsumer<Process, Exception>,
-		 Exception> contextBatchUnsafeConsumer;
+		<Collection<Process>, UnsafeConsumer<Process, Exception>, Exception>
+			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -740,6 +749,115 @@ public abstract class BaseProcessResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseProcessResourceImpl.class);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseProcessVersionResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseProcessVersionResourceImpl.java
@@ -17,15 +17,21 @@ package com.liferay.portal.workflow.metrics.rest.internal.resource.v1_0;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -41,15 +47,23 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 import com.liferay.portal.workflow.metrics.rest.dto.v1_0.ProcessVersion;
+import com.liferay.portal.workflow.metrics.rest.dto.v1_0.Role;
 import com.liferay.portal.workflow.metrics.rest.resource.v1_0.ProcessVersionResource;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -110,7 +124,7 @@ public abstract class BaseProcessVersionResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<ProcessVersion> processVersions,
+			Collection<ProcessVersion> processVersions,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -120,7 +134,7 @@ public abstract class BaseProcessVersionResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<ProcessVersion> processVersions,
+			Collection<ProcessVersion> processVersions,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -195,7 +209,7 @@ public abstract class BaseProcessVersionResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<ProcessVersion> processVersions,
+			Collection<ProcessVersion> processVersions,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -209,7 +223,7 @@ public abstract class BaseProcessVersionResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<ProcessVersion>,
+			<Collection<ProcessVersion>,
 			 UnsafeConsumer<ProcessVersion, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -388,8 +402,7 @@ public abstract class BaseProcessVersionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -401,8 +414,8 @@ public abstract class BaseProcessVersionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -415,8 +428,7 @@ public abstract class BaseProcessVersionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -430,8 +442,8 @@ public abstract class BaseProcessVersionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -447,9 +459,8 @@ public abstract class BaseProcessVersionResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<ProcessVersion>,
-		 UnsafeConsumer<ProcessVersion, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<ProcessVersion>, UnsafeConsumer<ProcessVersion, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -465,6 +476,115 @@ public abstract class BaseProcessVersionResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseProcessVersionResourceImpl.class);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseReindexStatusResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseReindexStatusResourceImpl.java
@@ -17,15 +17,21 @@ package com.liferay.portal.workflow.metrics.rest.internal.resource.v1_0;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -41,15 +47,23 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 import com.liferay.portal.workflow.metrics.rest.dto.v1_0.ReindexStatus;
+import com.liferay.portal.workflow.metrics.rest.dto.v1_0.Role;
 import com.liferay.portal.workflow.metrics.rest.resource.v1_0.ReindexStatusResource;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -95,7 +109,7 @@ public abstract class BaseReindexStatusResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<ReindexStatus> reindexStatuses,
+			Collection<ReindexStatus> reindexStatuses,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -105,7 +119,7 @@ public abstract class BaseReindexStatusResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<ReindexStatus> reindexStatuses,
+			Collection<ReindexStatus> reindexStatuses,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -174,7 +188,7 @@ public abstract class BaseReindexStatusResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<ReindexStatus> reindexStatuses,
+			Collection<ReindexStatus> reindexStatuses,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -188,7 +202,7 @@ public abstract class BaseReindexStatusResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<ReindexStatus>,
+			<Collection<ReindexStatus>,
 			 UnsafeConsumer<ReindexStatus, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -367,8 +381,7 @@ public abstract class BaseReindexStatusResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -380,8 +393,8 @@ public abstract class BaseReindexStatusResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -394,8 +407,7 @@ public abstract class BaseReindexStatusResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -409,8 +421,8 @@ public abstract class BaseReindexStatusResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -426,9 +438,8 @@ public abstract class BaseReindexStatusResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<ReindexStatus>,
-		 UnsafeConsumer<ReindexStatus, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<ReindexStatus>, UnsafeConsumer<ReindexStatus, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -444,6 +455,115 @@ public abstract class BaseReindexStatusResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseReindexStatusResourceImpl.class);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseRoleResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseRoleResourceImpl.java
@@ -17,15 +17,21 @@ package com.liferay.portal.workflow.metrics.rest.internal.resource.v1_0;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -41,6 +47,7 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
@@ -49,7 +56,13 @@ import com.liferay.portal.workflow.metrics.rest.resource.v1_0.RoleResource;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -115,8 +128,7 @@ public abstract class BaseRoleResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<Role> roles,
-			Map<String, Serializable> parameters)
+			Collection<Role> roles, Map<String, Serializable> parameters)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -125,8 +137,7 @@ public abstract class BaseRoleResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<Role> roles,
-			Map<String, Serializable> parameters)
+			Collection<Role> roles, Map<String, Serializable> parameters)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -201,8 +212,7 @@ public abstract class BaseRoleResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<Role> roles,
-			Map<String, Serializable> parameters)
+			Collection<Role> roles, Map<String, Serializable> parameters)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -215,8 +225,8 @@ public abstract class BaseRoleResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<Role>, UnsafeConsumer<Role, Exception>,
-			 Exception> contextBatchUnsafeConsumer) {
+			<Collection<Role>, UnsafeConsumer<Role, Exception>, Exception>
+				contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -393,8 +403,7 @@ public abstract class BaseRoleResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -406,8 +415,8 @@ public abstract class BaseRoleResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -420,8 +429,7 @@ public abstract class BaseRoleResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -435,8 +443,8 @@ public abstract class BaseRoleResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -452,7 +460,7 @@ public abstract class BaseRoleResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<Role>, UnsafeConsumer<Role, Exception>, Exception>
+		<Collection<Role>, UnsafeConsumer<Role, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
@@ -469,6 +477,115 @@ public abstract class BaseRoleResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseRoleResourceImpl.class);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseSLAResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseSLAResourceImpl.java
@@ -17,15 +17,21 @@ package com.liferay.portal.workflow.metrics.rest.internal.resource.v1_0;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -41,15 +47,23 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
+import com.liferay.portal.workflow.metrics.rest.dto.v1_0.Role;
 import com.liferay.portal.workflow.metrics.rest.dto.v1_0.SLA;
 import com.liferay.portal.workflow.metrics.rest.resource.v1_0.SLAResource;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -405,8 +419,7 @@ public abstract class BaseSLAResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<SLA> slas,
-			Map<String, Serializable> parameters)
+			Collection<SLA> slas, Map<String, Serializable> parameters)
 		throws Exception {
 
 		UnsafeConsumer<SLA, Exception> slaUnsafeConsumer = null;
@@ -443,8 +456,7 @@ public abstract class BaseSLAResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<SLA> slas,
-			Map<String, Serializable> parameters)
+			Collection<SLA> slas, Map<String, Serializable> parameters)
 		throws Exception {
 
 		for (SLA sla : slas) {
@@ -520,8 +532,7 @@ public abstract class BaseSLAResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<SLA> slas,
-			Map<String, Serializable> parameters)
+			Collection<SLA> slas, Map<String, Serializable> parameters)
 		throws Exception {
 
 		UnsafeConsumer<SLA, Exception> slaUnsafeConsumer = null;
@@ -558,8 +569,8 @@ public abstract class BaseSLAResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<SLA>, UnsafeConsumer<SLA, Exception>,
-			 Exception> contextBatchUnsafeConsumer) {
+			<Collection<SLA>, UnsafeConsumer<SLA, Exception>, Exception>
+				contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -736,8 +747,7 @@ public abstract class BaseSLAResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -749,8 +759,8 @@ public abstract class BaseSLAResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -763,8 +773,7 @@ public abstract class BaseSLAResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -778,8 +787,8 @@ public abstract class BaseSLAResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -795,7 +804,7 @@ public abstract class BaseSLAResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<SLA>, UnsafeConsumer<SLA, Exception>, Exception>
+		<Collection<SLA>, UnsafeConsumer<SLA, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
@@ -812,6 +821,115 @@ public abstract class BaseSLAResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseSLAResourceImpl.class);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseSLAResultResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseSLAResultResourceImpl.java
@@ -15,25 +15,41 @@
 package com.liferay.portal.workflow.metrics.rest.internal.resource.v1_0;
 
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
+import com.liferay.portal.workflow.metrics.rest.dto.v1_0.Role;
 import com.liferay.portal.workflow.metrics.rest.dto.v1_0.SLAResult;
 import com.liferay.portal.workflow.metrics.rest.resource.v1_0.SLAResultResource;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -183,8 +199,7 @@ public abstract class BaseSLAResultResourceImpl implements SLAResultResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -196,8 +211,8 @@ public abstract class BaseSLAResultResourceImpl implements SLAResultResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -210,8 +225,7 @@ public abstract class BaseSLAResultResourceImpl implements SLAResultResource {
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -225,8 +239,8 @@ public abstract class BaseSLAResultResourceImpl implements SLAResultResource {
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -254,6 +268,115 @@ public abstract class BaseSLAResultResourceImpl implements SLAResultResource {
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseSLAResultResourceImpl.class);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseTaskResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseTaskResourceImpl.java
@@ -17,15 +17,21 @@ package com.liferay.portal.workflow.metrics.rest.internal.resource.v1_0;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -41,16 +47,24 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
+import com.liferay.portal.workflow.metrics.rest.dto.v1_0.Role;
 import com.liferay.portal.workflow.metrics.rest.dto.v1_0.Task;
 import com.liferay.portal.workflow.metrics.rest.dto.v1_0.TaskBulkSelection;
 import com.liferay.portal.workflow.metrics.rest.resource.v1_0.TaskResource;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -377,8 +391,7 @@ public abstract class BaseTaskResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<Task> tasks,
-			Map<String, Serializable> parameters)
+			Collection<Task> tasks, Map<String, Serializable> parameters)
 		throws Exception {
 
 		UnsafeConsumer<Task, Exception> taskUnsafeConsumer = null;
@@ -415,8 +428,7 @@ public abstract class BaseTaskResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<Task> tasks,
-			Map<String, Serializable> parameters)
+			Collection<Task> tasks, Map<String, Serializable> parameters)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -490,8 +502,7 @@ public abstract class BaseTaskResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<Task> tasks,
-			Map<String, Serializable> parameters)
+			Collection<Task> tasks, Map<String, Serializable> parameters)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -504,8 +515,8 @@ public abstract class BaseTaskResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<Task>, UnsafeConsumer<Task, Exception>,
-			 Exception> contextBatchUnsafeConsumer) {
+			<Collection<Task>, UnsafeConsumer<Task, Exception>, Exception>
+				contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -682,8 +693,7 @@ public abstract class BaseTaskResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -695,8 +705,8 @@ public abstract class BaseTaskResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -709,8 +719,7 @@ public abstract class BaseTaskResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -724,8 +733,8 @@ public abstract class BaseTaskResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -741,7 +750,7 @@ public abstract class BaseTaskResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<Task>, UnsafeConsumer<Task, Exception>, Exception>
+		<Collection<Task>, UnsafeConsumer<Task, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
@@ -758,6 +767,115 @@ public abstract class BaseTaskResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseTaskResourceImpl.class);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseTimeRangeResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseTimeRangeResourceImpl.java
@@ -17,15 +17,21 @@ package com.liferay.portal.workflow.metrics.rest.internal.resource.v1_0;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -41,15 +47,23 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
+import com.liferay.portal.workflow.metrics.rest.dto.v1_0.Role;
 import com.liferay.portal.workflow.metrics.rest.dto.v1_0.TimeRange;
 import com.liferay.portal.workflow.metrics.rest.resource.v1_0.TimeRangeResource;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -93,7 +107,7 @@ public abstract class BaseTimeRangeResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<TimeRange> timeRanges,
+			Collection<TimeRange> timeRanges,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -103,7 +117,7 @@ public abstract class BaseTimeRangeResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<TimeRange> timeRanges,
+			Collection<TimeRange> timeRanges,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -171,7 +185,7 @@ public abstract class BaseTimeRangeResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<TimeRange> timeRanges,
+			Collection<TimeRange> timeRanges,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -185,9 +199,8 @@ public abstract class BaseTimeRangeResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<TimeRange>,
-			 UnsafeConsumer<TimeRange, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<TimeRange>, UnsafeConsumer<TimeRange, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -364,8 +377,7 @@ public abstract class BaseTimeRangeResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -377,8 +389,8 @@ public abstract class BaseTimeRangeResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -391,8 +403,7 @@ public abstract class BaseTimeRangeResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -406,8 +417,8 @@ public abstract class BaseTimeRangeResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -423,8 +434,8 @@ public abstract class BaseTimeRangeResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<TimeRange>, UnsafeConsumer<TimeRange, Exception>,
-		 Exception> contextBatchUnsafeConsumer;
+		<Collection<TimeRange>, UnsafeConsumer<TimeRange, Exception>, Exception>
+			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -440,6 +451,115 @@ public abstract class BaseTimeRangeResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseTimeRangeResourceImpl.class);

--- a/modules/dxp/apps/saml/saml-admin-rest-impl/src/main/java/com/liferay/saml/admin/rest/internal/resource/v1_0/BaseSamlProviderResourceImpl.java
+++ b/modules/dxp/apps/saml/saml-admin-rest-impl/src/main/java/com/liferay/saml/admin/rest/internal/resource/v1_0/BaseSamlProviderResourceImpl.java
@@ -17,15 +17,21 @@ package com.liferay.saml.admin.rest.internal.resource.v1_0;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -41,6 +47,7 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
@@ -49,7 +56,13 @@ import com.liferay.saml.admin.rest.resource.v1_0.SamlProviderResource;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -186,7 +199,7 @@ public abstract class BaseSamlProviderResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<SamlProvider> samlProviders,
+			Collection<SamlProvider> samlProviders,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -220,7 +233,7 @@ public abstract class BaseSamlProviderResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<SamlProvider> samlProviders,
+			Collection<SamlProvider> samlProviders,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -289,7 +302,7 @@ public abstract class BaseSamlProviderResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<SamlProvider> samlProviders,
+			Collection<SamlProvider> samlProviders,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -327,9 +340,8 @@ public abstract class BaseSamlProviderResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<SamlProvider>,
-			 UnsafeConsumer<SamlProvider, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<SamlProvider>, UnsafeConsumer<SamlProvider, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -506,8 +518,7 @@ public abstract class BaseSamlProviderResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -519,8 +530,8 @@ public abstract class BaseSamlProviderResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -533,8 +544,7 @@ public abstract class BaseSamlProviderResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -548,8 +558,8 @@ public abstract class BaseSamlProviderResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -565,9 +575,8 @@ public abstract class BaseSamlProviderResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<SamlProvider>,
-		 UnsafeConsumer<SamlProvider, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<SamlProvider>, UnsafeConsumer<SamlProvider, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -583,6 +592,115 @@ public abstract class BaseSamlProviderResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseSamlProviderResourceImpl.class);

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseEmbeddingProviderValidationResultResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseEmbeddingProviderValidationResultResourceImpl.java
@@ -15,26 +15,41 @@
 package com.liferay.search.experiences.rest.internal.resource.v1_0;
 
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 import com.liferay.search.experiences.rest.dto.v1_0.EmbeddingProviderConfiguration;
 import com.liferay.search.experiences.rest.dto.v1_0.EmbeddingProviderValidationResult;
 import com.liferay.search.experiences.rest.resource.v1_0.EmbeddingProviderValidationResultResource;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -180,8 +195,7 @@ public abstract class BaseEmbeddingProviderValidationResultResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -193,8 +207,8 @@ public abstract class BaseEmbeddingProviderValidationResultResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -207,8 +221,7 @@ public abstract class BaseEmbeddingProviderValidationResultResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -222,8 +235,8 @@ public abstract class BaseEmbeddingProviderValidationResultResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -251,6 +264,115 @@ public abstract class BaseEmbeddingProviderValidationResultResourceImpl
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseFieldMappingInfoResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseFieldMappingInfoResourceImpl.java
@@ -17,15 +17,21 @@ package com.liferay.search.experiences.rest.internal.resource.v1_0;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -41,6 +47,7 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
@@ -50,7 +57,13 @@ import com.liferay.search.experiences.rest.resource.v1_0.FieldMappingInfoResourc
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -123,7 +136,7 @@ public abstract class BaseFieldMappingInfoResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<FieldMappingInfo> fieldMappingInfos,
+			Collection<FieldMappingInfo> fieldMappingInfos,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -133,7 +146,7 @@ public abstract class BaseFieldMappingInfoResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<FieldMappingInfo> fieldMappingInfos,
+			Collection<FieldMappingInfo> fieldMappingInfos,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -204,7 +217,7 @@ public abstract class BaseFieldMappingInfoResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<FieldMappingInfo> fieldMappingInfos,
+			Collection<FieldMappingInfo> fieldMappingInfos,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -218,7 +231,7 @@ public abstract class BaseFieldMappingInfoResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<FieldMappingInfo>,
+			<Collection<FieldMappingInfo>,
 			 UnsafeConsumer<FieldMappingInfo, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -397,8 +410,7 @@ public abstract class BaseFieldMappingInfoResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -410,8 +422,8 @@ public abstract class BaseFieldMappingInfoResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -424,8 +436,7 @@ public abstract class BaseFieldMappingInfoResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -439,8 +450,8 @@ public abstract class BaseFieldMappingInfoResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -456,7 +467,7 @@ public abstract class BaseFieldMappingInfoResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<FieldMappingInfo>,
+		<Collection<FieldMappingInfo>,
 		 UnsafeConsumer<FieldMappingInfo, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -474,6 +485,115 @@ public abstract class BaseFieldMappingInfoResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseFieldMappingInfoResourceImpl.class);

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseKeywordQueryContributorResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseKeywordQueryContributorResourceImpl.java
@@ -17,15 +17,21 @@ package com.liferay.search.experiences.rest.internal.resource.v1_0;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -41,6 +47,7 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
@@ -49,7 +56,13 @@ import com.liferay.search.experiences.rest.resource.v1_0.KeywordQueryContributor
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -99,8 +112,7 @@ public abstract class BaseKeywordQueryContributorResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<KeywordQueryContributor>
-				keywordQueryContributors,
+			Collection<KeywordQueryContributor> keywordQueryContributors,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -110,8 +122,7 @@ public abstract class BaseKeywordQueryContributorResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<KeywordQueryContributor>
-				keywordQueryContributors,
+			Collection<KeywordQueryContributor> keywordQueryContributors,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -179,8 +190,7 @@ public abstract class BaseKeywordQueryContributorResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<KeywordQueryContributor>
-				keywordQueryContributors,
+			Collection<KeywordQueryContributor> keywordQueryContributors,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -194,7 +204,7 @@ public abstract class BaseKeywordQueryContributorResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<KeywordQueryContributor>,
+			<Collection<KeywordQueryContributor>,
 			 UnsafeConsumer<KeywordQueryContributor, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -373,8 +383,7 @@ public abstract class BaseKeywordQueryContributorResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -386,8 +395,8 @@ public abstract class BaseKeywordQueryContributorResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -400,8 +409,7 @@ public abstract class BaseKeywordQueryContributorResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -415,8 +423,8 @@ public abstract class BaseKeywordQueryContributorResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -432,7 +440,7 @@ public abstract class BaseKeywordQueryContributorResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<KeywordQueryContributor>,
+		<Collection<KeywordQueryContributor>,
 		 UnsafeConsumer<KeywordQueryContributor, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -450,6 +458,115 @@ public abstract class BaseKeywordQueryContributorResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseKeywordQueryContributorResourceImpl.class);

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseMLModelResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseMLModelResourceImpl.java
@@ -17,15 +17,21 @@ package com.liferay.search.experiences.rest.internal.resource.v1_0;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -41,6 +47,7 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
@@ -50,7 +57,13 @@ import com.liferay.search.experiences.rest.resource.v1_0.MLModelResource;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -128,8 +141,7 @@ public abstract class BaseMLModelResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<MLModel> mlModels,
-			Map<String, Serializable> parameters)
+			Collection<MLModel> mlModels, Map<String, Serializable> parameters)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -138,8 +150,7 @@ public abstract class BaseMLModelResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<MLModel> mlModels,
-			Map<String, Serializable> parameters)
+			Collection<MLModel> mlModels, Map<String, Serializable> parameters)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -207,8 +218,7 @@ public abstract class BaseMLModelResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<MLModel> mlModels,
-			Map<String, Serializable> parameters)
+			Collection<MLModel> mlModels, Map<String, Serializable> parameters)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -221,8 +231,8 @@ public abstract class BaseMLModelResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<MLModel>, UnsafeConsumer<MLModel, Exception>,
-			 Exception> contextBatchUnsafeConsumer) {
+			<Collection<MLModel>, UnsafeConsumer<MLModel, Exception>, Exception>
+				contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -399,8 +409,7 @@ public abstract class BaseMLModelResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -412,8 +421,8 @@ public abstract class BaseMLModelResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -426,8 +435,7 @@ public abstract class BaseMLModelResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -441,8 +449,8 @@ public abstract class BaseMLModelResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -458,8 +466,8 @@ public abstract class BaseMLModelResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<MLModel>, UnsafeConsumer<MLModel, Exception>,
-		 Exception> contextBatchUnsafeConsumer;
+		<Collection<MLModel>, UnsafeConsumer<MLModel, Exception>, Exception>
+			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -475,6 +483,115 @@ public abstract class BaseMLModelResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseMLModelResourceImpl.class);

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseModelPrefilterContributorResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseModelPrefilterContributorResourceImpl.java
@@ -17,15 +17,21 @@ package com.liferay.search.experiences.rest.internal.resource.v1_0;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -41,6 +47,7 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
@@ -49,7 +56,13 @@ import com.liferay.search.experiences.rest.resource.v1_0.ModelPrefilterContribut
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -99,8 +112,7 @@ public abstract class BaseModelPrefilterContributorResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<ModelPrefilterContributor>
-				modelPrefilterContributors,
+			Collection<ModelPrefilterContributor> modelPrefilterContributors,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -110,8 +122,7 @@ public abstract class BaseModelPrefilterContributorResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<ModelPrefilterContributor>
-				modelPrefilterContributors,
+			Collection<ModelPrefilterContributor> modelPrefilterContributors,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -179,8 +190,7 @@ public abstract class BaseModelPrefilterContributorResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<ModelPrefilterContributor>
-				modelPrefilterContributors,
+			Collection<ModelPrefilterContributor> modelPrefilterContributors,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -194,7 +204,7 @@ public abstract class BaseModelPrefilterContributorResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<ModelPrefilterContributor>,
+			<Collection<ModelPrefilterContributor>,
 			 UnsafeConsumer<ModelPrefilterContributor, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -373,8 +383,7 @@ public abstract class BaseModelPrefilterContributorResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -386,8 +395,8 @@ public abstract class BaseModelPrefilterContributorResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -400,8 +409,7 @@ public abstract class BaseModelPrefilterContributorResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -415,8 +423,8 @@ public abstract class BaseModelPrefilterContributorResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -432,7 +440,7 @@ public abstract class BaseModelPrefilterContributorResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<ModelPrefilterContributor>,
+		<Collection<ModelPrefilterContributor>,
 		 UnsafeConsumer<ModelPrefilterContributor, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -450,6 +458,115 @@ public abstract class BaseModelPrefilterContributorResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseModelPrefilterContributorResourceImpl.class);

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseQueryPrefilterContributorResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseQueryPrefilterContributorResourceImpl.java
@@ -17,15 +17,21 @@ package com.liferay.search.experiences.rest.internal.resource.v1_0;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -41,6 +47,7 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
@@ -49,7 +56,13 @@ import com.liferay.search.experiences.rest.resource.v1_0.QueryPrefilterContribut
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -99,8 +112,7 @@ public abstract class BaseQueryPrefilterContributorResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<QueryPrefilterContributor>
-				queryPrefilterContributors,
+			Collection<QueryPrefilterContributor> queryPrefilterContributors,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -110,8 +122,7 @@ public abstract class BaseQueryPrefilterContributorResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<QueryPrefilterContributor>
-				queryPrefilterContributors,
+			Collection<QueryPrefilterContributor> queryPrefilterContributors,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -179,8 +190,7 @@ public abstract class BaseQueryPrefilterContributorResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<QueryPrefilterContributor>
-				queryPrefilterContributors,
+			Collection<QueryPrefilterContributor> queryPrefilterContributors,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -194,7 +204,7 @@ public abstract class BaseQueryPrefilterContributorResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<QueryPrefilterContributor>,
+			<Collection<QueryPrefilterContributor>,
 			 UnsafeConsumer<QueryPrefilterContributor, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -373,8 +383,7 @@ public abstract class BaseQueryPrefilterContributorResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -386,8 +395,8 @@ public abstract class BaseQueryPrefilterContributorResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -400,8 +409,7 @@ public abstract class BaseQueryPrefilterContributorResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -415,8 +423,8 @@ public abstract class BaseQueryPrefilterContributorResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -432,7 +440,7 @@ public abstract class BaseQueryPrefilterContributorResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<QueryPrefilterContributor>,
+		<Collection<QueryPrefilterContributor>,
 		 UnsafeConsumer<QueryPrefilterContributor, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -450,6 +458,115 @@ public abstract class BaseQueryPrefilterContributorResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseQueryPrefilterContributorResourceImpl.class);

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSXPBlueprintResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSXPBlueprintResourceImpl.java
@@ -17,15 +17,21 @@ package com.liferay.search.experiences.rest.internal.resource.v1_0;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -41,6 +47,7 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
@@ -50,7 +57,13 @@ import com.liferay.search.experiences.rest.resource.v1_0.SXPBlueprintResource;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -415,7 +428,7 @@ public abstract class BaseSXPBlueprintResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<SXPBlueprint> sxpBlueprints,
+			Collection<SXPBlueprint> sxpBlueprints,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -449,7 +462,7 @@ public abstract class BaseSXPBlueprintResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<SXPBlueprint> sxpBlueprints,
+			Collection<SXPBlueprint> sxpBlueprints,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -518,7 +531,7 @@ public abstract class BaseSXPBlueprintResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<SXPBlueprint> sxpBlueprints,
+			Collection<SXPBlueprint> sxpBlueprints,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -558,9 +571,8 @@ public abstract class BaseSXPBlueprintResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<SXPBlueprint>,
-			 UnsafeConsumer<SXPBlueprint, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<SXPBlueprint>, UnsafeConsumer<SXPBlueprint, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -737,8 +749,7 @@ public abstract class BaseSXPBlueprintResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -750,8 +761,8 @@ public abstract class BaseSXPBlueprintResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -764,8 +775,7 @@ public abstract class BaseSXPBlueprintResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -779,8 +789,8 @@ public abstract class BaseSXPBlueprintResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -796,9 +806,8 @@ public abstract class BaseSXPBlueprintResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<SXPBlueprint>,
-		 UnsafeConsumer<SXPBlueprint, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<SXPBlueprint>, UnsafeConsumer<SXPBlueprint, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -814,6 +823,115 @@ public abstract class BaseSXPBlueprintResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseSXPBlueprintResourceImpl.class);

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSXPElementResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSXPElementResourceImpl.java
@@ -17,15 +17,21 @@ package com.liferay.search.experiences.rest.internal.resource.v1_0;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -41,6 +47,7 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
@@ -50,7 +57,13 @@ import com.liferay.search.experiences.rest.resource.v1_0.SXPElementResource;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -411,7 +424,7 @@ public abstract class BaseSXPElementResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<SXPElement> sxpElements,
+			Collection<SXPElement> sxpElements,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -443,7 +456,7 @@ public abstract class BaseSXPElementResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<SXPElement> sxpElements,
+			Collection<SXPElement> sxpElements,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -512,7 +525,7 @@ public abstract class BaseSXPElementResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<SXPElement> sxpElements,
+			Collection<SXPElement> sxpElements,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -551,9 +564,8 @@ public abstract class BaseSXPElementResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<SXPElement>,
-			 UnsafeConsumer<SXPElement, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<SXPElement>, UnsafeConsumer<SXPElement, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -730,8 +742,7 @@ public abstract class BaseSXPElementResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -743,8 +754,8 @@ public abstract class BaseSXPElementResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -757,8 +768,7 @@ public abstract class BaseSXPElementResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -772,8 +782,8 @@ public abstract class BaseSXPElementResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -789,9 +799,8 @@ public abstract class BaseSXPElementResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<SXPElement>,
-		 UnsafeConsumer<SXPElement, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<SXPElement>, UnsafeConsumer<SXPElement, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -807,6 +816,115 @@ public abstract class BaseSXPElementResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseSXPElementResourceImpl.class);

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSXPParameterContributorDefinitionResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSXPParameterContributorDefinitionResourceImpl.java
@@ -17,15 +17,21 @@ package com.liferay.search.experiences.rest.internal.resource.v1_0;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -41,6 +47,7 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
@@ -49,7 +56,13 @@ import com.liferay.search.experiences.rest.resource.v1_0.SXPParameterContributor
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -101,7 +114,7 @@ public abstract class BaseSXPParameterContributorDefinitionResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<SXPParameterContributorDefinition>
+			Collection<SXPParameterContributorDefinition>
 				sxpParameterContributorDefinitions,
 			Map<String, Serializable> parameters)
 		throws Exception {
@@ -112,7 +125,7 @@ public abstract class BaseSXPParameterContributorDefinitionResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<SXPParameterContributorDefinition>
+			Collection<SXPParameterContributorDefinition>
 				sxpParameterContributorDefinitions,
 			Map<String, Serializable> parameters)
 		throws Exception {
@@ -181,7 +194,7 @@ public abstract class BaseSXPParameterContributorDefinitionResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<SXPParameterContributorDefinition>
+			Collection<SXPParameterContributorDefinition>
 				sxpParameterContributorDefinitions,
 			Map<String, Serializable> parameters)
 		throws Exception {
@@ -196,7 +209,7 @@ public abstract class BaseSXPParameterContributorDefinitionResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<SXPParameterContributorDefinition>,
+			<Collection<SXPParameterContributorDefinition>,
 			 UnsafeConsumer<SXPParameterContributorDefinition, Exception>,
 			 Exception> contextBatchUnsafeConsumer) {
 
@@ -375,8 +388,7 @@ public abstract class BaseSXPParameterContributorDefinitionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -388,8 +400,8 @@ public abstract class BaseSXPParameterContributorDefinitionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -402,8 +414,7 @@ public abstract class BaseSXPParameterContributorDefinitionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -417,8 +428,8 @@ public abstract class BaseSXPParameterContributorDefinitionResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -434,7 +445,7 @@ public abstract class BaseSXPParameterContributorDefinitionResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<SXPParameterContributorDefinition>,
+		<Collection<SXPParameterContributorDefinition>,
 		 UnsafeConsumer<SXPParameterContributorDefinition, Exception>,
 		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -452,6 +463,115 @@ public abstract class BaseSXPParameterContributorDefinitionResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSearchIndexResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSearchIndexResourceImpl.java
@@ -17,15 +17,21 @@ package com.liferay.search.experiences.rest.internal.resource.v1_0;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -41,6 +47,7 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
@@ -49,7 +56,13 @@ import com.liferay.search.experiences.rest.resource.v1_0.SearchIndexResource;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -93,7 +106,7 @@ public abstract class BaseSearchIndexResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<SearchIndex> searchIndexes,
+			Collection<SearchIndex> searchIndexes,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -103,7 +116,7 @@ public abstract class BaseSearchIndexResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<SearchIndex> searchIndexes,
+			Collection<SearchIndex> searchIndexes,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -172,7 +185,7 @@ public abstract class BaseSearchIndexResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<SearchIndex> searchIndexes,
+			Collection<SearchIndex> searchIndexes,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -186,9 +199,8 @@ public abstract class BaseSearchIndexResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<SearchIndex>,
-			 UnsafeConsumer<SearchIndex, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<SearchIndex>, UnsafeConsumer<SearchIndex, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -365,8 +377,7 @@ public abstract class BaseSearchIndexResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -378,8 +389,8 @@ public abstract class BaseSearchIndexResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -392,8 +403,7 @@ public abstract class BaseSearchIndexResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -407,8 +417,8 @@ public abstract class BaseSearchIndexResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -424,9 +434,8 @@ public abstract class BaseSearchIndexResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<SearchIndex>,
-		 UnsafeConsumer<SearchIndex, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<SearchIndex>, UnsafeConsumer<SearchIndex, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -442,6 +451,115 @@ public abstract class BaseSearchIndexResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseSearchIndexResourceImpl.class);

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSearchResponseResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSearchResponseResourceImpl.java
@@ -15,19 +15,26 @@
 package com.liferay.search.experiences.rest.internal.resource.v1_0;
 
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 import com.liferay.search.experiences.rest.dto.v1_0.Parameter;
@@ -35,8 +42,16 @@ import com.liferay.search.experiences.rest.dto.v1_0.SXPBlueprint;
 import com.liferay.search.experiences.rest.dto.v1_0.SearchResponse;
 import com.liferay.search.experiences.rest.resource.v1_0.SearchResponseResource;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -199,8 +214,7 @@ public abstract class BaseSearchResponseResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -212,8 +226,8 @@ public abstract class BaseSearchResponseResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -226,8 +240,7 @@ public abstract class BaseSearchResponseResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -241,8 +254,8 @@ public abstract class BaseSearchResponseResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -270,6 +283,115 @@ public abstract class BaseSearchResponseResourceImpl
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseSearchResponseResourceImpl.class);

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSearchableAssetNameDisplayResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSearchableAssetNameDisplayResourceImpl.java
@@ -17,15 +17,21 @@ package com.liferay.search.experiences.rest.internal.resource.v1_0;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -41,6 +47,7 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
@@ -50,7 +57,13 @@ import com.liferay.search.experiences.rest.resource.v1_0.SearchableAssetNameDisp
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -112,8 +125,7 @@ public abstract class BaseSearchableAssetNameDisplayResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<SearchableAssetNameDisplay>
-				searchableAssetNameDisplays,
+			Collection<SearchableAssetNameDisplay> searchableAssetNameDisplays,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -123,8 +135,7 @@ public abstract class BaseSearchableAssetNameDisplayResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<SearchableAssetNameDisplay>
-				searchableAssetNameDisplays,
+			Collection<SearchableAssetNameDisplay> searchableAssetNameDisplays,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -193,8 +204,7 @@ public abstract class BaseSearchableAssetNameDisplayResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<SearchableAssetNameDisplay>
-				searchableAssetNameDisplays,
+			Collection<SearchableAssetNameDisplay> searchableAssetNameDisplays,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -208,7 +218,7 @@ public abstract class BaseSearchableAssetNameDisplayResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<SearchableAssetNameDisplay>,
+			<Collection<SearchableAssetNameDisplay>,
 			 UnsafeConsumer<SearchableAssetNameDisplay, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -387,8 +397,7 @@ public abstract class BaseSearchableAssetNameDisplayResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -400,8 +409,8 @@ public abstract class BaseSearchableAssetNameDisplayResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -414,8 +423,7 @@ public abstract class BaseSearchableAssetNameDisplayResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -429,8 +437,8 @@ public abstract class BaseSearchableAssetNameDisplayResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -446,7 +454,7 @@ public abstract class BaseSearchableAssetNameDisplayResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<SearchableAssetNameDisplay>,
+		<Collection<SearchableAssetNameDisplay>,
 		 UnsafeConsumer<SearchableAssetNameDisplay, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -464,6 +472,115 @@ public abstract class BaseSearchableAssetNameDisplayResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseSearchableAssetNameDisplayResourceImpl.class);

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSearchableAssetNameResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSearchableAssetNameResourceImpl.java
@@ -17,15 +17,21 @@ package com.liferay.search.experiences.rest.internal.resource.v1_0;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -41,6 +47,7 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
@@ -49,7 +56,13 @@ import com.liferay.search.experiences.rest.resource.v1_0.SearchableAssetNameReso
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -99,7 +112,7 @@ public abstract class BaseSearchableAssetNameResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<SearchableAssetName> searchableAssetNames,
+			Collection<SearchableAssetName> searchableAssetNames,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -109,7 +122,7 @@ public abstract class BaseSearchableAssetNameResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<SearchableAssetName> searchableAssetNames,
+			Collection<SearchableAssetName> searchableAssetNames,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -177,7 +190,7 @@ public abstract class BaseSearchableAssetNameResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<SearchableAssetName> searchableAssetNames,
+			Collection<SearchableAssetName> searchableAssetNames,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -191,7 +204,7 @@ public abstract class BaseSearchableAssetNameResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<SearchableAssetName>,
+			<Collection<SearchableAssetName>,
 			 UnsafeConsumer<SearchableAssetName, Exception>, Exception>
 				contextBatchUnsafeConsumer) {
 
@@ -370,8 +383,7 @@ public abstract class BaseSearchableAssetNameResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -383,8 +395,8 @@ public abstract class BaseSearchableAssetNameResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -397,8 +409,7 @@ public abstract class BaseSearchableAssetNameResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -412,8 +423,8 @@ public abstract class BaseSearchableAssetNameResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -429,7 +440,7 @@ public abstract class BaseSearchableAssetNameResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<SearchableAssetName>,
+		<Collection<SearchableAssetName>,
 		 UnsafeConsumer<SearchableAssetName, Exception>, Exception>
 			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
@@ -447,6 +458,115 @@ public abstract class BaseSearchableAssetNameResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseSearchableAssetNameResourceImpl.class);

--- a/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/BaseExperimentResourceImpl.java
+++ b/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/BaseExperimentResourceImpl.java
@@ -17,15 +17,21 @@ package com.liferay.segments.asah.rest.internal.resource.v1_0;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -41,6 +47,7 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
@@ -49,7 +56,13 @@ import com.liferay.segments.asah.rest.resource.v1_0.ExperimentResource;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -180,7 +193,7 @@ public abstract class BaseExperimentResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<Experiment> experiments,
+			Collection<Experiment> experiments,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -190,7 +203,7 @@ public abstract class BaseExperimentResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<Experiment> experiments,
+			Collection<Experiment> experiments,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -260,7 +273,7 @@ public abstract class BaseExperimentResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<Experiment> experiments,
+			Collection<Experiment> experiments,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -274,9 +287,8 @@ public abstract class BaseExperimentResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<Experiment>,
-			 UnsafeConsumer<Experiment, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
+			<Collection<Experiment>, UnsafeConsumer<Experiment, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -453,8 +465,7 @@ public abstract class BaseExperimentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -466,8 +477,8 @@ public abstract class BaseExperimentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -480,8 +491,7 @@ public abstract class BaseExperimentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -495,8 +505,8 @@ public abstract class BaseExperimentResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -512,9 +522,8 @@ public abstract class BaseExperimentResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<Experiment>,
-		 UnsafeConsumer<Experiment, Exception>, Exception>
-			contextBatchUnsafeConsumer;
+		<Collection<Experiment>, UnsafeConsumer<Experiment, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -530,6 +539,115 @@ public abstract class BaseExperimentResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseExperimentResourceImpl.class);

--- a/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/BaseExperimentRunResourceImpl.java
+++ b/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/BaseExperimentRunResourceImpl.java
@@ -15,25 +15,40 @@
 package com.liferay.segments.asah.rest.internal.resource.v1_0;
 
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 import com.liferay.segments.asah.rest.dto.v1_0.ExperimentRun;
 import com.liferay.segments.asah.rest.resource.v1_0.ExperimentRunResource;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -188,8 +203,7 @@ public abstract class BaseExperimentRunResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -201,8 +215,8 @@ public abstract class BaseExperimentRunResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -215,8 +229,7 @@ public abstract class BaseExperimentRunResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -230,8 +243,8 @@ public abstract class BaseExperimentRunResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -259,6 +272,115 @@ public abstract class BaseExperimentRunResourceImpl
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseExperimentRunResourceImpl.class);

--- a/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/BaseStatusResourceImpl.java
+++ b/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/BaseStatusResourceImpl.java
@@ -17,15 +17,21 @@ package com.liferay.segments.asah.rest.internal.resource.v1_0;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -41,6 +47,7 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
@@ -50,7 +57,13 @@ import com.liferay.segments.asah.rest.resource.v1_0.StatusResource;
 
 import java.io.Serializable;
 
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -164,8 +177,7 @@ public abstract class BaseStatusResourceImpl
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
-			java.util.Collection<Status> statuses,
-			Map<String, Serializable> parameters)
+			Collection<Status> statuses, Map<String, Serializable> parameters)
 		throws Exception {
 
 		UnsafeConsumer<Status, Exception> statusUnsafeConsumer = null;
@@ -203,8 +215,7 @@ public abstract class BaseStatusResourceImpl
 
 	@Override
 	public void delete(
-			java.util.Collection<Status> statuses,
-			Map<String, Serializable> parameters)
+			Collection<Status> statuses, Map<String, Serializable> parameters)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -272,8 +283,7 @@ public abstract class BaseStatusResourceImpl
 
 	@Override
 	public void update(
-			java.util.Collection<Status> statuses,
-			Map<String, Serializable> parameters)
+			Collection<Status> statuses, Map<String, Serializable> parameters)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -286,8 +296,8 @@ public abstract class BaseStatusResourceImpl
 
 	public void setContextBatchUnsafeConsumer(
 		UnsafeBiConsumer
-			<java.util.Collection<Status>, UnsafeConsumer<Status, Exception>,
-			 Exception> contextBatchUnsafeConsumer) {
+			<Collection<Status>, UnsafeConsumer<Status, Exception>, Exception>
+				contextBatchUnsafeConsumer) {
 
 		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
@@ -464,8 +474,7 @@ public abstract class BaseStatusResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
@@ -477,8 +486,8 @@ public abstract class BaseStatusResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] transformToArray(
-		java.util.Collection<T> collection,
-		UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz) {
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<?> clazz) {
 
 		return TransformUtil.transformToArray(
 			collection, unsafeFunction, clazz);
@@ -491,8 +500,7 @@ public abstract class BaseStatusResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> List<R> unsafeTransform(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
 		throws E {
 
 		return TransformUtil.unsafeTransform(collection, unsafeFunction);
@@ -506,8 +514,8 @@ public abstract class BaseStatusResourceImpl
 	}
 
 	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
-			java.util.Collection<T> collection,
-			UnsafeFunction<T, R, E> unsafeFunction, Class<?> clazz)
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<?> clazz)
 		throws E {
 
 		return TransformUtil.unsafeTransformToArray(
@@ -523,8 +531,8 @@ public abstract class BaseStatusResourceImpl
 
 	protected AcceptLanguage contextAcceptLanguage;
 	protected UnsafeBiConsumer
-		<java.util.Collection<Status>, UnsafeConsumer<Status, Exception>,
-		 Exception> contextBatchUnsafeConsumer;
+		<Collection<Status>, UnsafeConsumer<Status, Exception>, Exception>
+			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -540,6 +548,115 @@ public abstract class BaseStatusResourceImpl
 	protected SortParserProvider sortParserProvider;
 	protected VulcanBatchEngineImportTaskResource
 		vulcanBatchEngineImportTaskResource;
+
+	private void _checkResources(
+			long companyId, long resourceId, String resourceName)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		_checkResources(companyId, resourceId, resourceName);
+
+		Map<String, Permission> permissions = new LinkedHashMap<>();
+
+		List<ResourcePermission> resourcePermissionList = new ArrayList<>();
+
+		Class<? extends ResourcePermissionLocalService> clazz =
+			ResourcePermissionLocalService.class;
+
+		try {
+			Method method = clazz.getMethod(
+				"getResourcePermissions", String.class);
+
+			resourcePermissionList = (List<ResourcePermission>)method.invoke(
+				resourcePermissionLocalService, resourceName);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			resourcePermissionList =
+				resourcePermissionLocalService.getResourcePermissions(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId));
+		}
+
+		for (ResourcePermission resourcePermission : resourcePermissionList) {
+			if ((resourcePermission.getPrimKeyId() == 0) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					 ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission permission = permissions.get(role.getName());
+
+					if (permission == null) {
+						permission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
+					}
+					else {
+						Set<String> actionsIdsSet = new HashSet<>();
+
+						Collections.addAll(
+							actionsIdsSet, permission.getActionIds());
+
+						Permission newPermission = _toPermission(
+							resourceActions, resourcePermission, role);
+
+						Collections.addAll(
+							actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(
+							actionsIdsSet.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions.values();
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission,
+		com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseStatusResourceImpl.class);

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
@@ -753,18 +753,10 @@ public abstract class Base${schemaName}ResourceImpl
 			List<ResourceAction> resourceActions = resourceActionLocalService.getResourceActions(resourceName);
 
 			if (Validator.isNotNull(roleNames)) {
-				return Page.of(
-					actions,
-						_getResourcePermissionsByResourceName(
-						contextCompany.getCompanyId(), resourceActions, id,
-						resourceName, StringUtil.split(roleNames)));
+				return Page.of(actions, _getResourcePermissionsByResourceName(contextCompany.getCompanyId(), resourceActions, id, resourceName, StringUtil.split(roleNames)));
 			}
 
-			return Page.of(
-				actions,
-						_getResourcePermissionsByResourceName(
-						contextCompany.getCompanyId(), resourceActions, id,
-						resourceName, null));
+			return Page.of(actions, _getResourcePermissionsByResourceName(contextCompany.getCompanyId(), resourceActions, id, resourceName, null));
 		}
 	</#if>
 

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
@@ -953,7 +953,7 @@ public abstract class Base${schemaName}ResourceImpl
 		protected VulcanBatchEngineImportTaskResource vulcanBatchEngineImportTaskResource;
 	</#if>
 
-	private static void _checkResources(
+	private void _checkResources(
 			long companyId, long resourceId, String resourceName,
 			ResourcePermissionLocalService resourcePermissionLocalService)
 		throws PortalException {

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
@@ -10,9 +10,12 @@ import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
@@ -21,8 +24,10 @@ import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -43,6 +48,7 @@ import com.liferay.portal.vulcan.multipart.MultipartBody;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.permission.ModelPermissionsUtil;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.permission.PermissionUtil;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
@@ -51,7 +57,10 @@ import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -746,16 +755,16 @@ public abstract class Base${schemaName}ResourceImpl
 			if (Validator.isNotNull(roleNames)) {
 				return Page.of(
 					actions,
-					transform(
-						PermissionUtil.getRoles(contextCompany, roleLocalService, StringUtil.split(roleNames)),
-						role -> PermissionUtil.toPermission(contextCompany.getCompanyId(), id, resourceActions, resourceName, resourcePermissionLocalService, role)));
+						_getResourcePermissionsByResourceName(
+						contextCompany.getCompanyId(), resourceActions, id,
+						resourceName, StringUtil.split(roleNames)));
 			}
 
 			return Page.of(
 				actions,
-				transform(
-					PermissionUtil.getResourcePermissions(contextCompany.getCompanyId(), id, resourceName, resourcePermissionLocalService),
-					resourcePermission -> PermissionUtil.toPermission(resourceActions, resourcePermission, roleLocalService.getRole(resourcePermission.getRoleId()))));
+						_getResourcePermissionsByResourceName(
+						contextCompany.getCompanyId(), resourceActions, id,
+						resourceName, null));
 		}
 	</#if>
 
@@ -951,6 +960,100 @@ public abstract class Base${schemaName}ResourceImpl
 	<#if generateBatch>
 		protected VulcanBatchEngineImportTaskResource vulcanBatchEngineImportTaskResource;
 	</#if>
+
+	private static void _checkResources(
+			long companyId, long resourceId, String resourceName,
+			ResourcePermissionLocalService resourcePermissionLocalService)
+		throws PortalException {
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+	}
+
+	private List<Permission> _getResourcePermissionsByResourceName(
+		long companyId, List<ResourceAction> resourceActions,
+		long resourceId, String resourceName, String[] roleNames)
+		throws PortalException {
+
+		_checkResources(
+			companyId, resourceId, resourceName,
+			resourcePermissionLocalService);
+
+		List<ResourcePermission> resourcePermissions =
+			resourcePermissionLocalService.getResourcePermissions(resourceName);
+
+		List<Permission> permissions = new ArrayList<>();
+
+		Map<String, Permission> permissionMap = new HashMap<>();
+
+		for (ResourcePermission resourcePermission : resourcePermissions) {
+			if ((resourcePermission.getPrimKeyId() == 0L) ||
+				(resourcePermission.getPrimKeyId() == resourceId)) {
+
+				com.liferay.portal.kernel.model.Role role = roleLocalService.getRole(
+					resourcePermission.getRoleId());
+
+				if ((roleNames == null) ||
+					((roleNames != null) &&
+					ArrayUtil.contains(roleNames, role.getName()))) {
+
+					Permission existingPermission = permissionMap.get(
+						role.getName());
+					Permission newPermission = _toPermission(
+						resourceActions, resourcePermission, role);
+
+					if (existingPermission == null) {
+						permissionMap.put(role.getName(), newPermission);
+						permissions.add(newPermission);
+					}
+					else {
+						Set<String> actions = new HashSet<>();
+
+						Collections.addAll(
+							actions, existingPermission.getActionIds());
+						Collections.addAll(
+							actions, newPermission.getActionIds());
+
+						existingPermission.setActionIds(
+							actions.toArray(new String[0]));
+					}
+				}
+			}
+		}
+
+		return permissions;
+	}
+
+	private Permission _toPermission(
+		List<ResourceAction> resourceActions,
+		ResourcePermission resourcePermission, com.liferay.portal.kernel.model.Role role) {
+
+		Set<String> actionsIdsSet = new HashSet<>();
+
+		long actionIds = resourcePermission.getActionIds();
+
+		for (ResourceAction resourceAction : resourceActions) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
+
+			if ((actionIds & bitwiseValue) == bitwiseValue) {
+				actionsIdsSet.add(resourceAction.getActionId());
+			}
+		}
+
+		return new Permission() {
+			{
+				actionIds = actionsIdsSet.toArray(new String[0]);
+				roleName = role.getName();
+			}
+		};
+	}
 
 	private static final com.liferay.portal.kernel.log.Log _log = LogFactoryUtil.getLog(Base${schemaName}ResourceImpl.class);
 

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
@@ -1023,10 +1023,7 @@ public abstract class Base${schemaName}ResourceImpl
 		return permissions;
 	}
 
-	private Permission _toPermission(
-		List<ResourceAction> resourceActions,
-		ResourcePermission resourcePermission, com.liferay.portal.kernel.model.Role role) {
-
+	private Permission _toPermission(List<ResourceAction> resourceActions, ResourcePermission resourcePermission, com.liferay.portal.kernel.model.Role role) {
 		Set<String> actionsIdsSet = new HashSet<>();
 
 		long actionIds = resourcePermission.getActionIds();

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
@@ -57,10 +57,10 @@ import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
 
-import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -753,10 +753,10 @@ public abstract class Base${schemaName}ResourceImpl
 			List<ResourceAction> resourceActions = resourceActionLocalService.getResourceActions(resourceName);
 
 			if (Validator.isNotNull(roleNames)) {
-				return Page.of(actions, _getResourcePermissionsByResourceName(contextCompany.getCompanyId(), resourceActions, id, resourceName, StringUtil.split(roleNames)));
+				return Page.of(actions, _getPermissions(contextCompany.getCompanyId(), resourceActions, id, resourceName, StringUtil.split(roleNames)));
 			}
 
-			return Page.of(actions, _getResourcePermissionsByResourceName(contextCompany.getCompanyId(), resourceActions, id, resourceName, null));
+			return Page.of(actions, _getPermissions(contextCompany.getCompanyId(), resourceActions, id, resourceName, null));
 		}
 	</#if>
 
@@ -953,72 +953,49 @@ public abstract class Base${schemaName}ResourceImpl
 		protected VulcanBatchEngineImportTaskResource vulcanBatchEngineImportTaskResource;
 	</#if>
 
-	private void _checkResources(
-			long companyId, long resourceId, String resourceName)
-		throws PortalException {
-
-		int count = resourcePermissionLocalService.getResourcePermissionsCount(
-			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
-			String.valueOf(resourceId));
+	private void _checkResources(long companyId, long resourceId, String resourceName) throws PortalException {
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL, String.valueOf(resourceId));
 
 		if (count == 0) {
-			ResourceLocalServiceUtil.addResources(
-				companyId, resourceId, 0, resourceName,
-				String.valueOf(resourceId), false, true, true);
+			ResourceLocalServiceUtil.addResources(companyId, resourceId, 0, resourceName, String.valueOf(resourceId), false, true, true);
 		}
 	}
 
-	private List<Permission> _getResourcePermissionsByResourceName(
-		long companyId, List<ResourceAction> resourceActions,
-		long resourceId, String resourceName, String[] roleNames)
-		throws PortalException {
+	private Collection<Permission> _getPermissions(long companyId, List<ResourceAction> resourceActions, long resourceId, String resourceName, String[] roleNames) throws PortalException {
+		_checkResources(companyId, resourceId, resourceName);
 
-		_checkResources(
-			companyId, resourceId, resourceName);
+		Map<String, Permission> permissions = new LinkedHashMap<>();
 
-		List<ResourcePermission> resourcePermissions =
-			resourcePermissionLocalService.getResourcePermissions(resourceName);
-
-		List<Permission> permissions = new ArrayList<>();
-
-		Map<String, Permission> permissionMap = new HashMap<>();
-
-		for (ResourcePermission resourcePermission : resourcePermissions) {
-			if ((resourcePermission.getPrimKeyId() == 0L) ||
-				(resourcePermission.getPrimKeyId() == resourceId)) {
-
-				com.liferay.portal.kernel.model.Role role = roleLocalService.getRole(
-					resourcePermission.getRoleId());
+		for (ResourcePermission resourcePermission : resourcePermissionLocalService.getResourcePermissions(resourceName)) {
+			if ((resourcePermission.getPrimKeyId() == 0) || (resourcePermission.getPrimKeyId() == resourceId)) {
+				com.liferay.portal.kernel.model.Role role = roleLocalService.getRole(resourcePermission.getRoleId());
 
 				if ((roleNames == null) ||
-					((roleNames != null) &&
-					ArrayUtil.contains(roleNames, role.getName()))) {
+					((roleNames != null) && ArrayUtil.contains(roleNames, role.getName()))) {
 
-					Permission existingPermission = permissionMap.get(
-						role.getName());
-					Permission newPermission = _toPermission(
-						resourceActions, resourcePermission, role);
+					Permission permission = permissions.get(role.getName());
 
-					if (existingPermission == null) {
-						permissionMap.put(role.getName(), newPermission);
-						permissions.add(newPermission);
+					if (permission == null) {
+						permission = _toPermission(resourceActions, resourcePermission, role);
+
+						permissions.put(role.getName(), permission);
 					}
 					else {
-						Set<String> actions = new HashSet<>();
+						Set<String> actionsIdsSet = new HashSet<>();
 
-						Collections.addAll(
-							actions, existingPermission.getActionIds());
-						Collections.addAll(
-							actions, newPermission.getActionIds());
+						Collections.addAll(actionsIdsSet, permission.getActionIds());
 
-						existingPermission.setActionIds(
-							actions.toArray(new String[0]));
+						Permission newPermission = _toPermission(resourceActions, resourcePermission, role);
+
+						Collections.addAll(actionsIdsSet, newPermission.getActionIds());
+
+						permission.setActionIds(actionsIdsSet.toArray(new String[0]));
 					}
 				}
 			}
 		}
 
-		return permissions;
+		return permissions.values();
 	}
 
 	private Permission _toPermission(List<ResourceAction> resourceActions, ResourcePermission resourcePermission, com.liferay.portal.kernel.model.Role role) {

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
@@ -954,8 +954,7 @@ public abstract class Base${schemaName}ResourceImpl
 	</#if>
 
 	private void _checkResources(
-			long companyId, long resourceId, String resourceName,
-			ResourcePermissionLocalService resourcePermissionLocalService)
+			long companyId, long resourceId, String resourceName)
 		throws PortalException {
 
 		int count = resourcePermissionLocalService.getResourcePermissionsCount(
@@ -975,8 +974,7 @@ public abstract class Base${schemaName}ResourceImpl
 		throws PortalException {
 
 		_checkResources(
-			companyId, resourceId, resourceName,
-			resourcePermissionLocalService);
+			companyId, resourceId, resourceName);
 
 		List<ResourcePermission> resourcePermissions =
 			resourcePermissionLocalService.getResourcePermissions(resourceName);


### PR DESCRIPTION
**What is new?**
- Add new method `getResourcePermissionsByResourceName` that retrieves all Permissions give a `resourceName`, `roleName` and `EntityId`
- Changes in `base_resource_impl.ftl` adding new method `getResourcePermissionsByResourceName` and update `toPermissionPage`
- `buildREST` in `modules/apps` and `modules/dxp/apps` to update all BaseResourceImpls
- This new changes comes from: https://github.com/brianchandotcom/liferay-portal/pull/125266

**Note:** This PR also fix another inconsistency, when we retrieved all the Permissions given a `roleName`, it returned all Permissions of all the entities created.

**JIRA Tickets**
https://issues.liferay.com/browse/LPS-163446
https://issues.liferay.com/browse/LPS-162878