### PR TITLE
LPS-172590 Generate default methods when it is not clear the parameter belongs to the current entity schema

### DIFF
--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseCatalogResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseCatalogResourceTestCase.java
@@ -772,10 +772,20 @@ public abstract class BaseCatalogResourceTestCase {
 
 		Catalog getCatalog =
 			catalogResource.getProductByExternalReferenceCodeCatalog(
-				postCatalog.getExternalReferenceCode(), Pagination.of(1, 2));
+				testGetProductByExternalReferenceCodeCatalog_getExternalReferenceCode(
+					postCatalog),
+				Pagination.of(1, 2));
 
 		assertEquals(postCatalog, getCatalog);
 		assertValid(getCatalog);
+	}
+
+	protected String
+			testGetProductByExternalReferenceCodeCatalog_getExternalReferenceCode(
+				Catalog catalog)
+		throws Exception {
+
+		return catalog.getExternalReferenceCode();
 	}
 
 	protected Catalog testGetProductByExternalReferenceCodeCatalog_addCatalog()
@@ -805,14 +815,21 @@ public abstract class BaseCatalogResourceTestCase {
 										put(
 											"externalReferenceCode",
 											"\"" +
-												catalog.
-													getExternalReferenceCode() +
-														"\"");
+												testGraphQLGetProductByExternalReferenceCodeCatalog_getExternalReferenceCode(
+													catalog) + "\"");
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/productByExternalReferenceCodeCatalog"))));
+	}
+
+	protected String
+			testGraphQLGetProductByExternalReferenceCodeCatalog_getExternalReferenceCode(
+				Catalog catalog)
+		throws Exception {
+
+		return catalog.getExternalReferenceCode();
 	}
 
 	@Test
@@ -852,10 +869,16 @@ public abstract class BaseCatalogResourceTestCase {
 		Catalog postCatalog = testGetProductIdCatalog_addCatalog();
 
 		Catalog getCatalog = catalogResource.getProductIdCatalog(
-			postCatalog.getId(), Pagination.of(1, 2));
+			testGetProductIdCatalog_getId(postCatalog), Pagination.of(1, 2));
 
 		assertEquals(postCatalog, getCatalog);
 		assertValid(getCatalog);
