### PR TITLE
LPS-174904 Return all commerceChannelIds instead of empty long array when CommerceChannelAccountEntryRel is null

### DIFF
--- a/modules/apps/commerce/commerce-address-web/src/main/java/com/liferay/commerce/address/web/internal/display/context/CommerceChannelAccountEntryRelDisplayContext.java
+++ b/modules/apps/commerce/commerce-address-web/src/main/java/com/liferay/commerce/address/web/internal/display/context/CommerceChannelAccountEntryRelDisplayContext.java
@@ -265,30 +265,22 @@ public class CommerceChannelAccountEntryRelDisplayContext {
 		CommerceChannelAccountEntryRel commerceChannelAccountEntryRel =
 			fetchCommerceChannelAccountEntryRel();
 
-		List<CommerceChannelAccountEntryRel> commerceChannelAccountEntryRels =
+		long[] commerceChannelIds = TransformUtil.transformToLongArray(
 			_commerceChannelAccountEntryRelService.
 				getCommerceChannelAccountEntryRels(
 					_accountEntry.getAccountEntryId(), _type, QueryUtil.ALL_POS,
-					QueryUtil.ALL_POS, null);
+					QueryUtil.ALL_POS, null),
+			CommerceChannelAccountEntryRel::getCommerceChannelId);
 
 		if (commerceChannelAccountEntryRel == null) {
-			return TransformUtil.transformToLongArray(
-				commerceChannelAccountEntryRels,
-				CommerceChannelAccountEntryRel::getCommerceChannelId);
+			return commerceChannelIds;
 		}
 
-		return TransformUtil.transformToLongArray(
-			commerceChannelAccountEntryRels,
-			curCommerceChannelAccountEntryRel -> {
-				if (commerceChannelAccountEntryRel.getCommerceChannelId() ==
-						curCommerceChannelAccountEntryRel.
-							getCommerceChannelId()) {
-
-					return null;
-				}
-
-				return curCommerceChannelAccountEntryRel.getCommerceChannelId();
-			});
+		return ArrayUtil.filter(
+			commerceChannelIds,
+			commerceChannelId ->
+				commerceChannelAccountEntryRel.getCommerceChannelId() !=
+					commerceChannelId);
 	}
 
 	private final AccountEntry _accountEntry;

--- a/modules/apps/commerce/commerce-address-web/src/main/java/com/liferay/commerce/address/web/internal/display/context/CommerceChannelAccountEntryRelDisplayContext.java
+++ b/modules/apps/commerce/commerce-address-web/src/main/java/com/liferay/commerce/address/web/internal/display/context/CommerceChannelAccountEntryRelDisplayContext.java
@@ -265,15 +265,20 @@ public class CommerceChannelAccountEntryRelDisplayContext {
 		CommerceChannelAccountEntryRel commerceChannelAccountEntryRel =
 			fetchCommerceChannelAccountEntryRel();
 
-		if (commerceChannelAccountEntryRel == null) {
-			return new long[0];
-		}
-
-		return TransformUtil.transformToLongArray(
+		List<CommerceChannelAccountEntryRel> commerceChannelAccountEntryRels =
 			_commerceChannelAccountEntryRelService.
 				getCommerceChannelAccountEntryRels(
 					_accountEntry.getAccountEntryId(), _type, QueryUtil.ALL_POS,
-					QueryUtil.ALL_POS, null),
+					QueryUtil.ALL_POS, null);
+
+		if (commerceChannelAccountEntryRel == null) {
+			return TransformUtil.transformToLongArray(
+				commerceChannelAccountEntryRels,
+				CommerceChannelAccountEntryRel::getCommerceChannelId);
+		}
+
+		return TransformUtil.transformToLongArray(
+			commerceChannelAccountEntryRels,
 			curCommerceChannelAccountEntryRel -> {
 				if (commerceChannelAccountEntryRel.getCommerceChannelId() ==
 						curCommerceChannelAccountEntryRel.
@@ -282,7 +287,7 @@ public class CommerceChannelAccountEntryRelDisplayContext {
 					return null;
 				}
 
-				return commerceChannelAccountEntryRel.getCommerceChannelId();
+				return curCommerceChannelAccountEntryRel.getCommerceChannelId();
 			});
 	}
 


### PR DESCRIPTION
@brianchandotcom Hi Brian,
[4d68f37](https://github.com/brianchandotcom/liferay-portal/pull/130283/commits/4d68f37d089fee84ad5364c574206d148f59e78b) 
Returns two transforms: 1 with filter, 1 without filter
runtime only runs 1 if rel is null

[877ad9b](https://github.com/brianchandotcom/liferay-portal/pull/130283/commits/877ad9bf08e940901cdfcadc5eb4cc08b7d2de7d)
Uses 1 transform, 1 filter
runtime runs transform or transform and filter if rel is null
I think it's easier to read, but it does create the array twice if we need to filter