### PR TITLE
LPS-173137: Support PATCH and UPDATE by parentTaxonomyCategory and taxonomyVocabularyId for TaxonomyCategory entity

### DIFF
--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/dto/v1_0/TaxonomyCategory.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/dto/v1_0/TaxonomyCategory.java
@@ -453,7 +453,7 @@ public class TaxonomyCategory implements Serializable {
 	}
 
 	@GraphQLField(description = "The category's parent category, if it exists.")
-	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected ParentTaxonomyCategory parentTaxonomyCategory;
 
 	@Schema(

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/resources/com/liferay/headless/admin/taxonomy/dto/v1_0/packageinfo
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/resources/com/liferay/headless/admin/taxonomy/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 4.1.0
+version 4.1.1

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/rest-openapi.yaml
@@ -207,7 +207,6 @@ components:
                             type: integer
                         name:
                             type: string
-                    readOnly: true
                     type: object
                 parentTaxonomyVocabulary:
                     description:

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyCategoryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyCategoryResourceImpl.java
@@ -223,7 +223,7 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-taxonomy/v1.0/taxonomy-categories/{parentTaxonomyCategoryId}/taxonomy-categories' -d $'{"description": ___, "description_i18n": ___, "externalReferenceCode": ___, "name": ___, "name_i18n": ___, "taxonomyCategoryProperties": ___, "taxonomyVocabularyId": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-taxonomy/v1.0/taxonomy-categories/{parentTaxonomyCategoryId}/taxonomy-categories' -d $'{"description": ___, "description_i18n": ___, "externalReferenceCode": ___, "name": ___, "name_i18n": ___, "parentTaxonomyCategory": ___, "taxonomyCategoryProperties": ___, "taxonomyVocabularyId": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Inserts a new child taxonomy category."
@@ -384,7 +384,7 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PATCH' 'http://localhost:8080/o/headless-admin-taxonomy/v1.0/taxonomy-categories/{taxonomyCategoryId}' -d $'{"description": ___, "description_i18n": ___, "externalReferenceCode": ___, "name": ___, "name_i18n": ___, "taxonomyCategoryProperties": ___, "taxonomyVocabularyId": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PATCH' 'http://localhost:8080/o/headless-admin-taxonomy/v1.0/taxonomy-categories/{taxonomyCategoryId}' -d $'{"description": ___, "description_i18n": ___, "externalReferenceCode": ___, "name": ___, "name_i18n": ___, "parentTaxonomyCategory": ___, "taxonomyCategoryProperties": ___, "taxonomyVocabularyId": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Updates only the fields received in the request body. Other fields are left untouched."
@@ -494,7 +494,7 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/headless-admin-taxonomy/v1.0/taxonomy-categories/{taxonomyCategoryId}' -d $'{"description": ___, "description_i18n": ___, "externalReferenceCode": ___, "name": ___, "name_i18n": ___, "taxonomyCategoryProperties": ___, "taxonomyVocabularyId": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/headless-admin-taxonomy/v1.0/taxonomy-categories/{taxonomyCategoryId}' -d $'{"description": ___, "description_i18n": ___, "externalReferenceCode": ___, "name": ___, "name_i18n": ___, "parentTaxonomyCategory": ___, "taxonomyCategoryProperties": ___, "taxonomyVocabularyId": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Replaces the taxonomy category with the information sent in the request body. Any missing fields are deleted unless they are required."
@@ -787,7 +787,7 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-taxonomy/v1.0/taxonomy-vocabularies/{taxonomyVocabularyId}/taxonomy-categories' -d $'{"description": ___, "description_i18n": ___, "externalReferenceCode": ___, "name": ___, "name_i18n": ___, "taxonomyCategoryProperties": ___, "taxonomyVocabularyId": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-taxonomy/v1.0/taxonomy-vocabularies/{taxonomyVocabularyId}/taxonomy-categories' -d $'{"description": ___, "description_i18n": ___, "externalReferenceCode": ___, "name": ___, "name_i18n": ___, "parentTaxonomyCategory": ___, "taxonomyCategoryProperties": ___, "taxonomyVocabularyId": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Inserts a new taxonomy category in a taxonomy vocabulary."
@@ -979,7 +979,7 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/headless-admin-taxonomy/v1.0/taxonomy-vocabularies/{taxonomyVocabularyId}/taxonomy-categories/by-external-reference-code/{externalReferenceCode}' -d $'{"description": ___, "description_i18n": ___, "externalReferenceCode": ___, "name": ___, "name_i18n": ___, "taxonomyCategoryProperties": ___, "taxonomyVocabularyId": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/headless-admin-taxonomy/v1.0/taxonomy-vocabularies/{taxonomyVocabularyId}/taxonomy-categories/by-external-reference-code/{externalReferenceCode}' -d $'{"description": ___, "description_i18n": ___, "externalReferenceCode": ___, "name": ___, "name_i18n": ___, "parentTaxonomyCategory": ___, "taxonomyCategoryProperties": ___, "taxonomyVocabularyId": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Updates the site's taxonomy category with the given external reference code, or creates it if it not exists."

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyCategoryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyCategoryResourceImpl.java
@@ -294,10 +294,11 @@ public class TaxonomyCategoryResourceImpl
 
 		AssetCategory assetCategory = _getAssetCategory(taxonomyCategoryId);
 
-		long vocabularyId = _getVocabularyId(assetCategory, taxonomyCategory);
+		long assetVocabularyId = _getAssetVocabularyId(
+			assetCategory, taxonomyCategory);
 
-		long parentCategoryId = _getParentTaxonomyCategoryId(
-			assetCategory, taxonomyCategory, vocabularyId);
+		long parentAssetCategoryId = _getParentAssetCategoryId(
+			assetCategory, taxonomyCategory, assetVocabularyId);
 
 		if (!ArrayUtil.contains(
 				assetCategory.getAvailableLanguageIds(),
@@ -332,8 +333,8 @@ public class TaxonomyCategoryResourceImpl
 		return _toTaxonomyCategory(
 			_assetCategoryLocalService.updateCategory(
 				contextUser.getUserId(), assetCategory.getCategoryId(),
-				parentCategoryId, assetCategory.getTitleMap(),
-				assetCategory.getDescriptionMap(), vocabularyId,
+				parentAssetCategoryId, assetCategory.getTitleMap(),
+				assetCategory.getDescriptionMap(), assetVocabularyId,
 				_merge(
 					_assetCategoryPropertyLocalService.getCategoryProperties(
 						assetCategory.getCategoryId()),
@@ -462,6 +463,23 @@ public class TaxonomyCategoryResourceImpl
 			GetterUtil.getLong(taxonomyCategoryId));
 	}
 
+	private long _getAssetVocabularyId(
+			AssetCategory assetCategory, TaxonomyCategory taxonomyCategory)
+		throws Exception {
+
+		if ((taxonomyCategory.getTaxonomyVocabularyId() != null) &&
+			(taxonomyCategory.getTaxonomyVocabularyId() > 0)) {
+
+			AssetVocabulary existingAssetVocabulary =
+				_assetVocabularyService.getVocabulary(
+					taxonomyCategory.getTaxonomyVocabularyId());
+
+			return existingAssetVocabulary.getVocabularyId();
+		}
+
+		return assetCategory.getVocabularyId();
+	}
+
 	private Page<TaxonomyCategory> _getCategoriesPage(
 			Map<String, Map<String, String>> actions, Aggregation aggregation,
 			UnsafeConsumer<BooleanQuery, Exception> booleanQueryUnsafeConsumer,
@@ -484,7 +502,7 @@ public class TaxonomyCategoryResourceImpl
 						document.get(Field.ASSET_CATEGORY_ID)))));
 	}
 
-	private long _getParentTaxonomyCategoryId(
+	private long _getParentAssetCategoryId(
 			AssetCategory assetCategory, TaxonomyCategory taxonomyCategory,
 			long vocabularyId)
 		throws Exception {
@@ -559,23 +577,6 @@ public class TaxonomyCategoryResourceImpl
 					"assetCategoryId = this_.categoryId)"));
 
 		return _assetCategoryLocalService.dynamicQueryCount(dynamicQuery);
-	}
-
-	private long _getVocabularyId(
-			AssetCategory assetCategory, TaxonomyCategory taxonomyCategory)
-		throws Exception {
-
-		if ((taxonomyCategory.getTaxonomyVocabularyId() != null) &&
-			(taxonomyCategory.getTaxonomyVocabularyId() > 0)) {
-
-			AssetVocabulary existingAssetVocabulary =
-				_assetVocabularyService.getVocabulary(
-					taxonomyCategory.getTaxonomyVocabularyId());
-
-			return existingAssetVocabulary.getVocabularyId();
-		}
-
-		return assetCategory.getVocabularyId();
 	}
 
 	private String[] _merge(
@@ -684,10 +685,11 @@ public class TaxonomyCategoryResourceImpl
 			AssetCategory assetCategory, TaxonomyCategory taxonomyCategory)
 		throws Exception {
 
-		long vocabularyId = _getVocabularyId(assetCategory, taxonomyCategory);
+		long assetVocabularyId = _getAssetVocabularyId(
+			assetCategory, taxonomyCategory);
 
-		long parentCategoryId = _getParentTaxonomyCategoryId(
-			assetCategory, taxonomyCategory, vocabularyId);
+		long parentAssetCategoryId = _getParentAssetCategoryId(
+			assetCategory, taxonomyCategory, assetVocabularyId);
 
 		Map<Locale, String> titleMap = LocalizedMapUtil.getLocalizedMap(
 			contextAcceptLanguage.getPreferredLocale(),
@@ -709,8 +711,8 @@ public class TaxonomyCategoryResourceImpl
 		assetCategory.setDescriptionMap(descriptionMap);
 
 		return _assetCategoryService.updateCategory(
-			assetCategory.getCategoryId(), parentCategoryId, titleMap,
-			descriptionMap, vocabularyId,
+			assetCategory.getCategoryId(), parentAssetCategoryId, titleMap,
+			descriptionMap, assetVocabularyId,
 			_toStringArray(taxonomyCategory.getTaxonomyCategoryProperties()),
 			ServiceContextRequestUtil.createServiceContext(
 				assetCategory.getGroupId(), contextHttpServletRequest,

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyCategoryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyCategoryResourceImpl.java
@@ -568,11 +568,11 @@ public class TaxonomyCategoryResourceImpl
 		if ((taxonomyCategory.getTaxonomyVocabularyId() != null) &&
 			(taxonomyCategory.getTaxonomyVocabularyId() > 0)) {
 
-			AssetVocabulary newAssetVocabulary =
+			AssetVocabulary existingAssetVocabulary =
 				_assetVocabularyService.getVocabulary(
 					taxonomyCategory.getTaxonomyVocabularyId());
 
-			return newAssetVocabulary.getVocabularyId();
+			return existingAssetVocabulary.getVocabularyId();
 		}
 
 		return assetCategory.getVocabularyId();

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyCategoryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyCategoryResourceImpl.java
@@ -468,7 +468,8 @@ public class TaxonomyCategoryResourceImpl
 		throws Exception {
 
 		if ((taxonomyCategory.getTaxonomyVocabularyId() != null) &&
-			(taxonomyCategory.getTaxonomyVocabularyId() > 0)) {
+			(taxonomyCategory.getTaxonomyVocabularyId() !=
+				assetCategory.getVocabularyId())) {
 
 			AssetVocabulary existingAssetVocabulary =
 				_assetVocabularyService.getVocabulary(

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyCategoryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyCategoryResourceImpl.java
@@ -293,6 +293,8 @@ public class TaxonomyCategoryResourceImpl
 
 		AssetCategory assetCategory = _getAssetCategory(taxonomyCategoryId);
 
+		long vocabularyId = _getVocabularyId(assetCategory, taxonomyCategory);
+
 		if (!ArrayUtil.contains(
 				assetCategory.getAvailableLanguageIds(),
 				contextAcceptLanguage.getPreferredLanguageId())) {
@@ -328,7 +330,7 @@ public class TaxonomyCategoryResourceImpl
 				contextUser.getUserId(), assetCategory.getCategoryId(),
 				assetCategory.getParentCategoryId(),
 				assetCategory.getTitleMap(), assetCategory.getDescriptionMap(),
-				assetCategory.getVocabularyId(),
+				vocabularyId,
 				_merge(
 					_assetCategoryPropertyLocalService.getCategoryProperties(
 						assetCategory.getCategoryId()),
@@ -524,6 +526,21 @@ public class TaxonomyCategoryResourceImpl
 		return _assetCategoryLocalService.dynamicQueryCount(dynamicQuery);
 	}
 
+	private long _getVocabularyId(
+			AssetCategory assetCategory, TaxonomyCategory taxonomyCategory)
+		throws Exception {
+
+		if (taxonomyCategory.getTaxonomyVocabularyId() != null) {
+			AssetVocabulary newAssetVocabulary =
+				_assetVocabularyService.fetchVocabulary(
+					taxonomyCategory.getTaxonomyVocabularyId());
+
+			return newAssetVocabulary.getVocabularyId();
+		}
+
+		return assetCategory.getVocabularyId();
+	}
+
 	private String[] _merge(
 		List<AssetCategoryProperty> assetCategoryProperties,
 		TaxonomyCategoryProperty[] taxonomyCategoryProperties) {
@@ -630,6 +647,8 @@ public class TaxonomyCategoryResourceImpl
 			AssetCategory assetCategory, TaxonomyCategory taxonomyCategory)
 		throws Exception {
 
+		long vocabularyId = _getVocabularyId(assetCategory, taxonomyCategory);
+
 		Map<Locale, String> titleMap = LocalizedMapUtil.getLocalizedMap(
 			contextAcceptLanguage.getPreferredLocale(),
 			taxonomyCategory.getName(), taxonomyCategory.getName_i18n(),
@@ -651,7 +670,7 @@ public class TaxonomyCategoryResourceImpl
 
 		return _assetCategoryService.updateCategory(
 			assetCategory.getCategoryId(), assetCategory.getParentCategoryId(),
-			titleMap, descriptionMap, assetCategory.getVocabularyId(),
+			titleMap, descriptionMap, vocabularyId,
 			_toStringArray(taxonomyCategory.getTaxonomyCategoryProperties()),
 			ServiceContextRequestUtil.createServiceContext(
 				assetCategory.getGroupId(), contextHttpServletRequest,

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyCategoryResourceTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyCategoryResourceTest.java
@@ -26,7 +26,9 @@ import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 
+import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
@@ -45,6 +47,33 @@ public class TaxonomyCategoryResourceTest
 			UserLocalServiceUtil.getDefaultUserId(testGroup.getCompanyId()),
 			testGroup.getGroupId(), RandomTestUtil.randomString(),
 			new ServiceContext());
+	}
+
+	@Override
+	@Test
+	public void testPatchTaxonomyCategory() throws Exception {
+		super.testPatchTaxonomyCategory();
+
+		// Patch a TaxonomyCategory to a different TaxonomyVocabulary
+
+		TaxonomyCategory taxonomyCategory =
+			testPatchTaxonomyCategory_addTaxonomyCategory();
+
+		AssetVocabulary assetVocabulary = _createAssetVocabulary();
+
+		TaxonomyCategory patchTaxonomyCategory =
+			taxonomyCategoryResource.patchTaxonomyCategory(
+				taxonomyCategory.getId(),
+				new TaxonomyCategory() {
+					{
+						taxonomyVocabularyId =
+							assetVocabulary.getVocabularyId();
+					}
+				});
+
+		Assert.assertEquals(
+			patchTaxonomyCategory.getTaxonomyVocabularyId(),
+			Long.valueOf(assetVocabulary.getVocabularyId()));
 	}
 
 	@Override
@@ -189,6 +218,13 @@ public class TaxonomyCategoryResourceTest
 		throws Exception {
 
 		return testGetTaxonomyCategory_addTaxonomyCategory();
+	}
+
+	private AssetVocabulary _createAssetVocabulary() throws Exception {
+		return AssetVocabularyLocalServiceUtil.addVocabulary(
+			UserLocalServiceUtil.getDefaultUserId(testGroup.getCompanyId()),
+			testGroup.getGroupId(), RandomTestUtil.randomString(),
+			new ServiceContext());
 	}
 
 	private AssetVocabulary _assetVocabulary;

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyCategoryResourceTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyCategoryResourceTest.java
@@ -20,6 +20,7 @@ import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalServiceUtil;
 import com.liferay.asset.test.util.AssetTestUtil;
+import com.liferay.headless.admin.taxonomy.client.dto.v1_0.ParentTaxonomyCategory;
 import com.liferay.headless.admin.taxonomy.client.dto.v1_0.TaxonomyCategory;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
@@ -61,19 +62,43 @@ public class TaxonomyCategoryResourceTest
 
 		AssetVocabulary assetVocabulary = _createAssetVocabulary();
 
+		taxonomyCategoryResource.patchTaxonomyCategory(
+			taxonomyCategory.getId(),
+			new TaxonomyCategory() {
+				{
+					taxonomyVocabularyId = assetVocabulary.getVocabularyId();
+				}
+			});
+
+		final TaxonomyCategory patchParentTaxonomyCategory =
+			taxonomyCategoryResource.postTaxonomyVocabularyTaxonomyCategory(
+				assetVocabulary.getVocabularyId(), randomTaxonomyCategory());
+
 		TaxonomyCategory patchTaxonomyCategory =
 			taxonomyCategoryResource.patchTaxonomyCategory(
 				taxonomyCategory.getId(),
 				new TaxonomyCategory() {
 					{
-						taxonomyVocabularyId =
-							assetVocabulary.getVocabularyId();
+						parentTaxonomyCategory = new ParentTaxonomyCategory() {
+							{
+								setId(
+									Long.valueOf(
+										patchParentTaxonomyCategory.getId()));
+							}
+						};
 					}
 				});
 
 		Assert.assertEquals(
 			patchTaxonomyCategory.getTaxonomyVocabularyId(),
 			Long.valueOf(assetVocabulary.getVocabularyId()));
+
+		ParentTaxonomyCategory parentTaxonomyCategory =
+			patchTaxonomyCategory.getParentTaxonomyCategory();
+
+		Assert.assertEquals(
+			parentTaxonomyCategory.getId(),
+			Long.valueOf(patchParentTaxonomyCategory.getId()));
 	}
 
 	@Override


### PR DESCRIPTION
**What is new?**
- Add support `PATCH` and `UPDATE` `TaxonomyCategory` entity, allowing you to modify its `parentTaxonomyCategory` and `taxonomyVocabularyId`
- Change `parentTaxonomyCategory` param to not be _readOnly_.
- Changes requested [here](https://github.com/brianchandotcom/liferay-portal/pull/129702#issuecomment-1426915975) and [here](https://github.com/brianchandotcom/liferay-portal/pull/130156).
- To respond to this [comment](https://github.com/brianchandotcom/liferay-portal/pull/130156#issuecomment-1435668040), if the `taxonomyVocabularyId` from the request is not null and is different from the vocabulary's assetCategory that we want to update or patch, it will be checked if it exists. If it doesn't, a 404 status code error will be thrown. On the other hand, if the user doesn't provide a new `vocabularyId`, it will use the assetCategory one.
 
**How to reproduce it?**
1. Deploy `headless-admin-taxonomy-api` and `headless-admin-taxonomy-impl`.
2. Create two Vocabularies: `V1` and `V2`,
3. Create two Categories in `V1`: `Cat1` and `Cat2`.
4. If you want to add `Cat2` as a subcategory of `Cat1`, you have to execute this operation:

```
curl -X 'PATCH' \
  'http://localhost:8080/o/headless-admin-taxonomy/v1.0/taxonomy-categories/{Cat1.Id}' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -u 'test@liferay.com:test
  -d '{
  "parentTaxonomyCategory": {
    "id": ${Cat2.Id}
  }
}'
```
5. If you want to move `Cat1` into of `V2`, you have to execute this operation:
```
curl -X 'PATCH' \
  'http://localhost:8080/o/headless-admin-taxonomy/v1.0/taxonomy-categories/{Cat1.Id}' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -u 'test@liferay.com:test
  -d '{
  "taxonomyCategoryId": ${V2.Id}
 
}'
```
**JIRA Ticket**
https://issues.liferay.com/browse/LPP-47681
https://issues.liferay.com/browse/LPS-173137