### PR TITLE
LPS-174032 search-experiences-service: Include the ERC in errors

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/service/impl/SXPBlueprintLocalServiceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/service/impl/SXPBlueprintLocalServiceImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.search.experiences.service.impl;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.ResourceConstants;
@@ -215,7 +216,10 @@ public class SXPBlueprintLocalServiceImpl
 			externalReferenceCode, companyId);
 
 		if (sxpBlueprint != null) {
-			throw new DuplicateSXPBlueprintExternalReferenceCodeException();
+			throw new DuplicateSXPBlueprintExternalReferenceCodeException(
+				StringBundler.concat(
+					"Duplicate blueprint external reference code ",
+					externalReferenceCode, " in company ", companyId));
 		}
 	}
 

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/service/impl/SXPBlueprintLocalServiceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/service/impl/SXPBlueprintLocalServiceImpl.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.search.experiences.exception.DuplicateSXPBlueprintExternalReferenceCodeException;
 import com.liferay.search.experiences.exception.SXPBlueprintTitleException;
@@ -211,6 +212,10 @@ public class SXPBlueprintLocalServiceImpl
 	private void _validateExternalReferenceCode(
 			long companyId, String externalReferenceCode)
 		throws PortalException {
+
+		if (Validator.isNull(externalReferenceCode)) {
+			return;
+		}
 
 		SXPBlueprint sxpBlueprint = fetchSXPBlueprintByExternalReferenceCode(
 			externalReferenceCode, companyId);

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/service/impl/SXPElementLocalServiceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/service/impl/SXPElementLocalServiceImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.search.experiences.service.impl;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.ResourceConstants;
@@ -199,7 +200,10 @@ public class SXPElementLocalServiceImpl extends SXPElementLocalServiceBaseImpl {
 			externalReferenceCode, companyId);
 
 		if (sxpElement != null) {
-			throw new DuplicateSXPElementExternalReferenceCodeException();
+			throw new DuplicateSXPElementExternalReferenceCodeException(
+				StringBundler.concat(
+					"Duplicate element external reference code ",
+					externalReferenceCode, " in company ", companyId));
 		}
 	}
 

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/service/impl/SXPElementLocalServiceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/service/impl/SXPElementLocalServiceImpl.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.search.experiences.exception.DuplicateSXPElementExternalReferenceCodeException;
 import com.liferay.search.experiences.exception.SXPElementTitleException;
@@ -195,6 +196,10 @@ public class SXPElementLocalServiceImpl extends SXPElementLocalServiceBaseImpl {
 	private void _validateExternalReferenceCode(
 			long companyId, String externalReferenceCode)
 		throws PortalException {
+
+		if (Validator.isNull(externalReferenceCode)) {
+			return;
+		}
 
 		SXPElement sxpElement = fetchSXPElementByExternalReferenceCode(
 			externalReferenceCode, companyId);


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-174032

To help diagnosing issues. Applied pattern from other `_validateExternalReferenceCode` methods in `*ServiceImpl.java` like
* CPMeasurementUnitLocalServiceImpl
* JournalFolderLocalServiceImpl
* KBArticleLocalServiceImpl
  
Thanks,
Tibor

Tested in https://github.com/liferay-search/liferay-portal/pull/757
Failures are unrelated