### PR TITLE
LPS-174464 Implement improvements on performance of resolve modules servlet URL generation

### DIFF
--- a/modules/apps/frontend-js/frontend-js-loader-modules-extender-api/src/main/java/com/liferay/frontend/js/loader/modules/extender/npm/NPMRegistryUpdatesListener.java
+++ b/modules/apps/frontend-js/frontend-js-loader-modules-extender-api/src/main/java/com/liferay/frontend/js/loader/modules/extender/npm/NPMRegistryUpdatesListener.java
@@ -18,6 +18,23 @@ package com.liferay.frontend.js.loader.modules.extender.npm;
  * Can be implemented by any service needing to be notified when the
  * {@link NPMRegistry} is updated.
  *
+ * Note that implementers of this interface must not depend on
+ * {@link NPMRegistry}, since that would create circular references.
+ *
+ * If, for some reason, you need to invoke {@link NPMRegistry} from your
+ * listener, the best way to obtain a reference to it is by using a
+ * {@link org.osgi.util.tracker.ServiceTracker} and assuming that any data you
+ * compute that depends on {@link NPMRegistry} is optional, since it is possible
+ * that, by the time you need to access it, the {@link NPMRegistry} is not
+ * available.
+ *
+ * Another caveat: the {@link NPMRegistry} invokes listeners whenever it goes
+ * up and down, so you don't need to worry about that in your listener
+ * implementation. However, if your listener goes down, then up, the
+ * {@link NPMRegistry} won't invoke it, so it's your responsibility to handle
+ * that situation, whether by simulating an update or doing anything you need to
+ * make your data depending on {@link NPMRegistry} available.
+ *
  * @author Iván Zaera Avellón
  * @review
  */

--- a/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/npm/JSModulesCache.java
+++ b/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/npm/JSModulesCache.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.js.loader.modules.extender.internal.npm;
+
+import com.liferay.frontend.js.loader.modules.extender.npm.JSModule;
+import com.liferay.frontend.js.loader.modules.extender.npm.JSPackage;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Iván Zaera
+ */
+public class JSModulesCache {
+
+	public JSModulesCache() {
+		exactMatchMap = Collections.emptyMap();
+		jsModules = Collections.emptyMap();
+		jsPackages = Collections.emptyMap();
+		jsPackageVersions = Collections.emptyList();
+		resolvedJSModules = Collections.emptyMap();
+		resolvedJSPackages = Collections.emptyMap();
+	}
+
+	public JSModulesCache(
+		Map<String, String> exactMatchMap, Map<String, JSModule> jsModules,
+		Map<String, JSPackage> jsPackages,
+		List<JSPackageVersion> jsPackageVersions,
+		Map<String, JSModule> resolvedJSModules,
+		Map<String, JSPackage> resolvedJSPackages) {
+
+		this.exactMatchMap = Collections.unmodifiableMap(exactMatchMap);
+		this.jsModules = Collections.unmodifiableMap(jsModules);
+		this.jsPackages = Collections.unmodifiableMap(jsPackages);
+		this.jsPackageVersions = Collections.unmodifiableList(
+			jsPackageVersions);
+		this.resolvedJSModules = Collections.unmodifiableMap(resolvedJSModules);
+		this.resolvedJSPackages = Collections.unmodifiableMap(
+			resolvedJSPackages);
+	}
+
+	public final Map<String, String> exactMatchMap;
+	public final Map<String, JSModule> jsModules;
+	public final Map<String, JSPackage> jsPackages;
+	public final List<JSPackageVersion> jsPackageVersions;
+	public final Map<String, JSModule> resolvedJSModules;
+	public final Map<String, JSPackage> resolvedJSPackages;
+
+}

--- a/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/npm/JSPackageVersion.java
+++ b/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/npm/JSPackageVersion.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.js.loader.modules.extender.internal.npm;
+
+import com.github.yuchi.semver.Version;
+
+import com.liferay.frontend.js.loader.modules.extender.npm.JSPackage;
+
+/**
+ * @author Iván Zaera
+ */
+public class JSPackageVersion {
+
+	public JSPackageVersion(JSPackage jsPackage) {
+		this.jsPackage = jsPackage;
+
+		version = Version.from(jsPackage.getVersion(), true);
+	}
+
+	public Version getVersion() {
+		return version;
+	}
+
+	public final JSPackage jsPackage;
+	public final Version version;
+
+}