+	}
+
+	protected Long testGetProductIdCatalog_getId(Catalog catalog)
+		throws Exception {
+
+		return catalog.getId();
 	}
 
 	protected Catalog testGetProductIdCatalog_addCatalog() throws Exception {
@@ -877,11 +900,20 @@ public abstract class BaseCatalogResourceTestCase {
 								"productIdCatalog",
 								new HashMap<String, Object>() {
 									{
-										put("id", catalog.getId());
+										put(
+											"id",
+											testGraphQLGetProductIdCatalog_getId(
+												catalog));
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data", "Object/productIdCatalog"))));
+	}
+
+	protected Long testGraphQLGetProductIdCatalog_getId(Catalog catalog)
+		throws Exception {
+
+		return catalog.getId();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseDiagramResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseDiagramResourceTestCase.java
@@ -326,10 +326,16 @@ public abstract class BaseDiagramResourceTestCase {
 		Diagram postDiagram = testGetProductIdDiagram_addDiagram();
 
 		Diagram getDiagram = diagramResource.getProductIdDiagram(
-			postDiagram.getProductId());
+			testGetProductIdDiagram_getProductId(postDiagram));
 
 		assertEquals(postDiagram, getDiagram);
 		assertValid(getDiagram);
+	}
+
+	protected Long testGetProductIdDiagram_getProductId(Diagram diagram)
+		throws Exception {
+
+		return diagram.getProductId();
 	}
 
 	protected Diagram testGetProductIdDiagram_addDiagram() throws Exception {
@@ -353,11 +359,18 @@ public abstract class BaseDiagramResourceTestCase {
 									{
 										put(
 											"productId",
-											diagram.getProductId());
+											testGraphQLGetProductIdDiagram_getProductId(
+												diagram));
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data", "Object/productIdDiagram"))));
+	}
+
+	protected Long testGraphQLGetProductIdDiagram_getProductId(Diagram diagram)
+		throws Exception {
+
+		return diagram.getProductId();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseMappedProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseMappedProductResourceTestCase.java
@@ -615,6 +615,7 @@ public abstract class BaseMappedProductResourceTestCase {
 											"\"" +
 												testGraphQLGetProductByExternalReferenceCodeMappedProductBySequence_getExternalReferenceCode() +
 													"\"");
+
 										put(
 											"sequence",
 											"\"" + mappedProduct.getSequence() +
@@ -960,11 +961,19 @@ public abstract class BaseMappedProductResourceTestCase {
 
 		MappedProduct getMappedProduct =
 			mappedProductResource.getProductMappedProductBySequence(
-				postMappedProduct.getProductId(),
+				testGetProductMappedProductBySequence_getProductId(
+					postMappedProduct),
 				postMappedProduct.getSequence());
 
 		assertEquals(postMappedProduct, getMappedProduct);
 		assertValid(getMappedProduct);
+	}
+
+	protected Long testGetProductMappedProductBySequence_getProductId(
+			MappedProduct mappedProduct)
+		throws Exception {
+
+		return mappedProduct.getProductId();
 	}
 
 	protected MappedProduct
@@ -994,7 +1003,9 @@ public abstract class BaseMappedProductResourceTestCase {
 									{
 										put(
 											"productId",
-											mappedProduct.getProductId());
+											testGraphQLGetProductMappedProductBySequence_getProductId(
+												mappedProduct));
+
 										put(
 											"sequence",
 											"\"" + mappedProduct.getSequence() +
@@ -1004,6 +1015,13 @@ public abstract class BaseMappedProductResourceTestCase {
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/productMappedProductBySequence"))));
+	}
+
+	protected Long testGraphQLGetProductMappedProductBySequence_getProductId(
+			MappedProduct mappedProduct)
+		throws Exception {
+
+		return mappedProduct.getProductId();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductResourceTestCase.java
@@ -730,6 +730,7 @@ public abstract class BaseProductResourceTestCase {
 												product.
 													getExternalReferenceCode() +
 														"\"");
+
 										put("version", product.getVersion());
 									}
 								},
@@ -968,6 +969,7 @@ public abstract class BaseProductResourceTestCase {
 								new HashMap<String, Object>() {
 									{
 										put("id", product.getId());
+
 										put("version", product.getVersion());
 									}
 								},

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductTaxConfigurationResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductTaxConfigurationResourceTestCase.java
@@ -312,10 +312,18 @@ public abstract class BaseProductTaxConfigurationResourceTestCase {
 
 		ProductTaxConfiguration getProductTaxConfiguration =
 			productTaxConfigurationResource.getProductIdTaxConfiguration(
-				postProductTaxConfiguration.getId());
+				testGetProductIdTaxConfiguration_getId(
+					postProductTaxConfiguration));
 
 		assertEquals(postProductTaxConfiguration, getProductTaxConfiguration);
 		assertValid(getProductTaxConfiguration);
+	}
+
+	protected Long testGetProductIdTaxConfiguration_getId(
+			ProductTaxConfiguration productTaxConfiguration)
+		throws Exception {
+
+		return productTaxConfiguration.getId();
 	}
 
 	protected ProductTaxConfiguration
@@ -343,12 +351,20 @@ public abstract class BaseProductTaxConfigurationResourceTestCase {
 									{
 										put(
 											"id",
-											productTaxConfiguration.getId());
+											testGraphQLGetProductIdTaxConfiguration_getId(
+												productTaxConfiguration));
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/productIdTaxConfiguration"))));
+	}
+
+	protected Long testGraphQLGetProductIdTaxConfiguration_getId(
+			ProductTaxConfiguration productTaxConfiguration)
+		throws Exception {
+
+		return productTaxConfiguration.getId();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseAccountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseAccountResourceTestCase.java
@@ -287,10 +287,19 @@ public abstract class BaseAccountResourceTestCase {
 
 		Account getAccount =
 			accountResource.getOrderByExternalReferenceCodeAccount(
-				postAccount.getExternalReferenceCode());
+				testGetOrderByExternalReferenceCodeAccount_getExternalReferenceCode(
+					postAccount));
 
 		assertEquals(postAccount, getAccount);
 		assertValid(getAccount);
+	}
+
+	protected String
+			testGetOrderByExternalReferenceCodeAccount_getExternalReferenceCode(
+				Account account)
+		throws Exception {
+
+		return account.getExternalReferenceCode();
 	}
 
 	protected Account testGetOrderByExternalReferenceCodeAccount_addAccount()
@@ -320,14 +329,21 @@ public abstract class BaseAccountResourceTestCase {
 										put(
 											"externalReferenceCode",
 											"\"" +
-												account.
-													getExternalReferenceCode() +
-														"\"");
+												testGraphQLGetOrderByExternalReferenceCodeAccount_getExternalReferenceCode(
+													account) + "\"");
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/orderByExternalReferenceCodeAccount"))));
+	}
+
+	protected String
+			testGraphQLGetOrderByExternalReferenceCodeAccount_getExternalReferenceCode(
+				Account account)
+		throws Exception {
+
+		return account.getExternalReferenceCode();
 	}
 
 	@Test
@@ -367,10 +383,16 @@ public abstract class BaseAccountResourceTestCase {
 		Account postAccount = testGetOrderIdAccount_addAccount();
 
 		Account getAccount = accountResource.getOrderIdAccount(
-			postAccount.getId());
+			testGetOrderIdAccount_getId(postAccount));
 
 		assertEquals(postAccount, getAccount);
 		assertValid(getAccount);
+	}
+
+	protected Long testGetOrderIdAccount_getId(Account account)
+		throws Exception {
+
+		return account.getId();
 	}
 
 	protected Account testGetOrderIdAccount_addAccount() throws Exception {
@@ -392,11 +414,20 @@ public abstract class BaseAccountResourceTestCase {
 								"orderIdAccount",
 								new HashMap<String, Object>() {
 									{
-										put("id", account.getId());
+										put(
+											"id",
+											testGraphQLGetOrderIdAccount_getId(
+												account));
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data", "Object/orderIdAccount"))));
+	}
+
+	protected Long testGraphQLGetOrderIdAccount_getId(Account account)
+		throws Exception {
+
+		return account.getId();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseBillingAddressResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseBillingAddressResourceTestCase.java
@@ -222,10 +222,19 @@ public abstract class BaseBillingAddressResourceTestCase {
 		BillingAddress getBillingAddress =
 			billingAddressResource.
 				getOrderByExternalReferenceCodeBillingAddress(
-					postBillingAddress.getExternalReferenceCode());
+					testGetOrderByExternalReferenceCodeBillingAddress_getExternalReferenceCode(
+						postBillingAddress));
 
 		assertEquals(postBillingAddress, getBillingAddress);
 		assertValid(getBillingAddress);
+	}
+
+	protected String
+			testGetOrderByExternalReferenceCodeBillingAddress_getExternalReferenceCode(
+				BillingAddress billingAddress)
+		throws Exception {
+
+		return billingAddress.getExternalReferenceCode();
 	}
 
 	protected BillingAddress
@@ -256,14 +265,21 @@ public abstract class BaseBillingAddressResourceTestCase {
 										put(
 											"externalReferenceCode",
 											"\"" +
-												billingAddress.
-													getExternalReferenceCode() +
-														"\"");
+												testGraphQLGetOrderByExternalReferenceCodeBillingAddress_getExternalReferenceCode(
+													billingAddress) + "\"");
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/orderByExternalReferenceCodeBillingAddress"))));
+	}
+
+	protected String
+			testGraphQLGetOrderByExternalReferenceCodeBillingAddress_getExternalReferenceCode(
+				BillingAddress billingAddress)
+		throws Exception {
+
+		return billingAddress.getExternalReferenceCode();
 	}
 
 	@Test
@@ -312,10 +328,17 @@ public abstract class BaseBillingAddressResourceTestCase {
 
 		BillingAddress getBillingAddress =
 			billingAddressResource.getOrderIdBillingAddress(
-				postBillingAddress.getId());
+				testGetOrderIdBillingAddress_getId(postBillingAddress));
 
 		assertEquals(postBillingAddress, getBillingAddress);
 		assertValid(getBillingAddress);
+	}
+
+	protected Long testGetOrderIdBillingAddress_getId(
+			BillingAddress billingAddress)
+		throws Exception {
+
+		return billingAddress.getId();
 	}
 
 	protected BillingAddress testGetOrderIdBillingAddress_addBillingAddress()
@@ -340,11 +363,21 @@ public abstract class BaseBillingAddressResourceTestCase {
 								"orderIdBillingAddress",
 								new HashMap<String, Object>() {
 									{
-										put("id", billingAddress.getId());
+										put(
+											"id",
+											testGraphQLGetOrderIdBillingAddress_getId(
+												billingAddress));
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data", "Object/orderIdBillingAddress"))));
+	}
+
+	protected Long testGraphQLGetOrderIdBillingAddress_getId(
+			BillingAddress billingAddress)
+		throws Exception {
+
+		return billingAddress.getId();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseChannelResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseChannelResourceTestCase.java
@@ -372,10 +372,19 @@ public abstract class BaseChannelResourceTestCase {
 
 		Channel getChannel =
 			channelResource.getOrderByExternalReferenceCodeChannel(
-				postChannel.getExternalReferenceCode());
+				testGetOrderByExternalReferenceCodeChannel_getExternalReferenceCode(
+					postChannel));
 
 		assertEquals(postChannel, getChannel);
 		assertValid(getChannel);
+	}
+
+	protected String
+			testGetOrderByExternalReferenceCodeChannel_getExternalReferenceCode(
+				Channel channel)
+		throws Exception {
+
+		return channel.getExternalReferenceCode();
 	}
 
 	protected Channel testGetOrderByExternalReferenceCodeChannel_addChannel()
@@ -405,14 +414,21 @@ public abstract class BaseChannelResourceTestCase {
 										put(
 											"externalReferenceCode",
 											"\"" +
-												channel.
-													getExternalReferenceCode() +
-														"\"");
+												testGraphQLGetOrderByExternalReferenceCodeChannel_getExternalReferenceCode(
+													channel) + "\"");
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/orderByExternalReferenceCodeChannel"))));
+	}
+
+	protected String
+			testGraphQLGetOrderByExternalReferenceCodeChannel_getExternalReferenceCode(
+				Channel channel)
+		throws Exception {
+
+		return channel.getExternalReferenceCode();
 	}
 
 	@Test
@@ -452,10 +468,16 @@ public abstract class BaseChannelResourceTestCase {
 		Channel postChannel = testGetOrderIdChannel_addChannel();
 
 		Channel getChannel = channelResource.getOrderIdChannel(
-			postChannel.getId());
+			testGetOrderIdChannel_getId(postChannel));
 
 		assertEquals(postChannel, getChannel);
 		assertValid(getChannel);
+	}
+
+	protected Long testGetOrderIdChannel_getId(Channel channel)
+		throws Exception {
+
+		return channel.getId();
 	}
 
 	protected Channel testGetOrderIdChannel_addChannel() throws Exception {
@@ -477,11 +499,20 @@ public abstract class BaseChannelResourceTestCase {
 								"orderIdChannel",
 								new HashMap<String, Object>() {
 									{
-										put("id", channel.getId());
+										put(
+											"id",
+											testGraphQLGetOrderIdChannel_getId(
+												channel));
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data", "Object/orderIdChannel"))));
+	}
+
+	protected Long testGraphQLGetOrderIdChannel_getId(Channel channel)
+		throws Exception {
+
+		return channel.getId();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseShippingAddressResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseShippingAddressResourceTestCase.java
@@ -217,10 +217,17 @@ public abstract class BaseShippingAddressResourceTestCase {
 
 		ShippingAddress getShippingAddress =
 			shippingAddressResource.getOrderItemShippingAddress(
-				postShippingAddress.getId());
+				testGetOrderItemShippingAddress_getId(postShippingAddress));
 
 		assertEquals(postShippingAddress, getShippingAddress);
 		assertValid(getShippingAddress);
+	}
+
+	protected Long testGetOrderItemShippingAddress_getId(
+			ShippingAddress shippingAddress)
+		throws Exception {
+
+		return shippingAddress.getId();
 	}
 
 	protected ShippingAddress
@@ -246,12 +253,22 @@ public abstract class BaseShippingAddressResourceTestCase {
 								"orderItemShippingAddress",
 								new HashMap<String, Object>() {
 									{
-										put("id", shippingAddress.getId());
+										put(
+											"id",
+											testGraphQLGetOrderItemShippingAddress_getId(
+												shippingAddress));
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/orderItemShippingAddress"))));
+	}
+
+	protected Long testGraphQLGetOrderItemShippingAddress_getId(
+			ShippingAddress shippingAddress)
+		throws Exception {
+
+		return shippingAddress.getId();
 	}
 
 	@Test
@@ -293,10 +310,19 @@ public abstract class BaseShippingAddressResourceTestCase {
 		ShippingAddress getShippingAddress =
 			shippingAddressResource.
 				getOrderByExternalReferenceCodeShippingAddress(
-					postShippingAddress.getExternalReferenceCode());
+					testGetOrderByExternalReferenceCodeShippingAddress_getExternalReferenceCode(
+						postShippingAddress));
 
 		assertEquals(postShippingAddress, getShippingAddress);
 		assertValid(getShippingAddress);
+	}
+
+	protected String
+			testGetOrderByExternalReferenceCodeShippingAddress_getExternalReferenceCode(
+				ShippingAddress shippingAddress)
+		throws Exception {
+
+		return shippingAddress.getExternalReferenceCode();
 	}
 
 	protected ShippingAddress
@@ -327,14 +353,21 @@ public abstract class BaseShippingAddressResourceTestCase {
 										put(
 											"externalReferenceCode",
 											"\"" +
-												shippingAddress.
-													getExternalReferenceCode() +
-														"\"");
+												testGraphQLGetOrderByExternalReferenceCodeShippingAddress_getExternalReferenceCode(
+													shippingAddress) + "\"");
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/orderByExternalReferenceCodeShippingAddress"))));
+	}
+
+	protected String
+			testGraphQLGetOrderByExternalReferenceCodeShippingAddress_getExternalReferenceCode(
+				ShippingAddress shippingAddress)
+		throws Exception {
+
+		return shippingAddress.getExternalReferenceCode();
 	}
 
 	@Test
@@ -383,10 +416,17 @@ public abstract class BaseShippingAddressResourceTestCase {
 
 		ShippingAddress getShippingAddress =
 			shippingAddressResource.getOrderIdShippingAddress(
-				postShippingAddress.getId());
+				testGetOrderIdShippingAddress_getId(postShippingAddress));
 
 		assertEquals(postShippingAddress, getShippingAddress);
 		assertValid(getShippingAddress);
+	}
+
+	protected Long testGetOrderIdShippingAddress_getId(
+			ShippingAddress shippingAddress)
+		throws Exception {
+
+		return shippingAddress.getId();
 	}
 
 	protected ShippingAddress testGetOrderIdShippingAddress_addShippingAddress()
@@ -411,11 +451,21 @@ public abstract class BaseShippingAddressResourceTestCase {
 								"orderIdShippingAddress",
 								new HashMap<String, Object>() {
 									{
-										put("id", shippingAddress.getId());
+										put(
+											"id",
+											testGraphQLGetOrderIdShippingAddress_getId(
+												shippingAddress));
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data", "Object/orderIdShippingAddress"))));
+	}
+
+	protected Long testGraphQLGetOrderIdShippingAddress_getId(
+			ShippingAddress shippingAddress)
+		throws Exception {
+
+		return shippingAddress.getId();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-test/src/testIntegration/java/com/liferay/headless/commerce/admin/shipment/resource/v1_0/test/BaseShipmentItemResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-test/src/testIntegration/java/com/liferay/headless/commerce/admin/shipment/resource/v1_0/test/BaseShipmentItemResourceTestCase.java
@@ -611,7 +611,8 @@ public abstract class BaseShipmentItemResourceTestCase {
 
 		ShipmentItem putShipmentItem =
 			shipmentItemResource.putShipmentByExternalReferenceCodeItem(
-				postShipmentItem.getExternalReferenceCode(),
+				testPutShipmentByExternalReferenceCodeItem_getExternalReferenceCode(
+					postShipmentItem),
 				randomShipmentItem);
 
 		assertEquals(randomShipmentItem, putShipmentItem);
@@ -619,10 +620,19 @@ public abstract class BaseShipmentItemResourceTestCase {
 
 		ShipmentItem getShipmentItem =
 			shipmentItemResource.getShipmentByExternalReferenceCodeItem(
-				putShipmentItem.getExternalReferenceCode());
+				testPutShipmentByExternalReferenceCodeItem_getExternalReferenceCode(
+					putShipmentItem));
 
 		assertEquals(randomShipmentItem, getShipmentItem);
 		assertValid(getShipmentItem);
+	}
+
+	protected String
+			testPutShipmentByExternalReferenceCodeItem_getExternalReferenceCode(
+				ShipmentItem shipmentItem)
+		throws Exception {
+
+		return shipmentItem.getExternalReferenceCode();
 	}
 
 	protected ShipmentItem

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-test/src/testIntegration/java/com/liferay/headless/commerce/admin/shipment/resource/v1_0/test/BaseShippingAddressResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-test/src/testIntegration/java/com/liferay/headless/commerce/admin/shipment/resource/v1_0/test/BaseShippingAddressResourceTestCase.java
@@ -220,10 +220,19 @@ public abstract class BaseShippingAddressResourceTestCase {
 		ShippingAddress getShippingAddress =
 			shippingAddressResource.
 				getShipmentByExternalReferenceCodeShippingAddress(
-					postShippingAddress.getExternalReferenceCode());
+					testGetShipmentByExternalReferenceCodeShippingAddress_getExternalReferenceCode(
+						postShippingAddress));
 
 		assertEquals(postShippingAddress, getShippingAddress);
 		assertValid(getShippingAddress);
+	}
+
+	protected String
+			testGetShipmentByExternalReferenceCodeShippingAddress_getExternalReferenceCode(
+				ShippingAddress shippingAddress)
+		throws Exception {
+
+		return shippingAddress.getExternalReferenceCode();
 	}
 
 	protected ShippingAddress
@@ -254,14 +263,21 @@ public abstract class BaseShippingAddressResourceTestCase {
 										put(
 											"externalReferenceCode",
 											"\"" +
-												shippingAddress.
-													getExternalReferenceCode() +
-														"\"");
+												testGraphQLGetShipmentByExternalReferenceCodeShippingAddress_getExternalReferenceCode(
+													shippingAddress) + "\"");
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/shipmentByExternalReferenceCodeShippingAddress"))));
+	}
+
+	protected String
+			testGraphQLGetShipmentByExternalReferenceCodeShippingAddress_getExternalReferenceCode(
+				ShippingAddress shippingAddress)
+		throws Exception {
+
+		return shippingAddress.getExternalReferenceCode();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseProductResourceTestCase.java
@@ -569,6 +569,7 @@ public abstract class BaseProductResourceTestCase {
 										put(
 											"channelId",
 											testGraphQLGetChannelProduct_getChannelId());
+
 										put("productId", product.getId());
 									}
 								},

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataDefinitionResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataDefinitionResourceTestCase.java
@@ -1141,12 +1141,21 @@ public abstract class BaseDataDefinitionResourceTestCase {
 		DataDefinition getDataDefinition =
 			dataDefinitionResource.
 				getSiteDataDefinitionByContentTypeByDataDefinitionKey(
-					postDataDefinition.getSiteId(),
+					testGetSiteDataDefinitionByContentTypeByDataDefinitionKey_getSiteId(
+						postDataDefinition),
 					postDataDefinition.getContentType(),
 					postDataDefinition.getDataDefinitionKey());
 
 		assertEquals(postDataDefinition, getDataDefinition);
 		assertValid(getDataDefinition);
+	}
+
+	protected Long
+			testGetSiteDataDefinitionByContentTypeByDataDefinitionKey_getSiteId(
+				DataDefinition dataDefinition)
+		throws Exception {
+
+		return dataDefinition.getSiteId();
 	}
 
 	protected DataDefinition
@@ -1176,13 +1185,16 @@ public abstract class BaseDataDefinitionResourceTestCase {
 									{
 										put(
 											"siteKey",
-											"\"" + dataDefinition.getSiteId() +
-												"\"");
+											"\"" +
+												testGraphQLGetSiteDataDefinitionByContentTypeByDataDefinitionKey_getSiteId(
+													dataDefinition) + "\"");
+
 										put(
 											"contentType",
 											"\"" +
 												dataDefinition.
 													getContentType() + "\"");
+
 										put(
 											"dataDefinitionKey",
 											"\"" +
@@ -1194,6 +1206,14 @@ public abstract class BaseDataDefinitionResourceTestCase {
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/dataDefinitionByContentTypeByDataDefinitionKey"))));
+	}
+
+	protected Long
+			testGraphQLGetSiteDataDefinitionByContentTypeByDataDefinitionKey_getSiteId(
+				DataDefinition dataDefinition)
+		throws Exception {
+
+		return dataDefinition.getSiteId();
 	}
 
 	@Test

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataLayoutResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataLayoutResourceTestCase.java
@@ -208,7 +208,15 @@ public abstract class BaseDataLayoutResourceTestCase {
 		assertHttpResponseStatusCode(
 			204,
 			dataLayoutResource.deleteDataDefinitionDataLayoutHttpResponse(
-				dataLayout.getDataDefinitionId()));
+				testDeleteDataDefinitionDataLayout_getDataDefinitionId(
+					dataLayout)));
+	}
+
+	protected Long testDeleteDataDefinitionDataLayout_getDataDefinitionId(
+			DataLayout dataLayout)
+		throws Exception {
+
+		return dataLayout.getDataDefinitionId();
 	}
 
 	protected DataLayout testDeleteDataDefinitionDataLayout_addDataLayout()
@@ -660,11 +668,20 @@ public abstract class BaseDataLayoutResourceTestCase {
 
 		DataLayout getDataLayout =
 			dataLayoutResource.getSiteDataLayoutByContentTypeByDataLayoutKey(
-				postDataLayout.getSiteId(), postDataLayout.getContentType(),
+				testGetSiteDataLayoutByContentTypeByDataLayoutKey_getSiteId(
+					postDataLayout),
+				postDataLayout.getContentType(),
 				postDataLayout.getDataLayoutKey());
 
 		assertEquals(postDataLayout, getDataLayout);
 		assertValid(getDataLayout);
+	}
+
+	protected Long testGetSiteDataLayoutByContentTypeByDataLayoutKey_getSiteId(
+			DataLayout dataLayout)
+		throws Exception {
+
+		return dataLayout.getSiteId();
 	}
 
 	protected DataLayout
@@ -694,12 +711,15 @@ public abstract class BaseDataLayoutResourceTestCase {
 									{
 										put(
 											"siteKey",
-											"\"" + dataLayout.getSiteId() +
-												"\"");
+											"\"" +
+												testGraphQLGetSiteDataLayoutByContentTypeByDataLayoutKey_getSiteId(
+													dataLayout) + "\"");
+
 										put(
 											"contentType",
 											"\"" + dataLayout.getContentType() +
 												"\"");
+
 										put(
 											"dataLayoutKey",
 											"\"" +
@@ -710,6 +730,14 @@ public abstract class BaseDataLayoutResourceTestCase {
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/dataLayoutByContentTypeByDataLayoutKey"))));
+	}
+
+	protected Long
+			testGraphQLGetSiteDataLayoutByContentTypeByDataLayoutKey_getSiteId(
+				DataLayout dataLayout)
+		throws Exception {
+
+		return dataLayout.getSiteId();
 	}
 
 	@Test

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataListViewResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataListViewResourceTestCase.java
@@ -204,7 +204,15 @@ public abstract class BaseDataListViewResourceTestCase {
 		assertHttpResponseStatusCode(
 			204,
 			dataListViewResource.deleteDataDefinitionDataListViewHttpResponse(
-				dataListView.getDataDefinitionId()));
+				testDeleteDataDefinitionDataListView_getDataDefinitionId(
+					dataListView)));
+	}
+
+	protected Long testDeleteDataDefinitionDataListView_getDataDefinitionId(
+			DataListView dataListView)
+		throws Exception {
+
+		return dataListView.getDataDefinitionId();
 	}
 
 	protected DataListView

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataRecordCollectionResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataRecordCollectionResourceTestCase.java
@@ -207,10 +207,19 @@ public abstract class BaseDataRecordCollectionResourceTestCase {
 
 		DataRecordCollection getDataRecordCollection =
 			dataRecordCollectionResource.getDataDefinitionDataRecordCollection(
-				postDataRecordCollection.getDataDefinitionId());
+				testGetDataDefinitionDataRecordCollection_getDataDefinitionId(
+					postDataRecordCollection));
 
 		assertEquals(postDataRecordCollection, getDataRecordCollection);
 		assertValid(getDataRecordCollection);
+	}
+
+	protected Long
+			testGetDataDefinitionDataRecordCollection_getDataDefinitionId(
+				DataRecordCollection dataRecordCollection)
+		throws Exception {
+
+		return dataRecordCollection.getDataDefinitionId();
 	}
 
 	protected DataRecordCollection
@@ -240,13 +249,21 @@ public abstract class BaseDataRecordCollectionResourceTestCase {
 									{
 										put(
 											"dataDefinitionId",
-											dataRecordCollection.
-												getDataDefinitionId());
+											testGraphQLGetDataDefinitionDataRecordCollection_getDataDefinitionId(
+												dataRecordCollection));
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/dataDefinitionDataRecordCollection"))));
+	}
+
+	protected Long
+			testGraphQLGetDataDefinitionDataRecordCollection_getDataDefinitionId(
+				DataRecordCollection dataRecordCollection)
+		throws Exception {
+
+		return dataRecordCollection.getDataDefinitionId();
 	}
 
 	@Test
@@ -711,11 +728,20 @@ public abstract class BaseDataRecordCollectionResourceTestCase {
 		DataRecordCollection getDataRecordCollection =
 			dataRecordCollectionResource.
 				getSiteDataRecordCollectionByDataRecordCollectionKey(
-					postDataRecordCollection.getSiteId(),
+					testGetSiteDataRecordCollectionByDataRecordCollectionKey_getSiteId(
+						postDataRecordCollection),
 					postDataRecordCollection.getDataRecordCollectionKey());
 
 		assertEquals(postDataRecordCollection, getDataRecordCollection);
 		assertValid(getDataRecordCollection);
+	}
+
+	protected Long
+			testGetSiteDataRecordCollectionByDataRecordCollectionKey_getSiteId(
+				DataRecordCollection dataRecordCollection)
+		throws Exception {
+
+		return dataRecordCollection.getSiteId();
 	}
 
 	protected DataRecordCollection
@@ -746,8 +772,10 @@ public abstract class BaseDataRecordCollectionResourceTestCase {
 										put(
 											"siteKey",
 											"\"" +
-												dataRecordCollection.
-													getSiteId() + "\"");
+												testGraphQLGetSiteDataRecordCollectionByDataRecordCollectionKey_getSiteId(
+													dataRecordCollection) +
+														"\"");
+
 										put(
 											"dataRecordCollectionKey",
 											"\"" +
@@ -759,6 +787,14 @@ public abstract class BaseDataRecordCollectionResourceTestCase {
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/dataRecordCollectionByDataRecordCollectionKey"))));
+	}
+
+	protected Long
+			testGraphQLGetSiteDataRecordCollectionByDataRecordCollectionKey_getSiteId(
+				DataRecordCollection dataRecordCollection)
+		throws Exception {
+
+		return dataRecordCollection.getSiteId();
 	}
 
 	@Test

--- a/modules/apps/digital-signature/digital-signature-rest-test/src/testIntegration/java/com/liferay/digital/signature/rest/resource/v1_0/test/BaseDSEnvelopeResourceTestCase.java
+++ b/modules/apps/digital-signature/digital-signature-rest-test/src/testIntegration/java/com/liferay/digital/signature/rest/resource/v1_0/test/BaseDSEnvelopeResourceTestCase.java
@@ -335,10 +335,17 @@ public abstract class BaseDSEnvelopeResourceTestCase {
 		DSEnvelope postDSEnvelope = testGetSiteDSEnvelope_addDSEnvelope();
 
 		DSEnvelope getDSEnvelope = dsEnvelopeResource.getSiteDSEnvelope(
-			postDSEnvelope.getSiteId(), postDSEnvelope.getId());
+			testGetSiteDSEnvelope_getSiteId(postDSEnvelope),
+			postDSEnvelope.getId());
 
 		assertEquals(postDSEnvelope, getDSEnvelope);
 		assertValid(getDSEnvelope);
+	}
+
+	protected Long testGetSiteDSEnvelope_getSiteId(DSEnvelope dsEnvelope)
+		throws Exception {
+
+		return dsEnvelope.getSiteId();
 	}
 
 	protected DSEnvelope testGetSiteDSEnvelope_addDSEnvelope()
@@ -364,8 +371,10 @@ public abstract class BaseDSEnvelopeResourceTestCase {
 									{
 										put(
 											"siteKey",
-											"\"" + dsEnvelope.getSiteId() +
-												"\"");
+											"\"" +
+												testGraphQLGetSiteDSEnvelope_getSiteId(
+													dsEnvelope) + "\"");
+
 										put(
 											"dsEnvelopeId",
 											"\"" + dsEnvelope.getId() + "\"");
@@ -373,6 +382,12 @@ public abstract class BaseDSEnvelopeResourceTestCase {
 								},
 								getGraphQLFields())),
 						"JSONObject/data", "Object/dSEnvelope"))));
+	}
+
+	protected Long testGraphQLGetSiteDSEnvelope_getSiteId(DSEnvelope dsEnvelope)
+		throws Exception {
+
+		return dsEnvelope.getSiteId();
 	}
 
 	@Test

--- a/modules/apps/headless/headless-admin-address/headless-admin-address-test/src/testIntegration/java/com/liferay/headless/admin/address/resource/v1_0/test/BaseRegionResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-address/headless-admin-address-test/src/testIntegration/java/com/liferay/headless/admin/address/resource/v1_0/test/BaseRegionResourceTestCase.java
@@ -446,10 +446,17 @@ public abstract class BaseRegionResourceTestCase {
 		Region postRegion = testGetCountryRegionByRegionCode_addRegion();
 
 		Region getRegion = regionResource.getCountryRegionByRegionCode(
-			postRegion.getCountryId(), postRegion.getRegionCode());
+			testGetCountryRegionByRegionCode_getCountryId(postRegion),
+			postRegion.getRegionCode());
 
 		assertEquals(postRegion, getRegion);
 		assertValid(getRegion);
+	}
+
+	protected Long testGetCountryRegionByRegionCode_getCountryId(Region region)
+		throws Exception {
+
+		return region.getCountryId();
 	}
 
 	protected Region testGetCountryRegionByRegionCode_addRegion()
@@ -473,7 +480,11 @@ public abstract class BaseRegionResourceTestCase {
 								"countryRegionByRegionCode",
 								new HashMap<String, Object>() {
 									{
-										put("countryId", region.getCountryId());
+										put(
+											"countryId",
+											testGraphQLGetCountryRegionByRegionCode_getCountryId(
+												region));
+
 										put(
 											"regionCode",
 											"\"" + region.getRegionCode() +
@@ -483,6 +494,13 @@ public abstract class BaseRegionResourceTestCase {
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/countryRegionByRegionCode"))));
+	}
+
+	protected Long testGraphQLGetCountryRegionByRegionCode_getCountryId(
+			Region region)
+		throws Exception {
+
+		return region.getCountryId();
 	}
 
 	@Test

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/rest-openapi.yaml
@@ -71,7 +71,7 @@ info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
         'om.liferay.headless.admin.list.type.client', and version '1.0.0'.. A Java client JAR is available for use with
-        the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.list.type.client', and version '1.0.11'."
+        the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.list.type.client', and version '1.0.12'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'om.liferay.headless.admin.list.type.client', and version '1.0.0'.. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.list.type.client', and version '1.0.11'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "List Type", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'om.liferay.headless.admin.list.type.client', and version '1.0.0'.. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.list.type.client', and version '1.0.12'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "List Type", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
@@ -1441,22 +1441,33 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 			204,
 			taxonomyCategoryResource.
 				deleteTaxonomyVocabularyTaxonomyCategoryByExternalReferenceCodeHttpResponse(
-					taxonomyCategory.getTaxonomyVocabularyId(),
+					testDeleteTaxonomyVocabularyTaxonomyCategoryByExternalReferenceCode_getTaxonomyVocabularyId(
+						taxonomyCategory),
 					taxonomyCategory.getExternalReferenceCode()));
 
 		assertHttpResponseStatusCode(
 			404,
 			taxonomyCategoryResource.
 				getTaxonomyVocabularyTaxonomyCategoryByExternalReferenceCodeHttpResponse(
-					taxonomyCategory.getTaxonomyVocabularyId(),
+					testDeleteTaxonomyVocabularyTaxonomyCategoryByExternalReferenceCode_getTaxonomyVocabularyId(
+						taxonomyCategory),
 					taxonomyCategory.getExternalReferenceCode()));
 
 		assertHttpResponseStatusCode(
 			404,
 			taxonomyCategoryResource.
 				getTaxonomyVocabularyTaxonomyCategoryByExternalReferenceCodeHttpResponse(
-					taxonomyCategory.getTaxonomyVocabularyId(),
+					testDeleteTaxonomyVocabularyTaxonomyCategoryByExternalReferenceCode_getTaxonomyVocabularyId(
+						taxonomyCategory),
 					taxonomyCategory.getExternalReferenceCode()));
+	}
+
+	protected Long
+			testDeleteTaxonomyVocabularyTaxonomyCategoryByExternalReferenceCode_getTaxonomyVocabularyId(
+				TaxonomyCategory taxonomyCategory)
+		throws Exception {
+
+		return taxonomyCategory.getTaxonomyVocabularyId();
 	}
 
 	protected TaxonomyCategory
@@ -1477,11 +1488,20 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		TaxonomyCategory getTaxonomyCategory =
 			taxonomyCategoryResource.
 				getTaxonomyVocabularyTaxonomyCategoryByExternalReferenceCode(
-					postTaxonomyCategory.getTaxonomyVocabularyId(),
+					testGetTaxonomyVocabularyTaxonomyCategoryByExternalReferenceCode_getTaxonomyVocabularyId(
+						postTaxonomyCategory),
 					postTaxonomyCategory.getExternalReferenceCode());
 
 		assertEquals(postTaxonomyCategory, getTaxonomyCategory);
 		assertValid(getTaxonomyCategory);
+	}
+
+	protected Long
+			testGetTaxonomyVocabularyTaxonomyCategoryByExternalReferenceCode_getTaxonomyVocabularyId(
+				TaxonomyCategory taxonomyCategory)
+		throws Exception {
+
+		return taxonomyCategory.getTaxonomyVocabularyId();
 	}
 
 	protected TaxonomyCategory
@@ -1511,8 +1531,9 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 									{
 										put(
 											"taxonomyVocabularyId",
-											taxonomyCategory.
-												getTaxonomyVocabularyId());
+											testGraphQLGetTaxonomyVocabularyTaxonomyCategoryByExternalReferenceCode_getTaxonomyVocabularyId(
+												taxonomyCategory));
+
 										put(
 											"externalReferenceCode",
 											"\"" +
@@ -1524,6 +1545,14 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/taxonomyVocabularyTaxonomyCategoryByExternalReferenceCode"))));
+	}
+
+	protected Long
+			testGraphQLGetTaxonomyVocabularyTaxonomyCategoryByExternalReferenceCode_getTaxonomyVocabularyId(
+				TaxonomyCategory taxonomyCategory)
+		throws Exception {
+
+		return taxonomyCategory.getTaxonomyVocabularyId();
 	}
 
 	@Test
@@ -1574,7 +1603,8 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		TaxonomyCategory putTaxonomyCategory =
 			taxonomyCategoryResource.
 				putTaxonomyVocabularyTaxonomyCategoryByExternalReferenceCode(
-					postTaxonomyCategory.getTaxonomyVocabularyId(),
+					testPutTaxonomyVocabularyTaxonomyCategoryByExternalReferenceCode_getTaxonomyVocabularyId(
+						postTaxonomyCategory),
 					postTaxonomyCategory.getExternalReferenceCode(),
 					randomTaxonomyCategory);
 
@@ -1584,7 +1614,8 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		TaxonomyCategory getTaxonomyCategory =
 			taxonomyCategoryResource.
 				getTaxonomyVocabularyTaxonomyCategoryByExternalReferenceCode(
-					putTaxonomyCategory.getTaxonomyVocabularyId(),
+					testPutTaxonomyVocabularyTaxonomyCategoryByExternalReferenceCode_getTaxonomyVocabularyId(
+						putTaxonomyCategory),
 					putTaxonomyCategory.getExternalReferenceCode());
 
 		assertEquals(randomTaxonomyCategory, getTaxonomyCategory);
@@ -1596,7 +1627,8 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		putTaxonomyCategory =
 			taxonomyCategoryResource.
 				putTaxonomyVocabularyTaxonomyCategoryByExternalReferenceCode(
-					newTaxonomyCategory.getTaxonomyVocabularyId(),
+					testPutTaxonomyVocabularyTaxonomyCategoryByExternalReferenceCode_getTaxonomyVocabularyId(
+						newTaxonomyCategory),
 					newTaxonomyCategory.getExternalReferenceCode(),
 					newTaxonomyCategory);
 
@@ -1606,7 +1638,8 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		getTaxonomyCategory =
 			taxonomyCategoryResource.
 				getTaxonomyVocabularyTaxonomyCategoryByExternalReferenceCode(
-					putTaxonomyCategory.getTaxonomyVocabularyId(),
+					testPutTaxonomyVocabularyTaxonomyCategoryByExternalReferenceCode_getTaxonomyVocabularyId(
+						putTaxonomyCategory),
 					putTaxonomyCategory.getExternalReferenceCode());
 
 		assertEquals(newTaxonomyCategory, getTaxonomyCategory);
@@ -1614,6 +1647,14 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		Assert.assertEquals(
 			newTaxonomyCategory.getExternalReferenceCode(),
 			putTaxonomyCategory.getExternalReferenceCode());
+	}
+
+	protected Long
+			testPutTaxonomyVocabularyTaxonomyCategoryByExternalReferenceCode_getTaxonomyVocabularyId(
+				TaxonomyCategory taxonomyCategory)
+		throws Exception {
+
+		return taxonomyCategory.getTaxonomyVocabularyId();
 	}
 
 	protected TaxonomyCategory

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
@@ -739,6 +739,7 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 											"\"" +
 												testGraphQLGetAssetLibraryTaxonomyVocabularyByExternalReferenceCode_getAssetLibraryId() +
 													"\"");
