### PR TITLE
LPS-175513 Remove the property "verify.process.name" from verify processes and use bundleSymbolicName instead

### DIFF
--- a/modules/apps/archived/calevent-importer/src/main/java/com/liferay/calevent/importer/internal/verify/CalEventImporterVerifyProcess.java
+++ b/modules/apps/archived/calevent-importer/src/main/java/com/liferay/calevent/importer/internal/verify/CalEventImporterVerifyProcess.java
@@ -117,11 +117,7 @@ import org.osgi.service.component.annotations.Reference;
 /**
  * @author Adam Brandizzi
  */
-@Component(
-	immediate = true,
-	property = "verify.process.name=com.liferay.calevent.importer",
-	service = VerifyProcess.class
-)
+@Component(immediate = true, service = VerifyProcess.class)
 public class CalEventImporterVerifyProcess extends VerifyProcess {
 
 	@Override

--- a/modules/apps/archived/portal-security-sso-cas-impl/src/main/java/com/liferay/portal/security/sso/cas/internal/verify/CASCompanySettingsVerifyProcess.java
+++ b/modules/apps/archived/portal-security-sso-cas-impl/src/main/java/com/liferay/portal/security/sso/cas/internal/verify/CASCompanySettingsVerifyProcess.java
@@ -31,11 +31,7 @@ import org.osgi.service.component.annotations.Reference;
 /**
  * @author Brian Greenwald
  */
-@Component(
-	immediate = true,
-	property = "verify.process.name=com.liferay.portal.security.sso.cas",
-	service = VerifyProcess.class
-)
+@Component(immediate = true, service = VerifyProcess.class)
 public class CASCompanySettingsVerifyProcess
 	extends BaseCompanySettingsVerifyProcess {
 

--- a/modules/apps/archived/portal-security-sso-cas-test/src/testIntegration/java/com/liferay/portal/security/sso/cas/internal/verify/test/CASCompanySettingsVerifyProcessTest.java
+++ b/modules/apps/archived/portal-security-sso-cas-test/src/testIntegration/java/com/liferay/portal/security/sso/cas/internal/verify/test/CASCompanySettingsVerifyProcessTest.java
@@ -24,7 +24,9 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.security.sso.cas.constants.CASConfigurationKeys;
 import com.liferay.portal.security.sso.cas.constants.CASConstants;
 import com.liferay.portal.security.sso.cas.constants.LegacyCASPropsKeys;
+import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.verify.VerifyProcess;
 import com.liferay.portal.verify.test.util.BaseCompanySettingsVerifyProcessTestCase;
 
 import javax.portlet.PortletPreferences;
@@ -102,8 +104,8 @@ public class CASCompanySettingsVerifyProcessTest
 	}
 
 	@Override
-	protected String getVerifyProcessName() {
-		return "com.liferay.portal.security.sso.cas";
+	protected VerifyProcess getVerifyProcess() {
+		return _verifyProcess;
 	}
 
 	@Override
@@ -135,5 +137,10 @@ public class CASCompanySettingsVerifyProcessTest
 			LegacyCASPropsKeys.CAS_SERVICE_URL,
 			"http://test.com/cas/service/url");
 	}
+
+	@Inject(
+		filter = "component.name=com.liferay.portal.security.sso.cas.internal.verify.CASCompanySettingsVerifyProcess"
+	)
+	private VerifyProcess _verifyProcess;
 
 }

--- a/modules/apps/archived/portal-security-sso-google-impl/src/main/java/com/liferay/portal/security/sso/google/internal/verify/GoogleLoginCompanySettingsVerifyProcess.java
+++ b/modules/apps/archived/portal-security-sso-google-impl/src/main/java/com/liferay/portal/security/sso/google/internal/verify/GoogleLoginCompanySettingsVerifyProcess.java
@@ -31,11 +31,7 @@ import org.osgi.service.component.annotations.Reference;
 /**
  * @author Stian Sigvartsen
  */