--- a/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/npm/NPMRegistryResolutionStateDigestUtil.java
+++ b/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/npm/NPMRegistryResolutionStateDigestUtil.java
@@ -1,0 +1,204 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.js.loader.modules.extender.internal.npm;
+
+import com.liferay.frontend.js.loader.modules.extender.internal.npm.dynamic.DynamicJSModule;
+import com.liferay.frontend.js.loader.modules.extender.npm.JSModule;
+import com.liferay.frontend.js.loader.modules.extender.npm.JSModuleAlias;
+import com.liferay.frontend.js.loader.modules.extender.npm.JSPackage;
+import com.liferay.frontend.js.loader.modules.extender.npm.JSPackageDependency;
+import com.liferay.frontend.js.loader.modules.extender.npm.NPMRegistry;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.patcher.PatcherUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+
+import java.io.UnsupportedEncodingException;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Computes a digest (hash) with ALL values that can make module resolutions
+ * change.
+ *
+ * The data added to the digest is based on package names, versions,
+ * dependencies and any other information that, when changed, may alter the way
+ * modules are resolved.
+ *
+ * The digest is stable throughout different cluster nodes so that if two nodes
+ * share the same state, their digests are identical.
+ *
+ * @author Iván Zaera Avellón
+ * @review
+ */
+public class NPMRegistryResolutionStateDigestUtil {
+
+	public static String digest(NPMRegistry npmRegistry) {
+		MessageDigest messageDigest;
+
+		try {
+			messageDigest = MessageDigest.getInstance("SHA-1");
+		}
+		catch (NoSuchAlgorithmException noSuchAlgorithmException) {
+			throw new RuntimeException(noSuchAlgorithmException);
+		}
+
+		// Hash DynamicModules which don't honor immutability of packages
+		// with given (name, version) value
+
+		List<DynamicJSModule> dynamicJSModules = new ArrayList<>();
+
+		for (JSModule jsModule : npmRegistry.getResolvedJSModules()) {
+			if (jsModule instanceof DynamicJSModule) {
+				dynamicJSModules.add((DynamicJSModule)jsModule);
+			}
+		}
+
+		Collections.sort(
+			dynamicJSModules,
+			(dynamicJSModule1, dynamicJSModule2) -> {
+				String resolvedId = dynamicJSModule1.getResolvedId();
+
+				return resolvedId.compareTo(dynamicJSModule2.getResolvedId());
+			});
+
+		for (DynamicJSModule dynamicJSModule : dynamicJSModules) {
+			_update(messageDigest, dynamicJSModule);
+		}
+
+		// Now hash packages alone
+
+		List<JSPackage> jsPackages = new ArrayList<>(
+			npmRegistry.getResolvedJSPackages());
+
+		Collections.sort(
+			jsPackages,
+			(jsPackage1, jsPackage2) -> {
+				String resolvedId = jsPackage1.getResolvedId();
+
+				return resolvedId.compareTo(jsPackage2.getResolvedId());
+			});
+
+		for (JSPackage jsPackage : jsPackages) {
+			_update(messageDigest, jsPackage);
+		}
+
+		// Finally, hash the list of applied patches. This is necessary because
+		// Liferay Support's patches break the immutability convention of
+		// packages with given (name, version) value.
+
+		List<String> installedPatches = Arrays.asList(
+			PatcherUtil.getInstalledPatches());
+
+		Collections.sort(installedPatches);
+
+		for (String installedPatch : installedPatches) {
+			_update(messageDigest, installedPatch);
+		}
+
+		return StringUtil.bytesToHexString(messageDigest.digest());
+	}
+
+	private static void _update(
+		MessageDigest messageDigest, DynamicJSModule dynamicJSModule) {
+
+		_update(messageDigest, dynamicJSModule.getResolvedId());
+
+		List<String> dependencies = new ArrayList<>(
+			dynamicJSModule.getDependencies());
+
+		Collections.sort(dependencies);
+
+		for (String dependency : dependencies) {
+			_update(messageDigest, dependency);
+		}
+	}
+
+	private static void _update(
+		MessageDigest messageDigest, JSPackage jsPackage) {
+
+		// In theory name and version should be enough because npm packages are
+		// supposed to be immutable, but since it doesn't take too much longer,
+		// we add more fields to be safer.
+
+		_update(messageDigest, jsPackage.getMainModuleName());
+		_update(messageDigest, jsPackage.getName());
+		_update(messageDigest, jsPackage.getVersion());
+
+		List<JSPackageDependency> jsPackageDependencies = new ArrayList<>(
+			jsPackage.getJSPackageDependencies());
+
+		Collections.sort(
+			jsPackageDependencies,
+			(jsPackageDependency1, jsPackageDependency2) -> {
+				String packageName1 = jsPackageDependency1.getPackageName();
+				String packageName2 = jsPackageDependency2.getPackageName();
+
+				if (!Objects.equals(packageName1, packageName2)) {
+					packageName1.compareTo(packageName2);
+				}
+
+				String versionConstraints =
+					jsPackageDependency1.getVersionConstraints();
+
+				return versionConstraints.compareTo(
+					jsPackageDependency2.getVersionConstraints());
+			});
+
+		for (JSPackageDependency jsPackageDependency : jsPackageDependencies) {
+			_update(messageDigest, jsPackageDependency.getPackageName());
+			_update(messageDigest, jsPackageDependency.getVersionConstraints());
+		}
+
+		List<JSModuleAlias> jsModuleAliases = new ArrayList<>(
+			jsPackage.getJSModuleAliases());
+
+		Collections.sort(
+			jsModuleAliases,
+			(jsModuleAlias1, jsModuleAlias2) -> {
+				String alias1 = jsModuleAlias1.getAlias();
+				String alias2 = jsModuleAlias2.getAlias();
+
+				if (!Objects.equals(alias1, alias2)) {
+					return alias1.compareTo(alias2);
+				}
+
+				String moduleName = jsModuleAlias1.getModuleName();
+
+				return moduleName.compareTo(jsModuleAlias2.getModuleName());
+			});
+
+		for (JSModuleAlias jsModuleAlias : jsModuleAliases) {
+			_update(messageDigest, jsModuleAlias.getAlias());
+			_update(messageDigest, jsModuleAlias.getModuleName());
+		}
+	}
+
+	private static void _update(MessageDigest messageDigest, String string) {
+		try {
+			messageDigest.update(string.getBytes(StringPool.UTF8));
+		}
+		catch (UnsupportedEncodingException unsupportedEncodingException) {
+			throw new RuntimeException(unsupportedEncodingException);
+		}
+	}
+
+}