+
 										put(
 											"externalReferenceCode",
 											"\"" +
@@ -1415,22 +1416,33 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 			204,
 			taxonomyVocabularyResource.
 				deleteSiteTaxonomyVocabularyByExternalReferenceCodeHttpResponse(
-					taxonomyVocabulary.getSiteId(),
+					testDeleteSiteTaxonomyVocabularyByExternalReferenceCode_getSiteId(
+						taxonomyVocabulary),
 					taxonomyVocabulary.getExternalReferenceCode()));
 
 		assertHttpResponseStatusCode(
 			404,
 			taxonomyVocabularyResource.
 				getSiteTaxonomyVocabularyByExternalReferenceCodeHttpResponse(
-					taxonomyVocabulary.getSiteId(),
+					testDeleteSiteTaxonomyVocabularyByExternalReferenceCode_getSiteId(
+						taxonomyVocabulary),
 					taxonomyVocabulary.getExternalReferenceCode()));
 
 		assertHttpResponseStatusCode(
 			404,
 			taxonomyVocabularyResource.
 				getSiteTaxonomyVocabularyByExternalReferenceCodeHttpResponse(
-					taxonomyVocabulary.getSiteId(),
+					testDeleteSiteTaxonomyVocabularyByExternalReferenceCode_getSiteId(
+						taxonomyVocabulary),
 					taxonomyVocabulary.getExternalReferenceCode()));
+	}
+
+	protected Long
+			testDeleteSiteTaxonomyVocabularyByExternalReferenceCode_getSiteId(
+				TaxonomyVocabulary taxonomyVocabulary)
+		throws Exception {
+
+		return taxonomyVocabulary.getSiteId();
 	}
 
 	protected TaxonomyVocabulary
@@ -1451,11 +1463,20 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 		TaxonomyVocabulary getTaxonomyVocabulary =
 			taxonomyVocabularyResource.
 				getSiteTaxonomyVocabularyByExternalReferenceCode(
-					postTaxonomyVocabulary.getSiteId(),
+					testGetSiteTaxonomyVocabularyByExternalReferenceCode_getSiteId(
+						postTaxonomyVocabulary),
 					postTaxonomyVocabulary.getExternalReferenceCode());
 
 		assertEquals(postTaxonomyVocabulary, getTaxonomyVocabulary);
 		assertValid(getTaxonomyVocabulary);
+	}
+
+	protected Long
+			testGetSiteTaxonomyVocabularyByExternalReferenceCode_getSiteId(
+				TaxonomyVocabulary taxonomyVocabulary)
+		throws Exception {
+
+		return taxonomyVocabulary.getSiteId();
 	}
 
 	protected TaxonomyVocabulary
@@ -1486,8 +1507,9 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 										put(
 											"siteKey",
 											"\"" +
-												taxonomyVocabulary.getSiteId() +
-													"\"");
+												testGraphQLGetSiteTaxonomyVocabularyByExternalReferenceCode_getSiteId(
+													taxonomyVocabulary) + "\"");
+
 										put(
 											"externalReferenceCode",
 											"\"" +
@@ -1499,6 +1521,14 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/taxonomyVocabularyByExternalReferenceCode"))));
+	}
+
+	protected Long
+			testGraphQLGetSiteTaxonomyVocabularyByExternalReferenceCode_getSiteId(
+				TaxonomyVocabulary taxonomyVocabulary)
+		throws Exception {
+
+		return taxonomyVocabulary.getSiteId();
 	}
 
 	@Test
@@ -1549,7 +1579,8 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 		TaxonomyVocabulary putTaxonomyVocabulary =
 			taxonomyVocabularyResource.
 				putSiteTaxonomyVocabularyByExternalReferenceCode(
-					postTaxonomyVocabulary.getSiteId(),
+					testPutSiteTaxonomyVocabularyByExternalReferenceCode_getSiteId(
+						postTaxonomyVocabulary),
 					postTaxonomyVocabulary.getExternalReferenceCode(),
 					randomTaxonomyVocabulary);
 
@@ -1559,7 +1590,8 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 		TaxonomyVocabulary getTaxonomyVocabulary =
 			taxonomyVocabularyResource.
 				getSiteTaxonomyVocabularyByExternalReferenceCode(
-					putTaxonomyVocabulary.getSiteId(),
+					testPutSiteTaxonomyVocabularyByExternalReferenceCode_getSiteId(
+						putTaxonomyVocabulary),
 					putTaxonomyVocabulary.getExternalReferenceCode());
 
 		assertEquals(randomTaxonomyVocabulary, getTaxonomyVocabulary);
@@ -1571,7 +1603,8 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 		putTaxonomyVocabulary =
 			taxonomyVocabularyResource.
 				putSiteTaxonomyVocabularyByExternalReferenceCode(
-					newTaxonomyVocabulary.getSiteId(),
+					testPutSiteTaxonomyVocabularyByExternalReferenceCode_getSiteId(
+						newTaxonomyVocabulary),
 					newTaxonomyVocabulary.getExternalReferenceCode(),
 					newTaxonomyVocabulary);
 
@@ -1581,7 +1614,8 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 		getTaxonomyVocabulary =
 			taxonomyVocabularyResource.
 				getSiteTaxonomyVocabularyByExternalReferenceCode(
-					putTaxonomyVocabulary.getSiteId(),
+					testPutSiteTaxonomyVocabularyByExternalReferenceCode_getSiteId(
+						putTaxonomyVocabulary),
 					putTaxonomyVocabulary.getExternalReferenceCode());
 
 		assertEquals(newTaxonomyVocabulary, getTaxonomyVocabulary);
@@ -1589,6 +1623,14 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 		Assert.assertEquals(
 			newTaxonomyVocabulary.getExternalReferenceCode(),
 			putTaxonomyVocabulary.getExternalReferenceCode());
+	}
+
+	protected Long
+			testPutSiteTaxonomyVocabularyByExternalReferenceCode_getSiteId(
+				TaxonomyVocabulary taxonomyVocabulary)
+		throws Exception {
+
+		return taxonomyVocabulary.getSiteId();
 	}
 
 	protected TaxonomyVocabulary

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseAccountRoleResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseAccountRoleResourceTestCase.java
@@ -1350,8 +1350,18 @@ public abstract class BaseAccountRoleResourceTestCase {
 			204,
 			accountRoleResource.
 				deleteAccountAccountRoleUserAccountAssociationHttpResponse(
-					accountRole.getAccountId(), accountRole.getId(),
+					testDeleteAccountAccountRoleUserAccountAssociation_getAccountId(
+						accountRole),
+					accountRole.getId(),
 					testDeleteAccountAccountRoleUserAccountAssociation_getUserAccountId()));
+	}
+
+	protected Long
+			testDeleteAccountAccountRoleUserAccountAssociation_getAccountId(
+				AccountRole accountRole)
+		throws Exception {
+
+		return accountRole.getAccountId();
 	}
 
 	protected Long

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseOrganizationResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseOrganizationResourceTestCase.java
@@ -618,8 +618,17 @@ public abstract class BaseOrganizationResourceTestCase {
 			204,
 			organizationResource.
 				deleteAccountByExternalReferenceCodeOrganizationHttpResponse(
-					organization.getExternalReferenceCode(),
+					testDeleteAccountByExternalReferenceCodeOrganization_getExternalReferenceCode(
+						organization),
 					organization.getId()));
+	}
+
+	protected String
+			testDeleteAccountByExternalReferenceCodeOrganization_getExternalReferenceCode(
+				Organization organization)
+		throws Exception {
+
+		return organization.getExternalReferenceCode();
 	}
 
 	protected Organization

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseUserAccountResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseUserAccountResourceTestCase.java
@@ -717,7 +717,17 @@ public abstract class BaseUserAccountResourceTestCase {
 			204,
 			userAccountResource.
 				deleteAccountUserAccountsByExternalReferenceCodeByEmailAddressHttpResponse(
-					userAccount.getExternalReferenceCode(), null));
+					testDeleteAccountUserAccountsByExternalReferenceCodeByEmailAddress_getExternalReferenceCode(
+						userAccount),
+					null));
+	}
+
+	protected String
+			testDeleteAccountUserAccountsByExternalReferenceCodeByEmailAddress_getExternalReferenceCode(
+				UserAccount userAccount)
+		throws Exception {
+
+		return userAccount.getExternalReferenceCode();
 	}
 
 	protected UserAccount
@@ -769,8 +779,17 @@ public abstract class BaseUserAccountResourceTestCase {
 			204,
 			userAccountResource.
 				deleteAccountUserAccountByExternalReferenceCodeByEmailAddressHttpResponse(
-					userAccount.getExternalReferenceCode(),
+					testDeleteAccountUserAccountByExternalReferenceCodeByEmailAddress_getExternalReferenceCode(
+						userAccount),
 					userAccount.getEmailAddress()));
+	}
+
+	protected String
+			testDeleteAccountUserAccountByExternalReferenceCodeByEmailAddress_getExternalReferenceCode(
+				UserAccount userAccount)
+		throws Exception {
+
+		return userAccount.getExternalReferenceCode();
 	}
 
 	protected UserAccount

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingResourceTestCase.java
@@ -911,22 +911,32 @@ public abstract class BaseBlogPostingResourceTestCase {
 			204,
 			blogPostingResource.
 				deleteSiteBlogPostingByExternalReferenceCodeHttpResponse(
-					blogPosting.getSiteId(),
+					testDeleteSiteBlogPostingByExternalReferenceCode_getSiteId(
+						blogPosting),
 					blogPosting.getExternalReferenceCode()));
 
 		assertHttpResponseStatusCode(
 			404,
 			blogPostingResource.
 				getSiteBlogPostingByExternalReferenceCodeHttpResponse(
-					blogPosting.getSiteId(),
+					testDeleteSiteBlogPostingByExternalReferenceCode_getSiteId(
+						blogPosting),
 					blogPosting.getExternalReferenceCode()));
 
 		assertHttpResponseStatusCode(
 			404,
 			blogPostingResource.
 				getSiteBlogPostingByExternalReferenceCodeHttpResponse(
-					blogPosting.getSiteId(),
+					testDeleteSiteBlogPostingByExternalReferenceCode_getSiteId(
+						blogPosting),
 					blogPosting.getExternalReferenceCode()));