-@Component(
-	immediate = true,
-	property = "verify.process.name=com.liferay.portal.security.sso.google",
-	service = VerifyProcess.class
-)
+@Component(immediate = true, service = VerifyProcess.class)
 public class GoogleLoginCompanySettingsVerifyProcess
 	extends BaseCompanySettingsVerifyProcess {
 

--- a/modules/apps/archived/portal-security-sso-google-test/src/testIntegration/java/com/liferay/portal/security/sso/google/internal/verify/test/GoogleLoginCompanySettingsVerifyProcessTest.java
+++ b/modules/apps/archived/portal-security-sso-google-test/src/testIntegration/java/com/liferay/portal/security/sso/google/internal/verify/test/GoogleLoginCompanySettingsVerifyProcessTest.java
@@ -23,7 +23,9 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.security.sso.google.constants.GoogleAuthorizationConfigurationKeys;
 import com.liferay.portal.security.sso.google.constants.GoogleConstants;
 import com.liferay.portal.security.sso.google.constants.LegacyGoogleLoginPropsKeys;
+import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.verify.VerifyProcess;
 import com.liferay.portal.verify.test.util.BaseCompanySettingsVerifyProcessTestCase;
 
 import javax.portlet.PortletPreferences;
@@ -78,8 +80,8 @@ public class GoogleLoginCompanySettingsVerifyProcessTest
 	}
 
 	@Override
-	protected String getVerifyProcessName() {
-		return "com.liferay.portal.security.sso.google";
+	protected VerifyProcess getVerifyProcess() {
+		return _verifyProcess;
 	}
 
 	@Override
@@ -92,5 +94,10 @@ public class GoogleLoginCompanySettingsVerifyProcessTest
 		unicodeProperties.put(
 			LegacyGoogleLoginPropsKeys.CLIENT_SECRET, "test_client_secret");
 	}
+
+	@Inject(
+		filter = "component.name=com.liferay.portal.security.sso.google.internal.verify.GoogleLoginCompanySettingsVerifyProcess"
+	)
+	private VerifyProcess _verifyProcess;
 
 }

--- a/modules/apps/archived/portal-security-sso-ntlm-impl/src/main/java/com/liferay/portal/security/sso/ntlm/internal/verify/NtlmCompanySettingsVerifyProcess.java
+++ b/modules/apps/archived/portal-security-sso-ntlm-impl/src/main/java/com/liferay/portal/security/sso/ntlm/internal/verify/NtlmCompanySettingsVerifyProcess.java
@@ -31,11 +31,7 @@ import org.osgi.service.component.annotations.Reference;
 /**
  * @author Brian Greenwald
  */
-@Component(
-	immediate = true,
-	property = "verify.process.name=com.liferay.portal.security.sso.ntlm",
-	service = VerifyProcess.class
-)
+@Component(immediate = true, service = VerifyProcess.class)
 public class NtlmCompanySettingsVerifyProcess
 	extends BaseCompanySettingsVerifyProcess {
 

--- a/modules/apps/archived/portal-security-sso-ntlm-test/src/testIntegration/java/com/liferay/portal/security/sso/ntlm/internal/verify/test/NtlmCompanySettingsVerifyProcessTest.java
+++ b/modules/apps/archived/portal-security-sso-ntlm-test/src/testIntegration/java/com/liferay/portal/security/sso/ntlm/internal/verify/test/NtlmCompanySettingsVerifyProcessTest.java
@@ -24,7 +24,9 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.security.sso.ntlm.constants.LegacyNtlmPropsKeys;
 import com.liferay.portal.security.sso.ntlm.constants.NtlmConfigurationKeys;
 import com.liferay.portal.security.sso.ntlm.constants.NtlmConstants;
+import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.verify.VerifyProcess;
 import com.liferay.portal.verify.test.util.BaseCompanySettingsVerifyProcessTestCase;
 
 import javax.portlet.PortletPreferences;
@@ -94,8 +96,8 @@ public class NtlmCompanySettingsVerifyProcessTest
 	}
 
 	@Override
-	protected String getVerifyProcessName() {
-		return "com.liferay.portal.security.sso.ntlm";
+	protected VerifyProcess getVerifyProcess() {
+		return _verifyProcess;
 	}
 
 	@Override
@@ -122,5 +124,10 @@ public class NtlmCompanySettingsVerifyProcessTest
 			LegacyNtlmPropsKeys.NTLM_AUTH_SERVICE_PASSWORD,
 			"testServicePassword");
 	}
+
+	@Inject(
+		filter = "component.name=com.liferay.portal.security.sso.ntlm.internal.verify.NtlmCompanySettingsVerifyProcess"
+	)
+	private VerifyProcess _verifyProcess;
 
 }

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/verify/BlogsServiceVerifyProcess.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/verify/BlogsServiceVerifyProcess.java
@@ -35,10 +35,7 @@ import org.osgi.service.component.annotations.Reference;
 /**
  * @author Gergely Mathe
  */
