### PR TITLE
LPS-175083 | Access to the user notifications via API

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/HeadlessWebcontentFolderAPI.macro
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/HeadlessWebcontentFolderAPI.macro
@@ -208,6 +208,20 @@ definition {
 		return ${curl};
 	}
 
+	macro _subscribeStructuredContentFolder {
+		var portalURL = JSONCompany.getPortalURL();
+
+		var curl = '''
+			${portalURL}/o/headless-delivery/v1.0/structured-content-folders/${structuredContentFolderId}/subscribe \
+				-u ${userName}@liferay.com:test \
+				-H accept: application/json \
+		''';
+
+		var curl = JSONCurlUtil.put(${curl});
+
+		return ${curl};
+	}
+
 	macro _updateStructureContentFolderByErc {
 		Variables.assertDefined(parameterList = "${externalReferenceCode},${name}");
 
@@ -349,6 +363,21 @@ definition {
 		return ${response};
 	}
 
+	macro createStructuredContentInStructuredContentFolder {
+		Variables.assertDefined(parameterList = "${structuredContentFolderId},${name}");
+
+		var response = HeadlessWebcontentFolderAPI._addSubfolderInAnExistingStructuredContentFolder(
+			description = ${description},
+			externalReferenceCode = ${externalReferenceCode},
+			name = ${name},
+			parentStructuredContentFolderId = ${parentStructuredContentFolderId},
+			userEmailAddress = ${userEmailAddress},
+			userPassword = ${userPassword},
+			viewableBy = ${viewableBy});
+
+		return ${response};
+	}
+
 	macro createSubfolderInStructuredContentFolder {
 		Variables.assertDefined(parameterList = "${parentStructuredContentFolderId},${name}");
 
@@ -419,6 +448,16 @@ definition {
 			assetLibraryId = ${assetLibraryId},
 			parameter = ${parameter},
 			parameterValue = ${parameterValue});
+
+		return ${response};
+	}
+
+	macro structuredContentFolderSubscribeByUserName {
+		Variables.assertDefined(parameterList = "${structuredContentFolderId},${userName}");
+
+		var response = HeadlessWebcontentFolderAPI._subscribeStructuredContentFolder(
+			structuredContentFolderId = ${structuredContentFolderId},
+			userName = ${userName});
 
 		return ${response};
 	}

--- a/modules/apps/headless/headless-user-notification/headless-user-notification-test/src/testFunctional/macros/UserNotificationAPI.macro
+++ b/modules/apps/headless/headless-user-notification/headless-user-notification-test/src/testFunctional/macros/UserNotificationAPI.macro
@@ -1,0 +1,123 @@
+definition {
+
+	macro _curlNotificationTemplates {
+		var portalURL = JSONCompany.getPortalURL();
+
+		if (isSet(notificationTemplateId)) {
+			var api = "notification-templates/${notificationTemplateId}";
+		}
+		else {
+			var api = "notification-templates";
+		}
+
+		var curl = '''
+			${portalURL}/o/notification/v1.0/${api} \
+				-u test@liferay.com:test \
+				-H accept: application/json \
+				-H 'Content-Type: application/json' \
+		''';
+
+		return ${curl};
+	}
+
+	macro _curlUserNotifications {
+		var portalURL = JSONCompany.getPortalURL();
+
+		if (isSet(userNotificationId)) {
+			var api = "user-notifications/${userNotificationId}";
+
+			if (isSet(parameter)) {
+				var api = "user-notifications/${userNotificationId}/${parameter}";
+			}
+		}
+		else if (isSet(userAccountId)) {
+			var api = "user-accounts/${userAccountId}/user-notifications";
+		}
+		else {
+			var api = "my-user-notifications";
+		}
+
+		var curl = '''
+			${portalURL}/o/headless-user-notification/v1.0/${api} \
+				-H accept: application/json \
+				-H 'Content-Type: application/json' \
+				-u test@liferay.com:test \
+		''';
+
+		return ${curl};
+	}
+
+	macro createNotificationTemplate {
+		Variables.assertDefined(parameterList = "${name},${recipientType},${userScreenName},${en_US},${type}");
+
+		var curl = UserNotificationAPI._curlNotificationTemplates();
+		var body = '''
+			-d {
+				"editorType": "richText",
+				"externalReferenceCode": "${externalReferenceCode}",
+				"name": "${name}",
+				"recipientType": "${recipientType}",
+				"recipients": [
+					{
+						"userScreenName": "${userScreenName}"
+					}
+				],
+				"subject": {
+					"en_US": "${en_US}"
+				},
+				"type": "${type}"
+			}
+		''';
+
+		var curl = StringUtil.add(${curl}, ${body}, " ");
+
+		var curl = JSONCurlUtil.post(${curl});
+
+		var notificationTemplateId = JSONUtil.getWithJSONPath(${curl}, "$.id");
+
+		static var staticNotificationTemplateId = ${notificationTemplateId};
+
+		return ${staticNotificationTemplateId};
+	}
+
+	macro deleteNotificationTemplate {
+		var curl = UserNotificationAPI._curlNotificationTemplates(notificationTemplateId = ${staticNotificationTemplateId});
+
+		JSONCurlUtil.delete(${curl});
+	}
+
+	macro getUserAccountUserNotifications {
+		Variables.assertDefined(parameterList = ${userAccountId});
+
+		var curl = UserNotificationAPI._curlUserNotifications(userAccountId = ${userAccountId});
+
+		var response = JSONCurlUtil.get(${curl});
+
+		return ${response};
+	}
+
+	macro getUserNotifications {
+		var curl = UserNotificationAPI._curlUserNotifications();
+
+		var response = JSONCurlUtil.get(${curl});
+
+		return ${response};
+	}
+
+	macro putUserNotificationReadOrUnread {
+		Variables.assertDefined(parameterList = ${parameter});
+
+		var response = UserNotificationAPI.getUserNotifications();
+
+		var userNotificationId = JSONUtil.getWithJSONPath(${response}, "$..items..id");
+
+		var curl = UserNotificationAPI._curlUserNotifications(
+			parameter = ${parameter},
+			userNotificationId = ${userNotificationId});
+
+		var response = JSONCurlUtil.put(${curl});
+
+		return ${response};
+	}
+
+}

--- a/modules/apps/headless/headless-user-notification/headless-user-notification-test/src/testFunctional/tests/RecieveUserNotification.testcase
+++ b/modules/apps/headless/headless-user-notification/headless-user-notification-test/src/testFunctional/tests/RecieveUserNotification.testcase
@@ -1,0 +1,222 @@
+@component-name = "portal-headless"
+definition {
+
+	property custom.properties = "feature.flag.LPS-83384=true";
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.main.component.name = "Headless";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginPG();
+
+		JSONGroup.addGroup(groupName = "Site Name");
+
+		task ("Given user test2@liferay.com with Administrator role created") {
+			UserAccountAPI.setUpGlobalUserAccountId(
+				alternateName = "test2",
+				emailAddress = "test2@liferay.com",
+				familyName = "test2fn",
+				fieldName = "password",
+				fieldValue = "test",
+				givenName = "test2gn");
+
+			UserAccountAPI.createUserRoleByUserAccountId(
+				roleName = "Administrator",
+				streetNumber = 1,
+				userAccountId = ${staticUserAccountId});
+
+			Site.openSiteMembershipsAdmin(siteURLKey = "site-name");
+
+			Site.assignUserAsMemberCP(
+				userFirstName = "test2gn",
+				userLastName = "test2fn",
+				userScreenName = "test2");
+
+			Navigator.openURL();
+		}
+
+		task ("Given Notification Template created") {
+			UserNotificationAPI.createNotificationTemplate(
+				en_US = "The entry name is [%STUDENT_NAME%].",
+				externalReferenceCode = "test",
+				name = "User Notification Template",
+				recipientType = "user",
+				type = "userNotification",
+				userScreenName = "test");
+		}
+
+		task ("And Given Student object definition") {
+			var customObjectDefinitionId = ObjectDefinitionAPI.createAndPublishObjectDefinition(
+				en_US_label = "student",
+				en_US_plural_label = "students",
+				name = "Student",
+				requiredStringFieldName = "name");
+		}
+
+		task ("And Given in Student an Action of trigger OnAfterAdd including Notification Template created") {
+			ObjectActionAPI.createObjectAction(
+				label = "Object Entry Notification",
+				name = "objectEntryNotification",
+				notificationTemplateErc = "test",
+				notificationTemplateId = ${staticNotificationTemplateId},
+				objectActionExecutorKey = "notification",
+				objectActionTriggerKey = "onAfterAdd",
+				objectDefinitionId = ${customObjectDefinitionId},
+				type = "userNotification");
+		}
+
+		task ("Given student entry created") {
+			var studentId = ObjectDefinitionAPI.createObjectEntryWithName(
+				en_US_plural_label = "students",
+				name = "Student Name");
+		}
+	}
+
+	tearDown {
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
+
+		if (${testPortalInstance} == "true") {
+			PortalInstances.tearDownCP();
+		}
+		else {
+			JSONUser.deleteUserByUserId(userId = ${staticUserAccountId});
+
+			JSONGroup.deleteGroupByName(groupName = "Site Name");
+
+			Navigator.gotoNotifications();
+
+			Notifications.deleteNotification(contentBody = "The entry name is Student Name.");
+
+			UserNotificationAPI.deleteNotificationTemplate();
+
+			ObjectAdmin.deleteObjectViaAPI(objectName = "Student");
+		}
+	}
+
+	@priority = 4
+	test CanGetCurrentUserNotifications {
+		task ("When requesting getMyUserNotificationsPage") {
+			var response = UserNotificationAPI.getUserNotifications();
+		}
+
+		task ("Then the response contains a notification of the created Student entry") {
+			var actual = JSONUtil.getWithJSONPath(${response}, "$..items..message");
+
+			TestUtils.assertEquals(
+				actual = ${actual},
+				expected = "The entry name is Student Name.");
+		}
+	}
+
+	@priority = 4
+	test CanGetOwnedUserNotifications {
+		property portal.acceptance = "true";
+
+		task ("Given Web Content Folder created as user test@liferay.com") {
+			WebContentNavigator.openWebContentAdmin(siteURLKey = "site-name");
+
+			NavItem.gotoStructures();
+
+			WebContentStructures.addCP(structureName = "content-structure");
+
+			FormViewBuilder.addFieldByDoubleClick(fieldType = "Text");
+
+			FormFields.editFieldReference(key_fieldReference = "Text");
+
+			Button.clickSave();
+
+			var responseFromCreate = HeadlessWebcontentFolderAPI.createStructuredContentFolder(
+				groupName = "Site Name",
+				name = "Test Folder");
+		}
+
+		task ("And Given user test2 subscribed to the Web Content Folder") {
+			User.logoutAndLoginPG(
+				userLoginEmailAddress = "test2@liferay.com",
+				userLoginFullName = "test2fn test2gn");
+
+			var structuredContentFolderId = HeadlessWebcontentFolderAPI.getElementOfCreatedStructuredContentFolder(
+				element = "$.id",
+				responseToParse = ${responseFromCreate});
+
+			HeadlessWebcontentFolderAPI.structuredContentFolderSubscribeByUserName(
+				structuredContentFolderId = ${structuredContentFolderId},
+				userName = "test2");
+
+			User.logoutAndLoginPG(
+				userLoginEmailAddress = "test@liferay.com",
+				userLoginFullName = "Test Test");
+		}
+
+		task ("And Given Web Content in Web Content Folder created by test user") {
+			WebContentNavigator.openWebContentAdmin(siteURLKey = "site-name");
+
+			NavItem.gotoStructures();
+
+			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
+
+			HeadlessWebcontentAPI.createStructuredContent(
+				data = "<p>My content</p>",
+				ddmStructureId = ${ddmStructureId},
+				label = "Text",
+				name = "Text",
+				structuredContentFolderId = ${structuredContentFolderId},
+				title = "WC WebContent Title 1");
+
+			Navigator.openURL();
+		}
+
+		task ("When user test requests getUserAccountUserNotificationsPage with userAccountId of user test2") {
+			var response = UserNotificationAPI.getUserAccountUserNotifications(userAccountId = ${staticUserAccountId});
+		}
+
+		task ("Then the response contains the recently created notification") {
+			var actual = JSONUtil.getWithJSONPath(${response}, "$..items..message");
+
+			TestUtils.assertEquals(
+				actual = ${actual},
+				expected = "Test Test added a new web content article.");
+		}
+	}
+
+	@priority = 4
+	test CanPutUserNotificationRead {
+		task ("When requesting putUserNotificationRead") {
+			UserNotificationAPI.putUserNotificationReadOrUnread(parameter = "read");
+		}
+
+		task ("Then the response contains a notification of the created Student entry") {
+			var response = UserNotificationAPI.getUserNotifications();
+
+			var actual = JSONUtil.getWithJSONPath(${response}, "$..items..read");
+
+			TestUtils.assertEquals(
+				actual = ${actual},
+				expected = "true");
+		}
+	}
+
+	@priority = 4
+	test CanPutUserNotificationUnread {
+		task ("And Given boolean field 'read' set to 'true' with putUserNotificationRead") {
+			UserNotificationAPI.putUserNotificationReadOrUnread(parameter = "read");
+		}
+
+		task ("When requesting putUserNotificationUnread") {
+			UserNotificationAPI.putUserNotificationReadOrUnread(parameter = "unread");
+		}
+
+		task ("Then the read field of the response of getMyUserNotificationsPage shows false") {
+			var response = UserNotificationAPI.getUserNotifications();
+
+			var actual = JSONUtil.getWithJSONPath(${response}, "$..items..read");
+
+			TestUtils.assertEquals(
+				actual = ${actual},
+				expected = "false");
+		}
+	}
+
+}

