### PR TITLE
LPS-173703 External video cannot be added because of file ending restrictions

### DIFF
--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryLocalServiceTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryLocalServiceTest.java
@@ -728,6 +728,47 @@ public class DLFileEntryLocalServiceTest {
 	}
 
 	@Test
+	public void testExtensionValidationWithSystemScopedFileEntryType()
+		throws Exception {
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId());
+
+		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
+			_group.getGroupId(), DLFileEntryMetadata.class.getName());
+
+		DLFileEntryType dlFileEntryType =
+			DLFileEntryTypeLocalServiceUtil.addFileEntryType(
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				RandomTestUtil.randomString(), StringPool.BLANK,
+				new long[] {ddmStructure.getStructureId()}, serviceContext);
+
+		dlFileEntryType.setScope(
+			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_SCOPE_SYSTEM);
+
+		DLFileEntryTypeLocalServiceUtil.updateDLFileEntryType(dlFileEntryType);
+
+		try (ConfigurationTemporarySwapper configurationTemporarySwapper =
+				new ConfigurationTemporarySwapper(
+					DLConfiguration.class.getName(),
+					HashMapDictionaryBuilder.<String, Object>put(
+						"fileExtensions", ".jpg"
+					).build())) {
+
+			DLFileEntryLocalServiceUtil.addFileEntry(
+				null, TestPropsValues.getUserId(), _group.getGroupId(),
+				_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+				RandomTestUtil.randomString(),
+				ContentTypes.APPLICATION_OCTET_STREAM,
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				StringUtil.randomString(), RandomTestUtil.randomString(),
+				dlFileEntryType.getFileEntryTypeId(), null, null,
+				new UnsyncByteArrayInputStream(new byte[0]), 0, null, null,
+				serviceContext);
+		}
+	}
+
+	@Test
 	public void testFileNameUpdatedWhenUpdatingAFileEntryKeepingFileVersionLabel()
 		throws Exception {
 

--- a/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayRepositoryDefiner.java
+++ b/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayRepositoryDefiner.java
@@ -170,18 +170,15 @@ public class LiferayRepositoryDefiner extends BaseRepositoryDefiner {
 
 					DLValidatorUtil.validateFileName(
 						fileContentReference.getSourceFileName());
-				}
 
-				if ((fileContentReference.getFileEntryId() == 0) ||
-					Validator.isNotNull(
-						fileContentReference.getSourceFileName())) {
+					if (fileContentReference.getFileEntryId() == 0) {
+						DLValidatorUtil.validateFileExtension(
+							fileContentReference.getSourceFileName());
 
-					DLValidatorUtil.validateFileExtension(
-						fileContentReference.getSourceFileName());
-
-					DLValidatorUtil.validateSourceFileExtension(
-						fileContentReference.getExtension(),
-						fileContentReference.getSourceFileName());
+						DLValidatorUtil.validateSourceFileExtension(
+							fileContentReference.getExtension(),
+							fileContentReference.getSourceFileName());
+					}
 				}
 
 				DLValidatorUtil.validateFileSize(

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -160,7 +160,6 @@ import com.liferay.portlet.documentlibrary.service.base.DLFileEntryLocalServiceB
 import com.liferay.ratings.kernel.service.RatingsStatsLocalService;
 
 import java.io.File;
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
 
@@ -247,8 +246,7 @@ public class DLFileEntryLocalServiceImpl
 			fileEntryTypeId);
 
 		_validateFile(
-			groupId, folderId, 0, fileEntryTypeId, fileName, extension, title,
-			inputStream);
+			groupId, folderId, 0, fileEntryTypeId, fileName, extension, title);
 
 		long fileEntryId = counterLocalService.increment();
 
@@ -3327,7 +3325,7 @@ public class DLFileEntryLocalServiceImpl
 			_validateFile(
 				dlFileEntry.getGroupId(), dlFileEntry.getFolderId(),
 				dlFileEntry.getFileEntryId(), fileEntryTypeId, fileName,
-				extension, title, inputStream);
+				extension, title);
 
 			// File version
 
@@ -3474,8 +3472,7 @@ public class DLFileEntryLocalServiceImpl
 
 	private void _validateFile(
 			long groupId, long folderId, long fileEntryId, long fileEntryTypeId,
-			String fileName, String extension, String title,
-			InputStream inputStream)
+			String fileName, String extension, String title)
 		throws PortalException {
 
 		DLValidatorUtil.validateFileName(fileName);
@@ -3483,22 +3480,10 @@ public class DLFileEntryLocalServiceImpl
 		DLFileEntryType dlFileEntryType =
 			_dlFileEntryTypeLocalService.getDLFileEntryType(fileEntryTypeId);
 
-		boolean skipExtensionValidation = false;
+		if ((dlFileEntryType.getScope() !=
+				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_SCOPE_SYSTEM) ||
+			Validator.isNotNull(extension)) {
 
-		try {
-			skipExtensionValidation =
-				(dlFileEntryType.getScope() ==
-					DLFileEntryTypeConstants.FILE_ENTRY_TYPE_SCOPE_SYSTEM) &&
-				((inputStream == null) || (inputStream.available() == 0)) &&
-				Validator.isNull(extension);
-		}
-		catch (IOException ioException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(ioException);
-			}
-		}
-
-		if (!skipExtensionValidation) {
 			_validateFileExtension(fileName, extension);
 		}
 


### PR DESCRIPTION
Motivation
=======
When documents of only certain extensions are allowed, the extension validation will fail on external video shortcuts because those documents do not have an extension.

Proposed Solution
========
Skipping the extension validation for documents where an extension is not present in the name, no file is being uploaded, and the document type scope is system.

Steps to Verify
========
Please consult the linked LPS for reproduction steps.
https://issues.liferay.com/browse/LPS-173703

@brianchandotcom resending this pull directly to you since after a few retries we confirmed this pull is not related to any of the failing tests in https://github.com/liferay-lima/liferay-portal/pull/3969.