-@Component(
-	property = "verify.process.name=com.liferay.blogs.service",
-	service = VerifyProcess.class
-)
+@Component(service = VerifyProcess.class)
 public class BlogsServiceVerifyProcess extends VerifyProcess {
 
 	@Override

--- a/modules/apps/bookmarks/bookmarks-service/src/main/java/com/liferay/bookmarks/internal/verify/BookmarksServiceVerifyProcess.java
+++ b/modules/apps/bookmarks/bookmarks-service/src/main/java/com/liferay/bookmarks/internal/verify/BookmarksServiceVerifyProcess.java
@@ -45,10 +45,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author     Alexander Chow
  * @deprecated As of Mueller (7.2.x), with no direct replacement
  */
-@Component(
-	property = "verify.process.name=com.liferay.bookmarks.service",
-	service = VerifyProcess.class
-)
+@Component(service = VerifyProcess.class)
 @Deprecated
 public class BookmarksServiceVerifyProcess extends VerifyProcess {
 

--- a/modules/apps/bookmarks/bookmarks-test/src/testIntegration/java/com/liferay/bookmarks/verify/test/BookmarksServiceVerifyProcessTest.java
+++ b/modules/apps/bookmarks/bookmarks-test/src/testIntegration/java/com/liferay/bookmarks/verify/test/BookmarksServiceVerifyProcessTest.java
@@ -159,7 +159,9 @@ public class BookmarksServiceVerifyProcessTest
 	@DeleteAfterTestRun
 	private Group _group;
 
-	@Inject(filter = "component.name=com.liferay.bookmarks.internal.verify.BookmarksServiceVerifyProcess")
+	@Inject(
+		filter = "component.name=com.liferay.bookmarks.internal.verify.BookmarksServiceVerifyProcess"
+	)
 	private VerifyProcess _verifyProcess;
 
 }

--- a/modules/apps/bookmarks/bookmarks-test/src/testIntegration/java/com/liferay/bookmarks/verify/test/BookmarksServiceVerifyProcessTest.java
+++ b/modules/apps/bookmarks/bookmarks-test/src/testIntegration/java/com/liferay/bookmarks/verify/test/BookmarksServiceVerifyProcessTest.java
@@ -159,7 +159,7 @@ public class BookmarksServiceVerifyProcessTest
 	@DeleteAfterTestRun
 	private Group _group;
 
-	@Inject(filter = "verify.process.name=com.liferay.bookmarks.service")
+	@Inject(filter = "component.name=com.liferay.bookmarks.internal.verify.BookmarksServiceVerifyProcess")
 	private VerifyProcess _verifyProcess;
 
 }