+	}
+
+	protected Long testDeleteSiteBlogPostingByExternalReferenceCode_getSiteId(
+			BlogPosting blogPosting)
+		throws Exception {
+
+		return blogPosting.getSiteId();
 	}
 
 	protected BlogPosting
@@ -946,11 +956,19 @@ public abstract class BaseBlogPostingResourceTestCase {
 
 		BlogPosting getBlogPosting =
 			blogPostingResource.getSiteBlogPostingByExternalReferenceCode(
-				postBlogPosting.getSiteId(),
+				testGetSiteBlogPostingByExternalReferenceCode_getSiteId(
+					postBlogPosting),
 				postBlogPosting.getExternalReferenceCode());
 
 		assertEquals(postBlogPosting, getBlogPosting);
 		assertValid(getBlogPosting);
+	}
+
+	protected Long testGetSiteBlogPostingByExternalReferenceCode_getSiteId(
+			BlogPosting blogPosting)
+		throws Exception {
+
+		return blogPosting.getSiteId();
 	}
 
 	protected BlogPosting
@@ -980,8 +998,10 @@ public abstract class BaseBlogPostingResourceTestCase {
 									{
 										put(
 											"siteKey",
-											"\"" + blogPosting.getSiteId() +
-												"\"");
+											"\"" +
+												testGraphQLGetSiteBlogPostingByExternalReferenceCode_getSiteId(
+													blogPosting) + "\"");
+
 										put(
 											"externalReferenceCode",
 											"\"" +
@@ -993,6 +1013,14 @@ public abstract class BaseBlogPostingResourceTestCase {
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/blogPostingByExternalReferenceCode"))));
+	}
+
+	protected Long
+			testGraphQLGetSiteBlogPostingByExternalReferenceCode_getSiteId(
+				BlogPosting blogPosting)
+		throws Exception {
+
+		return blogPosting.getSiteId();
 	}
 
 	@Test
@@ -1041,7 +1069,8 @@ public abstract class BaseBlogPostingResourceTestCase {
 
 		BlogPosting putBlogPosting =
 			blogPostingResource.putSiteBlogPostingByExternalReferenceCode(
-				postBlogPosting.getSiteId(),
+				testPutSiteBlogPostingByExternalReferenceCode_getSiteId(
+					postBlogPosting),
 				postBlogPosting.getExternalReferenceCode(), randomBlogPosting);
 
 		assertEquals(randomBlogPosting, putBlogPosting);
@@ -1049,7 +1078,8 @@ public abstract class BaseBlogPostingResourceTestCase {
 
 		BlogPosting getBlogPosting =
 			blogPostingResource.getSiteBlogPostingByExternalReferenceCode(
-				putBlogPosting.getSiteId(),
+				testPutSiteBlogPostingByExternalReferenceCode_getSiteId(
+					putBlogPosting),
 				putBlogPosting.getExternalReferenceCode());
 
 		assertEquals(randomBlogPosting, getBlogPosting);
@@ -1060,7 +1090,8 @@ public abstract class BaseBlogPostingResourceTestCase {
 
 		putBlogPosting =
 			blogPostingResource.putSiteBlogPostingByExternalReferenceCode(
-				newBlogPosting.getSiteId(),
+				testPutSiteBlogPostingByExternalReferenceCode_getSiteId(
+					newBlogPosting),
 				newBlogPosting.getExternalReferenceCode(), newBlogPosting);
 
 		assertEquals(newBlogPosting, putBlogPosting);
@@ -1068,7 +1099,8 @@ public abstract class BaseBlogPostingResourceTestCase {
 
 		getBlogPosting =
 			blogPostingResource.getSiteBlogPostingByExternalReferenceCode(
-				putBlogPosting.getSiteId(),
+				testPutSiteBlogPostingByExternalReferenceCode_getSiteId(
+					putBlogPosting),
 				putBlogPosting.getExternalReferenceCode());
 
 		assertEquals(newBlogPosting, getBlogPosting);
@@ -1076,6 +1108,13 @@ public abstract class BaseBlogPostingResourceTestCase {
 		Assert.assertEquals(
 			newBlogPosting.getExternalReferenceCode(),
 			putBlogPosting.getExternalReferenceCode());
+	}
+
+	protected Long testPutSiteBlogPostingByExternalReferenceCode_getSiteId(
+			BlogPosting blogPosting)
+		throws Exception {
+
+		return blogPosting.getSiteId();
 	}
 
 	protected BlogPosting

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseCommentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseCommentResourceTestCase.java
@@ -1501,6 +1501,7 @@ public abstract class BaseCommentResourceTestCase {
 											"\"" +
 												testGraphQLGetSiteBlogPostingByExternalReferenceCodeBlogPostingExternalReferenceCodeCommentByExternalReferenceCode_getBlogPostingExternalReferenceCode() +
 													"\"");
+
 										put(
 											"externalReferenceCode",
 											"\"" +
@@ -1784,6 +1785,7 @@ public abstract class BaseCommentResourceTestCase {
 											"\"" +
 												testGraphQLGetSiteCommentByExternalReferenceCodeParentCommentExternalReferenceCodeCommentByExternalReferenceCode_getParentCommentExternalReferenceCode() +
 													"\"");
+
 										put(
 											"externalReferenceCode",
 											"\"" +
@@ -2067,6 +2069,7 @@ public abstract class BaseCommentResourceTestCase {
 											"\"" +
 												testGraphQLGetSiteDocumentByExternalReferenceCodeDocumentExternalReferenceCodeCommentByExternalReferenceCode_getDocumentExternalReferenceCode() +
 													"\"");
+
 										put(
 											"externalReferenceCode",
 											"\"" +
@@ -2350,6 +2353,7 @@ public abstract class BaseCommentResourceTestCase {
 											"\"" +
 												testGraphQLGetSiteStructuredContentByExternalReferenceCodeStructuredContentExternalReferenceCodeCommentByExternalReferenceCode_getStructuredContentExternalReferenceCode() +
 													"\"");
+
 										put(
 											"externalReferenceCode",
 											"\"" +

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentTemplateResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentTemplateResourceTestCase.java
@@ -1014,10 +1014,18 @@ public abstract class BaseContentTemplateResourceTestCase {
 
 		ContentTemplate getContentTemplate =
 			contentTemplateResource.getSiteContentTemplate(
-				postContentTemplate.getSiteId(), postContentTemplate.getId());
+				testGetSiteContentTemplate_getSiteId(postContentTemplate),
+				postContentTemplate.getId());
 
 		assertEquals(postContentTemplate, getContentTemplate);
 		assertValid(getContentTemplate);
+	}
+
+	protected Long testGetSiteContentTemplate_getSiteId(
+			ContentTemplate contentTemplate)
+		throws Exception {
+
+		return contentTemplate.getSiteId();
 	}
 
 	protected ContentTemplate testGetSiteContentTemplate_addContentTemplate()
@@ -1044,8 +1052,10 @@ public abstract class BaseContentTemplateResourceTestCase {
 									{
 										put(
 											"siteKey",
-											"\"" + contentTemplate.getSiteId() +
-												"\"");
+											"\"" +
+												testGraphQLGetSiteContentTemplate_getSiteId(
+													contentTemplate) + "\"");
+
 										put(
 											"contentTemplateId",
 											"\"" + contentTemplate.getId() +
@@ -1054,6 +1064,13 @@ public abstract class BaseContentTemplateResourceTestCase {
 								},
 								getGraphQLFields())),
 						"JSONObject/data", "Object/contentTemplate"))));
+	}
+
+	protected Long testGraphQLGetSiteContentTemplate_getSiteId(
+			ContentTemplate contentTemplate)
+		throws Exception {
+
+		return contentTemplate.getSiteId();
 	}
 
 	@Test

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentResourceTestCase.java
@@ -704,6 +704,7 @@ public abstract class BaseDocumentResourceTestCase {
 											"\"" +
 												testGraphQLGetAssetLibraryDocumentByExternalReferenceCode_getAssetLibraryId() +
 													"\"");
+
 										put(
 											"externalReferenceCode",
 											"\"" +
@@ -1947,17 +1948,30 @@ public abstract class BaseDocumentResourceTestCase {
 			204,
 			documentResource.
 				deleteSiteDocumentByExternalReferenceCodeHttpResponse(
-					document.getSiteId(), document.getExternalReferenceCode()));
+					testDeleteSiteDocumentByExternalReferenceCode_getSiteId(
+						document),
+					document.getExternalReferenceCode()));
 
 		assertHttpResponseStatusCode(
 			404,
 			documentResource.getSiteDocumentByExternalReferenceCodeHttpResponse(
-				document.getSiteId(), document.getExternalReferenceCode()));
+				testDeleteSiteDocumentByExternalReferenceCode_getSiteId(
+					document),
+				document.getExternalReferenceCode()));
 
 		assertHttpResponseStatusCode(
 			404,
 			documentResource.getSiteDocumentByExternalReferenceCodeHttpResponse(
-				document.getSiteId(), document.getExternalReferenceCode()));
+				testDeleteSiteDocumentByExternalReferenceCode_getSiteId(
+					document),
+				document.getExternalReferenceCode()));
+	}
+
+	protected Long testDeleteSiteDocumentByExternalReferenceCode_getSiteId(
+			Document document)
+		throws Exception {
+
+		return document.getSiteId();
 	}
 
 	protected Document
@@ -1975,11 +1989,19 @@ public abstract class BaseDocumentResourceTestCase {
 
 		Document getDocument =
 			documentResource.getSiteDocumentByExternalReferenceCode(
-				postDocument.getSiteId(),
+				testGetSiteDocumentByExternalReferenceCode_getSiteId(
+					postDocument),
 				postDocument.getExternalReferenceCode());
 
 		assertEquals(postDocument, getDocument);
 		assertValid(getDocument);
+	}
+
+	protected Long testGetSiteDocumentByExternalReferenceCode_getSiteId(
+			Document document)
+		throws Exception {
+
+		return document.getSiteId();
 	}
 
 	protected Document testGetSiteDocumentByExternalReferenceCode_addDocument()
@@ -2008,7 +2030,10 @@ public abstract class BaseDocumentResourceTestCase {
 									{
 										put(
 											"siteKey",
-											"\"" + document.getSiteId() + "\"");
+											"\"" +
+												testGraphQLGetSiteDocumentByExternalReferenceCode_getSiteId(
+													document) + "\"");
+
 										put(
 											"externalReferenceCode",
 											"\"" +
@@ -2020,6 +2045,13 @@ public abstract class BaseDocumentResourceTestCase {
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/documentByExternalReferenceCode"))));
+	}
+
+	protected Long testGraphQLGetSiteDocumentByExternalReferenceCode_getSiteId(
+			Document document)
+		throws Exception {
+
+		return document.getSiteId();
 	}
 
 	@Test
@@ -2068,7 +2100,8 @@ public abstract class BaseDocumentResourceTestCase {
 
 		Document putDocument =
 			documentResource.putSiteDocumentByExternalReferenceCode(
-				postDocument.getSiteId(),
+				testPutSiteDocumentByExternalReferenceCode_getSiteId(
+					postDocument),
 				postDocument.getExternalReferenceCode(), randomDocument,
 				multipartFiles);
 
@@ -2077,7 +2110,8 @@ public abstract class BaseDocumentResourceTestCase {
 
 		Document getDocument =
 			documentResource.getSiteDocumentByExternalReferenceCode(
-				putDocument.getSiteId(),
+				testPutSiteDocumentByExternalReferenceCode_getSiteId(
+					putDocument),
 				putDocument.getExternalReferenceCode());
 
 		assertEquals(randomDocument, getDocument);
@@ -2089,20 +2123,29 @@ public abstract class BaseDocumentResourceTestCase {
 			testPutSiteDocumentByExternalReferenceCode_createDocument();
 
 		putDocument = documentResource.putSiteDocumentByExternalReferenceCode(
-			newDocument.getSiteId(), newDocument.getExternalReferenceCode(),
-			newDocument, getMultipartFiles());
+			testPutSiteDocumentByExternalReferenceCode_getSiteId(newDocument),
+			newDocument.getExternalReferenceCode(), newDocument,
+			getMultipartFiles());
 
 		assertEquals(newDocument, putDocument);
 		assertValid(putDocument);
 
 		getDocument = documentResource.getSiteDocumentByExternalReferenceCode(
-			putDocument.getSiteId(), putDocument.getExternalReferenceCode());
+			testPutSiteDocumentByExternalReferenceCode_getSiteId(putDocument),
+			putDocument.getExternalReferenceCode());
 
 		assertEquals(newDocument, getDocument);
 
 		Assert.assertEquals(
 			newDocument.getExternalReferenceCode(),
 			putDocument.getExternalReferenceCode());
+	}
+
+	protected Long testPutSiteDocumentByExternalReferenceCode_getSiteId(
+			Document document)
+		throws Exception {
+
+		return document.getSiteId();
 	}
 
 	protected Document

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseArticleResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseArticleResourceTestCase.java
@@ -1943,22 +1943,33 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 			204,
 			knowledgeBaseArticleResource.
 				deleteSiteKnowledgeBaseArticleByExternalReferenceCodeHttpResponse(
-					knowledgeBaseArticle.getSiteId(),
+					testDeleteSiteKnowledgeBaseArticleByExternalReferenceCode_getSiteId(
+						knowledgeBaseArticle),
 					knowledgeBaseArticle.getExternalReferenceCode()));
 
 		assertHttpResponseStatusCode(
 			404,
 			knowledgeBaseArticleResource.
 				getSiteKnowledgeBaseArticleByExternalReferenceCodeHttpResponse(
-					knowledgeBaseArticle.getSiteId(),
+					testDeleteSiteKnowledgeBaseArticleByExternalReferenceCode_getSiteId(
+						knowledgeBaseArticle),
 					knowledgeBaseArticle.getExternalReferenceCode()));
 
 		assertHttpResponseStatusCode(
 			404,
 			knowledgeBaseArticleResource.
 				getSiteKnowledgeBaseArticleByExternalReferenceCodeHttpResponse(
-					knowledgeBaseArticle.getSiteId(),
+					testDeleteSiteKnowledgeBaseArticleByExternalReferenceCode_getSiteId(
+						knowledgeBaseArticle),
 					knowledgeBaseArticle.getExternalReferenceCode()));
+	}
+
+	protected Long
+			testDeleteSiteKnowledgeBaseArticleByExternalReferenceCode_getSiteId(
+				KnowledgeBaseArticle knowledgeBaseArticle)
+		throws Exception {
+
+		return knowledgeBaseArticle.getSiteId();
 	}
 
 	protected KnowledgeBaseArticle
@@ -1979,11 +1990,20 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 		KnowledgeBaseArticle getKnowledgeBaseArticle =
 			knowledgeBaseArticleResource.
 				getSiteKnowledgeBaseArticleByExternalReferenceCode(
-					postKnowledgeBaseArticle.getSiteId(),
+					testGetSiteKnowledgeBaseArticleByExternalReferenceCode_getSiteId(
+						postKnowledgeBaseArticle),
 					postKnowledgeBaseArticle.getExternalReferenceCode());
 
 		assertEquals(postKnowledgeBaseArticle, getKnowledgeBaseArticle);
 		assertValid(getKnowledgeBaseArticle);
+	}
+
+	protected Long
+			testGetSiteKnowledgeBaseArticleByExternalReferenceCode_getSiteId(
+				KnowledgeBaseArticle knowledgeBaseArticle)
+		throws Exception {
+
+		return knowledgeBaseArticle.getSiteId();
 	}
 
 	protected KnowledgeBaseArticle
@@ -2014,8 +2034,10 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 										put(
 											"siteKey",
 											"\"" +
-												knowledgeBaseArticle.
-													getSiteId() + "\"");
+												testGraphQLGetSiteKnowledgeBaseArticleByExternalReferenceCode_getSiteId(
+													knowledgeBaseArticle) +
+														"\"");
+
 										put(
 											"externalReferenceCode",
 											"\"" +
@@ -2027,6 +2049,14 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/knowledgeBaseArticleByExternalReferenceCode"))));
+	}
+
+	protected Long
+			testGraphQLGetSiteKnowledgeBaseArticleByExternalReferenceCode_getSiteId(
+				KnowledgeBaseArticle knowledgeBaseArticle)
+		throws Exception {
+
+		return knowledgeBaseArticle.getSiteId();
 	}
 
 	@Test
@@ -2077,7 +2107,8 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 		KnowledgeBaseArticle putKnowledgeBaseArticle =
 			knowledgeBaseArticleResource.
 				putSiteKnowledgeBaseArticleByExternalReferenceCode(
-					postKnowledgeBaseArticle.getSiteId(),
+					testPutSiteKnowledgeBaseArticleByExternalReferenceCode_getSiteId(
+						postKnowledgeBaseArticle),
 					postKnowledgeBaseArticle.getExternalReferenceCode(),
 					randomKnowledgeBaseArticle);
 
@@ -2087,7 +2118,8 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 		KnowledgeBaseArticle getKnowledgeBaseArticle =
 			knowledgeBaseArticleResource.
 				getSiteKnowledgeBaseArticleByExternalReferenceCode(
-					putKnowledgeBaseArticle.getSiteId(),
+					testPutSiteKnowledgeBaseArticleByExternalReferenceCode_getSiteId(
+						putKnowledgeBaseArticle),
 					putKnowledgeBaseArticle.getExternalReferenceCode());
 
 		assertEquals(randomKnowledgeBaseArticle, getKnowledgeBaseArticle);
