### PR TITLE
LPS-175319 It must be fetched by ERC field in order to work with other implementations of ObjectEntryManager

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
@@ -521,8 +521,8 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 
 		existingObjectEntry.setProperties(
 			() -> {
-				ObjectEntry getObjectEntry = getObjectEntry(
-					existingObjectEntry.getId());
+				ObjectEntry getObjectEntry = getByExternalReferenceCode(
+					existingObjectEntry.getExternalReferenceCode());
 
 				Map<String, Object> properties = getObjectEntry.getProperties();
 


### PR DESCRIPTION
CI errors [here](https://github.com/liferay-objects/liferay-portal/pull/1739#issuecomment-1426916341) and [here](https://github.com/liferay-objects/liferay-portal/pull/1739#issuecomment-1429172070) are not related.