### PR TITLE
COMMERCE-10711

### DIFF
--- a/modules/apps/commerce/commerce-product-test/src/testFunctional/macros/json/CommerceJSONProductsAPI.macro
+++ b/modules/apps/commerce/commerce-product-test/src/testFunctional/macros/json/CommerceJSONProductsAPI.macro
@@ -337,6 +337,40 @@ definition {
 		com.liferay.poshi.runner.util.JSONCurlUtil.post(${curl});
 	}
 
+	macro _addCommerceProductImageLinkedToOptionValue {
+		Variables.assertDefined(parameterList = "${productERC},${optionName},${optionValue}");
+
+		var baseURL = PropsUtil.get("portal.url");
+
+		if (!(isSet(imageTitle))) {
+			var imageTitle = "Simple Image Title API";
+		}
+
+		if (!(isSet(src))) {
+			var src = "${baseURL}/documents/d/guest/tree-png";
+		}
+
+		var curl = '''
+			${baseURL}/o/headless-commerce-admin-catalog/v1.0/products/by-externalReferenceCode/${productERC}/images \
+				-u test@liferay.com:test \
+				-H 'accept: application/json' \
+				-H 'Content-Type: application/json' \
+				-d '{
+					"options": {
+						"${optionName}": "${optionValue}"
+					},
+					"src": "${src}",
+					"title": {
+						"en_US": "${imageTitle}"
+					}
+				}'
+		''';
+
+		var responseBody = JSONCurlUtil.post(${curl});
+
+		return ${responseBody};
+	}
+
 	macro _addDiagramPin {
 		Variables.assertDefined(parameterList = "${pinType},${position},${positionX},${positionY},${quantity},${diagram}");
 

--- a/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CPCommerceProducts.testcase
+++ b/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CPCommerceProducts.testcase
@@ -1275,6 +1275,55 @@ definition {
 		}
 	}
 
