### PR TITLE
LPS-175359 Use Scoped service tracker map instead to provide the proper one based on the companyId of the object definition

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -398,7 +398,8 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 								_openAPIResource,
 								_systemObjectDefinitionMetadataRegistry),
 							HashMapDictionaryBuilder.<String, Object>put(
-								"companyId", objectDefinition.getCompanyId()
+								"companyId",
+								String.valueOf(objectDefinition.getCompanyId())
 							).put(
 								"openapi.resource", "true"
 							).put(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/openapi/v1_0/ObjectEntryOpenAPIResourceProviderImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/openapi/v1_0/ObjectEntryOpenAPIResourceProviderImpl.java
@@ -17,8 +17,8 @@ package com.liferay.object.rest.internal.openapi.v1_0;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.rest.openapi.v1_0.ObjectEntryOpenAPIResource;
 import com.liferay.object.rest.openapi.v1_0.ObjectEntryOpenAPIResourceProvider;
-import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
-import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
+import com.liferay.osgi.service.tracker.collections.map.ScopedServiceTrackerMap;
+import com.liferay.osgi.service.tracker.collections.map.ScopedServiceTrackerMapFactory;
 
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.Activate;
@@ -36,23 +36,24 @@ public class ObjectEntryOpenAPIResourceProviderImpl
 	public ObjectEntryOpenAPIResource getObjectEntryOpenAPIResource(
 		ObjectDefinition objectDefinition) {
 
-		return _serviceTrackerMap.getService(
+		return _scopedServiceTrackerMap.getService(
+			objectDefinition.getCompanyId(),
 			objectDefinition.getOSGiJaxRsName("ObjectEntryOpenAPIResource"));
 	}
 
 	@Activate
 	protected void activate(BundleContext bundleContext) {
-		_serviceTrackerMap = ServiceTrackerMapFactory.openSingleValueMap(
+		_scopedServiceTrackerMap = ScopedServiceTrackerMapFactory.create(
 			bundleContext, ObjectEntryOpenAPIResource.class,
-			"openapi.resource.key");
+			"openapi.resource.key", () -> null);
 	}
 
 	@Deactivate
 	protected void deactivate() {
-		_serviceTrackerMap.close();
+		_scopedServiceTrackerMap.close();
 	}
 
-	private ServiceTrackerMap<String, ObjectEntryOpenAPIResource>
-		_serviceTrackerMap;
+	private ScopedServiceTrackerMap<ObjectEntryOpenAPIResource>
+		_scopedServiceTrackerMap;
 
 }


### PR DESCRIPTION
This PR contains the code to fix this bug: https://issues.liferay.com/browse/LPS-175359

The scoped service tracker map is used to get the proper `ObjectEntryOpenAPIResource`, not only based on the value of the property `openapi.resource.key`, but also based on the property `companyId`, as for the case several objects are created with the same name in different companies, the value of the property `openapi.resource.key` is the same, so it is needed to have a scoped to filter by, and in this case is based on the property `companyId` of the Map of OSGi properties.