--- a/modules/apps/object/object-rest-test/src/testFunctional/macros/ObjectActionAPI.macro
+++ b/modules/apps/object/object-rest-test/src/testFunctional/macros/ObjectActionAPI.macro
@@ -1,0 +1,48 @@
+definition {
+
+	macro _curlCreateObjectAction {
+		var portalURL = JSONCompany.getPortalURL();
+
+		var curl = '''
+			${portalURL}/o/object-admin/v1.0/object-definitions/${objectDefinitionId}/object-actions \
+				-u test@liferay.com:test \
+				-H accept: application/json \
+				-H Content-Type: application/json \
+				-d {
+					"active": true,
+					"label":{
+						"en_US":"${label}"
+					},
+					"name": "${name}",
+					"objectActionExecutorKey": "${objectActionExecutorKey}",
+					"objectActionTriggerKey": "${objectActionTriggerKey}",
+					"parameters":{
+						"notificationTemplateExternalReferenceCode": "${notificationTemplateErc}",
+						"type": "${type}",
+						"notificationTemplateId": "${notificationTemplateId}"
+					}
+				}
+		''';
+
+		return ${curl};
+	}
+
+	macro createObjectAction {
+		Variables.assertDefined(parameterList = "${objectDefinitionId},${label},${name},${objectActionExecutorKey},${objectActionTriggerKey},${notificationTemplateId},${type},${notificationTemplateErc}");
+
+		var curl = ObjectActionAPI._curlCreateObjectAction(
+			label = ${label},
+			name = ${name},
+			notificationTemplateErc = ${notificationTemplateErc},
+			notificationTemplateId = ${notificationTemplateId},
+			objectActionExecutorKey = ${objectActionExecutorKey},
+			objectActionTriggerKey = ${objectActionTriggerKey},
+			objectDefinitionId = ${objectDefinitionId},
+			type = ${type});
+
+		var response = JSONCurlUtil.post(${curl});
+
+		return ${response};
+	}
+
+}