@@ -2099,7 +2131,8 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 		putKnowledgeBaseArticle =
 			knowledgeBaseArticleResource.
 				putSiteKnowledgeBaseArticleByExternalReferenceCode(
-					newKnowledgeBaseArticle.getSiteId(),
+					testPutSiteKnowledgeBaseArticleByExternalReferenceCode_getSiteId(
+						newKnowledgeBaseArticle),
 					newKnowledgeBaseArticle.getExternalReferenceCode(),
 					newKnowledgeBaseArticle);
 
@@ -2109,7 +2142,8 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 		getKnowledgeBaseArticle =
 			knowledgeBaseArticleResource.
 				getSiteKnowledgeBaseArticleByExternalReferenceCode(
-					putKnowledgeBaseArticle.getSiteId(),
+					testPutSiteKnowledgeBaseArticleByExternalReferenceCode_getSiteId(
+						putKnowledgeBaseArticle),
 					putKnowledgeBaseArticle.getExternalReferenceCode());
 
 		assertEquals(newKnowledgeBaseArticle, getKnowledgeBaseArticle);
@@ -2117,6 +2151,14 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 		Assert.assertEquals(
 			newKnowledgeBaseArticle.getExternalReferenceCode(),
 			putKnowledgeBaseArticle.getExternalReferenceCode());
+	}
+
+	protected Long
+			testPutSiteKnowledgeBaseArticleByExternalReferenceCode_getSiteId(
+				KnowledgeBaseArticle knowledgeBaseArticle)
+		throws Exception {
+
+		return knowledgeBaseArticle.getSiteId();
 	}
 
 	protected KnowledgeBaseArticle

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseFolderResourceTestCase.java
@@ -878,22 +878,33 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 			204,
 			knowledgeBaseFolderResource.
 				deleteSiteKnowledgeBaseFolderByExternalReferenceCodeHttpResponse(
-					knowledgeBaseFolder.getSiteId(),
+					testDeleteSiteKnowledgeBaseFolderByExternalReferenceCode_getSiteId(
+						knowledgeBaseFolder),
 					knowledgeBaseFolder.getExternalReferenceCode()));
 
 		assertHttpResponseStatusCode(
 			404,
 			knowledgeBaseFolderResource.
 				getSiteKnowledgeBaseFolderByExternalReferenceCodeHttpResponse(
-					knowledgeBaseFolder.getSiteId(),
+					testDeleteSiteKnowledgeBaseFolderByExternalReferenceCode_getSiteId(
+						knowledgeBaseFolder),
 					knowledgeBaseFolder.getExternalReferenceCode()));
 
 		assertHttpResponseStatusCode(
 			404,
 			knowledgeBaseFolderResource.
 				getSiteKnowledgeBaseFolderByExternalReferenceCodeHttpResponse(
-					knowledgeBaseFolder.getSiteId(),
+					testDeleteSiteKnowledgeBaseFolderByExternalReferenceCode_getSiteId(
+						knowledgeBaseFolder),
 					knowledgeBaseFolder.getExternalReferenceCode()));
+	}
+
+	protected Long
+			testDeleteSiteKnowledgeBaseFolderByExternalReferenceCode_getSiteId(
+				KnowledgeBaseFolder knowledgeBaseFolder)
+		throws Exception {
+
+		return knowledgeBaseFolder.getSiteId();
 	}
 
 	protected KnowledgeBaseFolder
@@ -914,11 +925,20 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 		KnowledgeBaseFolder getKnowledgeBaseFolder =
 			knowledgeBaseFolderResource.
 				getSiteKnowledgeBaseFolderByExternalReferenceCode(
-					postKnowledgeBaseFolder.getSiteId(),
+					testGetSiteKnowledgeBaseFolderByExternalReferenceCode_getSiteId(
+						postKnowledgeBaseFolder),
 					postKnowledgeBaseFolder.getExternalReferenceCode());
 
 		assertEquals(postKnowledgeBaseFolder, getKnowledgeBaseFolder);
 		assertValid(getKnowledgeBaseFolder);
+	}
+
+	protected Long
+			testGetSiteKnowledgeBaseFolderByExternalReferenceCode_getSiteId(
+				KnowledgeBaseFolder knowledgeBaseFolder)
+		throws Exception {
+
+		return knowledgeBaseFolder.getSiteId();
 	}
 
 	protected KnowledgeBaseFolder
@@ -949,8 +969,10 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 										put(
 											"siteKey",
 											"\"" +
-												knowledgeBaseFolder.
-													getSiteId() + "\"");
+												testGraphQLGetSiteKnowledgeBaseFolderByExternalReferenceCode_getSiteId(
+													knowledgeBaseFolder) +
+														"\"");
+
 										put(
 											"externalReferenceCode",
 											"\"" +
@@ -962,6 +984,14 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/knowledgeBaseFolderByExternalReferenceCode"))));
+	}
+
+	protected Long
+			testGraphQLGetSiteKnowledgeBaseFolderByExternalReferenceCode_getSiteId(
+				KnowledgeBaseFolder knowledgeBaseFolder)
+		throws Exception {
+
+		return knowledgeBaseFolder.getSiteId();
 	}
 
 	@Test
@@ -1012,7 +1042,8 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 		KnowledgeBaseFolder putKnowledgeBaseFolder =
 			knowledgeBaseFolderResource.
 				putSiteKnowledgeBaseFolderByExternalReferenceCode(
-					postKnowledgeBaseFolder.getSiteId(),
+					testPutSiteKnowledgeBaseFolderByExternalReferenceCode_getSiteId(
+						postKnowledgeBaseFolder),
 					postKnowledgeBaseFolder.getExternalReferenceCode(),
 					randomKnowledgeBaseFolder);
 
@@ -1022,7 +1053,8 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 		KnowledgeBaseFolder getKnowledgeBaseFolder =
 			knowledgeBaseFolderResource.
 				getSiteKnowledgeBaseFolderByExternalReferenceCode(
-					putKnowledgeBaseFolder.getSiteId(),
+					testPutSiteKnowledgeBaseFolderByExternalReferenceCode_getSiteId(
+						putKnowledgeBaseFolder),
 					putKnowledgeBaseFolder.getExternalReferenceCode());
 
 		assertEquals(randomKnowledgeBaseFolder, getKnowledgeBaseFolder);
@@ -1034,7 +1066,8 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 		putKnowledgeBaseFolder =
 			knowledgeBaseFolderResource.
 				putSiteKnowledgeBaseFolderByExternalReferenceCode(
-					newKnowledgeBaseFolder.getSiteId(),
+					testPutSiteKnowledgeBaseFolderByExternalReferenceCode_getSiteId(
+						newKnowledgeBaseFolder),
 					newKnowledgeBaseFolder.getExternalReferenceCode(),
 					newKnowledgeBaseFolder);
 
@@ -1044,7 +1077,8 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 		getKnowledgeBaseFolder =
 			knowledgeBaseFolderResource.
 				getSiteKnowledgeBaseFolderByExternalReferenceCode(
-					putKnowledgeBaseFolder.getSiteId(),
+					testPutSiteKnowledgeBaseFolderByExternalReferenceCode_getSiteId(
+						putKnowledgeBaseFolder),
 					putKnowledgeBaseFolder.getExternalReferenceCode());
 
 		assertEquals(newKnowledgeBaseFolder, getKnowledgeBaseFolder);
@@ -1052,6 +1086,14 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 		Assert.assertEquals(
 			newKnowledgeBaseFolder.getExternalReferenceCode(),
 			putKnowledgeBaseFolder.getExternalReferenceCode());
+	}
+
+	protected Long
+			testPutSiteKnowledgeBaseFolderByExternalReferenceCode_getSiteId(
+				KnowledgeBaseFolder knowledgeBaseFolder)
+		throws Exception {
+
+		return knowledgeBaseFolder.getSiteId();
 	}
 
 	protected KnowledgeBaseFolder

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardAttachmentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardAttachmentResourceTestCase.java
@@ -729,6 +729,7 @@ public abstract class BaseMessageBoardAttachmentResourceTestCase {
 											"\"" +
 												testGraphQLGetSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode_getMessageBoardMessageExternalReferenceCode() +
 													"\"");
+
 										put(
 											"externalReferenceCode",
 											"\"" +

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardMessageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardMessageResourceTestCase.java
@@ -1885,22 +1885,33 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 			204,
 			messageBoardMessageResource.
 				deleteSiteMessageBoardMessageByExternalReferenceCodeHttpResponse(
-					messageBoardMessage.getSiteId(),
+					testDeleteSiteMessageBoardMessageByExternalReferenceCode_getSiteId(
+						messageBoardMessage),
 					messageBoardMessage.getExternalReferenceCode()));
 
 		assertHttpResponseStatusCode(
 			404,
 			messageBoardMessageResource.
 				getSiteMessageBoardMessageByExternalReferenceCodeHttpResponse(
-					messageBoardMessage.getSiteId(),
+					testDeleteSiteMessageBoardMessageByExternalReferenceCode_getSiteId(
+						messageBoardMessage),
 					messageBoardMessage.getExternalReferenceCode()));
 
 		assertHttpResponseStatusCode(
 			404,
 			messageBoardMessageResource.
 				getSiteMessageBoardMessageByExternalReferenceCodeHttpResponse(
-					messageBoardMessage.getSiteId(),
+					testDeleteSiteMessageBoardMessageByExternalReferenceCode_getSiteId(
+						messageBoardMessage),
 					messageBoardMessage.getExternalReferenceCode()));
+	}
+
+	protected Long
+			testDeleteSiteMessageBoardMessageByExternalReferenceCode_getSiteId(
+				MessageBoardMessage messageBoardMessage)
+		throws Exception {
+
+		return messageBoardMessage.getSiteId();
 	}
 
 	protected MessageBoardMessage
@@ -1921,11 +1932,20 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 		MessageBoardMessage getMessageBoardMessage =
 			messageBoardMessageResource.
 				getSiteMessageBoardMessageByExternalReferenceCode(
-					postMessageBoardMessage.getSiteId(),
+					testGetSiteMessageBoardMessageByExternalReferenceCode_getSiteId(
+						postMessageBoardMessage),
 					postMessageBoardMessage.getExternalReferenceCode());
 
 		assertEquals(postMessageBoardMessage, getMessageBoardMessage);
 		assertValid(getMessageBoardMessage);
+	}
+
+	protected Long
+			testGetSiteMessageBoardMessageByExternalReferenceCode_getSiteId(
+				MessageBoardMessage messageBoardMessage)
+		throws Exception {
+
+		return messageBoardMessage.getSiteId();
 	}
 
 	protected MessageBoardMessage
@@ -1956,8 +1976,10 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 										put(
 											"siteKey",
 											"\"" +
-												messageBoardMessage.
-													getSiteId() + "\"");
+												testGraphQLGetSiteMessageBoardMessageByExternalReferenceCode_getSiteId(
+													messageBoardMessage) +
+														"\"");
+
 										put(
 											"externalReferenceCode",
 											"\"" +
@@ -1969,6 +1991,14 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/messageBoardMessageByExternalReferenceCode"))));
+	}
+
+	protected Long
+			testGraphQLGetSiteMessageBoardMessageByExternalReferenceCode_getSiteId(
+				MessageBoardMessage messageBoardMessage)
+		throws Exception {
+
+		return messageBoardMessage.getSiteId();
 	}
 
 	@Test
@@ -2019,7 +2049,8 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 		MessageBoardMessage putMessageBoardMessage =
 			messageBoardMessageResource.
 				putSiteMessageBoardMessageByExternalReferenceCode(
-					postMessageBoardMessage.getSiteId(),
+					testPutSiteMessageBoardMessageByExternalReferenceCode_getSiteId(
+						postMessageBoardMessage),
 					postMessageBoardMessage.getExternalReferenceCode(),
 					randomMessageBoardMessage);
 
@@ -2029,7 +2060,8 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 		MessageBoardMessage getMessageBoardMessage =
 			messageBoardMessageResource.
 				getSiteMessageBoardMessageByExternalReferenceCode(
-					putMessageBoardMessage.getSiteId(),
+					testPutSiteMessageBoardMessageByExternalReferenceCode_getSiteId(
+						putMessageBoardMessage),
 					putMessageBoardMessage.getExternalReferenceCode());
 
 		assertEquals(randomMessageBoardMessage, getMessageBoardMessage);
@@ -2041,7 +2073,8 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 		putMessageBoardMessage =
 			messageBoardMessageResource.
 				putSiteMessageBoardMessageByExternalReferenceCode(
-					newMessageBoardMessage.getSiteId(),
+					testPutSiteMessageBoardMessageByExternalReferenceCode_getSiteId(
+						newMessageBoardMessage),
 					newMessageBoardMessage.getExternalReferenceCode(),
 					newMessageBoardMessage);
 
@@ -2051,7 +2084,8 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 		getMessageBoardMessage =
 			messageBoardMessageResource.
 				getSiteMessageBoardMessageByExternalReferenceCode(
-					putMessageBoardMessage.getSiteId(),
+					testPutSiteMessageBoardMessageByExternalReferenceCode_getSiteId(
+						putMessageBoardMessage),
 					putMessageBoardMessage.getExternalReferenceCode());
 
 		assertEquals(newMessageBoardMessage, getMessageBoardMessage);
@@ -2059,6 +2093,14 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 		Assert.assertEquals(
 			newMessageBoardMessage.getExternalReferenceCode(),
 			putMessageBoardMessage.getExternalReferenceCode());
+	}
+
+	protected Long
+			testPutSiteMessageBoardMessageByExternalReferenceCode_getSiteId(
+				MessageBoardMessage messageBoardMessage)
+		throws Exception {
+
+		return messageBoardMessage.getSiteId();
 	}
 
 	protected MessageBoardMessage
@@ -2086,11 +2128,19 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 		MessageBoardMessage getMessageBoardMessage =
 			messageBoardMessageResource.
 				getSiteMessageBoardMessageByFriendlyUrlPath(
-					postMessageBoardMessage.getSiteId(),
+					testGetSiteMessageBoardMessageByFriendlyUrlPath_getSiteId(
+						postMessageBoardMessage),
 					postMessageBoardMessage.getFriendlyUrlPath());
 
 		assertEquals(postMessageBoardMessage, getMessageBoardMessage);
 		assertValid(getMessageBoardMessage);
+	}
+
+	protected Long testGetSiteMessageBoardMessageByFriendlyUrlPath_getSiteId(
+			MessageBoardMessage messageBoardMessage)
+		throws Exception {
+
+		return messageBoardMessage.getSiteId();
 	}
 
 	protected MessageBoardMessage
@@ -2121,8 +2171,10 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 										put(
 											"siteKey",
 											"\"" +
-												messageBoardMessage.
-													getSiteId() + "\"");
+												testGraphQLGetSiteMessageBoardMessageByFriendlyUrlPath_getSiteId(
+													messageBoardMessage) +
+														"\"");
+
 										put(
 											"friendlyUrlPath",
 											"\"" +
@@ -2134,6 +2186,14 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/messageBoardMessageByFriendlyUrlPath"))));
+	}
+
+	protected Long
+			testGraphQLGetSiteMessageBoardMessageByFriendlyUrlPath_getSiteId(
+				MessageBoardMessage messageBoardMessage)
+		throws Exception {
+
+		return messageBoardMessage.getSiteId();
 	}
 
 	@Test

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardThreadResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardThreadResourceTestCase.java
@@ -1722,11 +1722,19 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 		MessageBoardThread getMessageBoardThread =
 			messageBoardThreadResource.
 				getSiteMessageBoardThreadByFriendlyUrlPath(
-					postMessageBoardThread.getSiteId(),
+					testGetSiteMessageBoardThreadByFriendlyUrlPath_getSiteId(
+						postMessageBoardThread),
 					postMessageBoardThread.getFriendlyUrlPath());
 
 		assertEquals(postMessageBoardThread, getMessageBoardThread);
 		assertValid(getMessageBoardThread);
+	}
+
+	protected Long testGetSiteMessageBoardThreadByFriendlyUrlPath_getSiteId(
+			MessageBoardThread messageBoardThread)
+		throws Exception {
+
+		return messageBoardThread.getSiteId();
 	}
 
 	protected MessageBoardThread
@@ -1757,8 +1765,9 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 										put(
 											"siteKey",
 											"\"" +
-												messageBoardThread.getSiteId() +
-													"\"");
+												testGraphQLGetSiteMessageBoardThreadByFriendlyUrlPath_getSiteId(
+													messageBoardThread) + "\"");
+
 										put(
 											"friendlyUrlPath",
 											"\"" +
@@ -1770,6 +1779,14 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/messageBoardThreadByFriendlyUrlPath"))));
+	}
+
+	protected Long
+			testGraphQLGetSiteMessageBoardThreadByFriendlyUrlPath_getSiteId(
+				MessageBoardThread messageBoardThread)
+		throws Exception {
+
+		return messageBoardThread.getSiteId();
 	}
 
 	@Test

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentFolderResourceTestCase.java
@@ -774,6 +774,7 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 											"\"" +
 												testGraphQLGetAssetLibraryStructuredContentFolderByExternalReferenceCode_getAssetLibraryId() +
 													"\"");