--- a/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/servlet/JSResolveModulesServlet.java
+++ b/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/servlet/JSResolveModulesServlet.java
@@ -18,12 +18,13 @@ import com.liferay.frontend.js.loader.modules.extender.internal.configuration.De
 import com.liferay.frontend.js.loader.modules.extender.internal.resolution.BrowserModulesResolution;
 import com.liferay.frontend.js.loader.modules.extender.internal.resolution.BrowserModulesResolver;
 import com.liferay.frontend.js.loader.modules.extender.npm.NPMRegistryUpdatesListener;
-import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.url.builder.AbsolutePortalURLBuilder;
+import com.liferay.portal.url.builder.AbsolutePortalURLBuilderFactory;
 
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -50,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 	configurationPid = "com.liferay.frontend.js.loader.modules.extender.internal.configuration.Details",
 	property = {
 		"osgi.http.whiteboard.servlet.name=com.liferay.frontend.js.loader.modules.extender.internal.servlet.JSResolveModulesServlet",
-		"osgi.http.whiteboard.servlet.pattern=/js_resolve_modules",
+		"osgi.http.whiteboard.servlet.pattern=/js_resolve_modules/*",
 		"service.ranking:Integer=" + Details.MAX_VALUE_LESS_1K
 	},
 	service = {
@@ -65,10 +66,16 @@ public class JSResolveModulesServlet
 		onAfterUpdate();
 	}
 
+	public String getURL() {
+		return _url;
+	}
+
 	@Override
 	public void onAfterUpdate() {
-		_etag = StringBundler.concat(
-			"W/\"", UUID.randomUUID(), StringPool.QUOTE);
+		String hash = String.valueOf(UUID.randomUUID());
+
+		_expectedPathInfo = StringPool.SLASH + hash;
+		_url = "/js_resolve_modules/" + hash;
 	}
 
 	@Override
