### PR TITLE
LPS-166481 Continue to chain setGlobalParameter in PortletURLBuilder

### DIFF
--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/java/com/liferay/segments/experiment/web/internal/portlet/action/GetDataMVCResourceCommand.java
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/java/com/liferay/segments/experiment/web/internal/portlet/action/GetDataMVCResourceCommand.java
@@ -178,14 +178,14 @@ public class GetDataMVCResourceCommand extends BaseMVCResourceCommand {
 				).setActionName(
 					"/layout_content_page_editor/add_segments_experience"
 				).setGlobalParameter(
+					_getContentPageEditorPortletNamespace() + "groupId",
+					group.getGroupId()
+				).setGlobalParameter(
 					_getContentPageEditorPortletNamespace() + "p_l_mode",
 					Constants.EDIT
 				).setGlobalParameter(
 					_getContentPageEditorPortletNamespace() + "plid",
 					layout.getPlid()
-				).setGlobalParameter(
-					_getContentPageEditorPortletNamespace() + "groupId",
-					group.getGroupId()
 				).buildString()
 			).put(
 				"deleteSegmentsExperimentURL",

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/java/com/liferay/segments/experiment/web/internal/portlet/action/GetDataMVCResourceCommand.java
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/java/com/liferay/segments/experiment/web/internal/portlet/action/GetDataMVCResourceCommand.java
@@ -169,31 +169,24 @@ public class GetDataMVCResourceCommand extends BaseMVCResourceCommand {
 					httpServletRequest)
 			).put(
 				"createSegmentsVariantURL",
-				() -> {
-					String url = PortletURLBuilder.create(
-						_portal.getControlPanelPortletURL(
-							httpServletRequest, group,
-							ContentPageEditorPortletKeys.
-								CONTENT_PAGE_EDITOR_PORTLET,
-							0, 0, PortletRequest.ACTION_PHASE)
-					).setActionName(
-						"/layout_content_page_editor/add_segments_experience"
-					).buildString();
-
-					url = HttpComponentsUtil.addParameter(
-						url,
-						_getContentPageEditorPortletNamespace() + "p_l_mode",
-						Constants.EDIT);
-					url = HttpComponentsUtil.addParameter(
-						url, _getContentPageEditorPortletNamespace() + "plid",
-						layout.getPlid());
-					url = HttpComponentsUtil.addParameter(
-						url,
-						_getContentPageEditorPortletNamespace() + "groupId",
-						group.getGroupId());
-
-					return url;
-				}
+				() -> PortletURLBuilder.create(
+					_portal.getControlPanelPortletURL(
+						httpServletRequest, group,
+						ContentPageEditorPortletKeys.
+							CONTENT_PAGE_EDITOR_PORTLET,
+						0, 0, PortletRequest.ACTION_PHASE)
+				).setActionName(
+					"/layout_content_page_editor/add_segments_experience"
+				).setGlobalParameter(
+					_getContentPageEditorPortletNamespace() + "p_l_mode",
+					Constants.EDIT
+				).setGlobalParameter(
+					_getContentPageEditorPortletNamespace() + "plid",
+					layout.getPlid()
+				).setGlobalParameter(
+					_getContentPageEditorPortletNamespace() + "groupId",
+					group.getGroupId()
+				).buildString()
 			).put(
 				"deleteSegmentsExperimentURL",
 				_getSegmentsExperimentActionURL(

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/MethodCallsOrderCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/MethodCallsOrderCheck.java
@@ -366,6 +366,8 @@ public class MethodCallsOrderCheck extends BaseFileCheck {
 			"HashMapDictionaryBuilder", "JSONUtil", "SoyContext",
 			"TreeMapBuilder", "UnicodePropertiesBuilder");
 		content = _sortChainedMethodCalls(
+			content, "setGlobalParameter", 2, "PortletURLBuilder");
+		content = _sortChainedMethodCalls(
 			content, "setParameter", 2, "PortletURLBuilder");
 
 		content = _sortMethodCallsByMethodName(

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/PortletURLBuilderCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/PortletURLBuilderCheck.java
@@ -41,11 +41,11 @@ public class PortletURLBuilderCheck extends BaseBuilderCheck {
 		return ListUtil.fromArray(
 			new BaseBuilderCheck.BuilderInformation(
 				"PortletURL", "PortletURLBuilder", "setActionName",
-				"setBackURL", "setCMD", "setKeywords", "setMVCPath",
-				"setMVCRenderCommandName", "setNavigation", "setParameter",
-				"setParameters", "setPortletMode", "setPortletResource",
-				"setProperty", "setRedirect", "setSecure", "setTabs1",
-				"setTabs2", "setWindowState"));
+				"setBackURL", "setCMD", "setGlobalParameter", "setKeywords",
+				"setMVCPath", "setMVCRenderCommandName", "setNavigation",
+				"setParameter", "setParameters", "setPortletMode",
+				"setPortletResource", "setProperty", "setRedirect", "setSecure",
+				"setTabs1", "setTabs2", "setWindowState"));
 	}
 
 	@Override
@@ -79,7 +79,8 @@ public class PortletURLBuilderCheck extends BaseBuilderCheck {
 
 	@Override
 	protected List<String> getAvoidCastStringMethodNames() {
-		return ListUtil.fromArray("setParameter", "setRedirect");
+		return ListUtil.fromArray(
+			"setGlobalParameter", "setParameter", "setRedirect");
 	}
 
 	@Override
@@ -92,9 +93,10 @@ public class PortletURLBuilderCheck extends BaseBuilderCheck {
 	@Override
 	protected List<String> getSupportsFunctionMethodNames() {
 		return ListUtil.fromArray(
-			"setActionName", "setCMD", "setKeywords", "setMVCPath",
-			"setMVCRenderCommandName", "setNavigation", "setParameter",
-			"setPortletResource", "setRedirect", "setTabs1", "setTabs2");
+			"setActionName", "setCMD", "setGlobalParameter", "setKeywords",
+			"setMVCPath", "setMVCRenderCommandName", "setNavigation",
+			"setParameter", "setPortletResource", "setRedirect", "setTabs1",
+			"setTabs2");
 	}
 
 	@Override

--- a/portal-kernel/bnd.bnd
+++ b/portal-kernel/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 97.0.1
+Bundle-Version: 98.0.0
 Export-Package:\
 	!com.liferay.portal.kernel.internal.*,\
 	!com.liferay.portal.kernel.module.util,\

--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/url/builder/PortletURLBuilder.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/url/builder/PortletURLBuilder.java
@@ -18,6 +18,7 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.util.Constants;
+import com.liferay.portal.kernel.util.URLCodec;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.Map;
@@ -180,12 +181,13 @@ public class PortletURLBuilder {
 
 	public static class PortletURLStep
 		implements ActionNameStep, AfterActionNameStep, AfterBackURLStep,
-				   AfterCMDStep, AfterKeywordsStep, AfterMVCPathStep,
-				   AfterMVCRenderCommandNameStep, AfterNavigationStep,
-				   AfterParameterStep, AfterPortletModeStep,
-				   AfterPortletResourceStep, AfterRedirectStep, AfterSecureStep,
-				   AfterTabs1Step, AfterTabs2Step, AfterWindowStateStep,
-				   BackURLStep, BuildStep, CMDStep, KeywordsStep, MVCPathStep,
+				   AfterCMDStep, AfterGlobalParameterStep, AfterKeywordsStep,
+				   AfterMVCPathStep, AfterMVCRenderCommandNameStep,
+				   AfterNavigationStep, AfterParameterStep,
+				   AfterPortletModeStep, AfterPortletResourceStep,
+				   AfterRedirectStep, AfterSecureStep, AfterTabs1Step,
+				   AfterTabs2Step, AfterWindowStateStep, BackURLStep, BuildStep,
+				   CMDStep, GlobalParameterStep, KeywordsStep, MVCPathStep,
 				   MVCRenderCommandNameStep, NavigationStep, ParameterStep,
 				   PortletModeStep, PortletResourceStep, RedirectStep,
 				   SecureStep, Tabs1Step, Tabs2Step, WindowStateStep {
@@ -269,6 +271,60 @@ public class PortletURLBuilder {
 			UnsafeSupplier<Object, Exception> valueUnsafeSupplier) {
 
 			_setParameter(Constants.CMD, valueUnsafeSupplier, false);
+
+			return this;
+		}
+
+		@Override
+		public AfterGlobalParameterStep setGlobalParameter(
+			String key, boolean value) {
+
+			setGlobalParameter(key, String.valueOf(value));
+
+			return this;
+		}
+
+		@Override
+		public AfterGlobalParameterStep setGlobalParameter(
+			String key, double value) {
+
+			setGlobalParameter(key, String.valueOf(value));
+
+			return this;
+		}
+
+		@Override
+		public AfterGlobalParameterStep setGlobalParameter(
+			String key, int value) {
+
+			setGlobalParameter(key, String.valueOf(value));
+
+			return this;
+		}
+
+		@Override
+		public AfterGlobalParameterStep setGlobalParameter(
+			String key, long value) {
+
+			setGlobalParameter(key, String.valueOf(value));
+
+			return this;
+		}
+
+		@Override
+		public AfterGlobalParameterStep setGlobalParameter(
+			String key, short value) {
+
+			setGlobalParameter(key, String.valueOf(value));
+
+			return this;
+		}
+
+		@Override
+		public AfterGlobalParameterStep setGlobalParameter(
+			String key, String value) {
+
+			_setParameter(key, URLCodec.encodeURL(value), true);
 
 			return this;
 		}
@@ -596,53 +652,61 @@ public class PortletURLBuilder {
 	}
 
 	public interface AfterActionNameStep
-		extends BackURLStep, BuildStep, CMDStep, KeywordsStep, MVCPathStep,
-				MVCRenderCommandNameStep, NavigationStep, ParameterStep,
-				PortletModeStep, PortletResourceStep, RedirectStep, SecureStep,
-				Tabs1Step, Tabs2Step, WindowStateStep {
+		extends BackURLStep, BuildStep, CMDStep, GlobalParameterStep,
+				KeywordsStep, MVCPathStep, MVCRenderCommandNameStep,
+				NavigationStep, ParameterStep, PortletModeStep,
+				PortletResourceStep, RedirectStep, SecureStep, Tabs1Step,
+				Tabs2Step, WindowStateStep {
 	}
 
 	public interface AfterBackURLStep
-		extends BuildStep, KeywordsStep, NavigationStep, ParameterStep,
+		extends BuildStep, GlobalParameterStep, KeywordsStep, NavigationStep,
+				ParameterStep, PortletModeStep, PortletResourceStep, SecureStep,
+				Tabs1Step, Tabs2Step, WindowStateStep {
+	}
+
+	public interface AfterCMDStep
+		extends BackURLStep, BuildStep, GlobalParameterStep, KeywordsStep,
+				NavigationStep, ParameterStep, PortletModeStep,
+				PortletResourceStep, RedirectStep, SecureStep, Tabs1Step,
+				Tabs2Step, WindowStateStep {
+	}
+
+	public interface AfterGlobalParameterStep
+		extends BuildStep, GlobalParameterStep, ParameterStep, PortletModeStep,
+				SecureStep, WindowStateStep {
+	}
+
+	public interface AfterKeywordsStep
+		extends BuildStep, GlobalParameterStep, NavigationStep, ParameterStep,
 				PortletModeStep, PortletResourceStep, SecureStep, Tabs1Step,
 				Tabs2Step, WindowStateStep {
 	}
 
-	public interface AfterCMDStep
-		extends BackURLStep, BuildStep, KeywordsStep, NavigationStep,
+	public interface AfterMVCPathStep
+		extends BackURLStep, BuildStep, CMDStep, GlobalParameterStep,
+				KeywordsStep, MVCRenderCommandNameStep, NavigationStep,
 				ParameterStep, PortletModeStep, PortletResourceStep,
 				RedirectStep, SecureStep, Tabs1Step, Tabs2Step,
 				WindowStateStep {
 	}
 
-	public interface AfterKeywordsStep
-		extends BuildStep, NavigationStep, ParameterStep, PortletModeStep,
+	public interface AfterMVCRenderCommandNameStep
+		extends BackURLStep, BuildStep, CMDStep, GlobalParameterStep,
+				KeywordsStep, NavigationStep, ParameterStep, PortletModeStep,
+				PortletResourceStep, RedirectStep, SecureStep, Tabs1Step,
+				Tabs2Step, WindowStateStep {
+	}
+
+	public interface AfterNavigationStep
+		extends BuildStep, GlobalParameterStep, ParameterStep, PortletModeStep,
 				PortletResourceStep, SecureStep, Tabs1Step, Tabs2Step,
 				WindowStateStep {
 	}
 
-	public interface AfterMVCPathStep
-		extends BackURLStep, BuildStep, CMDStep, KeywordsStep,
-				MVCRenderCommandNameStep, NavigationStep, ParameterStep,
-				PortletModeStep, PortletResourceStep, RedirectStep, SecureStep,
-				Tabs1Step, Tabs2Step, WindowStateStep {
-	}
-
-	public interface AfterMVCRenderCommandNameStep
-		extends BackURLStep, BuildStep, CMDStep, KeywordsStep, NavigationStep,
-				ParameterStep, PortletModeStep, PortletResourceStep,
-				RedirectStep, SecureStep, Tabs1Step, Tabs2Step,
-				WindowStateStep {
-	}
-
-	public interface AfterNavigationStep
-		extends BuildStep, ParameterStep, PortletModeStep, PortletResourceStep,
-				SecureStep, Tabs1Step, Tabs2Step, WindowStateStep {
-	}
-
 	public interface AfterParameterStep
-		extends BuildStep, ParameterStep, PortletModeStep, SecureStep,
-				WindowStateStep {
+		extends BuildStep, GlobalParameterStep, ParameterStep, PortletModeStep,
+				SecureStep, WindowStateStep {
 	}
 
 	public interface AfterPortletModeStep
@@ -650,27 +714,28 @@ public class PortletURLBuilder {
 	}
 
 	public interface AfterPortletResourceStep
-		extends BuildStep, ParameterStep, PortletModeStep, SecureStep,
-				Tabs1Step, Tabs2Step, WindowStateStep {
+		extends BuildStep, GlobalParameterStep, ParameterStep, PortletModeStep,
+				SecureStep, Tabs1Step, Tabs2Step, WindowStateStep {
 	}
 
 	public interface AfterRedirectStep
-		extends BackURLStep, BuildStep, KeywordsStep, NavigationStep,
-				ParameterStep, PortletModeStep, PortletResourceStep, SecureStep,
-				Tabs1Step, Tabs2Step, WindowStateStep {
+		extends BackURLStep, BuildStep, GlobalParameterStep, KeywordsStep,
+				NavigationStep, ParameterStep, PortletModeStep,
+				PortletResourceStep, SecureStep, Tabs1Step, Tabs2Step,
+				WindowStateStep {
 	}
 
 	public interface AfterSecureStep extends BuildStep, WindowStateStep {
 	}
 
 	public interface AfterTabs1Step
-		extends BuildStep, ParameterStep, PortletModeStep, SecureStep,
-				Tabs2Step, WindowStateStep {
+		extends BuildStep, GlobalParameterStep, ParameterStep, PortletModeStep,
+				SecureStep, Tabs2Step, WindowStateStep {
 	}
 
 	public interface AfterTabs2Step
-		extends BuildStep, ParameterStep, PortletModeStep, SecureStep,
-				WindowStateStep {
+		extends BuildStep, GlobalParameterStep, ParameterStep, PortletModeStep,
+				SecureStep, WindowStateStep {
 	}
 
 	public interface AfterWindowStateStep extends BuildStep {
@@ -710,6 +775,28 @@ public class PortletURLBuilder {
 
 		public AfterCMDStep setCMD(
 			UnsafeSupplier<Object, Exception> valueUnsafeSupplier);
+
+	}
+
+	public interface GlobalParameterStep {
+
+		public AfterGlobalParameterStep setGlobalParameter(
+			String key, boolean value);
+
+		public AfterGlobalParameterStep setGlobalParameter(
+			String key, double value);
+
+		public AfterGlobalParameterStep setGlobalParameter(
+			String key, int value);
+
+		public AfterGlobalParameterStep setGlobalParameter(
+			String key, long value);
+
+		public AfterGlobalParameterStep setGlobalParameter(
+			String key, short value);
+
+		public AfterGlobalParameterStep setGlobalParameter(
+			String key, String value);
 
 	}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/url/builder/PortletURLBuilder.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/url/builder/PortletURLBuilder.java
@@ -324,7 +324,7 @@ public class PortletURLBuilder {
 		public AfterGlobalParameterStep setGlobalParameter(
 			String key, String value) {
 
-			_setParameter(key, URLCodec.encodeURL(value), true);
+			_setParameter(key, URLCodec.encodeURL(value), false);
 
 			return this;
 		}

--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/url/builder/PortletURLBuilder.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/url/builder/PortletURLBuilder.java
@@ -330,6 +330,15 @@ public class PortletURLBuilder {
 		}
 
 		@Override
+		public AfterGlobalParameterStep setGlobalParameter(
+			String key, UnsafeSupplier<Object, Exception> valueUnsafeSupplier) {
+
+			_setParameter(key, valueUnsafeSupplier, false);
+
+			return this;
+		}
+
+		@Override
 		public AfterKeywordsStep setKeywords(String value) {
 			_setParameter("keywords", value, false);
 
@@ -797,6 +806,9 @@ public class PortletURLBuilder {
 
 		public AfterGlobalParameterStep setGlobalParameter(
 			String key, String value);
+
+		public AfterGlobalParameterStep setGlobalParameter(
+			String key, UnsafeSupplier<Object, Exception> valueUnsafeSupplier);
 
 	}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/url/builder/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/url/builder/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 2.0.0


### PR DESCRIPTION
Tested [here](https://github.com/ling-alan-huang/liferay-portal/pull/1629), unrelated failures.



```
From Brian,

See GetDataMVCResourceCommand.java in my origin.

I think we should  add a "setGlobalParameter" that will call HttpComponentsUtil.
Then we can continue to chain this.

Let's make it so setGlobalParameter appears before setParameter. 
The class PortletURLBuilder has a forced order for setters.

I think it should be setGlobalParameter, setParameter, and then setRenderParameter.
```