+
 										put(
 											"externalReferenceCode",
 											"\"" +
@@ -1477,22 +1478,33 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 			204,
 			structuredContentFolderResource.
 				deleteSiteStructuredContentFolderByExternalReferenceCodeHttpResponse(
-					structuredContentFolder.getSiteId(),
+					testDeleteSiteStructuredContentFolderByExternalReferenceCode_getSiteId(
+						structuredContentFolder),
 					structuredContentFolder.getExternalReferenceCode()));
 
 		assertHttpResponseStatusCode(
 			404,
 			structuredContentFolderResource.
 				getSiteStructuredContentFolderByExternalReferenceCodeHttpResponse(
-					structuredContentFolder.getSiteId(),
+					testDeleteSiteStructuredContentFolderByExternalReferenceCode_getSiteId(
+						structuredContentFolder),
 					structuredContentFolder.getExternalReferenceCode()));
 
 		assertHttpResponseStatusCode(
 			404,
 			structuredContentFolderResource.
 				getSiteStructuredContentFolderByExternalReferenceCodeHttpResponse(
-					structuredContentFolder.getSiteId(),
+					testDeleteSiteStructuredContentFolderByExternalReferenceCode_getSiteId(
+						structuredContentFolder),
 					structuredContentFolder.getExternalReferenceCode()));
+	}
+
+	protected Long
+			testDeleteSiteStructuredContentFolderByExternalReferenceCode_getSiteId(
+				StructuredContentFolder structuredContentFolder)
+		throws Exception {
+
+		return structuredContentFolder.getSiteId();
 	}
 
 	protected StructuredContentFolder
@@ -1513,11 +1525,20 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 		StructuredContentFolder getStructuredContentFolder =
 			structuredContentFolderResource.
 				getSiteStructuredContentFolderByExternalReferenceCode(
-					postStructuredContentFolder.getSiteId(),
+					testGetSiteStructuredContentFolderByExternalReferenceCode_getSiteId(
+						postStructuredContentFolder),
 					postStructuredContentFolder.getExternalReferenceCode());
 
 		assertEquals(postStructuredContentFolder, getStructuredContentFolder);
 		assertValid(getStructuredContentFolder);
+	}
+
+	protected Long
+			testGetSiteStructuredContentFolderByExternalReferenceCode_getSiteId(
+				StructuredContentFolder structuredContentFolder)
+		throws Exception {
+
+		return structuredContentFolder.getSiteId();
 	}
 
 	protected StructuredContentFolder
@@ -1548,8 +1569,10 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 										put(
 											"siteKey",
 											"\"" +
-												structuredContentFolder.
-													getSiteId() + "\"");
+												testGraphQLGetSiteStructuredContentFolderByExternalReferenceCode_getSiteId(
+													structuredContentFolder) +
+														"\"");
+
 										put(
 											"externalReferenceCode",
 											"\"" +
@@ -1561,6 +1584,14 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/structuredContentFolderByExternalReferenceCode"))));
+	}
+
+	protected Long
+			testGraphQLGetSiteStructuredContentFolderByExternalReferenceCode_getSiteId(
+				StructuredContentFolder structuredContentFolder)
+		throws Exception {
+
+		return structuredContentFolder.getSiteId();
 	}
 
 	@Test
@@ -1611,7 +1642,8 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 		StructuredContentFolder putStructuredContentFolder =
 			structuredContentFolderResource.
 				putSiteStructuredContentFolderByExternalReferenceCode(
-					postStructuredContentFolder.getSiteId(),
+					testPutSiteStructuredContentFolderByExternalReferenceCode_getSiteId(
+						postStructuredContentFolder),
 					postStructuredContentFolder.getExternalReferenceCode(),
 					randomStructuredContentFolder);
 
@@ -1621,7 +1653,8 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 		StructuredContentFolder getStructuredContentFolder =
 			structuredContentFolderResource.
 				getSiteStructuredContentFolderByExternalReferenceCode(
-					putStructuredContentFolder.getSiteId(),
+					testPutSiteStructuredContentFolderByExternalReferenceCode_getSiteId(
+						putStructuredContentFolder),
 					putStructuredContentFolder.getExternalReferenceCode());
 
 		assertEquals(randomStructuredContentFolder, getStructuredContentFolder);
@@ -1633,7 +1666,8 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 		putStructuredContentFolder =
 			structuredContentFolderResource.
 				putSiteStructuredContentFolderByExternalReferenceCode(
-					newStructuredContentFolder.getSiteId(),
+					testPutSiteStructuredContentFolderByExternalReferenceCode_getSiteId(
+						newStructuredContentFolder),
 					newStructuredContentFolder.getExternalReferenceCode(),
 					newStructuredContentFolder);
 
@@ -1643,7 +1677,8 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 		getStructuredContentFolder =
 			structuredContentFolderResource.
 				getSiteStructuredContentFolderByExternalReferenceCode(
-					putStructuredContentFolder.getSiteId(),
+					testPutSiteStructuredContentFolderByExternalReferenceCode_getSiteId(
+						putStructuredContentFolder),
 					putStructuredContentFolder.getExternalReferenceCode());
 
 		assertEquals(newStructuredContentFolder, getStructuredContentFolder);
@@ -1651,6 +1686,14 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 		Assert.assertEquals(
 			newStructuredContentFolder.getExternalReferenceCode(),
 			putStructuredContentFolder.getExternalReferenceCode());
+	}
+
+	protected Long
+			testPutSiteStructuredContentFolderByExternalReferenceCode_getSiteId(
+				StructuredContentFolder structuredContentFolder)
+		throws Exception {
+
+		return structuredContentFolder.getSiteId();
 	}
 
 	protected StructuredContentFolder

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
@@ -741,6 +741,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 											"\"" +
 												testGraphQLGetAssetLibraryStructuredContentByExternalReferenceCode_getAssetLibraryId() +
 													"\"");
+
 										put(
 											"externalReferenceCode",
 											"\"" +
@@ -1810,22 +1811,33 @@ public abstract class BaseStructuredContentResourceTestCase {
 			204,
 			structuredContentResource.
 				deleteSiteStructuredContentByExternalReferenceCodeHttpResponse(
-					structuredContent.getSiteId(),
+					testDeleteSiteStructuredContentByExternalReferenceCode_getSiteId(
+						structuredContent),
 					structuredContent.getExternalReferenceCode()));
 
 		assertHttpResponseStatusCode(
 			404,
 			structuredContentResource.
 				getSiteStructuredContentByExternalReferenceCodeHttpResponse(
-					structuredContent.getSiteId(),
+					testDeleteSiteStructuredContentByExternalReferenceCode_getSiteId(
+						structuredContent),
 					structuredContent.getExternalReferenceCode()));
 
 		assertHttpResponseStatusCode(
 			404,
 			structuredContentResource.
 				getSiteStructuredContentByExternalReferenceCodeHttpResponse(
-					structuredContent.getSiteId(),
+					testDeleteSiteStructuredContentByExternalReferenceCode_getSiteId(
+						structuredContent),
 					structuredContent.getExternalReferenceCode()));
+	}
+
+	protected Long
+			testDeleteSiteStructuredContentByExternalReferenceCode_getSiteId(
+				StructuredContent structuredContent)
+		throws Exception {
+
+		return structuredContent.getSiteId();
 	}
 
 	protected StructuredContent
@@ -1846,11 +1858,20 @@ public abstract class BaseStructuredContentResourceTestCase {
 		StructuredContent getStructuredContent =
 			structuredContentResource.
 				getSiteStructuredContentByExternalReferenceCode(
-					postStructuredContent.getSiteId(),
+					testGetSiteStructuredContentByExternalReferenceCode_getSiteId(
+						postStructuredContent),
 					postStructuredContent.getExternalReferenceCode());
 
 		assertEquals(postStructuredContent, getStructuredContent);
 		assertValid(getStructuredContent);
+	}
+
+	protected Long
+			testGetSiteStructuredContentByExternalReferenceCode_getSiteId(
+				StructuredContent structuredContent)
+		throws Exception {
+
+		return structuredContent.getSiteId();
 	}
 
 	protected StructuredContent
@@ -1881,8 +1902,9 @@ public abstract class BaseStructuredContentResourceTestCase {
 										put(
 											"siteKey",
 											"\"" +
-												structuredContent.getSiteId() +
-													"\"");
+												testGraphQLGetSiteStructuredContentByExternalReferenceCode_getSiteId(
+													structuredContent) + "\"");
+
 										put(
 											"externalReferenceCode",
 											"\"" +
@@ -1894,6 +1916,14 @@ public abstract class BaseStructuredContentResourceTestCase {
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/structuredContentByExternalReferenceCode"))));
+	}
+
+	protected Long
+			testGraphQLGetSiteStructuredContentByExternalReferenceCode_getSiteId(
+				StructuredContent structuredContent)
+		throws Exception {
+
+		return structuredContent.getSiteId();
 	}
 
 	@Test
@@ -1943,7 +1973,8 @@ public abstract class BaseStructuredContentResourceTestCase {
 		StructuredContent putStructuredContent =
 			structuredContentResource.
 				putSiteStructuredContentByExternalReferenceCode(
-					postStructuredContent.getSiteId(),
+					testPutSiteStructuredContentByExternalReferenceCode_getSiteId(
+						postStructuredContent),
 					postStructuredContent.getExternalReferenceCode(),
 					randomStructuredContent);
 
@@ -1953,7 +1984,8 @@ public abstract class BaseStructuredContentResourceTestCase {
 		StructuredContent getStructuredContent =
 			structuredContentResource.
 				getSiteStructuredContentByExternalReferenceCode(
-					putStructuredContent.getSiteId(),
+					testPutSiteStructuredContentByExternalReferenceCode_getSiteId(
+						putStructuredContent),
 					putStructuredContent.getExternalReferenceCode());
 
 		assertEquals(randomStructuredContent, getStructuredContent);
@@ -1965,7 +1997,8 @@ public abstract class BaseStructuredContentResourceTestCase {
 		putStructuredContent =
 			structuredContentResource.
 				putSiteStructuredContentByExternalReferenceCode(
-					newStructuredContent.getSiteId(),
+					testPutSiteStructuredContentByExternalReferenceCode_getSiteId(
+						newStructuredContent),
 					newStructuredContent.getExternalReferenceCode(),
 					newStructuredContent);
 
@@ -1975,7 +2008,8 @@ public abstract class BaseStructuredContentResourceTestCase {
 		getStructuredContent =
 			structuredContentResource.
 				getSiteStructuredContentByExternalReferenceCode(
-					putStructuredContent.getSiteId(),
+					testPutSiteStructuredContentByExternalReferenceCode_getSiteId(
+						putStructuredContent),
 					putStructuredContent.getExternalReferenceCode());
 
 		assertEquals(newStructuredContent, getStructuredContent);
@@ -1983,6 +2017,14 @@ public abstract class BaseStructuredContentResourceTestCase {
 		Assert.assertEquals(
 			newStructuredContent.getExternalReferenceCode(),
 			putStructuredContent.getExternalReferenceCode());
+	}
+
+	protected Long
+			testPutSiteStructuredContentByExternalReferenceCode_getSiteId(
+				StructuredContent structuredContent)
+		throws Exception {
+
+		return structuredContent.getSiteId();
 	}
 
 	protected StructuredContent
@@ -2007,11 +2049,19 @@ public abstract class BaseStructuredContentResourceTestCase {
 
 		StructuredContent getStructuredContent =
 			structuredContentResource.getSiteStructuredContentByKey(
-				postStructuredContent.getSiteId(),
+				testGetSiteStructuredContentByKey_getSiteId(
+					postStructuredContent),
 				postStructuredContent.getKey());
 
 		assertEquals(postStructuredContent, getStructuredContent);
 		assertValid(getStructuredContent);
+	}
+
+	protected Long testGetSiteStructuredContentByKey_getSiteId(
+			StructuredContent structuredContent)
+		throws Exception {
+
+		return structuredContent.getSiteId();
 	}
 
 	protected StructuredContent
@@ -2040,8 +2090,9 @@ public abstract class BaseStructuredContentResourceTestCase {
 										put(
 											"siteKey",
 											"\"" +
-												structuredContent.getSiteId() +
-													"\"");
+												testGraphQLGetSiteStructuredContentByKey_getSiteId(
+													structuredContent) + "\"");
+
 										put(
 											"key",
 											"\"" + structuredContent.getKey() +
@@ -2050,6 +2101,13 @@ public abstract class BaseStructuredContentResourceTestCase {
 								},
 								getGraphQLFields())),
 						"JSONObject/data", "Object/structuredContentByKey"))));
+	}
+
+	protected Long testGraphQLGetSiteStructuredContentByKey_getSiteId(
+			StructuredContent structuredContent)
+		throws Exception {
+
+		return structuredContent.getSiteId();
 	}
 
 	@Test
@@ -2091,11 +2149,19 @@ public abstract class BaseStructuredContentResourceTestCase {
 
 		StructuredContent getStructuredContent =
 			structuredContentResource.getSiteStructuredContentByUuid(
-				postStructuredContent.getSiteId(),
+				testGetSiteStructuredContentByUuid_getSiteId(
+					postStructuredContent),
 				postStructuredContent.getUuid());
 
 		assertEquals(postStructuredContent, getStructuredContent);
 		assertValid(getStructuredContent);
+	}
+
+	protected Long testGetSiteStructuredContentByUuid_getSiteId(
+			StructuredContent structuredContent)
+		throws Exception {
+
+		return structuredContent.getSiteId();
 	}
 
 	protected StructuredContent
@@ -2124,8 +2190,9 @@ public abstract class BaseStructuredContentResourceTestCase {
 										put(
 											"siteKey",
 											"\"" +
-												structuredContent.getSiteId() +
-													"\"");
+												testGraphQLGetSiteStructuredContentByUuid_getSiteId(
+													structuredContent) + "\"");
+
 										put(
 											"uuid",
 											"\"" + structuredContent.getUuid() +
@@ -2134,6 +2201,13 @@ public abstract class BaseStructuredContentResourceTestCase {
 								},
 								getGraphQLFields())),
 						"JSONObject/data", "Object/structuredContentByUuid"))));
+	}
+
+	protected Long testGraphQLGetSiteStructuredContentByUuid_getSiteId(
+			StructuredContent structuredContent)
+		throws Exception {
+
+		return structuredContent.getSiteId();
 	}
 
 	@Test

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiNodeResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiNodeResourceTestCase.java
@@ -607,17 +607,30 @@ public abstract class BaseWikiNodeResourceTestCase {
 			204,
 			wikiNodeResource.
 				deleteSiteWikiNodeByExternalReferenceCodeHttpResponse(
-					wikiNode.getSiteId(), wikiNode.getExternalReferenceCode()));
+					testDeleteSiteWikiNodeByExternalReferenceCode_getSiteId(
+						wikiNode),
+					wikiNode.getExternalReferenceCode()));
 
 		assertHttpResponseStatusCode(
 			404,
 			wikiNodeResource.getSiteWikiNodeByExternalReferenceCodeHttpResponse(
-				wikiNode.getSiteId(), wikiNode.getExternalReferenceCode()));
+				testDeleteSiteWikiNodeByExternalReferenceCode_getSiteId(
+					wikiNode),
+				wikiNode.getExternalReferenceCode()));
 
 		assertHttpResponseStatusCode(
 			404,
 			wikiNodeResource.getSiteWikiNodeByExternalReferenceCodeHttpResponse(
-				wikiNode.getSiteId(), wikiNode.getExternalReferenceCode()));
+				testDeleteSiteWikiNodeByExternalReferenceCode_getSiteId(
+					wikiNode),
+				wikiNode.getExternalReferenceCode()));
+	}
+
+	protected Long testDeleteSiteWikiNodeByExternalReferenceCode_getSiteId(
+			WikiNode wikiNode)
+		throws Exception {
+
+		return wikiNode.getSiteId();
 	}
 
 	protected WikiNode
@@ -635,11 +648,19 @@ public abstract class BaseWikiNodeResourceTestCase {
 
 		WikiNode getWikiNode =
 			wikiNodeResource.getSiteWikiNodeByExternalReferenceCode(
-				postWikiNode.getSiteId(),
+				testGetSiteWikiNodeByExternalReferenceCode_getSiteId(
+					postWikiNode),
 				postWikiNode.getExternalReferenceCode());
 
 		assertEquals(postWikiNode, getWikiNode);
 		assertValid(getWikiNode);
+	}
+
+	protected Long testGetSiteWikiNodeByExternalReferenceCode_getSiteId(
+			WikiNode wikiNode)
+		throws Exception {
+
+		return wikiNode.getSiteId();
 	}
 
 	protected WikiNode testGetSiteWikiNodeByExternalReferenceCode_addWikiNode()
