### PR TITLE
LPS-174903 Override the other getTitle method to avoid default behaviour of deleting the notification in some cases

### DIFF
--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/notifications/ObjectUserNotificationsHandler.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/notifications/ObjectUserNotificationsHandler.java
@@ -15,7 +15,6 @@
 package com.liferay.object.web.internal.notifications;
 
 import com.liferay.asset.display.page.portlet.AssetDisplayPageFriendlyURLProvider;
-import com.liferay.asset.kernel.model.AssetRenderer;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -97,11 +96,13 @@ public class ObjectUserNotificationsHandler
 
 	@Override
 	protected String getTitle(
-		JSONObject jsonObject, AssetRenderer<?> assetRenderer,
-		UserNotificationEvent userNotificationEvent,
-		ServiceContext serviceContext) {
+			UserNotificationEvent userNotificationEvent,
+			ServiceContext serviceContext)
+		throws Exception {
 
-		return _getMessage(jsonObject);
+		return _getMessage(
+			JSONFactoryUtil.createJSONObject(
+				userNotificationEvent.getPayload()));
 	}
 
 	private String _getMessage(JSONObject jsonObject) {

--- a/modules/apps/sharing/sharing-notifications/src/main/java/com/liferay/sharing/notifications/internal/notifications/SharingUserNotificationHandler.java
+++ b/modules/apps/sharing/sharing-notifications/src/main/java/com/liferay/sharing/notifications/internal/notifications/SharingUserNotificationHandler.java
@@ -60,12 +60,13 @@ public class SharingUserNotificationHandler
 
 	@Override
 	protected String getTitle(
-			JSONObject jsonObject, AssetRenderer<?> assetRenderer,
 			UserNotificationEvent userNotificationEvent,
 			ServiceContext serviceContext)
 		throws Exception {
 
-		return _getMessage(jsonObject, userNotificationEvent);
+		return _getMessage(
+			_jsonFactory.createJSONObject(userNotificationEvent.getPayload()),
+			userNotificationEvent);
 	}
 
 	private String _getMessage(

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-web/src/main/java/com/liferay/multi/factor/authentication/web/internal/notifications/MFASystemConfigurationUserNotificationHandler.java
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-web/src/main/java/com/liferay/multi/factor/authentication/web/internal/notifications/MFASystemConfigurationUserNotificationHandler.java
@@ -14,7 +14,6 @@
 
 package com.liferay.multi.factor.authentication.web.internal.notifications;
 
-import com.liferay.asset.kernel.model.AssetRenderer;
 import com.liferay.configuration.admin.constants.ConfigurationAdminPortletKeys;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -72,17 +71,15 @@ public class MFASystemConfigurationUserNotificationHandler
 		return StringUtil.replace(
 			getBodyTemplate(), new String[] {"[$BODY$]", "[$TITLE$]"},
 			new String[] {
-				body,
-				getTitle(
-					jsonObject, null, userNotificationEvent, serviceContext)
+				body, getTitle(userNotificationEvent, serviceContext)
 			});
 	}
 
 	@Override
 	protected String getTitle(
-		JSONObject jsonObject, AssetRenderer<?> assetRenderer,
-		UserNotificationEvent userNotificationEvent,
-		ServiceContext serviceContext) {
+			UserNotificationEvent userNotificationEvent,
+			ServiceContext serviceContext)
+		throws Exception {
 
 		return _language.get(
 			serviceContext.getLocale(), "multi-factor-authentication");

--- a/portal-kernel/src/com/liferay/portal/kernel/notifications/BaseModelUserNotificationHandler.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/notifications/BaseModelUserNotificationHandler.java
@@ -179,7 +179,7 @@ public abstract class BaseModelUserNotificationHandler
 	}
 
 	@Override
-	protected final String getTitle(
+	protected String getTitle(
 			UserNotificationEvent userNotificationEvent,
 			ServiceContext serviceContext)
 		throws Exception {

--- a/portal-kernel/src/com/liferay/portal/kernel/notifications/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/notifications/packageinfo
@@ -1,1 +1,1 @@
-version 11.0.0
+version 11.1.0


### PR DESCRIPTION
This PR contains the code to override the other `getTitle` method of the `BaseModelUserNotificationHandler` class. The target of overriding that method is to avoid the `getTitle` invocation that deletes the `UserNotificationEvent` in case there is no `AssetRenderer`.

---

**Before the PR:**

Once the notification is shown, the next time there are no notifications in the notification list:

![image](https://user-images.githubusercontent.com/32699538/217241344-b7ff1b95-8eb4-4f34-8be3-d18173975e4a.png)

---

**After the PR:**

Once the notification is shown, the next time the notifications are shown in the notification list:

![image](https://user-images.githubusercontent.com/32699538/217242204-1298e737-80e0-4074-9b37-152761f9c275.png)

![image](https://user-images.githubusercontent.com/32699538/217242308-471ee549-9b28-4855-be0e-956de7eb0474.png)

@brianchandotcom resending this pull directly to you since after a few retries we confirmed this pull is not related to any of the failing tests in https://github.com/liferay-lima/liferay-portal/pull/3979.