@@ -77,16 +84,27 @@ public class JSResolveModulesServlet
 			HttpServletResponse httpServletResponse)
 		throws IOException {
 
-		if (_etag.equals(
-				httpServletRequest.getHeader(HttpHeaders.IF_NONE_MATCH))) {
+		if (!_expectedPathInfo.equals(httpServletRequest.getPathInfo())) {
+			AbsolutePortalURLBuilder absolutePortalURLBuilder =
+				_absolutePortalURLBuilderFactory.getAbsolutePortalURLBuilder(
+					httpServletRequest);
 
-			httpServletResponse.setStatus(HttpServletResponse.SC_NOT_MODIFIED);
+			String url = absolutePortalURLBuilder.forServlet(
+				getURL()
+			).build();
+
+			// Send a redirect so that the AMD loader knows that it must update
+			// its resolvePath to the new URL.
+
+			httpServletResponse.sendRedirect(url);
 
 			return;
 		}
 
-		httpServletResponse.addHeader(HttpHeaders.CACHE_CONTROL, "no-cache");
-		httpServletResponse.addHeader(HttpHeaders.ETAG, _etag);
+		// See https://ashton.codes/set-cache-control-max-age-1-year/
+
+		httpServletResponse.addHeader(
+			HttpHeaders.CACHE_CONTROL, "public, max-age=31536000, immutable");
 		httpServletResponse.setCharacterEncoding(StringPool.UTF8);
 		httpServletResponse.setContentType(ContentTypes.APPLICATION_JSON);
 
@@ -134,8 +152,12 @@ public class JSResolveModulesServlet
 	}
 
 	@Reference
+	private AbsolutePortalURLBuilderFactory _absolutePortalURLBuilderFactory;
+
+	@Reference
 	private BrowserModulesResolver _browserModulesResolver;
 
-	private volatile String _etag;
+	private volatile String _expectedPathInfo;
+	private volatile String _url;
 
 }

--- a/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/servlet/JSResolveModulesServlet.java
+++ b/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/servlet/JSResolveModulesServlet.java
@@ -15,9 +15,12 @@
 package com.liferay.frontend.js.loader.modules.extender.internal.servlet;
 
 import com.liferay.frontend.js.loader.modules.extender.internal.configuration.Details;
+import com.liferay.frontend.js.loader.modules.extender.internal.npm.NPMRegistryResolutionStateDigestUtil;
 import com.liferay.frontend.js.loader.modules.extender.internal.resolution.BrowserModulesResolution;
 import com.liferay.frontend.js.loader.modules.extender.internal.resolution.BrowserModulesResolver;
+import com.liferay.frontend.js.loader.modules.extender.npm.NPMRegistry;
 import com.liferay.frontend.js.loader.modules.extender.npm.NPMRegistryUpdatesListener;
+import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.util.ContentTypes;
@@ -34,7 +37,6 @@ import java.net.URLDecoder;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 
 import javax.servlet.Servlet;
