### PR TITLE
LPS-174904 Fix CommerceChannelAccountEntryRel logic

### DIFF
--- a/modules/apps/commerce/commerce-address-web/src/main/java/com/liferay/commerce/address/web/internal/display/context/CommerceChannelAccountEntryRelDisplayContext.java
+++ b/modules/apps/commerce/commerce-address-web/src/main/java/com/liferay/commerce/address/web/internal/display/context/CommerceChannelAccountEntryRelDisplayContext.java
@@ -265,30 +265,22 @@ public class CommerceChannelAccountEntryRelDisplayContext {
 		CommerceChannelAccountEntryRel commerceChannelAccountEntryRel =
 			fetchCommerceChannelAccountEntryRel();
 
-		List<CommerceChannelAccountEntryRel> commerceChannelAccountEntryRels =
+		long[] commerceChannelIds = TransformUtil.transformToLongArray(
 			_commerceChannelAccountEntryRelService.
 				getCommerceChannelAccountEntryRels(
 					_accountEntry.getAccountEntryId(), _type, QueryUtil.ALL_POS,
-					QueryUtil.ALL_POS, null);
+					QueryUtil.ALL_POS, null),
+			CommerceChannelAccountEntryRel::getCommerceChannelId);
 
 		if (commerceChannelAccountEntryRel == null) {
-			return TransformUtil.transformToLongArray(
-				commerceChannelAccountEntryRels,
-				CommerceChannelAccountEntryRel::getCommerceChannelId);
+			return commerceChannelIds;
 		}
 
-		return TransformUtil.transformToLongArray(
-			commerceChannelAccountEntryRels,
-			curCommerceChannelAccountEntryRel -> {
-				if (commerceChannelAccountEntryRel.getCommerceChannelId() ==
-						curCommerceChannelAccountEntryRel.
-							getCommerceChannelId()) {
-
-					return null;
-				}
-
-				return curCommerceChannelAccountEntryRel.getCommerceChannelId();
-			});
+		return ArrayUtil.filter(
+			commerceChannelIds,
+			commerceChannelId ->
+				commerceChannelAccountEntryRel.getCommerceChannelId() !=
+					commerceChannelId);
 	}
 
 	private final AccountEntry _accountEntry;

--- a/modules/apps/commerce/commerce-address-web/src/main/java/com/liferay/commerce/address/web/internal/display/context/CommerceChannelAccountEntryRelDisplayContext.java
+++ b/modules/apps/commerce/commerce-address-web/src/main/java/com/liferay/commerce/address/web/internal/display/context/CommerceChannelAccountEntryRelDisplayContext.java
@@ -265,15 +265,20 @@ public class CommerceChannelAccountEntryRelDisplayContext {
 		CommerceChannelAccountEntryRel commerceChannelAccountEntryRel =
 			fetchCommerceChannelAccountEntryRel();
 
-		if (commerceChannelAccountEntryRel == null) {
-			return new long[0];
-		}
-
-		return TransformUtil.transformToLongArray(
+		List<CommerceChannelAccountEntryRel> commerceChannelAccountEntryRels =
 			_commerceChannelAccountEntryRelService.
 				getCommerceChannelAccountEntryRels(
 					_accountEntry.getAccountEntryId(), _type, QueryUtil.ALL_POS,
-					QueryUtil.ALL_POS, null),
+					QueryUtil.ALL_POS, null);
+
+		if (commerceChannelAccountEntryRel == null) {
+			return TransformUtil.transformToLongArray(
+				commerceChannelAccountEntryRels,
+				CommerceChannelAccountEntryRel::getCommerceChannelId);
+		}
+
+		return TransformUtil.transformToLongArray(
+			commerceChannelAccountEntryRels,
 			curCommerceChannelAccountEntryRel -> {
 				if (commerceChannelAccountEntryRel.getCommerceChannelId() ==
 						curCommerceChannelAccountEntryRel.
@@ -282,7 +287,7 @@ public class CommerceChannelAccountEntryRelDisplayContext {
 					return null;
 				}
 
-				return commerceChannelAccountEntryRel.getCommerceChannelId();
+				return curCommerceChannelAccountEntryRel.getCommerceChannelId();
 			});
 	}
 


### PR DESCRIPTION
@brianchandotcom Hi Brian,
[11b5cdf](https://github.com/brianchandotcom/liferay-portal/pull/130290/commits/11b5cdf5fa475e9b7820ef6b3f0e11feafee3a0b)
Returns two transforms: 1 with filter, 1 without filter
runtime only runs 1 if rel is null

[6f6a03f](https://github.com/brianchandotcom/liferay-portal/pull/130290/commits/6f6a03f670805995ca29f03cc05f23682c362a9a)
Uses 1 transform, 1 filter
runtime runs transform or transform and filter if rel is null
I think it's easier to read, but it does create the array twice if we need to filter