### PR TITLE
LPS-171666 Check the site membership policy when handling default site associations 

### DIFF
--- a/modules/apps/user/user-test/src/testIntegration/java/com/liferay/user/service/test/UserServiceWhenAddingDefaultGroupTest.java
+++ b/modules/apps/user/user-test/src/testIntegration/java/com/liferay/user/service/test/UserServiceWhenAddingDefaultGroupTest.java
@@ -1,0 +1,149 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.user.service.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.CompanyTestUtil;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Huy Le Nguyen
+ */
+@RunWith(Arquillian.class)
+public class UserServiceWhenAddingDefaultGroupTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_company = CompanyTestUtil.addCompany();
+
+		_parentGroup = GroupTestUtil.addGroupToCompany(_company.getCompanyId());
+
+		_childGroup = GroupTestUtil.addGroupToCompany(
+			_company.getCompanyId(), _parentGroup.getGroupId());
+
+		_childGroup.setMembershipRestriction(
+			GroupConstants.MEMBERSHIP_RESTRICTION_TO_PARENT_SITE_MEMBERS);
+
+		_groupLocalService.updateGroup(_childGroup);
+
+		_grandChildGroup1 = GroupTestUtil.addGroupToCompany(
+			_company.getCompanyId(), _childGroup.getGroupId());
+
+		_grandChildGroup1.setMembershipRestriction(
+			GroupConstants.MEMBERSHIP_RESTRICTION_TO_PARENT_SITE_MEMBERS);
+
+		_groupLocalService.updateGroup(_grandChildGroup1);
+
+		_grandChildGroup2 = GroupTestUtil.addGroupToCompany(
+			_company.getCompanyId(), _childGroup.getGroupId());
+
+		_user = UserTestUtil.addUser(_company);
+
+		_companyLocalService.updatePreferences(
+			_company.getCompanyId(),
+			UnicodePropertiesBuilder.put(
+				PropsKeys.ADMIN_DEFAULT_GROUP_NAMES,
+				StringBundler.concat(
+					_parentGroup.getName(LocaleUtil.US), StringPool.NEW_LINE,
+					_grandChildGroup2.getName(LocaleUtil.US),
+					StringPool.NEW_LINE,
+					_grandChildGroup1.getName(LocaleUtil.US))
+			).build());
+	}
+
+	@After
+	public void tearDown() throws PortalException {
+		_userLocalService.deleteUser(_user);
+
+		_groupLocalService.deleteGroup(_grandChildGroup1);
+
+		_groupLocalService.deleteGroup(_grandChildGroup2);
+
+		_groupLocalService.deleteGroup(_childGroup);
+
+		_groupLocalService.deleteGroup(_parentGroup);
+
+		_companyLocalService.deleteCompany(_company);
+	}
+
+	@Test
+	public void testAddDefaultGroup() throws Exception {
+		_userLocalService.addDefaultGroups(_user.getUserId());
+
+		Assert.assertTrue(
+			ArrayUtil.contains(_user.getGroupIds(), _parentGroup.getGroupId()));
+
+		Assert.assertTrue(
+			ArrayUtil.contains(
+				_user.getGroupIds(), _grandChildGroup2.getGroupId()));
+
+		Assert.assertFalse(
+			ArrayUtil.contains(_user.getGroupIds(), _childGroup.getGroupId()));
+
+		Assert.assertFalse(
+			ArrayUtil.contains(
+				_user.getGroupIds(), _grandChildGroup1.getGroupId()));
+	}
+
+	private Group _childGroup;
+	private Company _company;
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	private Group _grandChildGroup1;
+	private Group _grandChildGroup2;
+
+	@Inject
+	private GroupLocalService _groupLocalService;
+
+	private Group _parentGroup;
+	private User _user;
+
+	@Inject
+	private UserLocalService _userLocalService;
+
+}


### PR DESCRIPTION
Manual forward from https://github.com/liferay-usm/liferay-portal/pull/926:

From @ces-huynguyen:

> Problem: https://issues.liferay.com/browse/LPS-171666
> Users that are not members of the parent site are added to the child site when applying default user associations.
> 
> Solution:
> We iterate in treePath order and add sites one at a time, which avoids duplicating the logic in the default policy (which restricts membership based on whether you are a member of the parent group), while also ensuring that the default policy has accurate knowledge of whether you were made a member of one of the ancestor groups as part of the default site associations.