### PR TITLE
LPS-175384 Transform AC expression into a Valid frontend JSON format

### DIFF
--- a/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/criteria/contributor/EventSegmentsCriteriaContributor.java
+++ b/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/criteria/contributor/EventSegmentsCriteriaContributor.java
@@ -17,9 +17,7 @@ package com.liferay.segments.asah.connector.internal.criteria.contributor;
 import com.liferay.item.selector.ItemSelector;
 import com.liferay.item.selector.criteria.FileEntryItemSelectorReturnType;
 import com.liferay.item.selector.criteria.file.criterion.FileItemSelectorCriterion;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONObject;
-import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -30,9 +28,11 @@ import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.segments.asah.connector.internal.criteria.mapper.SegmentsCriteriaJSONObjectMapperImpl;
 import com.liferay.segments.asah.connector.internal.odata.entity.EventEntityModel;
 import com.liferay.segments.criteria.Criteria;
 import com.liferay.segments.criteria.contributor.SegmentsCriteriaContributor;
+import com.liferay.segments.criteria.mapper.SegmentsCriteriaJSONObjectMapper;
 import com.liferay.segments.field.Field;
 
 import java.util.Collections;
@@ -60,10 +60,13 @@ public class EventSegmentsCriteriaContributor
 	public static final String KEY = "event";
 
 	@Override
