### PR TITLE
[TS] LPS-172530 Root Folder configuration in the Document & Media widget is lost when searching

### DIFF
--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/spi/model/index/contributor/DLFolderModelDocumentContributor.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/spi/model/index/contributor/DLFolderModelDocumentContributor.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
 import com.liferay.trash.TrashHelper;
@@ -59,7 +60,9 @@ public class DLFolderModelDocumentContributor
 		document.addKeyword(Field.TREE_PATH, dlFolder.getTreePath());
 		document.addKeyword(
 			Field.TREE_PATH,
-			StringUtil.split(dlFolder.getTreePath(), CharPool.SLASH));
+			ArrayUtil.remove(
+				StringUtil.split(dlFolder.getTreePath(), CharPool.SLASH),
+				String.valueOf(dlFolder.getFolderId())));
 
 		if (_log.isDebugEnabled()) {
 			_log.debug("Document " + dlFolder + " indexed successfully");

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFolderIndexerIndexedFieldsTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFolderIndexerIndexedFieldsTest.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.search.searcher.SearchResponse;
@@ -203,7 +204,9 @@ public class DLFolderIndexerIndexedFieldsTest extends BaseDLIndexerTestCase {
 
 		List<String> treePathValues = new ArrayList<>(
 			Arrays.asList(
-				StringUtil.split(dlFolder.getTreePath(), CharPool.SLASH)));
+				ArrayUtil.remove(
+					StringUtil.split(dlFolder.getTreePath(), CharPool.SLASH),
+					String.valueOf(dlFolder.getFolderId()))));
 
 		if (treePathValues.size() == 1) {
 			map.put(Field.TREE_PATH, treePathValues.get(0));

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry_descriptive.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry_descriptive.jsp
@@ -17,6 +17,8 @@
 <%@ include file="/document_library/init.jsp" %>
 
 <%
+DLAdminDisplayContext dlAdminDisplayContext = (DLAdminDisplayContext)request.getAttribute(DLAdminDisplayContext.class.getName());
+
 ResultRow row = (ResultRow)request.getAttribute(WebKeys.SEARCH_CONTAINER_RESULT_ROW);
 
 Object result = row.getObject();
@@ -93,7 +95,7 @@ else {
 	<liferay-ui:message arguments="<%= new String[] {modifiedDateDescription, HtmlUtil.escape(latestFileVersion.getUserName())} %>" key="modified-x-ago-by-x" />
 </span>
 <span>
-	<%= DLUtil.getAbsolutePath(liferayPortletRequest, fileEntry.getFolderId()).replace(StringPool.RAQUO_CHAR, StringPool.GREATER_THAN) %>
+	<%= DLUtil.getAbsolutePath(liferayPortletRequest, dlAdminDisplayContext.getRootFolderId(), fileEntry.getFolderId()).replace(StringPool.RAQUO_CHAR, StringPool.GREATER_THAN) %>
 </span>
 
 <c:if test="<%= latestFileVersion.getModel() instanceof DLFileVersion %>">

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_folder_descriptive.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_folder_descriptive.jsp
@@ -17,6 +17,8 @@
 <%@ include file="/document_library/init.jsp" %>
 
 <%
+DLAdminDisplayContext dlAdminDisplayContext = (DLAdminDisplayContext)request.getAttribute(DLAdminDisplayContext.class.getName());
+
 ResultRow row = (ResultRow)request.getAttribute(WebKeys.SEARCH_CONTAINER_RESULT_ROW);
 
 Folder folder = (Folder)row.getObject();
@@ -57,5 +59,5 @@ String modifiedDateDescription = LanguageUtil.getTimeDescription(request, System
 	</c:choose>
 </span>
 <span>
-	<%= DLUtil.getAbsolutePath(liferayPortletRequest, folder.getParentFolderId()).replace(StringPool.RAQUO_CHAR, StringPool.GREATER_THAN) %>
+	<%= DLUtil.getAbsolutePath(liferayPortletRequest, dlAdminDisplayContext.getRootFolderId(), folder.getParentFolderId()).replace(StringPool.RAQUO_CHAR, StringPool.GREATER_THAN) %>
 </span>

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/FolderFacetTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/FolderFacetTest.java
@@ -199,18 +199,21 @@ public class FolderFacetTest extends BaseFacetedSearcherTestCase {
 
 		Hits hits = search(searchContext);
 
-		Assert.assertEquals(hits.toString(), 2, hits.getLength());
+		Assert.assertEquals(hits.toString(), 1, hits.getLength());
 
 		assertEntryClassNames(
-			Arrays.asList(
-				DLFolder.class.getName(), DLFileEntry.class.getName()),
-			hits, facet, searchContext);
+			Arrays.asList(DLFileEntry.class.getName()), hits, facet,
+			searchContext);
 
 		List<String> dlFolderIds = Arrays.asList(
 			ArrayUtil.append(getFolderIds(_dlFolders), StringPool.BLANK));
 
+		Map<String, Integer> expected = toMap(dlFolderIds, 1);
+
+		expected.put(StringPool.BLANK, 2);
+
 		FacetsAssert.assertFrequencies(
-			facet.getFieldName(), searchContext, hits, toMap(dlFolderIds, 2));
+			facet.getFieldName(), searchContext, hits, expected);
 	}
 
 	protected void assertEntryClassNames(

--- a/portal-impl/bnd.bnd
+++ b/portal-impl/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 66.0.1
+Bundle-Version: 66.1.0
 Export-Package:\
 	com.liferay.portal.bean,\
 	com.liferay.portal.dao.orm.hibernate,\

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLImpl.java
@@ -63,6 +63,7 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PrefsPropsUtil;
@@ -139,16 +140,38 @@ public class DLImpl implements DL {
 	public String getAbsolutePath(PortletRequest portletRequest, long folderId)
 		throws PortalException {
 
+		return getAbsolutePath(
+			portletRequest, DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			folderId);
+	}
+
+	@Override
+	public String getAbsolutePath(
+			PortletRequest portletRequest, long rootFolderId, long folderId)
+		throws PortalException {
+
 		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
-		if (folderId == DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
+		if ((folderId == DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) ||
+			(rootFolderId == folderId)) {
+
 			return themeDisplay.translate("home");
 		}
 
 		Folder folder = DLAppLocalServiceUtil.getFolder(folderId);
 
 		List<Folder> folders = folder.getAncestors();
+
+		if (rootFolderId != DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
+			Folder rootFolder = DLAppLocalServiceUtil.getFolder(rootFolderId);
+
+			if (!folders.contains(rootFolder)) {
+				throw new PortalException("Invalid root folder");
+			}
+
+			folders = ListUtil.subList(folders, 0, folders.indexOf(rootFolder));
+		}
 
 		Collections.reverse(folders);
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/packageinfo
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/packageinfo
@@ -1,1 +1,1 @@
-version 7.0.0
+version 7.1.0

--- a/portal-kernel/src/com/liferay/document/library/kernel/util/DL.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/util/DL.java
@@ -57,6 +57,10 @@ public interface DL {
 	public String getAbsolutePath(PortletRequest portletRequest, long folderId)
 		throws PortalException;
 
+	public String getAbsolutePath(
+			PortletRequest portletRequest, long rootFolderId, long folderId)
+		throws PortalException;
+
 	public Set<String> getAllMediaGalleryMimeTypes();
 
 	public String getDDMStructureKey(DLFileEntryType dlFileEntryType);

--- a/portal-kernel/src/com/liferay/document/library/kernel/util/DLUtil.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/util/DLUtil.java
@@ -48,6 +48,13 @@ public class DLUtil {
 		return _dl.getAbsolutePath(portletRequest, folderId);
 	}
 
+	public static String getAbsolutePath(
+			PortletRequest portletRequest, long rootFolderId, long folderId)
+		throws PortalException {
+
+		return _dl.getAbsolutePath(portletRequest, rootFolderId, folderId);
+	}
+
 	public static Set<String> getAllMediaGalleryMimeTypes() {
 		return _dl.getAllMediaGalleryMimeTypes();
 	}

--- a/portal-kernel/src/com/liferay/document/library/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/document/library/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 7.1.0
+version 7.2.0


### PR DESCRIPTION
The original PR comment:

> Hi Team,
> Here is the PR for fixing https://issues.liferay.com/browse/LPS-172530. The original PR(https://github.com/thienquach87/liferay-portal/pull/24) was passed my review.
> Please help review it and leave your comments.
> Thanks.
> 
> Notes:
> Since we are indexing the treePath to search in folders and the tree path of the folder includes its folderId, that's why the search folder will be shown in the result. The idea is to index the folders with the tree path without the folderId.
> 
> cc:@tototrinh
> 
> In this PR, I add an integration test for this LPS. This is reviewed in :https://github.com/liferay-lima/liferay-portal/pull/3907

@brianchandotcom  resending this pull directly to you since after a few retries we confirmed this pull is not related to any of the failing tests in https://github.com/liferay-lima/liferay-portal/pull/3931.