--- a/modules/apps/commerce/commerce-account-service/src/main/java/com/liferay/commerce/account/internal/verify/CommerceAccountServiceVerifyProcess.java
+++ b/modules/apps/commerce/commerce-account-service/src/main/java/com/liferay/commerce/account/internal/verify/CommerceAccountServiceVerifyProcess.java
@@ -36,10 +36,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = {
-		"initial.deployment=true",
-		"verify.process.name=com.liferay.commerce.account.service"
-	},
+	property = "initial.deployment=true",
 	service = {CommerceAccountServiceVerifyProcess.class, VerifyProcess.class}
 )
 public class CommerceAccountServiceVerifyProcess extends VerifyProcess {

--- a/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/internal/verify/CommercePriceListServiceVerifyProcess.java
+++ b/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/internal/verify/CommercePriceListServiceVerifyProcess.java
@@ -30,10 +30,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Riccardo Alberti
  */
 @Component(
-	property = {
-		"initial.deployment=true",
-		"verify.process.name=com.liferay.commerce.price.list.service"
-	},
+	property = "initial.deployment=true",
 	service = {CommercePriceListServiceVerifyProcess.class, VerifyProcess.class}
 )
 public class CommercePriceListServiceVerifyProcess extends VerifyProcess {

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/verify/CommerceProductServiceVerifyProcess.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/verify/CommerceProductServiceVerifyProcess.java
@@ -36,10 +36,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = {
-		"initial.deployment=true",
-		"verify.process.name=com.liferay.commerce.product.service"
-	},
+	property = "initial.deployment=true",
 	service = {CommerceProductServiceVerifyProcess.class, VerifyProcess.class}
 )
 public class CommerceProductServiceVerifyProcess extends VerifyProcess {

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/verify/DepotServiceVerifyProcess.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/verify/DepotServiceVerifyProcess.java
@@ -31,10 +31,7 @@ import org.osgi.service.component.annotations.Reference;
 /**
  * @author Shuyang Zhou
  */
-@Component(
-	property = "verify.process.name=com.liferay.depot.service",
-	service = VerifyProcess.class
-)
+@Component(service = VerifyProcess.class)
 public class DepotServiceVerifyProcess extends VerifyProcess {
 
 	@Override

--- a/modules/apps/document-library-google-docs/document-library-google-docs/src/main/java/com/liferay/document/library/google/docs/internal/verify/DLGoogleDocsVerifyProcess.java
+++ b/modules/apps/document-library-google-docs/document-library-google-docs/src/main/java/com/liferay/document/library/google/docs/internal/verify/DLGoogleDocsVerifyProcess.java
@@ -30,10 +30,7 @@ import org.osgi.service.component.annotations.Reference;
 /**
  * @author Shuyang Zhou
  */
-@Component(
-	property = "verify.process.name=com.liferay.document.library.google.docs",
-	service = VerifyProcess.class
-)
+@Component(service = VerifyProcess.class)
 public class DLGoogleDocsVerifyProcess extends VerifyProcess {
 
 	@Override

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/verify/DLServiceVerifyProcess.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/verify/DLServiceVerifyProcess.java
@@ -82,10 +82,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author     Alexander Chow
  * @deprecated As of Mueller (7.2.x), with no direct replacement
  */
-@Component(
-	property = "verify.process.name=com.liferay.document.library.service",
-	service = VerifyProcess.class
-)
+@Component(service = VerifyProcess.class)
 @Deprecated
 public class DLServiceVerifyProcess extends VerifyProcess {
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/verify/test/DLServiceVerifyProcessTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/verify/test/DLServiceVerifyProcessTest.java
@@ -515,7 +515,7 @@ public class DLServiceVerifyProcessTest extends BaseVerifyProcessTestCase {
 	}
 
 	@Inject(
-		filter = "verify.process.name=com.liferay.document.library.service",
+		filter = "component.name=com.liferay.document.library.internal.verify.DLServiceVerifyProcess",
 		type = VerifyProcess.class
 	)
 	private static VerifyProcess _verifyProcess;

--- a/modules/apps/document-library/document-library-video/src/main/java/com/liferay/document/library/video/internal/verify/DLVideoVerifyProcess.java
+++ b/modules/apps/document-library/document-library-video/src/main/java/com/liferay/document/library/video/internal/verify/DLVideoVerifyProcess.java
@@ -30,10 +30,7 @@ import org.osgi.service.component.annotations.Reference;
 /**
  * @author Shuyang Zhou
  */
-@Component(
-	property = "verify.process.name=com.liferay.document.library.video",
-	service = VerifyProcess.class
-)
+@Component(service = VerifyProcess.class)
 public class DLVideoVerifyProcess extends VerifyProcess {
 
 	@Override

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/verify/DDMServiceVerifyProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/verify/DDMServiceVerifyProcess.java
@@ -41,10 +41,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author     Rafael Praxedes
  * @deprecated As of Mueller (7.2.x), with no direct replacement
  */
-@Component(
-	property = "verify.process.name=com.liferay.dynamic.data.mapping.service",
-	service = VerifyProcess.class
-)
+@Component(service = VerifyProcess.class)
 @Deprecated
 public class DDMServiceVerifyProcess extends VerifyProcess {
 

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/verify/MessageBoardsServiceVerifyProcess.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/verify/MessageBoardsServiceVerifyProcess.java
@@ -43,10 +43,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author     Zsolt Berentey
  * @deprecated As of Mueller (7.2.x), with no direct replacement
  */
-@Component(
-	property = "verify.process.name=com.liferay.message.boards.service",
-	service = VerifyProcess.class
-)
+@Component(service = VerifyProcess.class)
 @Deprecated
 public class MessageBoardsServiceVerifyProcess extends VerifyProcess {
 

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/verify/test/MessageBoardsServiceVerifyProcessTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/verify/test/MessageBoardsServiceVerifyProcessTest.java
@@ -42,7 +42,9 @@ public class MessageBoardsServiceVerifyProcessTest
 		return _verifyProcess;
 	}
 
-	@Inject(filter = "component.name=com.liferay.message.boards.internal.verify.MessageBoardsServiceVerifyProcess")
+	@Inject(
+		filter = "component.name=com.liferay.message.boards.internal.verify.MessageBoardsServiceVerifyProcess"
+	)
 	private VerifyProcess _verifyProcess;
 
 }

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/verify/test/MessageBoardsServiceVerifyProcessTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/verify/test/MessageBoardsServiceVerifyProcessTest.java
@@ -42,7 +42,7 @@ public class MessageBoardsServiceVerifyProcessTest
 		return _verifyProcess;
 	}
 
-	@Inject(filter = "verify.process.name=com.liferay.message.boards.service")
+	@Inject(filter = "component.name=com.liferay.message.boards.internal.verify.MessageBoardsServiceVerifyProcess")
 	private VerifyProcess _verifyProcess;
 
 }

--- a/modules/apps/organizations/organizations-service/src/main/java/com/liferay/organizations/internal/verify/OrganizationServiceVerifyProcess.java
+++ b/modules/apps/organizations/organizations-service/src/main/java/com/liferay/organizations/internal/verify/OrganizationServiceVerifyProcess.java
@@ -44,10 +44,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Brian Wing Shun Chan
  * @author Daniel Kocsis
  */
-@Component(
-	property = "verify.process.name=com.liferay.organizations.service",
-	service = VerifyProcess.class
-)
+@Component(service = VerifyProcess.class)
 public class OrganizationServiceVerifyProcess extends VerifyProcess {
 
 	@Override

--- a/modules/apps/portal-security-sso/portal-security-sso-facebook-connect-impl/src/main/java/com/liferay/portal/security/sso/facebook/connect/internal/verify/FacebookConnectCompanySettingsVerifyProcess.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-facebook-connect-impl/src/main/java/com/liferay/portal/security/sso/facebook/connect/internal/verify/FacebookConnectCompanySettingsVerifyProcess.java
@@ -34,10 +34,7 @@ import org.osgi.service.component.annotations.Reference;
 /**
  * @author Stian Sigvartsen
  */
-@Component(
-	property = "verify.process.name=com.liferay.portal.security.sso.facebook.connect",
-	service = VerifyProcess.class
-)
+@Component(service = VerifyProcess.class)
 public class FacebookConnectCompanySettingsVerifyProcess
 	extends BaseCompanySettingsVerifyProcess {
 

--- a/modules/apps/portal-security-sso/portal-security-sso-facebook-connect-test/src/testIntegration/java/com/liferay/portal/security/sso/facebook/connect/internal/verify/test/FacebookConnectCompanySettingsVerifyProcessTest.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-facebook-connect-test/src/testIntegration/java/com/liferay/portal/security/sso/facebook/connect/internal/verify/test/FacebookConnectCompanySettingsVerifyProcessTest.java
@@ -23,7 +23,9 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.security.sso.facebook.connect.constants.FacebookConnectConfigurationKeys;
 import com.liferay.portal.security.sso.facebook.connect.constants.FacebookConnectConstants;
 import com.liferay.portal.security.sso.facebook.connect.constants.LegacyFacebookConnectPropsKeys;
+import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.verify.VerifyProcess;
 import com.liferay.portal.verify.test.util.BaseCompanySettingsVerifyProcessTestCase;
 
 import javax.portlet.PortletPreferences;
@@ -102,8 +104,8 @@ public class FacebookConnectCompanySettingsVerifyProcessTest
 	}
 
 	@Override
-	protected String getVerifyProcessName() {
-		return "com.liferay.portal.security.sso.facebook.connect";
+	protected VerifyProcess getVerifyProcess() {
+		return _verifyProcess;
 	}
 
 	@Override
@@ -130,5 +132,10 @@ public class FacebookConnectCompanySettingsVerifyProcessTest
 		unicodeProperties.put(
 			LegacyFacebookConnectPropsKeys.VERIFIED_ACCOUNT_REQUIRED, "true");
 	}
+
+	@Inject(
+		filter = "component.name=com.liferay.portal.security.sso.facebook.connect.internal.verify.FacebookConnectCompanySettingsVerifyProcess"
+	)
+	private VerifyProcess _verifyProcess;
 
 }

--- a/modules/apps/portal-security-sso/portal-security-sso-opensso-impl/src/main/java/com/liferay/portal/security/sso/opensso/internal/verify/OpenSSOCompanySettingsVerifyProcess.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-opensso-impl/src/main/java/com/liferay/portal/security/sso/opensso/internal/verify/OpenSSOCompanySettingsVerifyProcess.java
@@ -31,10 +31,7 @@ import org.osgi.service.component.annotations.Reference;
 /**
  * @author Brian Greenwald
  */
-@Component(
-	property = "verify.process.name=com.liferay.portal.security.sso.opensso",
-	service = VerifyProcess.class
-)
+@Component(service = VerifyProcess.class)
 public class OpenSSOCompanySettingsVerifyProcess
 	extends BaseCompanySettingsVerifyProcess {
 

--- a/modules/apps/portal-security-sso/portal-security-sso-opensso-test/src/testIntegration/java/com/liferay/portal/security/sso/opensso/internal/verify/test/OpenSSOCompanySettingsVerifyProcessTest.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-opensso-test/src/testIntegration/java/com/liferay/portal/security/sso/opensso/internal/verify/test/OpenSSOCompanySettingsVerifyProcessTest.java
@@ -24,7 +24,9 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.security.sso.opensso.constants.LegacyOpenSSOPropsKeys;
 import com.liferay.portal.security.sso.opensso.constants.OpenSSOConfigurationKeys;
 import com.liferay.portal.security.sso.opensso.constants.OpenSSOConstants;
+import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.verify.VerifyProcess;
 import com.liferay.portal.verify.test.util.BaseCompanySettingsVerifyProcessTestCase;
 
 import javax.portlet.PortletPreferences;
@@ -106,8 +108,8 @@ public class OpenSSOCompanySettingsVerifyProcessTest
 	}
 
 	@Override
-	protected String getVerifyProcessName() {
-		return "com.liferay.portal.security.sso.opensso";
+	protected VerifyProcess getVerifyProcess() {
+		return _verifyProcess;
 	}
 
 	@Override
@@ -142,5 +144,10 @@ public class OpenSSOCompanySettingsVerifyProcessTest
 			LegacyOpenSSOPropsKeys.OPENSSO_SERVICE_URL,
 			"http://test.com/service/url");
 	}
+
+	@Inject(
+		filter = "component.name=com.liferay.portal.security.sso.opensso.internal.verify.OpenSSOCompanySettingsVerifyProcess"
+	)
+	private VerifyProcess _verifyProcess;
 
 }

--- a/modules/apps/portal-security/portal-security-service-access-policy-service/src/main/java/com/liferay/portal/security/service/access/policy/internal/verify/SAPServiceVerifyProcess.java
+++ b/modules/apps/portal-security/portal-security-service-access-policy-service/src/main/java/com/liferay/portal/security/service/access/policy/internal/verify/SAPServiceVerifyProcess.java
@@ -30,10 +30,7 @@ import org.osgi.service.component.annotations.Reference;
  * @deprecated As of Mueller (7.2.x), with no direct replacement
  */
 @Component(
-	property = {
-		"initial.deployment=true",
-		"verify.process.name=com.liferay.portal.security.service.access.policy.service"
-	},
+	property = "initial.deployment=true",
 	service = {SAPServiceVerifyProcess.class, VerifyProcess.class}
 )
 @Deprecated

--- a/modules/apps/portal/portal-verify-extender/src/main/java/com/liferay/portal/verify/extender/internal/osgi/commands/VerifyProcessTrackerOSGiCommands.java
+++ b/modules/apps/portal/portal-verify-extender/src/main/java/com/liferay/portal/verify/extender/internal/osgi/commands/VerifyProcessTrackerOSGiCommands.java
@@ -71,7 +71,9 @@ import org.osgi.service.component.annotations.Reference;
 )
 public class VerifyProcessTrackerOSGiCommands {
 
-	@Descriptor("List latest execution result for a specific verify process")
+	@Descriptor(
+		"List latest execution result for a module's verify process via symbolic name"
+	)
 	public void check(String bundleSymbolicName) {
 		VerifyProcess verifyProcess;
 
@@ -120,7 +122,7 @@ public class VerifyProcessTrackerOSGiCommands {
 		}
 	}
 
-	@Descriptor("Execute a specific verify process")
+	@Descriptor("Execute a module's verify process via symbolic name")
 	public void execute(String bundleSymbolicName) {
 		TeeLoggingUtil.runWithTeeLogging(
 			() -> {
@@ -153,7 +155,7 @@ public class VerifyProcessTrackerOSGiCommands {
 		}
 	}
 
-	@Descriptor("Show the verify process name if the verify process exists")
+	@Descriptor("Show the verify process class name via module's symbolic name")
 	public void show(String bundleSymbolicName) {
 		VerifyProcess verifyProcess;
 

--- a/modules/apps/portal/portal-verify-test-util/bnd.bnd
+++ b/modules/apps/portal/portal-verify-test-util/bnd.bnd
@@ -1,4 +1,4 @@
 Bundle-Name: Liferay Portal Verify Test Utilities
 Bundle-SymbolicName: com.liferay.portal.verify.test.util
-Bundle-Version: 3.0.7
+Bundle-Version: 4.0.0
 Export-Package: com.liferay.portal.verify.test.util

--- a/modules/apps/portal/portal-verify-test-util/src/main/java/com/liferay/portal/verify/test/util/BaseCompanySettingsVerifyProcessTestCase.java
+++ b/modules/apps/portal/portal-verify-test-util/src/main/java/com/liferay/portal/verify/test/util/BaseCompanySettingsVerifyProcessTestCase.java
@@ -14,21 +14,16 @@
 
 package com.liferay.portal.verify.test.util;
 
-import com.liferay.petra.string.StringBundler;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.settings.CompanyServiceSettingsLocator;
 import com.liferay.portal.kernel.settings.ModifiableSettings;
 import com.liferay.portal.kernel.settings.Settings;
 import com.liferay.portal.kernel.settings.SettingsException;
 import com.liferay.portal.kernel.settings.SettingsFactory;
-import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.PrefsProps;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.verify.VerifyException;
-import com.liferay.portal.verify.VerifyProcess;
 
 import javax.portlet.PortletPreferences;
 
@@ -40,7 +35,6 @@ import org.junit.BeforeClass;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
-import org.osgi.framework.ServiceReference;
 
 /**
  * @author Michael C. Han
@@ -120,35 +114,6 @@ public abstract class BaseCompanySettingsVerifyProcessTestCase
 
 	protected abstract String getSettingsId();
 
-	@Override
-	protected VerifyProcess getVerifyProcess() {
-		try {
-			ServiceReference<?>[] serviceReferences =
-				_bundleContext.getServiceReferences(
-					VerifyProcess.class.getName(),
-					StringBundler.concat(
-						"(&(objectClass=", VerifyProcess.class.getName(),
-						")(verify.process.name=", getVerifyProcessName(),
-						"))"));
-
-			if (ArrayUtil.isEmpty(serviceReferences)) {
-				throw new IllegalStateException("Unable to get verify process");
-			}
-
-			return (VerifyProcess)_bundleContext.getService(
-				serviceReferences[0]);
-		}
-		catch (Exception exception) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(exception);
-			}
-
-			throw new IllegalStateException("Unable to get verify process");
-		}
-	}
-
-	protected abstract String getVerifyProcessName();
-
 	protected abstract void populateLegacyProperties(
 		UnicodeProperties unicodeProperties);
 
@@ -160,9 +125,6 @@ public abstract class BaseCompanySettingsVerifyProcessTestCase
 
 	@Inject
 	protected SettingsFactory settingsFactory;
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		BaseCompanySettingsVerifyProcessTestCase.class);
 
 	private static BundleContext _bundleContext;
 

--- a/modules/apps/portal/portal-verify-test-util/src/main/resources/com/liferay/portal/verify/test/util/packageinfo
+++ b/modules/apps/portal/portal-verify-test-util/src/main/resources/com/liferay/portal/verify/test/util/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 2.0.0

--- a/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/VerifyProcessTrackerOSGiCommandsTest.java
+++ b/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/VerifyProcessTrackerOSGiCommandsTest.java
@@ -210,8 +210,6 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 					VerifyProcess.class, _initialDeploymentVerifyProcess,
 					HashMapDictionaryBuilder.<String, Object>put(
 						"initial.deployment", true
-					).put(
-						"verify.process.name", _VERIFY_PROCESS_NAME
 					).build());
 
 		return initialDeploymentVerifyProcessRegistration::unregister;
@@ -224,8 +222,6 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 					VerifyProcess.class, _runOnPortalUpgradeVerifyProcess,
 					HashMapDictionaryBuilder.<String, Object>put(
 						"run.on.portal.upgrade", true
-					).put(
-						"verify.process.name", "verify.process.name"
 					).build());
 
 		return runOnPortalUpgradeVerifyProcessRegistration::unregister;
@@ -234,9 +230,7 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 	private SafeCloseable _registerVerifyProcess() {
 		ServiceRegistration<VerifyProcess> verifyProcessRegistration =
 			_bundleContext.registerService(
-				VerifyProcess.class, _verifyProcess,
-				MapUtil.singletonDictionary(
-					"verify.process.name", "verify.process.name"));
+				VerifyProcess.class, _verifyProcess, null);
 
 		return verifyProcessRegistration::unregister;
 	}
@@ -266,8 +260,6 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 
 		return () -> StartupHelperUtil.setUpgrading(false);
 	}
-
-	private static final String _VERIFY_PROCESS_NAME = "verify.process.name";
 
 	private static BundleContext _bundleContext;
 	private static String _symbolicName;

--- a/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/VerifyProcessTrackerOSGiCommandsTest.java
+++ b/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/VerifyProcessTrackerOSGiCommandsTest.java
@@ -24,7 +24,6 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
 import com.liferay.portal.kernel.upgrade.UpgradeStep;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
-import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.verify.VerifyProcess;

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/verify/WikiServiceVerifyProcess.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/verify/WikiServiceVerifyProcess.java
@@ -35,10 +35,7 @@ import org.osgi.service.component.annotations.Reference;
 /**
  * @author Gergely Mathe
  */
-@Component(
-	property = "verify.process.name=com.liferay.wiki.service",
-	service = VerifyProcess.class
-)
+@Component(service = VerifyProcess.class)
 public class WikiServiceVerifyProcess extends VerifyProcess {
 
 	@Override

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/java/com/liferay/portal/workflow/kaleo/designer/web/internal/verify/KaleoDesignerWebVerifyProcess.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/java/com/liferay/portal/workflow/kaleo/designer/web/internal/verify/KaleoDesignerWebVerifyProcess.java
@@ -37,10 +37,7 @@ import org.osgi.service.component.annotations.Reference;
 /**
  * @author Inácio Nery
  */
-@Component(
-	property = "verify.process.name=com.liferay.portal.workflow.kaleo.designer.web",
-	service = VerifyProcess.class
-)
+@Component(service = VerifyProcess.class)
 public class KaleoDesignerWebVerifyProcess extends VerifyProcess {
 
 	@Override

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/verify/SXPServiceVerifyProcess.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/verify/SXPServiceVerifyProcess.java
@@ -26,11 +26,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Shuyang Zhou
  */
 @Component(
-	enabled = false,
-	property = {
-		"initial.deployment=true",
-		"verify.process.name=com.liferay.search.experiences.service"
-	},
+	enabled = false, property = "initial.deployment=true",
 	service = VerifyProcess.class
 )
 public class SXPServiceVerifyProcess extends VerifyProcess {

--- a/modules/util/portal-tools-db-upgrade-client/src/testFunctional/dependencies/check-upgrade-client-gogoshell-help-output.expect
+++ b/modules/util/portal-tools-db-upgrade-client/src/testFunctional/dependencies/check-upgrade-client-gogoshell-help-output.expect
@@ -32,7 +32,7 @@ expect {
 }
 
 expect {
-	"show - Show the verify process name if the verify process exists\r\r\n   scope: verify" {}
+	"show - Show the verify process class name via module's symbolic name\r\r\n   scope: verify" {}
 	timeout {send_user "No available command verify:show";exit 2}
 }
 
@@ -47,7 +47,7 @@ expect {
 }
 
 expect {
-	"execute - Execute a specific verify process\r\r\n   scope: verify" {}
+	"execute - Execute a module's verify process via symbolic name\r\r\n   scope: verify" {}
 	timeout {send_user "No available command verify:execute";exit 2}
 }
 
@@ -77,7 +77,7 @@ expect {
 }
 
 expect {
-	"execute - Execute a specific verify process" {send "help verify:executeAll\r"}
+	"execute - Execute a module's verify process via symbolic name" {send "help verify:executeAll\r"}
 	timeout {send_user "No help output for command verify:execute";exit 2}
 }
 
@@ -92,6 +92,6 @@ expect {
 }
 
 expect {
-	"show - Show the verify process name if the verify process exists" {send_user "PASS"}
+	"show - Show the verify process class name via module's symbolic name" {send_user "PASS"}
 	timeout {send_user "No help output for command verify:show";exit 2}
 }


### PR DESCRIPTION
Manually forwarded as test failures are not related :heavy_check_mark: 

Original PR here: https://github.com/liferay-uniform/liferay-portal/pull/982

https://issues.liferay.com/browse/LPS-175513