-	public JSONObject getCriteriaJSONObject(Criteria criteria) {
-		return JSONUtil.put(
-			"conjunctionName",
-			_getCriterionConjunction(criteria.getCriterion(getKey())));
+	public JSONObject getCriteriaJSONObject(Criteria criteria)
+		throws Exception {
+
+		SegmentsCriteriaJSONObjectMapper segmentsCriteriaJSONObjectMapper =
+			new SegmentsCriteriaJSONObjectMapperImpl();
+
+		return segmentsCriteriaJSONObjectMapper.toJSONObject(criteria, this);
 	}
 
 	@Override
@@ -116,14 +119,6 @@ public class EventSegmentsCriteriaContributor
 		if (_serviceRegistration != null) {
 			_serviceRegistration.unregister();
 		}
-	}
-
-	private String _getCriterionConjunction(Criteria.Criterion criterion) {
-		if (criterion == null) {
-			return StringPool.BLANK;
-		}
-
-		return criterion.getConjunction();
 	}
 
 	private Field.SelectEntity _getSelectEntity(PortletRequest portletRequest) {

--- a/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/criteria/mapper/SegmentsCriteriaJSONObjectMapperImpl.java
+++ b/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/criteria/mapper/SegmentsCriteriaJSONObjectMapperImpl.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.segments.asah.connector.internal.criteria.mapper;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.odata.filter.expression.BinaryExpression;
+import com.liferay.segments.asah.connector.internal.expression.JSONObjectIndividualSegmentsExpressionVisitorImpl;
+import com.liferay.segments.asah.connector.internal.expression.parser.IndividualSegmentsExpressionLexer;
+import com.liferay.segments.asah.connector.internal.expression.parser.IndividualSegmentsExpressionParser;
+import com.liferay.segments.criteria.Criteria;
+import com.liferay.segments.criteria.contributor.SegmentsCriteriaContributor;
+import com.liferay.segments.criteria.mapper.SegmentsCriteriaJSONObjectMapper;
+
+import org.antlr.v4.runtime.ANTLRInputStream;
+import org.antlr.v4.runtime.CommonTokenStream;
+
+/**
+ * @author Cristina González
+ */
+public class SegmentsCriteriaJSONObjectMapperImpl
+	implements SegmentsCriteriaJSONObjectMapper {
+
+	@Override
+	public JSONObject toJSONObject(
+		Criteria criteria,
+		SegmentsCriteriaContributor segmentsCriteriaContributor) {
+
+		Criteria.Criterion criterion = segmentsCriteriaContributor.getCriterion(
+			criteria);
+
+		return JSONUtil.put(
+			"conjunctionId", _getCriterionConjunction(criterion)
+		).put(
+			"propertyKey", segmentsCriteriaContributor.getKey()
+		).put(
+			"query", _getQueryJSONObject(criterion)
+		);
+	}
+
+	private String _getCriterionConjunction(Criteria.Criterion criterion) {
+		if (criterion == null) {
+			return StringPool.BLANK;
+		}
+
+		return criterion.getConjunction();
+	}
+
+	private String _getCriterionFilterString(Criteria.Criterion criterion) {
+		if (criterion == null) {
+			return StringPool.BLANK;
+		}
+
+		return criterion.getFilterString();
+	}
+
+	private JSONObject _getQueryJSONObject(Criteria.Criterion criterion) {
+		String criterionFilterString = _getCriterionFilterString(criterion);
+
+		if (Validator.isNull(criterionFilterString)) {
+			return null;
+		}
+
+		IndividualSegmentsExpressionParser individualSegmentsExpressionParser =
+			new IndividualSegmentsExpressionParser(
+				new CommonTokenStream(
+					new IndividualSegmentsExpressionLexer(
+						new ANTLRInputStream(criterionFilterString))));
+
+		IndividualSegmentsExpressionParser.ExpressionContext expressionContext =
+			individualSegmentsExpressionParser.expression();
+
+		JSONObject jsonObject = (JSONObject)expressionContext.accept(
+			new JSONObjectIndividualSegmentsExpressionVisitorImpl());
+
+		if (Validator.isNull(jsonObject.getString("groupId"))) {
+			jsonObject = JSONUtil.put(
+				"conjunctionName",
+				StringUtil.toLowerCase(
+					String.valueOf(BinaryExpression.Operation.AND))
+			).put(
+				"groupId", "group_0"
+			).put(
+				"items", JSONUtil.putAll(jsonObject)
+			);
+		}
+
+		return jsonObject;
+	}
+
+}

--- a/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/expression/FilterByCountIndividualSegmentsExpressionVisitorImpl.java
+++ b/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/expression/FilterByCountIndividualSegmentsExpressionVisitorImpl.java
@@ -41,13 +41,15 @@ public class FilterByCountIndividualSegmentsExpressionVisitorImpl
 			andExpressionContext) {
 
 		ParseTree leftParseTree = andExpressionContext.getChild(0);
-		ParseTree rightParseTree = andExpressionContext.getChild(2);
 
 		Object left = leftParseTree.accept(this);
+
+		ParseTree rightParseTree = andExpressionContext.getChild(2);
+
 		Object right = rightParseTree.accept(this);
 
-		if ((right instanceof FilterByCount.Day) &&
-			(left instanceof FilterByCount.Event)) {
+		if ((left instanceof FilterByCount.Event) &&
+			(right instanceof FilterByCount.Day)) {
 
 			return new FilterByCount(
 				(FilterByCount.Day)right, (FilterByCount.Event)left);
@@ -55,21 +57,21 @@ public class FilterByCountIndividualSegmentsExpressionVisitorImpl
 
 		throw new UnsupportedOperationException(
 			StringBundler.concat(
-				"Trying to create a FilterByCount Expression with  ",
+				"Trying to create a filter by count expression with  ",
 				String.valueOf(left.getClass()), " and ",
 				String.valueOf(right.getClass())));
 	}
 
 	@Override
-	public Object visitChildren(@NotNull RuleNode node) {
+	public Object visitChildren(@NotNull RuleNode ruleNode) {
 		Object result = defaultResult();
 
-		for (int i = 0; i < node.getChildCount(); i++) {
-			if (!shouldVisitNextChild(node, result)) {
+		for (int i = 0; i < ruleNode.getChildCount(); i++) {
+			if (!shouldVisitNextChild(ruleNode, result)) {
 				break;
 			}
 
-			ParseTree parseTree = node.getChild(i);
+			ParseTree parseTree = ruleNode.getChild(i);
 
 			Object object = parseTree.accept(this);
 

--- a/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/expression/FilterByCountIndividualSegmentsExpressionVisitorImpl.java
+++ b/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/expression/FilterByCountIndividualSegmentsExpressionVisitorImpl.java
@@ -1,0 +1,311 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.segments.asah.connector.internal.expression;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.segments.asah.connector.internal.expression.parser.IndividualSegmentsExpressionBaseVisitor;
+import com.liferay.segments.asah.connector.internal.expression.parser.IndividualSegmentsExpressionParser;
+
+import java.util.Objects;
+
+import org.antlr.v4.runtime.misc.NotNull;
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.antlr.v4.runtime.tree.RuleNode;
+import org.antlr.v4.runtime.tree.TerminalNode;
+
+/**
+ * @author Cristina González
+ */
+public class FilterByCountIndividualSegmentsExpressionVisitorImpl
+	extends IndividualSegmentsExpressionBaseVisitor<Object> {
+
+	@Override
+	public FilterByCount visitAndExpression(
+		@NotNull IndividualSegmentsExpressionParser.AndExpressionContext
+			andExpressionContext) {
+
+		ParseTree leftParseTree = andExpressionContext.getChild(0);
+		ParseTree rightParseTree = andExpressionContext.getChild(2);
+
+		Object left = leftParseTree.accept(this);
+		Object right = rightParseTree.accept(this);
+
+		if ((right instanceof FilterByCount.Day) &&
+			(left instanceof FilterByCount.Event)) {
+
+			return new FilterByCount(
+				(FilterByCount.Day)right, (FilterByCount.Event)left);
+		}
+
+		throw new UnsupportedOperationException(
+			StringBundler.concat(
+				"Trying to create a FilterByCount Expression with  ",
+				String.valueOf(left.getClass()), " and ",
+				String.valueOf(right.getClass())));
+	}
+
+	@Override
+	public Object visitChildren(@NotNull RuleNode node) {
+		Object result = defaultResult();
+
+		for (int i = 0; i < node.getChildCount(); i++) {
+			if (!shouldVisitNextChild(node, result)) {
+				break;
+			}
+
+			ParseTree parseTree = node.getChild(i);
+
+			Object object = parseTree.accept(this);
+
+			result = aggregateResult(result, object);
+		}
+
+		return result;
+	}
+
+	@Override
+	public Object visitEqualsExpression(
+		@NotNull IndividualSegmentsExpressionParser.EqualsExpressionContext
+			equalsExpressionContext) {
+
+		ParseTree leftParseTree = equalsExpressionContext.getChild(0);
+
+		Object value = leftParseTree.accept(this);
+
+		if (Objects.equals("activityKey", value)) {
+			ParseTree rightParseTree = equalsExpressionContext.getChild(2);
+
+			String eventString = (String)rightParseTree.accept(this);
+
+			String[] parts = eventString.split(StringPool.POUND);
+
+			if (parts.length != 3) {
+				throw new UnsupportedOperationException(
+					"invalid event " + eventString);
+			}
+
+			return new FilterByCount.Event(parts[1], parts[2]);
+		}
+		else if (Objects.equals("day", value)) {
+			return _getFilterByCountDay(
+				leftParseTree, equalsExpressionContext.getChild(1),
+				equalsExpressionContext.getChild(2));
+		}
+
+		throw new UnsupportedOperationException(
+			"Unsupported operation with value " + value);
+	}
+
+	@Override
+	public FilterByCount.Day visitGreaterThanExpression(
+		@NotNull IndividualSegmentsExpressionParser.GreaterThanExpressionContext
+			greaterThanExpressionContext) {
+
+		return _getFilterByCountDay(
+			greaterThanExpressionContext.getChild(0),
+			greaterThanExpressionContext.getChild(1),
+			greaterThanExpressionContext.getChild(2));
+	}
+
+	@Override
+	public FilterByCount.Day visitGreaterThanOrEqualsExpression(
+		@NotNull
+			IndividualSegmentsExpressionParser.
+				GreaterThanOrEqualsExpressionContext
+					greaterThanOrEqualsExpressionContext) {
+
+		return _getFilterByCountDay(
+			greaterThanOrEqualsExpressionContext.getChild(0),
+			greaterThanOrEqualsExpressionContext.getChild(1),
+			greaterThanOrEqualsExpressionContext.getChild(2));
+	}
+
+	@Override
+	public FilterByCount.Day visitLessThanExpression(
+		@NotNull IndividualSegmentsExpressionParser.LessThanExpressionContext
+			lessThanExpressionContext) {
+
+		return _getFilterByCountDay(
+			lessThanExpressionContext.getChild(0),
+			lessThanExpressionContext.getChild(1),
+			lessThanExpressionContext.getChild(2));
+	}
+
+	@Override
+	public FilterByCount.Day visitLessThanOrEqualsExpression(
+		@NotNull
+			IndividualSegmentsExpressionParser.LessThanOrEqualsExpressionContext
+				lessThanOrEqualsExpressionContext) {
+
+		return _getFilterByCountDay(
+			lessThanOrEqualsExpressionContext.getChild(0),
+			lessThanOrEqualsExpressionContext.getChild(1),
+			lessThanOrEqualsExpressionContext.getChild(2));
+	}
+
+	@Override
+	public String visitTerminal(TerminalNode terminalNode) {
+		if (Objects.equals(terminalNode.getText(), "<EOF>")) {
+			return null;
+		}
+
+		return _normalizeStringLiteral(terminalNode.getText());
+	}
+
+	@Override
+	public FilterByCount visitToLogicalAndExpression(
+		@NotNull
+			IndividualSegmentsExpressionParser.ToLogicalAndExpressionContext
+				toLogicalAndExpressionContext) {
+
+		Object object = visitChildren(toLogicalAndExpressionContext);
+
+		if (object instanceof FilterByCount.Event) {
+			return new FilterByCount(null, (FilterByCount.Event)object);
+		}
+
+		return (FilterByCount)object;
+	}
+
+	public static class FilterByCount {
+
+		public FilterByCount(Day day, Event event) {
+			_day = day;
+			_event = event;
+		}
+
+		public Day getDay() {
+			return _day;
+		}
+
+		public Event getEvent() {
+			return _event;
+		}
+
+		public JSONObject toJSONObject() {
+			if (_event != null) {
+				JSONObject jsonObject = _event.toJSONObject();
+
+				if (_day != null) {
+					jsonObject.put("day", _day.toJSONObject());
+				}
+
+				return jsonObject;
+			}
+
+			return null;
+		}
+
+		public static class Day {
+
+			public Day(String operator, String value) {
+				_operator = operator;
+				_value = value;
+			}
+
+			public String getOperator() {
+				return _operator;
+			}
+
+			public String getValue() {
+				return _value;
+			}
+
+			public JSONObject toJSONObject() {
+				return JSONUtil.put(
+					"operatorName", _operator
+				).put(
+					"value", _value
+				);
+			}
+
+			private final String _operator;
+			private final String _value;
+
+		}
+
+		public static class Event {
+
+			public Event(String event, String assetId) {
+				_event = event;
+				_assetId = assetId;
+			}
+
+			public String getAssetId() {
+				return _assetId;
+			}
+
+			public String getEvent() {
+				return _event;
+			}
+
+			public JSONObject toJSONObject() {
+				return JSONUtil.put(
+					"assetId", _assetId
+				).put(
+					"propertyName", _event
+				);
+			}
+
+			private final String _assetId;
+			private String _event;
+
+		}
+
+		private final Day _day;
+		private Event _event;
+
+	}
+
+	@Override
+	protected Object aggregateResult(Object query, Object object) {
+		if (query == null) {
+			return object;
+		}
+		else if (object == null) {
+			return query;
+		}
+
+		return object;
+	}
+
+	private FilterByCount.Day _getFilterByCountDay(
+		ParseTree leftParseTree, ParseTree operatorParseTree,
+		ParseTree rightParseTree) {
+
+		Object value = leftParseTree.accept(this);
+
+		if (!Objects.equals("day", value)) {
+			throw new UnsupportedOperationException(
+				"Unsupported operation with value " + value);
+		}
+
+		return new FilterByCount.Day(
+			(String)operatorParseTree.accept(this),
+			(String)rightParseTree.accept(this));
+	}
+
+	private String _normalizeStringLiteral(String literal) {
+		literal = StringUtil.unquote(literal);
+
+		return StringUtil.replace(
+			literal, StringPool.DOUBLE_APOSTROPHE, StringPool.APOSTROPHE);
+	}
+
+}

--- a/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/expression/JSONObjectIndividualSegmentsExpressionVisitorImpl.java
+++ b/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/expression/JSONObjectIndividualSegmentsExpressionVisitorImpl.java
@@ -1,0 +1,223 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.segments.asah.connector.internal.expression;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.segments.asah.connector.internal.expression.parser.IndividualSegmentsExpressionBaseVisitor;
+import com.liferay.segments.asah.connector.internal.expression.parser.IndividualSegmentsExpressionLexer;
+import com.liferay.segments.asah.connector.internal.expression.parser.IndividualSegmentsExpressionParser;
+
+import java.util.Objects;
+
+import org.antlr.v4.runtime.ANTLRInputStream;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.misc.NotNull;
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.antlr.v4.runtime.tree.RuleNode;
+import org.antlr.v4.runtime.tree.TerminalNode;
+
+/**
+ * @author Cristina González
+ */
+public class JSONObjectIndividualSegmentsExpressionVisitorImpl
+	extends IndividualSegmentsExpressionBaseVisitor<Object> {
+
+	@Override
+	public JSONObject visitAndExpression(
+		@NotNull IndividualSegmentsExpressionParser.AndExpressionContext
+			andExpressionContext) {
+
+		ParseTree parseTree1 = andExpressionContext.getChild(0);
+		ParseTree parseTree2 = andExpressionContext.getChild(2);
+
+		return _getConjunctionJSONObject(
+			"and", (JSONObject)parseTree1.accept(this),
+			(JSONObject)parseTree2.accept(this));
+	}
+
+	@Override
+	public Object visitBooleanParenthesis(
+		@NotNull IndividualSegmentsExpressionParser.BooleanParenthesisContext
+			booleanParenthesisContext) {
+
+		ParseTree parseTree = booleanParenthesisContext.getChild(1);
+
+		return parseTree.accept(this);
+	}
+
+	@Override
+	public Object visitChildren(@NotNull RuleNode node) {
+		Object result = defaultResult();
+
+		for (int i = 0; i < node.getChildCount(); i++) {
+			if (!shouldVisitNextChild(node, result)) {
+				break;
+			}
+
+			ParseTree parseTree = node.getChild(i);
+
+			Object object = parseTree.accept(this);
+
+			result = aggregateResult(result, object);
+		}
+
+		return result;
+	}
+
+	@Override
+	public JSONObject visitOrExpression(
+		@NotNull IndividualSegmentsExpressionParser.OrExpressionContext
+			orExpressionContext) {
+
+		ParseTree parseTree1 = orExpressionContext.getChild(0);
+		ParseTree parseTree2 = orExpressionContext.getChild(2);
+
+		return _getConjunctionJSONObject(
+			"or", (JSONObject)parseTree1.accept(this),
+			(JSONObject)parseTree2.accept(this));
+	}
+
+	@Override
+	public String visitStringLiteral(
+		@NotNull IndividualSegmentsExpressionParser.StringLiteralContext
+			stringLiteralContext) {
+
+		return _normalizeStringLiteral(stringLiteralContext.getText());
+	}
+
+	@Override
+	public String visitTerminal(TerminalNode terminalNode) {
+		if (Objects.equals(terminalNode.getText(), "<EOF>")) {
+			return null;
+		}
+
+		return _normalizeStringLiteral(terminalNode.getText());
+	}
+
+	@Override
+	public JSONObject visitToFilterByCountExpression(
+		@NotNull
+			IndividualSegmentsExpressionParser.ToFilterByCountExpressionContext
+				toFilterByCountExpressionContext) {
+
+		IndividualSegmentsExpressionParser.FilterByCountExpressionContext
+			filterByCountExpressionContext =
+				(IndividualSegmentsExpressionParser.
+					FilterByCountExpressionContext)
+						toFilterByCountExpressionContext.getChild(0);
+
+		Token token = filterByCountExpressionContext.filter;
+
+		String filterString = token.getText();
+
+		filterString = filterString.substring(2, filterString.length() - 2);
+
+		filterString = filterString.replaceAll("''", "'");
+
+		IndividualSegmentsExpressionParser individualSegmentsExpressionParser =
+			new IndividualSegmentsExpressionParser(
+				new CommonTokenStream(
+					new IndividualSegmentsExpressionLexer(
+						new ANTLRInputStream(filterString))));
+
+		IndividualSegmentsExpressionParser.ExpressionContext expressionContext =
+			individualSegmentsExpressionParser.expression();
+
+		Token tokenValue = filterByCountExpressionContext.value;
+
+		FilterByCountIndividualSegmentsExpressionVisitorImpl.FilterByCount
+			filterByCount =
+				(FilterByCountIndividualSegmentsExpressionVisitorImpl.
+					FilterByCount)expressionContext.accept(
+						new FilterByCountIndividualSegmentsExpressionVisitorImpl());
+
+		JSONObject jsonObject = filterByCount.toJSONObject();
+
+		return jsonObject.put(
+			"operatorName",
+			_normalizeOperator(filterByCountExpressionContext.operator)
+		).put(
+			"value", _normalizeStringLiteral(tokenValue.getText())
+		);
+	}
+
+	@Override
+	protected Object aggregateResult(Object query, Object object) {
+		if (query == null) {
+			return object;
+		}
+		else if (object == null) {
+			return query;
+		}
+
+		return object;
+	}
+
+	private JSONObject _getConjunctionJSONObject(
+		String operation, JSONObject leftJSONObject,
+		JSONObject rightJSONObject) {
+
+		String conjunctionName = leftJSONObject.getString("conjunctionName");
+
+		_groupCount++;
+
+		if (Validator.isNotNull(conjunctionName) &&
+			Objects.equals(
+				conjunctionName.toLowerCase(LocaleUtil.ROOT),
+				operation.toLowerCase(LocaleUtil.ROOT))) {
+
+			return JSONUtil.put(
+				"conjunctionName", operation
+			).put(
+				"groupId", "group_" + _groupCount
+			).put(
+				"items",
+				leftJSONObject.getJSONArray(
+					"items"
+				).put(
+					rightJSONObject
+				)
+			);
+		}
+
+		return JSONUtil.put(
+			"conjunctionName", StringUtil.lowerCase(String.valueOf(operation))
+		).put(
+			"groupId", "group_" + _groupCount
+		).put(
+			"items", JSONUtil.putAll(leftJSONObject, rightJSONObject)
+		);
+	}
+
+	private String _normalizeOperator(Token token) {
+		return _normalizeStringLiteral(StringUtil.toLowerCase(token.getText()));
+	}
+
+	private String _normalizeStringLiteral(String literal) {
+		literal = StringUtil.unquote(literal);
+
+		return StringUtil.replace(
+			literal, StringPool.DOUBLE_APOSTROPHE, StringPool.APOSTROPHE);
+	}
+
+	private int _groupCount;
+
+}

--- a/modules/dxp/apps/segments/segments-asah-connector/src/test/java/com/liferay/segments/asah/connector/internal/criteria/mapper/SegmentsCriteriaJSONObjectMapperImplTest.java
+++ b/modules/dxp/apps/segments/segments-asah-connector/src/test/java/com/liferay/segments/asah/connector/internal/criteria/mapper/SegmentsCriteriaJSONObjectMapperImplTest.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.segments.asah.connector.internal.criteria.mapper;
+
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.segments.criteria.Criteria;
+import com.liferay.segments.criteria.contributor.SegmentsCriteriaContributor;
+import com.liferay.segments.criteria.mapper.SegmentsCriteriaJSONObjectMapper;
+import com.liferay.segments.field.Field;
+
+import java.util.List;
+
+import javax.portlet.PortletRequest;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Cristina González
+ */
+public class SegmentsCriteriaJSONObjectMapperImplTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testToJSONObject() throws Exception {
+		SegmentsCriteriaJSONObjectMapper segmentsCriteriaJSONObjectMapper =
+			new SegmentsCriteriaJSONObjectMapperImpl();
+
+		SegmentsCriteriaContributor segmentsCriteriaContributor =
+			new SegmentsCriteriaContributorImpl();
+
+		Criteria criteria = new Criteria();
+
+		criteria.addCriterion(
+			segmentsCriteriaContributor.getKey(), Criteria.Type.ANALYTICS,
+			StringBundler.concat(
+				"activities.filterByCount(filter='(activityKey eq ",
+				"''Page#pageViewed#585976064510133365'' and day gt ",
+				"''last24Hours'')',operator='ge',value=1)"),
+			Criteria.Conjunction.AND);
+
+		JSONObject jsonObject = segmentsCriteriaJSONObjectMapper.toJSONObject(
+			criteria, segmentsCriteriaContributor);
+
+		Assert.assertEquals(
+			segmentsCriteriaContributor.getKey(),
+			jsonObject.get("propertyKey"));
+		Assert.assertEquals("and", jsonObject.get("conjunctionId"));
+		Assert.assertEquals(
+			StringBundler.concat(
+				"{\"groupId\":\"group_0\",\"items\":[{\"propertyName\":",
+				"\"pageViewed\",\"assetId\":\"585976064510133365\",\"day\":{",
+				"\"operatorName\":\"gt\",\"value\":\"last24Hours\"},",
+				"\"operatorName\":\"ge\",\"value\":\"1\"}],",
+				"\"conjunctionName\":\"and\"}"),
+			String.valueOf(jsonObject.get("query")));
+	}
+
+	private static class SegmentsCriteriaContributorImpl
+		implements SegmentsCriteriaContributor {
+
+		@Override
+		public JSONObject getCriteriaJSONObject(Criteria criteria) {
+			return null;
+		}
+
+		@Override
+		public EntityModel getEntityModel() {
+			return null;
+		}
+
+		@Override
+		public String getEntityName() {
+			return null;
+		}
+
+		@Override
+		public List<Field> getFields(PortletRequest portletRequest) {
+			return null;
+		}
+
+		@Override
+		public String getKey() {
+			return "KEY";
+		}
+
+		@Override
+		public Criteria.Type getType() {
+			return null;
+		}
+
+	}
+
+}

--- a/modules/dxp/apps/segments/segments-asah-connector/src/test/java/com/liferay/segments/asah/connector/internal/criteria/mapper/SegmentsCriteriaJSONObjectMapperImplTest.java
+++ b/modules/dxp/apps/segments/segments-asah-connector/src/test/java/com/liferay/segments/asah/connector/internal/criteria/mapper/SegmentsCriteriaJSONObjectMapperImplTest.java
@@ -15,9 +15,10 @@
 package com.liferay.segments.asah.connector.internal.criteria.mapper;
 
 import com.liferay.portal.kernel.json.JSONObject;
-import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.segments.asah.connector.internal.expression.parser.test.util.IndividualSegmentsExpressionUtil;
 import com.liferay.segments.criteria.Criteria;
 import com.liferay.segments.criteria.contributor.SegmentsCriteriaContributor;
 import com.liferay.segments.criteria.mapper.SegmentsCriteriaJSONObjectMapper;
@@ -54,10 +55,10 @@ public class SegmentsCriteriaJSONObjectMapperImplTest {
 
 		criteria.addCriterion(
 			segmentsCriteriaContributor.getKey(), Criteria.Type.ANALYTICS,
-			StringBundler.concat(
-				"activities.filterByCount(filter='(activityKey eq ",
-				"''Page#pageViewed#585976064510133365'' and day gt ",
-				"''last24Hours'')',operator='ge',value=1)"),
+			IndividualSegmentsExpressionUtil.getFilterByCount(
+				IndividualSegmentsExpressionUtil.getFilter(
+					"Page#pageViewed#585976064510133365", "gt", "last24Hours"),
+				"ge", 1),
 			Criteria.Conjunction.AND);
 
 		JSONObject jsonObject = segmentsCriteriaJSONObjectMapper.toJSONObject(
@@ -68,12 +69,30 @@ public class SegmentsCriteriaJSONObjectMapperImplTest {
 			jsonObject.get("propertyKey"));
 		Assert.assertEquals("and", jsonObject.get("conjunctionId"));
 		Assert.assertEquals(
-			StringBundler.concat(
-				"{\"groupId\":\"group_0\",\"items\":[{\"propertyName\":",
-				"\"pageViewed\",\"assetId\":\"585976064510133365\",\"day\":{",
-				"\"operatorName\":\"gt\",\"value\":\"last24Hours\"},",
-				"\"operatorName\":\"ge\",\"value\":\"1\"}],",
-				"\"conjunctionName\":\"and\"}"),
+			JSONUtil.put(
+				"conjunctionName", "and"
+			).put(
+				"groupId", "group_0"
+			).put(
+				"items",
+				JSONUtil.putAll(
+					JSONUtil.put(
+						"assetId", "585976064510133365"
+					).put(
+						"day",
+						JSONUtil.put(
+							"operatorName", "gt"
+						).put(
+							"value", "last24Hours"
+						)
+					).put(
+						"operatorName", "ge"
+					).put(
+						"propertyName", "pageViewed"
+					).put(
+						"value", "1"
+					))
+			).toString(),
 			String.valueOf(jsonObject.get("query")));
 	}
 

--- a/modules/dxp/apps/segments/segments-asah-connector/src/test/java/com/liferay/segments/asah/connector/internal/expression/FilterByCountIndividualSegmentsExpressionVisitorImplTest.java
+++ b/modules/dxp/apps/segments/segments-asah-connector/src/test/java/com/liferay/segments/asah/connector/internal/expression/FilterByCountIndividualSegmentsExpressionVisitorImplTest.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.segments.asah.connector.internal.expression;
+
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.segments.asah.connector.internal.expression.parser.IndividualSegmentsExpressionLexer;
+import com.liferay.segments.asah.connector.internal.expression.parser.IndividualSegmentsExpressionParser;
+
+import org.antlr.v4.runtime.ANTLRInputStream;
+import org.antlr.v4.runtime.CommonTokenStream;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Cristina González
+ */
+public class FilterByCountIndividualSegmentsExpressionVisitorImplTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testAccept() {
+		IndividualSegmentsExpressionParser individualSegmentsExpressionParser =
+			new IndividualSegmentsExpressionParser(
+				new CommonTokenStream(
+					new IndividualSegmentsExpressionLexer(
+						new ANTLRInputStream(
+							"activityKey eq " +
+								"'Page#pageViewed#545188693724480037' and " +
+									"day eq '2023-02-06'"))));
+
+		IndividualSegmentsExpressionParser.ExpressionContext expressionContext =
+			individualSegmentsExpressionParser.expression();
+
+		FilterByCountIndividualSegmentsExpressionVisitorImpl.FilterByCount
+			filterByCount =
+				(FilterByCountIndividualSegmentsExpressionVisitorImpl.
+					FilterByCount)expressionContext.accept(
+						new FilterByCountIndividualSegmentsExpressionVisitorImpl());
+
+		FilterByCountIndividualSegmentsExpressionVisitorImpl.FilterByCount.Day
+			day = filterByCount.getDay();
+
+		Assert.assertEquals("eq", day.getOperator());
+		Assert.assertEquals("2023-02-06", day.getValue());
+
+		FilterByCountIndividualSegmentsExpressionVisitorImpl.FilterByCount.Event
+			event = filterByCount.getEvent();
+
+		Assert.assertEquals("pageViewed", event.getEvent());
+		Assert.assertEquals("545188693724480037", event.getAssetId());
+	}
+
+	@Test
+	public void testAcceptWithoutDay() {
+		IndividualSegmentsExpressionParser individualSegmentsExpressionParser =
+			new IndividualSegmentsExpressionParser(
+				new CommonTokenStream(
+					new IndividualSegmentsExpressionLexer(
+						new ANTLRInputStream(
+							"activityKey eq " +
+								"'Page#pageViewed#545188693724480037'"))));
+
+		IndividualSegmentsExpressionParser.ExpressionContext expressionContext =
+			individualSegmentsExpressionParser.expression();
+
+		FilterByCountIndividualSegmentsExpressionVisitorImpl.FilterByCount
+			filterByCount =
+				(FilterByCountIndividualSegmentsExpressionVisitorImpl.
+					FilterByCount)expressionContext.accept(
+						new FilterByCountIndividualSegmentsExpressionVisitorImpl());
+
+		Assert.assertNull(filterByCount.getDay());
+
+		FilterByCountIndividualSegmentsExpressionVisitorImpl.FilterByCount.Event
+			event = filterByCount.getEvent();
+
+		Assert.assertEquals("pageViewed", event.getEvent());
+		Assert.assertEquals("545188693724480037", event.getAssetId());
+	}
+
+}

--- a/modules/dxp/apps/segments/segments-asah-connector/src/test/java/com/liferay/segments/asah/connector/internal/expression/FilterByCountIndividualSegmentsExpressionVisitorImplTest.java
+++ b/modules/dxp/apps/segments/segments-asah-connector/src/test/java/com/liferay/segments/asah/connector/internal/expression/FilterByCountIndividualSegmentsExpressionVisitorImplTest.java
@@ -17,6 +17,7 @@ package com.liferay.segments.asah.connector.internal.expression;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 import com.liferay.segments.asah.connector.internal.expression.parser.IndividualSegmentsExpressionLexer;
 import com.liferay.segments.asah.connector.internal.expression.parser.IndividualSegmentsExpressionParser;
+import com.liferay.segments.asah.connector.internal.expression.parser.test.util.IndividualSegmentsExpressionUtil;
 
 import org.antlr.v4.runtime.ANTLRInputStream;
 import org.antlr.v4.runtime.CommonTokenStream;
@@ -43,9 +44,9 @@ public class FilterByCountIndividualSegmentsExpressionVisitorImplTest {
 				new CommonTokenStream(
 					new IndividualSegmentsExpressionLexer(
 						new ANTLRInputStream(
-							"activityKey eq " +
-								"'Page#pageViewed#545188693724480037' and " +
-									"day eq '2023-02-06'"))));
+							IndividualSegmentsExpressionUtil.getFilter(
+								"Page#pageViewed#545188693724480037", "eq",
+								"2023-02-06")))));
 
 		IndividualSegmentsExpressionParser.ExpressionContext expressionContext =
 			individualSegmentsExpressionParser.expression();

--- a/modules/dxp/apps/segments/segments-asah-connector/src/test/java/com/liferay/segments/asah/connector/internal/expression/JSONObjectIndividualSegmentsExpressionVisitorImplTest.java
+++ b/modules/dxp/apps/segments/segments-asah-connector/src/test/java/com/liferay/segments/asah/connector/internal/expression/JSONObjectIndividualSegmentsExpressionVisitorImplTest.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.segments.asah.connector.internal.expression;
+
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.segments.asah.connector.internal.expression.parser.IndividualSegmentsExpressionLexer;
+import com.liferay.segments.asah.connector.internal.expression.parser.IndividualSegmentsExpressionParser;
+
+import org.antlr.v4.runtime.ANTLRInputStream;
+import org.antlr.v4.runtime.CommonTokenStream;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Cristina González
+ */
+public class JSONObjectIndividualSegmentsExpressionVisitorImplTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testAcceptMultipleFilterByCount() {
+		IndividualSegmentsExpressionParser individualSegmentsExpressionParser =
+			new IndividualSegmentsExpressionParser(
+				new CommonTokenStream(
+					new IndividualSegmentsExpressionLexer(
+						new ANTLRInputStream(
+							StringBundler.concat(
+								"activities.filterByCount(filter='",
+								"(activityKey eq ",
+								"''Page#pageViewed#545188693724480043'' and ",
+								"day gt ''last24Hours'')',operator='ge',",
+								"value=1)) and ",
+								"((activities.filterByCount(filter='",
+								"(activityKey eq ",
+								"''Page#pageViewed#545188693724480041'' and ",
+								"day lt ''2023-02-09'')',operator='ge',",
+								"value=1)) or ",
+								"(activities.filterByCount(filter='(",
+								"activityKey eq ",
+								"''Page#pageViewed#545188693724480037'' and ",
+								"day gt ''2023-02-08'')',",
+								"operator='ge',value=1")))));
+
+		IndividualSegmentsExpressionParser.ExpressionContext expressionContext =
+			individualSegmentsExpressionParser.expression();
+
+		JSONObject jsonObject = (JSONObject)expressionContext.accept(
+			new JSONObjectIndividualSegmentsExpressionVisitorImpl());
+
+		Assert.assertEquals(
+			StringBundler.concat(
+				"{\"groupId\":\"group_2\",\"items\":[",
+				"{\"propertyName\":\"pageViewed\",",
+				"\"assetId\":\"545188693724480043\",",
+				"\"day\":{\"operatorName\":\"gt\",\"value\":\"last24Hours\"},",
+				"\"operatorName\":\"ge\",\"value\":\"1\"},",
+				"{\"groupId\":\"group_1\",\"items\":[",
+				"{\"propertyName\":\"pageViewed\",",
+				"\"assetId\":\"545188693724480041\",",
+				"\"day\":{\"operatorName\":\"lt\",\"value\":\"2023-02-09\"},",
+				"\"operatorName\":\"ge\",\"value\":\"1\"},",
+				"{\"propertyName\":\"pageViewed\",",
+				"\"assetId\":\"545188693724480037\",",
+				"\"day\":{\"operatorName\":\"gt\",\"value\":\"2023-02-08\"},",
+				"\"operatorName\":\"ge\",\"value\":\"1\"}],",
+				"\"conjunctionName\":\"or\"}],",
+				"\"conjunctionName\":\"and\"}"),
+			jsonObject.toString());
+	}
+
+	@Test
+	public void testAcceptSimpleFilterByCount() {
+		IndividualSegmentsExpressionParser individualSegmentsExpressionParser =
+			new IndividualSegmentsExpressionParser(
+				new CommonTokenStream(
+					new IndividualSegmentsExpressionLexer(
+						new ANTLRInputStream(
+							StringBundler.concat(
+								"activities.filterByCount(filter='",
+								"(activityKey eq ",
+								"''Page#pageViewed#545188693724480037'' and ",
+								"day gt ''2023-02-07'')',",
+								"operator='ge',value=1)")))));
+
+		IndividualSegmentsExpressionParser.ExpressionContext expressionContext =
+			individualSegmentsExpressionParser.expression();
+
+		JSONObject jsonObject = (JSONObject)expressionContext.accept(
+			new JSONObjectIndividualSegmentsExpressionVisitorImpl());
+
+		Assert.assertEquals("1", jsonObject.get("value"));
+		Assert.assertEquals("545188693724480037", jsonObject.get("assetId"));
+		Assert.assertEquals("ge", jsonObject.get("operatorName"));
+		Assert.assertEquals("pageViewed", jsonObject.get("propertyName"));
+
+		JSONObject dayJSONObject = jsonObject.getJSONObject("day");
+
+		Assert.assertEquals("2023-02-07", dayJSONObject.get("value"));
+		Assert.assertEquals("gt", dayJSONObject.get("operatorName"));
+	}
+
+}

--- a/modules/dxp/apps/segments/segments-asah-connector/src/test/java/com/liferay/segments/asah/connector/internal/expression/JSONObjectIndividualSegmentsExpressionVisitorImplTest.java
+++ b/modules/dxp/apps/segments/segments-asah-connector/src/test/java/com/liferay/segments/asah/connector/internal/expression/JSONObjectIndividualSegmentsExpressionVisitorImplTest.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 import com.liferay.segments.asah.connector.internal.expression.parser.IndividualSegmentsExpressionLexer;
 import com.liferay.segments.asah.connector.internal.expression.parser.IndividualSegmentsExpressionParser;
+import com.liferay.segments.asah.connector.internal.expression.parser.test.util.IndividualSegmentsExpressionUtil;
 
 import org.antlr.v4.runtime.ANTLRInputStream;
 import org.antlr.v4.runtime.CommonTokenStream;
@@ -42,25 +43,19 @@ public class JSONObjectIndividualSegmentsExpressionVisitorImplTest {
 	@Test
 	public void testAcceptMultipleFilterByCount() {
 		String filter = StringBundler.concat(
-			String.format(
-				_FILTER_BY_COUNT,
-				String.format(
-					_FILTER, "Page#pageViewed#545188693724480043", "gt",
-					"last24Hours"),
+			IndividualSegmentsExpressionUtil.getFilterByCount(
+				IndividualSegmentsExpressionUtil.getFilter(
+					"Page#pageViewed#545188693724480043", "gt", "last24Hours"),
 				"ge", 1),
 			" and (",
-			String.format(
-				_FILTER_BY_COUNT,
-				String.format(
-					_FILTER, "Page#pageViewed#545188693724480041", "lt",
-					"2023-02-09"),
+			IndividualSegmentsExpressionUtil.getFilterByCount(
+				IndividualSegmentsExpressionUtil.getFilter(
+					"Page#pageViewed#545188693724480041", "lt", "2023-02-09"),
 				"ge", 1),
 			" or ",
-			String.format(
-				_FILTER_BY_COUNT,
-				String.format(
-					_FILTER, "Page#pageViewed#545188693724480037", "gt",
-					"2023-02-08"),
+			IndividualSegmentsExpressionUtil.getFilterByCount(
+				IndividualSegmentsExpressionUtil.getFilter(
+					"Page#pageViewed#545188693724480037", "gt", "2023-02-08"),
 				"ge", 1),
 			")");
 
@@ -151,10 +146,8 @@ public class JSONObjectIndividualSegmentsExpressionVisitorImplTest {
 				new CommonTokenStream(
 					new IndividualSegmentsExpressionLexer(
 						new ANTLRInputStream(
-							String.format(
-								_FILTER_BY_COUNT,
-								String.format(
-									_FILTER,
+							IndividualSegmentsExpressionUtil.getFilterByCount(
+								IndividualSegmentsExpressionUtil.getFilter(
 									"Page#pageViewed#545188693724480037", "gt",
 									"2023-02-07"),
 								"ge", 1)))));
@@ -175,11 +168,5 @@ public class JSONObjectIndividualSegmentsExpressionVisitorImplTest {
 		Assert.assertEquals("2023-02-07", dayJSONObject.get("value"));
 		Assert.assertEquals("gt", dayJSONObject.get("operatorName"));
 	}
-
-	private static final String _FILTER =
-		"(activityKey eq ''%s'' and day %s ''%s'')";
-
-	private static final String _FILTER_BY_COUNT =
-		"activities.filterByCount(filter='%s',operator='%s',value=%d)";
 
 }

--- a/modules/dxp/apps/segments/segments-asah-connector/src/test/java/com/liferay/segments/asah/connector/internal/expression/JSONObjectIndividualSegmentsExpressionVisitorImplTest.java
+++ b/modules/dxp/apps/segments/segments-asah-connector/src/test/java/com/liferay/segments/asah/connector/internal/expression/JSONObjectIndividualSegmentsExpressionVisitorImplTest.java
@@ -15,6 +15,7 @@
 package com.liferay.segments.asah.connector.internal.expression;
 
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 import com.liferay.segments.asah.connector.internal.expression.parser.IndividualSegmentsExpressionLexer;
@@ -40,27 +41,34 @@ public class JSONObjectIndividualSegmentsExpressionVisitorImplTest {
 
 	@Test
 	public void testAcceptMultipleFilterByCount() {
+		String filter = StringBundler.concat(
+			String.format(
+				_FILTER_BY_COUNT,
+				String.format(
+					_FILTER, "Page#pageViewed#545188693724480043", "gt",
+					"last24Hours"),
+				"ge", 1),
+			" and (",
+			String.format(
+				_FILTER_BY_COUNT,
+				String.format(
+					_FILTER, "Page#pageViewed#545188693724480041", "lt",
+					"2023-02-09"),
+				"ge", 1),
+			" or ",
+			String.format(
+				_FILTER_BY_COUNT,
+				String.format(
+					_FILTER, "Page#pageViewed#545188693724480037", "gt",
+					"2023-02-08"),
+				"ge", 1),
+			")");
+
 		IndividualSegmentsExpressionParser individualSegmentsExpressionParser =
 			new IndividualSegmentsExpressionParser(
 				new CommonTokenStream(
 					new IndividualSegmentsExpressionLexer(
-						new ANTLRInputStream(
-							StringBundler.concat(
-								"activities.filterByCount(filter='",
-								"(activityKey eq ",
-								"''Page#pageViewed#545188693724480043'' and ",
-								"day gt ''last24Hours'')',operator='ge',",
-								"value=1)) and ",
-								"((activities.filterByCount(filter='",
-								"(activityKey eq ",
-								"''Page#pageViewed#545188693724480041'' and ",
-								"day lt ''2023-02-09'')',operator='ge',",
-								"value=1)) or ",
-								"(activities.filterByCount(filter='(",
-								"activityKey eq ",
-								"''Page#pageViewed#545188693724480037'' and ",
-								"day gt ''2023-02-08'')',",
-								"operator='ge',value=1")))));
+						new ANTLRInputStream(filter))));
 
 		IndividualSegmentsExpressionParser.ExpressionContext expressionContext =
 			individualSegmentsExpressionParser.expression();
@@ -69,23 +77,70 @@ public class JSONObjectIndividualSegmentsExpressionVisitorImplTest {
 			new JSONObjectIndividualSegmentsExpressionVisitorImpl());
 
 		Assert.assertEquals(
-			StringBundler.concat(
-				"{\"groupId\":\"group_2\",\"items\":[",
-				"{\"propertyName\":\"pageViewed\",",
-				"\"assetId\":\"545188693724480043\",",
-				"\"day\":{\"operatorName\":\"gt\",\"value\":\"last24Hours\"},",
-				"\"operatorName\":\"ge\",\"value\":\"1\"},",
-				"{\"groupId\":\"group_1\",\"items\":[",
-				"{\"propertyName\":\"pageViewed\",",
-				"\"assetId\":\"545188693724480041\",",
-				"\"day\":{\"operatorName\":\"lt\",\"value\":\"2023-02-09\"},",
-				"\"operatorName\":\"ge\",\"value\":\"1\"},",
-				"{\"propertyName\":\"pageViewed\",",
-				"\"assetId\":\"545188693724480037\",",
-				"\"day\":{\"operatorName\":\"gt\",\"value\":\"2023-02-08\"},",
-				"\"operatorName\":\"ge\",\"value\":\"1\"}],",
-				"\"conjunctionName\":\"or\"}],",
-				"\"conjunctionName\":\"and\"}"),
+			JSONUtil.put(
+				"conjunctionName", "and"
+			).put(
+				"groupId", "group_2"
+			).put(
+				"items",
+				JSONUtil.putAll(
+					JSONUtil.put(
+						"assetId", "545188693724480043"
+					).put(
+						"day",
+						JSONUtil.put(
+							"operatorName", "gt"
+						).put(
+							"value", "last24Hours"
+						)
+					).put(
+						"operatorName", "ge"
+					).put(
+						"propertyName", "pageViewed"
+					).put(
+						"value", "1"
+					),
+					JSONUtil.put(
+						"conjunctionName", "or"
+					).put(
+						"groupId", "group_1"
+					).put(
+						"items",
+						JSONUtil.putAll(
+							JSONUtil.put(
+								"assetId", "545188693724480041"
+							).put(
+								"day",
+								JSONUtil.put(
+									"operatorName", "lt"
+								).put(
+									"value", "2023-02-09"
+								)
+							).put(
+								"operatorName", "ge"
+							).put(
+								"propertyName", "pageViewed"
+							).put(
+								"value", "1"
+							),
+							JSONUtil.put(
+								"assetId", "545188693724480037"
+							).put(
+								"day",
+								JSONUtil.put(
+									"operatorName", "gt"
+								).put(
+									"value", "2023-02-08"
+								)
+							).put(
+								"operatorName", "ge"
+							).put(
+								"propertyName", "pageViewed"
+							).put(
+								"value", "1"
+							))
+					))
+			).toString(),
 			jsonObject.toString());
 	}
 
@@ -96,12 +151,13 @@ public class JSONObjectIndividualSegmentsExpressionVisitorImplTest {
 				new CommonTokenStream(
 					new IndividualSegmentsExpressionLexer(
 						new ANTLRInputStream(
-							StringBundler.concat(
-								"activities.filterByCount(filter='",
-								"(activityKey eq ",
-								"''Page#pageViewed#545188693724480037'' and ",
-								"day gt ''2023-02-07'')',",
-								"operator='ge',value=1)")))));
+							String.format(
+								_FILTER_BY_COUNT,
+								String.format(
+									_FILTER,
+									"Page#pageViewed#545188693724480037", "gt",
+									"2023-02-07"),
+								"ge", 1)))));
 
 		IndividualSegmentsExpressionParser.ExpressionContext expressionContext =
 			individualSegmentsExpressionParser.expression();
@@ -109,8 +165,8 @@ public class JSONObjectIndividualSegmentsExpressionVisitorImplTest {
 		JSONObject jsonObject = (JSONObject)expressionContext.accept(
 			new JSONObjectIndividualSegmentsExpressionVisitorImpl());
 
-		Assert.assertEquals("1", jsonObject.get("value"));
-		Assert.assertEquals("545188693724480037", jsonObject.get("assetId"));
+		Assert.assertEquals(1, jsonObject.getInt("value"));
+		Assert.assertEquals(545188693724480037L, jsonObject.getLong("assetId"));
 		Assert.assertEquals("ge", jsonObject.get("operatorName"));
 		Assert.assertEquals("pageViewed", jsonObject.get("propertyName"));
 
@@ -119,5 +175,11 @@ public class JSONObjectIndividualSegmentsExpressionVisitorImplTest {
 		Assert.assertEquals("2023-02-07", dayJSONObject.get("value"));
 		Assert.assertEquals("gt", dayJSONObject.get("operatorName"));
 	}
+
+	private static final String _FILTER =
+		"(activityKey eq ''%s'' and day %s ''%s'')";
+
+	private static final String _FILTER_BY_COUNT =
+		"activities.filterByCount(filter='%s',operator='%s',value=%d)";
 
 }

--- a/modules/dxp/apps/segments/segments-asah-connector/src/test/java/com/liferay/segments/asah/connector/internal/expression/parser/test/util/IndividualSegmentsExpressionUtil.java
+++ b/modules/dxp/apps/segments/segments-asah-connector/src/test/java/com/liferay/segments/asah/connector/internal/expression/parser/test/util/IndividualSegmentsExpressionUtil.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.segments.asah.connector.internal.expression.parser.test.util;
+
+import com.liferay.portal.kernel.util.StringUtil;
+
+/**
+ * @author Cristina González
+ */
+public class IndividualSegmentsExpressionUtil {
+
+	public static String getFilter(
+		String activityKey, String operator, String value) {
+
+		return String.format(_FILTER, activityKey, operator, value);
+	}
+
+	public static String getFilterByCount(
+		String filter, String operator, int value) {
+
+		return String.format(
+			_FILTER_BY_COUNT, StringUtil.replace(filter, '\'', "''"), operator,
+			value);
+	}
+
+	private static final String _FILTER = "activityKey eq '%s' and day %s '%s'";
+
+	private static final String _FILTER_BY_COUNT =
+		"activities.filterByCount(filter='(%s)',operator='%s',value=%d)";
+
+}


### PR DESCRIPTION
Ci:forward fails because unrelated failing tests: https://github.com/liferay-tango/liferay-portal/pull/3248

Approved by QA in https://github.com/liferay-tango/liferay-portal/pull/3248#issuecomment-1431214977

Motivation
=======
In order to unify AC/DXP segments we need to be able to see Event AC Segments in DXP.

[View AC Event Segments in DXP](https://issues.liferay.com/browse/LPS-171785)
[Transform AC expression into a Valid frontend JSON format](https://issues.liferay.com/browse/LPS-175384 )

Proposed Solution
========
We have created a custom SegmentsCriteriaJSONObjectMapperImpl that can transform between AC grammar an the JSON expressions that are read by the fronted in segments-web

To implement this SegmentsCriteriaJSONObjectMapperImpl we have need to implement an JSONObjectIndividualSegmentsExpressionVisitorImpl that extends IndividualSegmentsExpressionBaseVisitor, so it can reads a AC Criteria and tranndform it to a valid JSON formant.

Steps to Verify:
----------------
No functional changes.

Unit/Integration tests are provided.