@@ -668,7 +689,10 @@ public abstract class BaseWikiNodeResourceTestCase {
 									{
 										put(
 											"siteKey",
-											"\"" + wikiNode.getSiteId() + "\"");
+											"\"" +
+												testGraphQLGetSiteWikiNodeByExternalReferenceCode_getSiteId(
+													wikiNode) + "\"");
+
 										put(
 											"externalReferenceCode",
 											"\"" +
@@ -680,6 +704,13 @@ public abstract class BaseWikiNodeResourceTestCase {
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/wikiNodeByExternalReferenceCode"))));
+	}
+
+	protected Long testGraphQLGetSiteWikiNodeByExternalReferenceCode_getSiteId(
+			WikiNode wikiNode)
+		throws Exception {
+
+		return wikiNode.getSiteId();
 	}
 
 	@Test
@@ -726,7 +757,8 @@ public abstract class BaseWikiNodeResourceTestCase {
 
 		WikiNode putWikiNode =
 			wikiNodeResource.putSiteWikiNodeByExternalReferenceCode(
-				postWikiNode.getSiteId(),
+				testPutSiteWikiNodeByExternalReferenceCode_getSiteId(
+					postWikiNode),
 				postWikiNode.getExternalReferenceCode(), randomWikiNode);
 
 		assertEquals(randomWikiNode, putWikiNode);
@@ -734,7 +766,8 @@ public abstract class BaseWikiNodeResourceTestCase {
 
 		WikiNode getWikiNode =
 			wikiNodeResource.getSiteWikiNodeByExternalReferenceCode(
-				putWikiNode.getSiteId(),
+				testPutSiteWikiNodeByExternalReferenceCode_getSiteId(
+					putWikiNode),
 				putWikiNode.getExternalReferenceCode());
 
 		assertEquals(randomWikiNode, getWikiNode);
@@ -744,20 +777,28 @@ public abstract class BaseWikiNodeResourceTestCase {
 			testPutSiteWikiNodeByExternalReferenceCode_createWikiNode();
 
 		putWikiNode = wikiNodeResource.putSiteWikiNodeByExternalReferenceCode(
-			newWikiNode.getSiteId(), newWikiNode.getExternalReferenceCode(),
-			newWikiNode);
+			testPutSiteWikiNodeByExternalReferenceCode_getSiteId(newWikiNode),
+			newWikiNode.getExternalReferenceCode(), newWikiNode);
 
 		assertEquals(newWikiNode, putWikiNode);
 		assertValid(putWikiNode);
 
 		getWikiNode = wikiNodeResource.getSiteWikiNodeByExternalReferenceCode(
-			putWikiNode.getSiteId(), putWikiNode.getExternalReferenceCode());
+			testPutSiteWikiNodeByExternalReferenceCode_getSiteId(putWikiNode),
+			putWikiNode.getExternalReferenceCode());
 
 		assertEquals(newWikiNode, getWikiNode);
 
 		Assert.assertEquals(
 			newWikiNode.getExternalReferenceCode(),
 			putWikiNode.getExternalReferenceCode());
+	}
+
+	protected Long testPutSiteWikiNodeByExternalReferenceCode_getSiteId(
+			WikiNode wikiNode)
+		throws Exception {
+
+		return wikiNode.getSiteId();
 	}
 
 	protected WikiNode

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiPageAttachmentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiPageAttachmentResourceTestCase.java
@@ -333,6 +333,7 @@ public abstract class BaseWikiPageAttachmentResourceTestCase {
 											"\"" +
 												testGraphQLGetSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_getWikiPageExternalReferenceCode() +
 													"\"");
+
 										put(
 											"externalReferenceCode",
 											"\"" +

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiPageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiPageResourceTestCase.java
@@ -220,17 +220,30 @@ public abstract class BaseWikiPageResourceTestCase {
 			204,
 			wikiPageResource.
 				deleteSiteWikiPageByExternalReferenceCodeHttpResponse(
-					wikiPage.getSiteId(), wikiPage.getExternalReferenceCode()));
+					testDeleteSiteWikiPageByExternalReferenceCode_getSiteId(
+						wikiPage),
+					wikiPage.getExternalReferenceCode()));
 
 		assertHttpResponseStatusCode(
 			404,
 			wikiPageResource.getSiteWikiPageByExternalReferenceCodeHttpResponse(
-				wikiPage.getSiteId(), wikiPage.getExternalReferenceCode()));
+				testDeleteSiteWikiPageByExternalReferenceCode_getSiteId(
+					wikiPage),
+				wikiPage.getExternalReferenceCode()));
 
 		assertHttpResponseStatusCode(
 			404,
 			wikiPageResource.getSiteWikiPageByExternalReferenceCodeHttpResponse(
-				wikiPage.getSiteId(), wikiPage.getExternalReferenceCode()));
+				testDeleteSiteWikiPageByExternalReferenceCode_getSiteId(
+					wikiPage),
+				wikiPage.getExternalReferenceCode()));
+	}
+
+	protected Long testDeleteSiteWikiPageByExternalReferenceCode_getSiteId(
+			WikiPage wikiPage)
+		throws Exception {
+
+		return wikiPage.getSiteId();
 	}
 
 	protected WikiPage
@@ -248,11 +261,19 @@ public abstract class BaseWikiPageResourceTestCase {
 
 		WikiPage getWikiPage =
 			wikiPageResource.getSiteWikiPageByExternalReferenceCode(
-				postWikiPage.getSiteId(),
+				testGetSiteWikiPageByExternalReferenceCode_getSiteId(
+					postWikiPage),
 				postWikiPage.getExternalReferenceCode());
 
 		assertEquals(postWikiPage, getWikiPage);
 		assertValid(getWikiPage);
+	}
+
+	protected Long testGetSiteWikiPageByExternalReferenceCode_getSiteId(
+			WikiPage wikiPage)
+		throws Exception {
+
+		return wikiPage.getSiteId();
 	}
 
 	protected WikiPage testGetSiteWikiPageByExternalReferenceCode_addWikiPage()
@@ -281,7 +302,10 @@ public abstract class BaseWikiPageResourceTestCase {
 									{
 										put(
 											"siteKey",
-											"\"" + wikiPage.getSiteId() + "\"");
+											"\"" +
+												testGraphQLGetSiteWikiPageByExternalReferenceCode_getSiteId(
+													wikiPage) + "\"");
+
 										put(
 											"externalReferenceCode",
 											"\"" +
@@ -293,6 +317,13 @@ public abstract class BaseWikiPageResourceTestCase {
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/wikiPageByExternalReferenceCode"))));
+	}
+
+	protected Long testGraphQLGetSiteWikiPageByExternalReferenceCode_getSiteId(
+			WikiPage wikiPage)
+		throws Exception {
+
+		return wikiPage.getSiteId();
 	}
 
 	@Test
@@ -339,7 +370,8 @@ public abstract class BaseWikiPageResourceTestCase {
 
 		WikiPage putWikiPage =
 			wikiPageResource.putSiteWikiPageByExternalReferenceCode(
-				postWikiPage.getSiteId(),
+				testPutSiteWikiPageByExternalReferenceCode_getSiteId(
+					postWikiPage),
 				postWikiPage.getExternalReferenceCode(), randomWikiPage);
 
 		assertEquals(randomWikiPage, putWikiPage);
@@ -347,7 +379,8 @@ public abstract class BaseWikiPageResourceTestCase {
 
 		WikiPage getWikiPage =
 			wikiPageResource.getSiteWikiPageByExternalReferenceCode(
-				putWikiPage.getSiteId(),
+				testPutSiteWikiPageByExternalReferenceCode_getSiteId(
+					putWikiPage),
 				putWikiPage.getExternalReferenceCode());
 
 		assertEquals(randomWikiPage, getWikiPage);
@@ -357,20 +390,28 @@ public abstract class BaseWikiPageResourceTestCase {
 			testPutSiteWikiPageByExternalReferenceCode_createWikiPage();
 
 		putWikiPage = wikiPageResource.putSiteWikiPageByExternalReferenceCode(
-			newWikiPage.getSiteId(), newWikiPage.getExternalReferenceCode(),
-			newWikiPage);
+			testPutSiteWikiPageByExternalReferenceCode_getSiteId(newWikiPage),
+			newWikiPage.getExternalReferenceCode(), newWikiPage);
 
 		assertEquals(newWikiPage, putWikiPage);
 		assertValid(putWikiPage);
 
 		getWikiPage = wikiPageResource.getSiteWikiPageByExternalReferenceCode(
-			putWikiPage.getSiteId(), putWikiPage.getExternalReferenceCode());
+			testPutSiteWikiPageByExternalReferenceCode_getSiteId(putWikiPage),
+			putWikiPage.getExternalReferenceCode());
 
 		assertEquals(newWikiPage, getWikiPage);
 
 		Assert.assertEquals(
 			newWikiPage.getExternalReferenceCode(),
 			putWikiPage.getExternalReferenceCode());
+	}
+
+	protected Long testPutSiteWikiPageByExternalReferenceCode_getSiteId(
+			WikiPage wikiPage)
+		throws Exception {
+
+		return wikiPage.getSiteId();
 	}
 
 	protected WikiPage

--- a/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormRecordResourceTestCase.java
+++ b/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormRecordResourceTestCase.java
@@ -400,10 +400,17 @@ public abstract class BaseFormRecordResourceTestCase {
 
 		FormRecord getFormRecord =
 			formRecordResource.getFormFormRecordByLatestDraft(
-				postFormRecord.getFormId());
+				testGetFormFormRecordByLatestDraft_getFormId(postFormRecord));
 
 		assertEquals(postFormRecord, getFormRecord);
 		assertValid(getFormRecord);
+	}
+
+	protected Long testGetFormFormRecordByLatestDraft_getFormId(
+			FormRecord formRecord)
+		throws Exception {
+
+		return formRecord.getFormId();
 	}
 
 	protected FormRecord testGetFormFormRecordByLatestDraft_addFormRecord()
@@ -428,12 +435,22 @@ public abstract class BaseFormRecordResourceTestCase {
 								"formFormRecordByLatestDraft",
 								new HashMap<String, Object>() {
 									{
-										put("formId", formRecord.getFormId());
+										put(
+											"formId",
+											testGraphQLGetFormFormRecordByLatestDraft_getFormId(
+												formRecord));
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/formFormRecordByLatestDraft"))));
+	}
+
+	protected Long testGraphQLGetFormFormRecordByLatestDraft_getFormId(
+			FormRecord formRecord)
+		throws Exception {
+
+		return formRecord.getFormId();
 	}
 
 	@Test

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseInstanceResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseInstanceResourceTestCase.java
@@ -460,17 +460,25 @@ public abstract class BaseInstanceResourceTestCase {
 		assertHttpResponseStatusCode(
 			204,
 			instanceResource.deleteProcessInstanceHttpResponse(
-				instance.getProcessId(), instance.getId()));
+				testDeleteProcessInstance_getProcessId(instance),
+				instance.getId()));
 
 		assertHttpResponseStatusCode(
 			404,
 			instanceResource.getProcessInstanceHttpResponse(
-				instance.getProcessId(), instance.getId()));
+				testDeleteProcessInstance_getProcessId(instance),
+				instance.getId()));
 
 		assertHttpResponseStatusCode(
 			404,
 			instanceResource.getProcessInstanceHttpResponse(
-				instance.getProcessId(), 0L));
+				testDeleteProcessInstance_getProcessId(instance), 0L));
+	}
+
+	protected Long testDeleteProcessInstance_getProcessId(Instance instance)
+		throws Exception {
+
+		return instance.getProcessId();
 	}
 
 	protected Instance testDeleteProcessInstance_addInstance()
@@ -485,10 +493,17 @@ public abstract class BaseInstanceResourceTestCase {
 		Instance postInstance = testGetProcessInstance_addInstance();
 
 		Instance getInstance = instanceResource.getProcessInstance(
-			postInstance.getProcessId(), postInstance.getId());
+			testGetProcessInstance_getProcessId(postInstance),
+			postInstance.getId());
 
 		assertEquals(postInstance, getInstance);
 		assertValid(getInstance);