--- a/modules/apps/object/object-rest-test/src/testFunctional/macros/UserAccountAPI.macro
+++ b/modules/apps/object/object-rest-test/src/testFunctional/macros/UserAccountAPI.macro
@@ -73,6 +73,25 @@ definition {
 		return ${response};
 	}
 
+	macro createUserRoleByUserAccountId {
+		Variables.assertDefined(parameterList = "${roleName},${streetNumber},${userAccountId}");
+
+		var portalURL = JSONCompany.getPortalURL();
+		var roleId = UserAccountAPI.getRoleId(
+			roleName = ${roleName},
+			streetNumber = ${streetNumber});
+
+		var curl = '''
+			${portalURL}/o/headless-admin-user/v1.0/roles/${roleId}/association/user-account/${userAccountId} \
+				-H accept: application/json \
+				-u test@liferay.com:test \
+		''';
+
+		var response = JSONCurlUtil.post(${curl});
+
+		return ${response};
+	}
+
 	macro deleteObjectEntryRelatedToUserAccount {
 		Variables.assertDefined(parameterList = "${userAccountId},${relationshipName},${customObjectEntryId}");
 
@@ -99,6 +118,29 @@ definition {
 		var response = JSONCurlUtil.get(${curl});
 
 		return ${response};
+	}
+
+	macro getRoleId {
+		Variables.assertDefined(parameterList = "${roleName},${streetNumber}");
+
+		var portalURL = JSONCompany.getPortalURL();
+
+		var curl = '''
+			${portalURL}/o/headless-admin-user/v1.0/roles \
+				-H accept: application/json \
+				-u test@liferay.com:test \
+		''';
+
+		var response = JSONCurlUtil.get(${curl});
+
+		if (isSet(streetNumber)) {
+			var roleId = JSONUtil.getWithJSONPath(${response}, "$.items[${streetNumber}].id");
+
+			return ${roleId};
+		}
+		else {
+			return ${response};
+		}
 	}
 
 	macro getSystemObjectsWithNestedField {
@@ -173,12 +215,12 @@ definition {
 
 	macro setUpGlobalUserAccountId {
 		var response = UserAccountAPI.createUserAccount(
-			alternateName = "user",
-			emailAddress = "user@liferay.com",
-			familyName = "userfn",
+			alternateName = ${alternateName},
+			emailAddress = ${emailAddress},
+			familyName = ${familyName},
 			fieldName = ${fieldName},
 			fieldValue = ${fieldValue},
-			givenName = "usergn");
+			givenName = ${givenName});
 
 		static var staticResponse = ${response};
 

--- a/modules/apps/object/object-rest-test/src/testFunctional/tests/BreakRelationshipBetweenSystemAndCustonObjects.testcase
+++ b/modules/apps/object/object-rest-test/src/testFunctional/tests/BreakRelationshipBetweenSystemAndCustonObjects.testcase
@@ -53,7 +53,11 @@ definition {
 		}
 
 		task ("Given userAccount entry created") {
-			UserAccountAPI.setUpGlobalUserAccountId();
+			UserAccountAPI.setUpGlobalUserAccountId(
+				alternateName = "user",
+				emailAddress = "user@liferay.com",
+				familyName = "userfn",
+				givenName = "usergn");
 		}
 	}
 

--- a/modules/apps/object/object-rest-test/src/testFunctional/tests/ExtendPropertiesForSystemObjects.testcase
+++ b/modules/apps/object/object-rest-test/src/testFunctional/tests/ExtendPropertiesForSystemObjects.testcase
@@ -20,8 +20,12 @@ definition {
 
 		task ("When with post request postUserAccount to create a user with the new field") {
 			UserAccountAPI.setUpGlobalUserAccountId(
+				alternateName = "user",
+				emailAddress = "user@liferay.com",
+				familyName = "userfn",
 				fieldName = "passportNumber",
-				fieldValue = "passportNum2022");
+				fieldValue = "passportNum2022",
+				givenName = "usergn");
 		}
 	}
 

--- a/portal-web/poshi.properties
+++ b/portal-web/poshi.properties
@@ -24,6 +24,7 @@ test.dirs=\
     ../modules/apps/headless/headless-batch-engine/headless-batch-engine-test/src/testFunctional,\
     ../modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional,\
     ../modules/apps/headless/headless-discovery/headless-discovery-test/src/testFunctional,\
+    ../modules/apps/headless/headless-user-notification/headless-user-notification-test/src/testFunctional,\
     ../modules/apps/item-selector/item-selector-test/src/testFunctional,\
     ../modules/apps/layout/layout-admin-web-test/src/testFunctional,\
     ../modules/apps/layout/layout-content-page-editor-web-test/src/testFunctional,\


### PR DESCRIPTION
**Background**
Add a test case to Access the user notifications via API.

**Test Plan**
Background Steps:
Given Notification Template created
And Given Student object definition
And Given in Student an Action of trigger OnAfterAdd including Notification Template created
Given Student entry created

CanGetCurrentUserNotifications
When requesting getMyUserNotificationsPage
Then the response contains a notification of the created Student entry

CanPutUserNotificationRead
When requesting putUserNotificationRead
Then the response contains a notification of the created Student entry

CanPutUserNotificationUnread
And Given the boolean field 'read' set to 'true' with putUserNotificationRead
When requesting putUserNotificationUnread
Then the read field of the response of getMyUserNotificationsPage shows false

CanGetOwnedUserNotifications
Given Web Content Folder created as user [test@liferay.com](mailto:test@liferay.com)
And Given user [test2@liferay.com](mailto:test2@liferay.com) with Administrator role created
And Given user test2 subscribed to the Web Content Folder
And Given Web Content in Web Content Folder created by test user
When user test requests getUserAccountUserNotificationsPage with userAccountId of user test2
Then the response contains the recently created notification

**JIRA Link:**
https://issues.liferay.com/browse/LPS-175083