### PR TITLE
LPS-168452 Bundle blacklist integration test is aborted when running testAddToAndRemoveFromBlacklist

### DIFF
--- a/modules/apps/static/portal-bundle-blacklist/portal-bundle-blacklist-test/src/testIntegration/java/com/liferay/portal/bundle/blacklist/test/BundleBlacklistTest.java
+++ b/modules/apps/static/portal-bundle-blacklist/portal-bundle-blacklist-test/src/testIntegration/java/com/liferay/portal/bundle/blacklist/test/BundleBlacklistTest.java
@@ -41,7 +41,6 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -76,7 +75,7 @@ public class BundleBlacklistTest {
 		_bundleBlacklistConfiguration = OSGiServiceUtil.callService(
 			_bundleContext, ConfigurationAdmin.class,
 			configurationAdmin -> configurationAdmin.getConfiguration(
-				_CONFIG_NAME, null));
+				_CONFIG_NAME, StringPool.QUESTION));
 
 		_properties = _bundleBlacklistConfiguration.getProperties();
 
@@ -150,7 +149,6 @@ public class BundleBlacklistTest {
 		_updateConfiguration(_properties);
 	}
 
-	@Ignore
 	@Test
 	public void testAddToAndRemoveFromBlacklist() throws Exception {
 		Bundle bundle = _findBundle(_SYMBOLIC_NAME);
@@ -193,7 +191,6 @@ public class BundleBlacklistTest {
 			blacklistBundleSymbolicNames.contains(_SYMBOLIC_NAME));
 	}
 
-	@Ignore
 	@Test
 	public void testBundleBlacklist() throws Exception {
 		Bundle jarBundle = null;


### PR DESCRIPTION
Manual forward from https://github.com/liferay-usm/liferay-portal/pull/970

This is an update for [LPS-168452](https://issues.liferay.com/browse/LPS-168452).