+	}
+
+	protected Long testGetProcessInstance_getProcessId(Instance instance)
+		throws Exception {
+
+		return instance.getProcessId();
 	}
 
 	protected Instance testGetProcessInstance_addInstance() throws Exception {
@@ -512,12 +527,20 @@ public abstract class BaseInstanceResourceTestCase {
 									{
 										put(
 											"processId",
-											instance.getProcessId());
+											testGraphQLGetProcessInstance_getProcessId(
+												instance));
+
 										put("instanceId", instance.getId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data", "Object/processInstance"))));
+	}
+
+	protected Long testGraphQLGetProcessInstance_getProcessId(Instance instance)
+		throws Exception {
+
+		return instance.getProcessId();
 	}
 
 	@Test

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseNodeResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseNodeResourceTestCase.java
@@ -273,7 +273,13 @@ public abstract class BaseNodeResourceTestCase {
 		assertHttpResponseStatusCode(
 			204,
 			nodeResource.deleteProcessNodeHttpResponse(
-				node.getProcessId(), node.getId()));
+				testDeleteProcessNode_getProcessId(node), node.getId()));
+	}
+
+	protected Long testDeleteProcessNode_getProcessId(Node node)
+		throws Exception {
+
+		return node.getProcessId();
 	}
 
 	protected Node testDeleteProcessNode_addNode() throws Exception {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseTaskResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseTaskResourceTestCase.java
@@ -277,16 +277,23 @@ public abstract class BaseTaskResourceTestCase {
 		assertHttpResponseStatusCode(
 			204,
 			taskResource.deleteProcessTaskHttpResponse(
-				task.getProcessId(), task.getId()));
+				testDeleteProcessTask_getProcessId(task), task.getId()));
 
 		assertHttpResponseStatusCode(
 			404,
 			taskResource.getProcessTaskHttpResponse(
-				task.getProcessId(), task.getId()));
+				testDeleteProcessTask_getProcessId(task), task.getId()));
 
 		assertHttpResponseStatusCode(
 			404,
-			taskResource.getProcessTaskHttpResponse(task.getProcessId(), 0L));
+			taskResource.getProcessTaskHttpResponse(
+				testDeleteProcessTask_getProcessId(task), 0L));
+	}
+
+	protected Long testDeleteProcessTask_getProcessId(Task task)
+		throws Exception {
+
+		return task.getProcessId();
 	}
 
 	protected Task testDeleteProcessTask_addTask() throws Exception {
@@ -299,10 +306,14 @@ public abstract class BaseTaskResourceTestCase {
 		Task postTask = testGetProcessTask_addTask();
 
 		Task getTask = taskResource.getProcessTask(
-			postTask.getProcessId(), postTask.getId());
+			testGetProcessTask_getProcessId(postTask), postTask.getId());
 
 		assertEquals(postTask, getTask);
 		assertValid(getTask);
+	}
+
+	protected Long testGetProcessTask_getProcessId(Task task) throws Exception {
+		return task.getProcessId();
 	}
 
 	protected Task testGetProcessTask_addTask() throws Exception {
@@ -324,12 +335,22 @@ public abstract class BaseTaskResourceTestCase {
 								"processTask",
 								new HashMap<String, Object>() {
 									{
-										put("processId", task.getProcessId());
+										put(
+											"processId",
+											testGraphQLGetProcessTask_getProcessId(
+												task));
+
 										put("taskId", task.getId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data", "Object/processTask"))));
+	}
+
+	protected Long testGraphQLGetProcessTask_getProcessId(Task task)
+		throws Exception {
+
+		return task.getProcessId();
 	}
 
 	@Test

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
@@ -942,6 +942,29 @@ public class FreeMarkerTool {
 		return false;
 	}
 
+	public boolean isParameterNameSchemaRelated(
+		String parameterName, String path, String schemaName) {
+
+		String parameterNameSubpath = "/{" + parameterName + "}";
+
+		if (StringUtil.endsWith(path, parameterNameSubpath)) {
+			return true;
+		}
+
+		String prefixPath = path.substring(
+			0, path.indexOf(parameterNameSubpath));
+
+		if (prefixPath.contains(
+				TextFormatter.format(schemaName, TextFormatter.I)) ||
+			prefixPath.contains(
+				TextFormatter.format(schemaName, TextFormatter.K))) {
+
+			return true;
+		}
+
+		return false;
+	}
+
 	public boolean isPathParameter(
 		JavaMethodParameter javaMethodParameter, Operation operation) {
 

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
@@ -3009,8 +3009,8 @@ public abstract class Base${schemaName}ResourceTestCase {
 </#macro>
 
 <#macro getTestGetterMethods
-	javaMethodSignature
 	getterJavaMethodParametersMap
+	javaMethodSignature
 	testNamePrefix
 >
 	<#list getterJavaMethodParametersMap?values as javaMethodParameter>

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
@@ -251,7 +251,11 @@ public abstract class Base${schemaName}ResourceTestCase {
 		</#if>
 
 		<#if freeMarkerTool.hasHTTPMethod(javaMethodSignature, "delete")>
-			<#assign missingGetterJavaMethodParametersMap = {} />
+			<#assign
+				addGetterMethod = false
+				defaultImplementationGetterMethod = false
+				getterJavaMethodParametersMap = {}
+			/>
 
 			@Test
 			public void test${javaMethodSignature.methodName?cap_first}() throws Exception {
@@ -270,14 +274,35 @@ public abstract class Base${schemaName}ResourceTestCase {
 							<#if stringUtil.equals(javaMethodParameter.parameterName, schemaVarName + "Id")>
 								${schemaVarName}.getId()
 							<#elseif properties?keys?seq_contains(javaMethodParameter.parameterName)>
-								${schemaVarName}.get${javaMethodParameter.parameterName?cap_first}()
+								<#if freeMarkerTool.isParameterNameSchemaRelated(javaMethodParameter.parameterName, javaMethodSignature.path, schemaName)>
+									${schemaVarName}.get${javaMethodParameter.parameterName?cap_first}()
+								<#else>
+									<#assign
+										addGetterMethod = true
+										defaultImplementationGetterMethod = true
+									/>
+								</#if>
 							<#else>
-								<#assign missingGetterJavaMethodParametersMap = missingGetterJavaMethodParametersMap + {javaMethodParameter.parameterName: javaMethodParameter} />
-
-								test${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}()
+								<#assign
+									addGetterMethod = true
+									defaultImplementationGetterMethod = false
+								/>
 							</#if>
 						<#else>
 							null
+						</#if>
+
+						<#if addGetterMethod>
+							<#if defaultImplementationGetterMethod>
+								test${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}(${schemaVarName})
+							<#else>
+								test${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}()
+							</#if>
+
+							<#assign
+								addGetterMethod = false
+								getterJavaMethodParametersMap = getterJavaMethodParametersMap + {javaMethodParameter.parameterName: javaMethodParameter}
+							/>
 						</#if>
 					</#list>
 
@@ -294,11 +319,32 @@ public abstract class Base${schemaName}ResourceTestCase {
 							<#if freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation) && stringUtil.equals(javaMethodParameter.parameterName, schemaVarName + "Id")>
 								${schemaVarName}.getId()
 							<#elseif freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation) && properties?keys?seq_contains(javaMethodParameter.parameterName)>
-								${schemaVarName}.get${javaMethodParameter.parameterName?cap_first}()
+								<#if freeMarkerTool.isParameterNameSchemaRelated(javaMethodParameter.parameterName, javaMethodSignature.path, schemaName)>
+									${schemaVarName}.get${javaMethodParameter.parameterName?cap_first}()
+								<#else>
+									<#assign
+										addGetterMethod = true
+										defaultImplementationGetterMethod = true
+									/>
+								</#if>
 							<#else>
-								<#assign missingGetterJavaMethodParametersMap = missingGetterJavaMethodParametersMap + {javaMethodParameter.parameterName: javaMethodParameter} />
+								<#assign
+									addGetterMethod = true
+									defaultImplementationGetterMethod = false
+								/>
+							</#if>
 
-								test${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}()
+							<#if addGetterMethod>
+								<#if defaultImplementationGetterMethod>
+									test${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}(${schemaVarName})
+								<#else>
+									test${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}()
+								</#if>
+
+								<#assign
+									addGetterMethod = false
+									getterJavaMethodParametersMap = getterJavaMethodParametersMap + {javaMethodParameter.parameterName: javaMethodParameter}
+								/>
 							</#if>
 
 							<#sep>, </#sep>
@@ -312,11 +358,32 @@ public abstract class Base${schemaName}ResourceTestCase {
 							<#if freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation) && stringUtil.equals(javaMethodParameter.parameterName, schemaVarName + "Id")>
 								<@getDefaultParameter javaMethodParameter=javaMethodParameter />
 							<#elseif freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation) && properties?keys?seq_contains(javaMethodParameter.parameterName)>
-								${schemaVarName}.get${javaMethodParameter.parameterName?cap_first}()
+								<#if freeMarkerTool.isParameterNameSchemaRelated(javaMethodParameter.parameterName, javaMethodSignature.path, schemaName)>
+									${schemaVarName}.get${javaMethodParameter.parameterName?cap_first}()
+								<#else>
+									<#assign
+										addGetterMethod = true
+										defaultImplementationGetterMethod = true
+									/>
+								</#if>
 							<#else>
-								<#assign missingGetterJavaMethodParametersMap = missingGetterJavaMethodParametersMap + {javaMethodParameter.parameterName: javaMethodParameter} />
+								<#assign
+									addGetterMethod = true
+									defaultImplementationGetterMethod = false
+								/>
+							</#if>
 
-								test${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}()
+							<#if addGetterMethod>
+								<#if defaultImplementationGetterMethod>
+									test${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}(${schemaVarName})
+								<#else>
+									test${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}()
+								</#if>
+
+								<#assign
+									addGetterMethod = false
+									getterJavaMethodParametersMap = getterJavaMethodParametersMap + {javaMethodParameter.parameterName: javaMethodParameter}
+								/>
 							</#if>
 
 							<#sep>, </#sep>
@@ -330,8 +397,8 @@ public abstract class Base${schemaName}ResourceTestCase {
 			}
 
 			<@getTestGetterMethods
+				getterJavaMethodParametersMap=getterJavaMethodParametersMap
 				javaMethodSignature=javaMethodSignature
-				missingGetterJavaMethodParametersMap=missingGetterJavaMethodParametersMap
 				testNamePrefix="test"
 			/>
 
@@ -1045,7 +1112,11 @@ public abstract class Base${schemaName}ResourceTestCase {
 				</#list>
 			</#if>
 		<#elseif freeMarkerTool.hasHTTPMethod(javaMethodSignature, "get") && javaMethodSignature.returnType?ends_with(schemaName)>
-			<#assign missingGetterJavaMethodParametersMap = {} />
+			<#assign
+				addGetterMethod = false
+				defaultImplementationGetterMethod = false
+				getterJavaMethodParametersMap = {}
+			/>
 
 			@Test
 			public void test${javaMethodSignature.methodName?cap_first}() throws Exception {
@@ -1065,14 +1136,35 @@ public abstract class Base${schemaName}ResourceTestCase {
 							<#if stringUtil.equals(javaMethodParameter.parameterName, schemaVarName + "Id")>
 								post${schemaName}.getId()
 							<#elseif properties?keys?seq_contains(javaMethodParameter.parameterName)>
-								post${schemaName}.get${javaMethodParameter.parameterName?cap_first}()
+								<#if freeMarkerTool.isParameterNameSchemaRelated(javaMethodParameter.parameterName, javaMethodSignature.path, schemaName)>
+									post${schemaName}.get${javaMethodParameter.parameterName?cap_first}()
+								<#else>
+									<#assign
+										addGetterMethod = true
+										defaultImplementationGetterMethod = true
+									/>
+								</#if>
 							<#else>
-								<#assign missingGetterJavaMethodParametersMap = missingGetterJavaMethodParametersMap + {javaMethodParameter.parameterName: javaMethodParameter} />
-
-								test${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}()
+								<#assign
+									addGetterMethod = true
+									defaultImplementationGetterMethod = false
+								/>
 							</#if>
 						<#else>
 							null
+						</#if>
+
+						<#if addGetterMethod>
+							<#if defaultImplementationGetterMethod>
+								test${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}(post${schemaName})
+							<#else>
+								test${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}()
+							</#if>
+
+							<#assign
+								addGetterMethod = false
+								getterJavaMethodParametersMap = getterJavaMethodParametersMap + {javaMethodParameter.parameterName: javaMethodParameter}
+							/>
 						</#if>
 					</#list>
 
@@ -1086,8 +1178,8 @@ public abstract class Base${schemaName}ResourceTestCase {
 			}
 
 			<@getTestGetterMethods
+				getterJavaMethodParametersMap=getterJavaMethodParametersMap
 				javaMethodSignature=javaMethodSignature
-				missingGetterJavaMethodParametersMap=missingGetterJavaMethodParametersMap
 				testNamePrefix="test"
 			/>
 
@@ -1332,7 +1424,10 @@ public abstract class Base${schemaName}ResourceTestCase {
 				</#if>
 			}
 		<#elseif freeMarkerTool.hasHTTPMethod(javaMethodSignature, "put") && javaMethodSignature.returnType?ends_with(schemaName)>
-			<#assign missingGetterJavaMethodParametersMap = {} />
+			<#assign
+				addGetterMethod = false
+				getterJavaMethodParametersMap = {}
+			/>
 
 			@Test
 			public void test${javaMethodSignature.methodName?cap_first}() throws Exception {
@@ -1405,8 +1500,8 @@ public abstract class Base${schemaName}ResourceTestCase {
 			}
 
 			<@getTestGetterMethods
+				getterJavaMethodParametersMap=getterJavaMethodParametersMap
 				javaMethodSignature=javaMethodSignature
-				missingGetterJavaMethodParametersMap=missingGetterJavaMethodParametersMap
 				testNamePrefix="test"
 			/>
 
@@ -1665,7 +1760,10 @@ public abstract class Base${schemaName}ResourceTestCase {
 				</#if>
 			}
 		<#elseif configYAML.generateGraphQL && freeMarkerTool.hasHTTPMethod(javaMethodSignature, "get") && javaMethodSignature.returnType?ends_with(schemaName)>
-			<#assign missingGetterJavaMethodParametersMap = {} />
+			<#assign
+				addGetterMethod = false
+				getterJavaMethodParametersMap = {}
+			/>
 
 			@Test
 			public void testGraphQL${javaMethodSignature.methodName?cap_first}() throws Exception {
@@ -1694,33 +1792,55 @@ public abstract class Base${schemaName}ResourceTestCase {
 																</#if>
 															);
 														<#elseif properties?keys?seq_contains(javaMethodParameter.parameterName)>
-															<#if stringUtil.equals(javaMethodParameter.parameterName, "siteId")>
-																put("siteKey", <@getQuotedString unquotedString="${schemaVarName}.get${javaMethodParameter.parameterName?cap_first}()" />);
+															<#if freeMarkerTool.isParameterNameSchemaRelated(javaMethodParameter.parameterName, javaMethodSignature.path, schemaName)>
+																<#if stringUtil.equals(javaMethodParameter.parameterName, "siteId")>
+																	put("siteKey", <@getQuotedString unquotedString="${schemaVarName}.get${javaMethodParameter.parameterName?cap_first}()" />);
+																<#else>
+																	put("${javaMethodParameter.parameterName}",
+																		<#if stringUtil.equals(javaMethodParameter.parameterType, "java.lang.String")>
+																			<@getQuotedString unquotedString="${schemaVarName}.get${javaMethodParameter.parameterName?cap_first}()" />
+																		<#else>
+																			${schemaVarName}.get${javaMethodParameter.parameterName?cap_first}()
+																		</#if>
+																	);
+																</#if>
 															<#else>
-																put("${javaMethodParameter.parameterName}",
-																	<#if stringUtil.equals(javaMethodParameter.parameterType, "java.lang.String")>
-																		<@getQuotedString unquotedString="${schemaVarName}.get${javaMethodParameter.parameterName?cap_first}()" />
-																	<#else>
-																		${schemaVarName}.get${javaMethodParameter.parameterName?cap_first}()
-																	</#if>
-																);
+																<#assign
+																	addGetterMethod = true
+																	defaultImplementationGetterMethod = true
+																/>
 															</#if>
 														<#else>
-															<#assign missingGetterJavaMethodParametersMap = missingGetterJavaMethodParametersMap + {javaMethodParameter.parameterName: javaMethodParameter} />
+															<#assign
+																addGetterMethod = true
+																defaultImplementationGetterMethod = false
+															/>
+														</#if>
+
+														<#if addGetterMethod>
+															<#assign getterMethodArgument = "" />
+															<#if defaultImplementationGetterMethod>
+																<#assign getterMethodArgument = "${schemaVarName}" />
+															</#if>
 
 															<#if stringUtil.equals(javaMethodParameter.parameterName, "assetLibraryId")>
-																put("${javaMethodParameter.parameterName}", <@getQuotedString unquotedString="testGraphQL${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}()" />);
+																put("${javaMethodParameter.parameterName}", <@getQuotedString unquotedString="testGraphQL${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}(${getterMethodArgument})" />);
 															<#elseif stringUtil.equals(javaMethodParameter.parameterName, "siteId")>
-																put("siteKey", <@getQuotedString unquotedString="testGraphQL${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}()" />);
+																put("siteKey", <@getQuotedString unquotedString="testGraphQL${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}(${getterMethodArgument})" />);
 															<#else>
 																put("${javaMethodParameter.parameterName}",
-																	<#if stringUtil.equals(javaMethodParameter.parameterType, "java.lang.String")>
-																		<@getQuotedString unquotedString="testGraphQL${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}()" />
-																	<#else>
-																		testGraphQL${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}()
-																	</#if>
+																<#if stringUtil.equals(javaMethodParameter.parameterType, "java.lang.String")>
+																	<@getQuotedString unquotedString="testGraphQL${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}(${getterMethodArgument})" />
+																<#else>
+																	testGraphQL${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}(${getterMethodArgument})
+																</#if>
 																);
 															</#if>
+
+															<#assign
+																addGetterMethod = false
+																getterJavaMethodParametersMap = getterJavaMethodParametersMap + {javaMethodParameter.parameterName: javaMethodParameter}
+															/>
 														</#if>
 													</#if>
 												</#list>
@@ -1735,8 +1855,8 @@ public abstract class Base${schemaName}ResourceTestCase {
 			}
 
 			<@getTestGetterMethods
+				getterJavaMethodParametersMap=getterJavaMethodParametersMap
 				javaMethodSignature=javaMethodSignature
-				missingGetterJavaMethodParametersMap=missingGetterJavaMethodParametersMap
 				testNamePrefix="testGraphQL"
 			/>
 
@@ -2763,11 +2883,33 @@ public abstract class Base${schemaName}ResourceTestCase {
 		<#if freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation) && stringUtil.equals(javaMethodParameter.parameterName, schemaVarName + "Id")>
 			put${schemaName}.getId()
 		<#elseif freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation) && properties?keys?seq_contains(javaMethodParameter.parameterName)>
-			put${schemaName}.get${javaMethodParameter.parameterName?cap_first}()
+			<#if freeMarkerTool.isParameterNameSchemaRelated(javaMethodParameter.parameterName, javaMethodSignature.path, schemaName)>
+				put${schemaName}.get${javaMethodParameter.parameterName?cap_first}()
+			<#else>
+				<#assign
+					addGetterMethod = true
+					defaultImplementationGetterMethod = true
+				/>
+			</#if>
 		<#else>
-			<#assign missingGetterJavaMethodParametersMap = missingGetterJavaMethodParametersMap + {javaMethodParameter.parameterName: javaMethodParameter} />
+			<#assign
+				addGetterMethod = true
+				defaultImplementationGetterMethod = false
+			/>
+		</#if>
 
-			test${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}()
+		<#if addGetterMethod>
+			<#if defaultImplementationGetterMethod>
+				test${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}(put${schemaName})
+			<#else>
+				test${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}()
+			</#if>
+
+			<#assign
+				addGetterMethod = false
+				defaultImplementationGetterMethod = false
+				getterJavaMethodParametersMap = getterJavaMethodParametersMap + {javaMethodParameter.parameterName: javaMethodParameter}
+			/>
 		</#if>
 
 		<#sep>, </#sep>
@@ -2826,13 +2968,35 @@ public abstract class Base${schemaName}ResourceTestCase {
 		<#if freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation) && stringUtil.equals(javaMethodParameter.parameterName, schemaVarName + "Id")>
 			${schemaVarNamePrefix}${schemaName}.getId()
 		<#elseif freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation) && properties?keys?seq_contains(javaMethodParameter.parameterName)>
-			${schemaVarNamePrefix}${schemaName}.get${javaMethodParameter.parameterName?cap_first}()
+			<#if freeMarkerTool.isParameterNameSchemaRelated(javaMethodParameter.parameterName, javaMethodSignature.path, schemaName)>
+				${schemaVarNamePrefix}${schemaName}.get${javaMethodParameter.parameterName?cap_first}()
+			<#else>
+				<#assign
+					addGetterMethod = true
+					defaultImplementationGetterMethod = true
+				/>
+			</#if>
 		<#elseif stringUtil.equals(javaMethodParameter.parameterName, "multipartBody") || stringUtil.equals(javaMethodParameter.parameterName, schemaVarName)>
 			${newSchemaVarNamePrefix}${schemaName}
 		<#else>
-			<#assign missingGetterJavaMethodParametersMap = missingGetterJavaMethodParametersMap + {javaMethodParameter.parameterName: javaMethodParameter} />
+			<#assign
+				addGetterMethod = true
+				defaultImplementationGetterMethod = false
+			/>
+		</#if>
 
-			test${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}()
+		<#if addGetterMethod>
+			<#if defaultImplementationGetterMethod>
+				test${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}(${schemaVarNamePrefix}${schemaName})
+			<#else>
+				test${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}()
+			</#if>
+
+			<#assign
+				addGetterMethod = false
+				defaultImplementationGetterMethod = false
+				getterJavaMethodParametersMap = getterJavaMethodParametersMap + {javaMethodParameter.parameterName: javaMethodParameter}
+			/>
 		</#if>
 		<#sep>, </#sep>
 	</#list>
@@ -2846,12 +3010,19 @@ public abstract class Base${schemaName}ResourceTestCase {
 
 <#macro getTestGetterMethods
 	javaMethodSignature
-	missingGetterJavaMethodParametersMap
+	getterJavaMethodParametersMap
 	testNamePrefix
 >
-	<#list missingGetterJavaMethodParametersMap?values as javaMethodParameter>
-		protected ${javaMethodParameter.parameterType} ${testNamePrefix}${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}() throws Exception {
-			throw new UnsupportedOperationException("This method needs to be implemented");
+	<#list getterJavaMethodParametersMap?values as javaMethodParameter>
+			<#if properties?keys?seq_contains(javaMethodParameter.parameterName)>
+				protected ${javaMethodParameter.parameterType} ${testNamePrefix}${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}(${schemaName} ${schemaVarName}) throws Exception {
+
+				return ${schemaVarName}.get${javaMethodParameter.parameterName?cap_first}();
+			<#else>
+				protected ${javaMethodParameter.parameterType} ${testNamePrefix}${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}() throws Exception {
+
+				throw new UnsupportedOperationException("This method needs to be implemented");
+			</#if>
 		}
 	</#list>
 </#macro>


### PR DESCRIPTION
Manually forwarded from: https://github.com/liferay-headless/liferay-portal/pull/1013

---

This PR contains the code to modify REST Builder for the following case:

When in the path, there is a path parameter which name matches with a parameter of the entity schema but it is not clear that the parameter must belong to the entity schema, then a Getter method is auto-generated and invoked from the test with a default implementation returning the parameter of the entity schema.

---

**When the getter method is NOT being autogenerated and the parameter of the entity schema is being directy used as before?**

Given a parameter, for example `externalReferenceCode`

1. When the substring of the path after the parameter that is being analyzed is empty.

    For example, for a schema called `MySchema`: `/random-path/{externalReferenceCode}` 

2. When there is an evidence that the substring before the path is related to the entity schema

    For example, for a schema called `MySchema`:

  -  `/my-schemas/{externalReferenceCode}/[...]` 
  -  `/mySchemas/{externalReferenceCode}/[...]` 
 
---

**NOTE:** The default implementation will not cause a breaking change as it is executing the same code than before, and it is a decission of the API developer to override the getter method with the desired behaviour