@@ -42,8 +44,14 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.util.tracker.ServiceTracker;
+import org.osgi.util.tracker.ServiceTrackerCustomizer;
 
 /**
  * @author Rodolfo Roza Miranda
@@ -63,10 +71,6 @@ import org.osgi.service.component.annotations.Reference;
 public class JSResolveModulesServlet
 	extends HttpServlet implements NPMRegistryUpdatesListener {
 
-	public JSResolveModulesServlet() {
-		onAfterUpdate();
-	}
-
 	public String getURL() {
 		State state = _state.get();
 
@@ -75,7 +79,53 @@ public class JSResolveModulesServlet
 
 	@Override
 	public void onAfterUpdate() {
-		_state.set(new State());
+		_updateState(_npmRegistry.get());
+	}
+
+	@Activate
+	protected void activate(BundleContext bundleContext) {
+		_serviceTracker = ServiceTrackerFactory.open(
+			bundleContext, NPMRegistry.class,
+			new ServiceTrackerCustomizer<NPMRegistry, NPMRegistry>() {
+
+				@Override
+				public NPMRegistry addingService(
+					ServiceReference<NPMRegistry> serviceReference) {
+
+					NPMRegistry npmRegistry = bundleContext.getService(
+						serviceReference);
+
+					_npmRegistry.set(npmRegistry);
+
+					_updateState(npmRegistry);
+
+					return npmRegistry;
+				}
+
+				@Override
+				public void modifiedService(
+					ServiceReference<NPMRegistry> serviceReference,
+					NPMRegistry npmRegistry) {
+				}
+
+				@Override
+				public void removedService(
+					ServiceReference<NPMRegistry> serviceReference,
+					NPMRegistry npmRegistry) {
+
+					_npmRegistry.set(null);
+
+					_updateState(null);
+				}
+
+			});
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		_serviceTracker.close();
+
+		_serviceTracker = null;
 	}
 
 	@Override
@@ -85,6 +135,13 @@ public class JSResolveModulesServlet
 		throws IOException {
 
 		State state = _state.get();
+
+		if (state == null) {
+			httpServletResponse.sendError(
+				HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+
+			return;
+		}
 
 		if (!state.expectedPathInfo.equals(httpServletRequest.getPathInfo())) {
 			AbsolutePortalURLBuilder absolutePortalURLBuilder =
@@ -153,21 +210,34 @@ public class JSResolveModulesServlet
 		return Collections.emptyList();
 	}
 
+	private void _updateState(NPMRegistry npmRegistry) {
+		if (npmRegistry == null) {
+			_state.set(null);
+
+			return;
+		}
+
+		_state.set(
+			new State(
+				NPMRegistryResolutionStateDigestUtil.digest(npmRegistry)));
+	}
+
 	@Reference
 	private AbsolutePortalURLBuilderFactory _absolutePortalURLBuilderFactory;
 
 	@Reference
 	private BrowserModulesResolver _browserModulesResolver;
 
+	private final AtomicReference<NPMRegistry> _npmRegistry =
+		new AtomicReference<>();
+	private ServiceTracker<NPMRegistry, NPMRegistry> _serviceTracker;
 	private final AtomicReference<State> _state = new AtomicReference<>();
 
 	private static class State {
 
-		public State() {
-			String hash = String.valueOf(UUID.randomUUID());
-
-			expectedPathInfo = StringPool.SLASH + hash;
-			url = "/js_resolve_modules/" + hash;
+		public State(String digest) {
+			expectedPathInfo = StringPool.SLASH + digest;
+			url = "/js_resolve_modules/" + digest;
 		}
 
 		public final String expectedPathInfo;

--- a/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/servlet/taglib/JSLoaderTopHeadDynamicInclude.java
+++ b/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/servlet/taglib/JSLoaderTopHeadDynamicInclude.java
@@ -15,6 +15,7 @@
 package com.liferay.frontend.js.loader.modules.extender.internal.servlet.taglib;
 
 import com.liferay.frontend.js.loader.modules.extender.internal.configuration.Details;
+import com.liferay.frontend.js.loader.modules.extender.internal.servlet.JSResolveModulesServlet;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.frontend.esm.FrontendESMUtil;
@@ -139,7 +140,7 @@ public class JSLoaderTopHeadDynamicInclude extends BaseDynamicInclude {
 				httpServletRequest);
 
 		return absolutePortalURLBuilder.forServlet(
-			"/js_resolve_modules"
+			_jsResolveModulesServlet.getURL()
 		).build();
 	}
 
@@ -166,6 +167,10 @@ public class JSLoaderTopHeadDynamicInclude extends BaseDynamicInclude {
 
 	private volatile Bundle _bundle;
 	private volatile Details _details;
+
+	@Reference
+	private JSResolveModulesServlet _jsResolveModulesServlet;
+
 	private volatile String _lastModified;
 
 	@Reference


### PR DESCRIPTION
This is an alternative to https://github.com/liferay-frontend/liferay-portal/pull/3023, similar to the first PR we sent and was rolled back.

However, this time, the SHA-1 computation only takes 50-90 ms for a vanilla DXP installation. This huge enhancement is due to having hashed a lot of duplicate data in the first PR because of the use recursivity in the code computing the hash.

----

Manual forward of https://github.com/liferay-frontend/liferay-portal/pull/3030 as per https://github.com/liferay-frontend/liferay-portal/pull/3030#issuecomment-1419784743