+	@description = "This is a test for bug COMMERCE-10711. Verify a product image linked to an option value can be uploaded via headless API."
+	@priority = 3
+	test CanUploadProductImageLinkedToAnOptionValueViaAPI {
+		property portal.acceptance = "false";
+
+		task ("Given a Minium Site is created") {
+			CommerceAccelerators.initializeNewSiteViaAccelerator(siteName = "Minium");
+		}
+
+		task ("When an image linked to an option value for the product Brake Fluid is uploaded via API") {
+			var responseBody = CommerceJSONProductsAPI._addCommerceProductImageLinkedToOptionValue(
+				optionName = "package-quantity",
+				optionValue = 112,
+				productERC = "MIN93016minium-initializer");
+
+			var status = JSONUtil.getWithJSONPath(${responseBody}, "$..['status']");
+
+			if (${status} != "") {
+				fail("Something went wrong with the API call");
+			}
+		}
+
+		task ("Then the image is uploaded successfully") {
+			CommerceProducts.openProductsAdmin();
+
+			AppBuilderAdmin.searchByItem(itemName = "Brake Fluid");
+
+			CommerceNavigator.gotoEntry(entryName = "Brake Fluid");
+
+			CommerceEntry.gotoMenuTab(menuTab = "Media");
+
+			AssertElementPresent(
+				key_entryName = "Simple Image Title API",
+				locator1 = "CommerceEntry#TABLE_LIST_TITLE");
+		}
+
+		task ("And the option value is linked to the image") {
+			Click(
+				key_entryName = "Simple Image Title API",
+				locator1 = "CommerceEntry#TABLE_LIST_TITLE");
+
+			SelectFrame.selectFrameNoLoading(locator1 = "CommerceEntry#IFRAME_SIDE_PANEL");
+
+			AssertTextEquals(
+				locator1 = "Dropdown#SELECTED_VALUE",
+				value1 = 112);
+		}
+	}
+
 	@description = "This is a test for bug COMMERCE-9448. Verify a product image can be uploaded via headless API."
 	@priority = 3
 	test CanUploadProductImageViaAPI {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/jaxrs/exception/mapper/NoSuchOptionExceptionMapper.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/jaxrs/exception/mapper/NoSuchOptionExceptionMapper.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.headless.commerce.admin.catalog.internal.jaxrs.exception.mapper;
+
+import com.liferay.commerce.product.exception.NoSuchCPOptionException;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.BaseExceptionMapper;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.Problem;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Brian I. Kim
+ */
+@Component(
+	property = {
+		"osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Catalog)",
+		"osgi.jaxrs.extension=true",
+		"osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Inventory.NoSuchOptionExceptionMapper"
+	},
+	service = ExceptionMapper.class
+)
+public class NoSuchOptionExceptionMapper
+	extends BaseExceptionMapper<NoSuchCPOptionException> {
+
+	@Override
+	protected Problem getProblem(
+		NoSuchCPOptionException noSuchCPOptionException) {
+
+		return new Problem(Response.Status.CONFLICT, "CPOption not found");
+	}
+
+}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/jaxrs/exception/mapper/NoSuchOptionRelExceptionMapper.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/jaxrs/exception/mapper/NoSuchOptionRelExceptionMapper.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.headless.commerce.admin.catalog.internal.jaxrs.exception.mapper;
+
+import com.liferay.commerce.product.exception.NoSuchCPDefinitionOptionRelException;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.BaseExceptionMapper;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.Problem;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Brian I. Kim
+ */
+@Component(
+	property = {
+		"osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Catalog)",
+		"osgi.jaxrs.extension=true",
+		"osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Inventory.NoSuchOptionRelExceptionMapper"
+	},
+	service = ExceptionMapper.class
+)
+public class NoSuchOptionRelExceptionMapper
+	extends BaseExceptionMapper<NoSuchCPDefinitionOptionRelException> {
+
+	@Override
+	protected Problem getProblem(
+		NoSuchCPDefinitionOptionRelException
+			noSuchCPDefinitionOptionRelException) {
+
+		return new Problem(
+			Response.Status.CONFLICT, "CPDefinitionOptionRel not found");
+	}
+
+}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/jaxrs/exception/mapper/NoSuchOptionValueRelExceptionMapper.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/jaxrs/exception/mapper/NoSuchOptionValueRelExceptionMapper.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.headless.commerce.admin.catalog.internal.jaxrs.exception.mapper;
+
+import com.liferay.commerce.product.exception.NoSuchCPDefinitionOptionValueRelException;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.BaseExceptionMapper;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.Problem;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Brian I. Kim
+ */
+@Component(
+	property = {
+		"osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Catalog)",
+		"osgi.jaxrs.extension=true",
+		"osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Inventory.NoSuchOptionValueRelExceptionMapper"
+	},
+	service = ExceptionMapper.class
+)
+public class NoSuchOptionValueRelExceptionMapper
+	extends BaseExceptionMapper<NoSuchCPDefinitionOptionValueRelException> {
+
+	@Override
+	protected Problem getProblem(
+		NoSuchCPDefinitionOptionValueRelException
+			noSuchCPDefinitionOptionValueRelException) {
+
+		return new Problem(
+			Response.Status.CONFLICT, "CPDefinitionOptionValueRel not found");
+	}
+
+}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/AttachmentResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/AttachmentResourceImpl.java
@@ -19,7 +19,10 @@ import com.liferay.commerce.product.exception.NoSuchCPDefinitionException;
 import com.liferay.commerce.product.model.CPAttachmentFileEntry;
 import com.liferay.commerce.product.model.CPDefinition;
 import com.liferay.commerce.product.service.CPAttachmentFileEntryService;
+import com.liferay.commerce.product.service.CPDefinitionOptionRelService;
+import com.liferay.commerce.product.service.CPDefinitionOptionValueRelService;
 import com.liferay.commerce.product.service.CPDefinitionService;
+import com.liferay.commerce.product.service.CPOptionService;
 import com.liferay.headless.commerce.admin.catalog.dto.v1_0.Attachment;
 import com.liferay.headless.commerce.admin.catalog.dto.v1_0.AttachmentBase64;
 import com.liferay.headless.commerce.admin.catalog.dto.v1_0.AttachmentUrl;
@@ -381,6 +384,8 @@ public class AttachmentResourceImpl
 		CPAttachmentFileEntry cpAttachmentFileEntry =
 			AttachmentUtil.addOrUpdateCPAttachmentFileEntry(
 				cpDefinition.getGroupId(), _cpAttachmentFileEntryService,
+				_cpDefinitionOptionRelService,
+				_cpDefinitionOptionValueRelService, _cpOptionService,
 				_uniqueFileNameProvider, attachment,
 				_classNameLocalService.getClassNameId(
 					cpDefinition.getModelClassName()),
@@ -407,8 +412,9 @@ public class AttachmentResourceImpl
 
 		CPAttachmentFileEntry cpAttachmentFileEntry =
 			AttachmentUtil.addOrUpdateCPAttachmentFileEntry(
-				_cpAttachmentFileEntryService, _uniqueFileNameProvider,
-				attachmentBase64,
+				_cpAttachmentFileEntryService, _cpDefinitionOptionRelService,
+				_cpDefinitionOptionValueRelService, _cpOptionService,
+				_uniqueFileNameProvider, attachmentBase64,
 				_classNameLocalService.getClassNameId(
 					cpDefinition.getModelClassName()),
 				cpDefinition.getCPDefinitionId(), type, serviceContext);
@@ -433,8 +439,9 @@ public class AttachmentResourceImpl
 
 		CPAttachmentFileEntry cpAttachmentFileEntry =
 			AttachmentUtil.addOrUpdateCPAttachmentFileEntry(
-				_cpAttachmentFileEntryService, _uniqueFileNameProvider,
-				attachmentUrl,
+				_cpAttachmentFileEntryService, _cpDefinitionOptionRelService,
+				_cpDefinitionOptionValueRelService, _cpOptionService,
+				_uniqueFileNameProvider, attachmentUrl,
 				_classNameLocalService.getClassNameId(
 					cpDefinition.getModelClassName()),
 				cpDefinition.getCPDefinitionId(), type, serviceContext);
@@ -583,7 +590,17 @@ public class AttachmentResourceImpl
 	private CPAttachmentFileEntryService _cpAttachmentFileEntryService;
 
 	@Reference
+	private CPDefinitionOptionRelService _cpDefinitionOptionRelService;
+
+	@Reference
+	private CPDefinitionOptionValueRelService
+		_cpDefinitionOptionValueRelService;
+
+	@Reference
 	private CPDefinitionService _cpDefinitionService;
+
+	@Reference
+	private CPOptionService _cpOptionService;
 
 	@Reference
 	private ServiceContextHelper _serviceContextHelper;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/DiagramResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/DiagramResourceImpl.java
@@ -17,7 +17,10 @@ package com.liferay.headless.commerce.admin.catalog.internal.resource.v1_0;
 import com.liferay.commerce.product.exception.NoSuchCPDefinitionException;
 import com.liferay.commerce.product.model.CPDefinition;
 import com.liferay.commerce.product.service.CPAttachmentFileEntryService;
+import com.liferay.commerce.product.service.CPDefinitionOptionRelService;
+import com.liferay.commerce.product.service.CPDefinitionOptionValueRelService;
 import com.liferay.commerce.product.service.CPDefinitionService;
+import com.liferay.commerce.product.service.CPOptionService;
 import com.liferay.commerce.shop.by.diagram.model.CSDiagramSetting;
 import com.liferay.commerce.shop.by.diagram.service.CSDiagramSettingService;
 import com.liferay.headless.commerce.admin.catalog.dto.v1_0.Diagram;
@@ -100,8 +103,9 @@ public class DiagramResourceImpl
 
 		DiagramUtil.updateCSDiagramSetting(
 			contextCompany.getCompanyId(), _cpAttachmentFileEntryService,
-			csDiagramSetting, _csDiagramSettingService, diagram,
-			cpDefinition.getGroupId(),
+			_cpDefinitionOptionRelService, _cpDefinitionOptionValueRelService,
+			_cpOptionService, csDiagramSetting, _csDiagramSettingService,
+			diagram, cpDefinition.getGroupId(),
 			contextAcceptLanguage.getPreferredLocale(), _serviceContextHelper,
 			_uniqueFileNameProvider);
 
@@ -126,8 +130,9 @@ public class DiagramResourceImpl
 
 		CSDiagramSetting csDiagramSetting = DiagramUtil.addCSDiagramSetting(
 			contextCompany.getCompanyId(), _cpAttachmentFileEntryService,
-			cpDefinition.getCPDefinitionId(), _csDiagramSettingService, diagram,
-			cpDefinition.getGroupId(),
+			cpDefinition.getCPDefinitionId(), _cpDefinitionOptionRelService,
+			_cpDefinitionOptionValueRelService, _cpOptionService,
+			_csDiagramSettingService, diagram, cpDefinition.getGroupId(),
 			contextAcceptLanguage.getPreferredLocale(), _serviceContextHelper,
 			_uniqueFileNameProvider);
 
@@ -148,8 +153,9 @@ public class DiagramResourceImpl
 
 		CSDiagramSetting csDiagramSetting = DiagramUtil.addCSDiagramSetting(
 			contextCompany.getCompanyId(), _cpAttachmentFileEntryService,
-			cpDefinition.getCPDefinitionId(), _csDiagramSettingService, diagram,
-			cpDefinition.getGroupId(),
+			cpDefinition.getCPDefinitionId(), _cpDefinitionOptionRelService,
+			_cpDefinitionOptionValueRelService, _cpOptionService,
+			_csDiagramSettingService, diagram, cpDefinition.getGroupId(),
 			contextAcceptLanguage.getPreferredLocale(), _serviceContextHelper,
 			_uniqueFileNameProvider);
 
@@ -167,7 +173,17 @@ public class DiagramResourceImpl
 	private CPAttachmentFileEntryService _cpAttachmentFileEntryService;
 
 	@Reference
+	private CPDefinitionOptionRelService _cpDefinitionOptionRelService;
+
+	@Reference
+	private CPDefinitionOptionValueRelService
+		_cpDefinitionOptionValueRelService;
+
+	@Reference
 	private CPDefinitionService _cpDefinitionService;
+
+	@Reference
+	private CPOptionService _cpOptionService;
 
 	@Reference
 	private CSDiagramSettingService _csDiagramSettingService;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/ProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/ProductResourceImpl.java
@@ -923,6 +923,8 @@ public class ProductResourceImpl extends BaseProductResourceImpl {
 
 				AttachmentUtil.addOrUpdateCPAttachmentFileEntry(
 					cpDefinition.getGroupId(), _cpAttachmentFileEntryService,
+					_cpDefinitionOptionRelService,
+					_cpDefinitionOptionValueRelService, _cpOptionService,
 					_uniqueFileNameProvider, attachment,
 					_classNameLocalService.getClassNameId(
 						cpDefinition.getModelClassName()),
@@ -947,6 +949,8 @@ public class ProductResourceImpl extends BaseProductResourceImpl {
 
 				AttachmentUtil.addOrUpdateCPAttachmentFileEntry(
 					cpDefinition.getGroupId(), _cpAttachmentFileEntryService,
+					_cpDefinitionOptionRelService,
+					_cpDefinitionOptionValueRelService, _cpOptionService,
 					_uniqueFileNameProvider, attachment,
 					_classNameLocalService.getClassNameId(
 						cpDefinition.getModelClassName()),
@@ -1092,8 +1096,11 @@ public class ProductResourceImpl extends BaseProductResourceImpl {
 				DiagramUtil.addOrUpdateCSDiagramSetting(
 					contextCompany.getCompanyId(),
 					_cpAttachmentFileEntryService,
-					cpDefinition.getCPDefinitionId(), _csDiagramSettingService,
-					diagram, cpDefinition.getGroupId(),
+					cpDefinition.getCPDefinitionId(),
+					_cpDefinitionOptionRelService,
+					_cpDefinitionOptionValueRelService, _cpOptionService,
+					_csDiagramSettingService, diagram,
+					cpDefinition.getGroupId(),
 					contextAcceptLanguage.getPreferredLocale(),
 					_serviceContextHelper, _uniqueFileNameProvider);
 			}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/util/v1_0/AttachmentUtil.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/util/v1_0/AttachmentUtil.java
@@ -150,6 +150,9 @@ public class AttachmentUtil {
 
 	public static CPAttachmentFileEntry addOrUpdateCPAttachmentFileEntry(
 			CPAttachmentFileEntryService cpAttachmentFileEntryService,
+			CPDefinitionOptionRelService cpDefinitionOptionRelService,
+			CPDefinitionOptionValueRelService cpDefinitionOptionValueRelService,
+			CPOptionService cpOptionService,
 			UniqueFileNameProvider uniqueFileNameProvider,
 			AttachmentBase64 attachmentBase64, long classNameId, long classPK,
 			int type, ServiceContext serviceContext)
@@ -197,13 +200,19 @@ public class AttachmentUtil {
 			expirationDateConfig.getHour(), expirationDateConfig.getMinute(),
 			GetterUtil.get(attachmentBase64.getNeverExpire(), false),
 			getTitleMap(null, attachmentBase64.getTitle()),
-			GetterUtil.getString(attachmentBase64.getOptions()),
+			_getOptions(
+				cpDefinitionOptionRelService, cpDefinitionOptionValueRelService,
+				cpOptionService, attachmentBase64.getOptions(), classPK,
+				serviceContext.getCompanyId()),
 			GetterUtil.getDouble(attachmentBase64.getPriority()), type,
 			serviceContext);
 	}
 
 	public static CPAttachmentFileEntry addOrUpdateCPAttachmentFileEntry(
 			CPAttachmentFileEntryService cpAttachmentFileEntryService,
+			CPDefinitionOptionRelService cpDefinitionOptionRelService,
+			CPDefinitionOptionValueRelService cpDefinitionOptionValueRelService,
+			CPOptionService cpOptionService,
 			UniqueFileNameProvider uniqueFileNameProvider,
 			AttachmentUrl attachmentUrl, long classNameId, long classPK,
 			int type, ServiceContext serviceContext)
@@ -251,7 +260,10 @@ public class AttachmentUtil {
 			expirationDateConfig.getHour(), expirationDateConfig.getMinute(),
 			GetterUtil.get(attachmentUrl.getNeverExpire(), false),
 			getTitleMap(null, attachmentUrl.getTitle()),
-			GetterUtil.getString(attachmentUrl.getOptions()),
+			_getOptions(
+				cpDefinitionOptionRelService, cpDefinitionOptionValueRelService,
+				cpOptionService, attachmentUrl.getOptions(), classPK,
+				serviceContext.getCompanyId()),
 			GetterUtil.getDouble(attachmentUrl.getPriority()), type,
 			serviceContext);
 	}
@@ -259,6 +271,9 @@ public class AttachmentUtil {
 	public static CPAttachmentFileEntry addOrUpdateCPAttachmentFileEntry(
 			long groupId,
 			CPAttachmentFileEntryService cpAttachmentFileEntryService,
+			CPDefinitionOptionRelService cpDefinitionOptionRelService,
+			CPDefinitionOptionValueRelService cpDefinitionOptionValueRelService,
+			CPOptionService cpOptionService,
 			UniqueFileNameProvider uniqueFileNameProvider,
 			Attachment attachment, long classNameId, long classPK, int type,
 			ServiceContext serviceContext)
@@ -312,7 +327,10 @@ public class AttachmentUtil {
 			expirationDateConfig.getHour(), expirationDateConfig.getMinute(),
 			GetterUtil.get(attachment.getNeverExpire(), false),
 			getTitleMap(null, attachment.getTitle()),
-			GetterUtil.getString(attachment.getOptions()),
+			_getOptions(
+				cpDefinitionOptionRelService, cpDefinitionOptionValueRelService,
+				cpOptionService, attachment.getOptions(), classPK,
+				serviceContext.getCompanyId()),
 			GetterUtil.getDouble(attachment.getPriority()), type,
 			cloneServiceContext);
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/util/v1_0/DiagramUtil.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/util/v1_0/DiagramUtil.java
@@ -17,6 +17,9 @@ package com.liferay.headless.commerce.admin.catalog.internal.util.v1_0;
 import com.liferay.commerce.product.model.CPAttachmentFileEntry;
 import com.liferay.commerce.product.model.CPDefinition;
 import com.liferay.commerce.product.service.CPAttachmentFileEntryService;
+import com.liferay.commerce.product.service.CPDefinitionOptionRelService;
+import com.liferay.commerce.product.service.CPDefinitionOptionValueRelService;
+import com.liferay.commerce.product.service.CPOptionService;
 import com.liferay.commerce.shop.by.diagram.constants.CSDiagramSettingsConstants;
 import com.liferay.commerce.shop.by.diagram.model.CSDiagramSetting;
 import com.liferay.commerce.shop.by.diagram.service.CSDiagramSettingService;
@@ -43,6 +46,9 @@ public class DiagramUtil {
 			long companyId,
 			CPAttachmentFileEntryService cpAttachmentFileEntryService,
 			long cpDefinitionId,
+			CPDefinitionOptionRelService cpDefinitionOptionRelService,
+			CPDefinitionOptionValueRelService cpDefinitionOptionValueRelService,
+			CPOptionService cpOptionService,
 			CSDiagramSettingService csDiagramSettingService, Diagram diagram,
 			long groupId, Locale locale,
 			ServiceContextHelper serviceContextHelper,
@@ -52,8 +58,10 @@ public class DiagramUtil {
 		diagram = _addOrUpdateDiagramImage(
 			ClassNameLocalServiceUtil.getClassNameId(
 				CPDefinition.class.getName()),
-			cpDefinitionId, companyId, cpAttachmentFileEntryService, diagram,
-			groupId, locale, serviceContextHelper, uniqueFileNameProvider);
+			cpDefinitionId, companyId, cpAttachmentFileEntryService,
+			cpDefinitionOptionRelService, cpDefinitionOptionValueRelService,
+			cpOptionService, diagram, groupId, locale, serviceContextHelper,
+			uniqueFileNameProvider);
 
 		return csDiagramSettingService.addCSDiagramSetting(
 			cpDefinitionId, GetterUtil.getLong(diagram.getImageId()),
@@ -66,6 +74,9 @@ public class DiagramUtil {
 			long companyId,
 			CPAttachmentFileEntryService cpAttachmentFileEntryService,
 			long cpDefinitionId,
+			CPDefinitionOptionRelService cpDefinitionOptionRelService,
+			CPDefinitionOptionValueRelService cpDefinitionOptionValueRelService,
+			CPOptionService cpOptionService,
 			CSDiagramSettingService csDiagramSettingService, Diagram diagram,
 			long groupId, Locale locale,
 			ServiceContextHelper serviceContextHelper,
@@ -79,20 +90,24 @@ public class DiagramUtil {
 		if (csDiagramSetting == null) {
 			return addCSDiagramSetting(
 				companyId, cpAttachmentFileEntryService, cpDefinitionId,
-				csDiagramSettingService, diagram, groupId, locale,
-				serviceContextHelper, uniqueFileNameProvider);
+				cpDefinitionOptionRelService, cpDefinitionOptionValueRelService,
+				cpOptionService, csDiagramSettingService, diagram, groupId,
+				locale, serviceContextHelper, uniqueFileNameProvider);
 		}
 
 		return updateCSDiagramSetting(
-			companyId, cpAttachmentFileEntryService, csDiagramSetting,
-			csDiagramSettingService, diagram, groupId, locale,
-			serviceContextHelper, uniqueFileNameProvider);
+			companyId, cpAttachmentFileEntryService,
+			cpDefinitionOptionRelService, cpDefinitionOptionValueRelService,
+			cpOptionService, csDiagramSetting, csDiagramSettingService, diagram,
+			groupId, locale, serviceContextHelper, uniqueFileNameProvider);
 	}
 
 	public static CSDiagramSetting updateCSDiagramSetting(
 			long companyId,
 			CPAttachmentFileEntryService cpAttachmentFileEntryService,
-			CSDiagramSetting csDiagramSetting,
+			CPDefinitionOptionRelService cpDefinitionOptionRelService,
+			CPDefinitionOptionValueRelService cpDefinitionOptionValueRelService,
+			CPOptionService cpOptionService, CSDiagramSetting csDiagramSetting,
 			CSDiagramSettingService csDiagramSettingService, Diagram diagram,
 			long groupId, Locale locale,
 			ServiceContextHelper serviceContextHelper,
@@ -103,8 +118,9 @@ public class DiagramUtil {
 			ClassNameLocalServiceUtil.getClassNameId(
 				CPDefinition.class.getName()),
 			csDiagramSetting.getCPDefinitionId(), companyId,
-			cpAttachmentFileEntryService, diagram, groupId, locale,
-			serviceContextHelper, uniqueFileNameProvider);
+			cpAttachmentFileEntryService, cpDefinitionOptionRelService,
+			cpDefinitionOptionValueRelService, cpOptionService, diagram,
+			groupId, locale, serviceContextHelper, uniqueFileNameProvider);
 
 		return csDiagramSettingService.updateCSDiagramSetting(
 			csDiagramSetting.getCSDiagramSettingId(),
@@ -122,8 +138,10 @@ public class DiagramUtil {
 	private static Diagram _addOrUpdateDiagramImage(
 			long classNameId, long classPK, long companyId,
 			CPAttachmentFileEntryService cpAttachmentFileEntryService,
-			Diagram diagram, long groupId, Locale locale,
-			ServiceContextHelper serviceContextHelper,
+			CPDefinitionOptionRelService cpDefinitionOptionRelService,
+			CPDefinitionOptionValueRelService cpDefinitionOptionValueRelService,
+			CPOptionService cpOptionService, Diagram diagram, long groupId,
+			Locale locale, ServiceContextHelper serviceContextHelper,
 			UniqueFileNameProvider uniqueFileNameProvider)
 		throws Exception {
 
@@ -133,9 +151,10 @@ public class DiagramUtil {
 
 		CPAttachmentFileEntry cpAttachmentFileEntry =
 			AttachmentUtil.addOrUpdateCPAttachmentFileEntry(
-				cpAttachmentFileEntryService, uniqueFileNameProvider,
-				diagram.getAttachmentBase64(), classNameId, classPK,
-				CSDiagramSettingsConstants.TYPE_DIAGRAM,
+				cpAttachmentFileEntryService, cpDefinitionOptionRelService,
+				cpDefinitionOptionValueRelService, cpOptionService,
+				uniqueFileNameProvider, diagram.getAttachmentBase64(),
+				classNameId, classPK, CSDiagramSettingsConstants.TYPE_DIAGRAM,
 				_getDiagramServiceContext(
 					companyId, diagram, groupId, locale, serviceContextHelper));
 


### PR DESCRIPTION
Resent from: https://github.com/brianchandotcom/liferay-portal/pull/130432

https://issues.liferay.com/browse/COMMERCE-10711


@brianchandotcom , this should be the exception because we are handling `Rel` updates in headless API, but we do not provide their own classes to handle this. We already have examples in code where we have `RelExceptionMappers` that are not dependent on the REST tier names.

At best, we can do following:
`NoSuchOptionExceptionMapper.java`
`NoSuchOptionRelExceptionMapper.java`
`NoSuchOptionValueRelExceptionMapper.java`