### PR TITLE
LPS-167280 Add liferay npm scripts for frontend-css-common

### DIFF
--- a/modules/apps/frontend-css/frontend-css-common/package.json
+++ b/modules/apps/frontend-css/frontend-css-common/package.json
@@ -1,0 +1,9 @@
+{
+	"name": "@liferay/frontend-css-common",
+	"private": true,
+	"scripts": {
+		"checkFormat": "liferay-npm-scripts check",
+		"format": "liferay-npm-scripts fix"
+	},
+	"version": "6.0.8"
+}


### PR DESCRIPTION
Fix for this revert https://github.com/brianchandotcom/liferay-portal/commit/907dd018
Hi @brianchandotcom , I add [`private: true` property](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#private) to let npm refuse to publish this module, since this module has never been published to npm repo before, I think we can just keep it private, it will not break anything. Have discussed with frontend team here https://github.com/liferay-frontend/liferay-portal/pull/3013