### PR TITLE
LPS-174905 Remove Stream usages for module: commerce-account-service

### DIFF
--- a/modules/apps/commerce/commerce-account-service/src/main/java/com/liferay/commerce/account/internal/util/CommerceAccountHelperImpl.java
+++ b/modules/apps/commerce/commerce-account-service/src/main/java/com/liferay/commerce/account/internal/util/CommerceAccountHelperImpl.java
@@ -31,6 +31,7 @@ import com.liferay.commerce.account.service.CommerceAccountUserRelLocalService;
 import com.liferay.commerce.account.util.CommerceAccountHelper;
 import com.liferay.commerce.product.model.CommerceChannel;
 import com.liferay.commerce.product.service.CommerceChannelLocalService;
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -47,9 +48,7 @@ import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
-import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Stream;
 
 import javax.portlet.PortletRequest;
 import javax.portlet.PortletURL;
@@ -108,17 +107,9 @@ public class CommerceAccountHelperImpl implements CommerceAccountHelper {
 			return new long[0];
 		}
 
-		Stream<AccountGroupRel> stream = accountGroupRels.stream();
-
-		long[] accountGroupIds = stream.mapToLong(
-			AccountGroupRel::getAccountGroupId
-		).toArray();
-
-		accountGroupIds = ArrayUtil.unique(accountGroupIds);
-
-		Arrays.sort(accountGroupIds);
-
-		return accountGroupIds;
+		return ArrayUtil.sortedUnique(
+			TransformUtil.transformToLongArray(
+				accountGroupRels, AccountGroupRel::getAccountGroupId));
 	}
 
 	/**

--- a/modules/apps/commerce/commerce-account-service/src/main/java/com/liferay/commerce/account/service/impl/CommerceAccountGroupLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-account-service/src/main/java/com/liferay/commerce/account/service/impl/CommerceAccountGroupLocalServiceImpl.java
@@ -58,7 +58,6 @@ import com.liferay.portal.kernel.util.Validator;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Stream;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -249,16 +248,12 @@ public class CommerceAccountGroupLocalServiceImpl
 			return new ArrayList<>();
 		}
 
-		Stream<CommerceAccountGroupCommerceAccountRel> stream =
-			commerceAccountGroupCommerceAccountRels.stream();
-
-		long[] commerceAccountGroupIds = stream.mapToLong(
-			CommerceAccountGroupCommerceAccountRel::getCommerceAccountGroupId
-		).toArray();
-
 		return TransformUtil.transform(
 			_accountGroupLocalService.getAccountGroupsByAccountGroupId(
-				commerceAccountGroupIds),
+				TransformUtil.transformToLongArray(
+					commerceAccountGroupCommerceAccountRels,
+					CommerceAccountGroupCommerceAccountRel::
+						getCommerceAccountGroupId)),
 			CommerceAccountGroupImpl::fromAccountGroup);
 	}
 

--- a/modules/apps/commerce/commerce-account-service/src/main/java/com/liferay/commerce/account/service/impl/CommerceAccountUserRelLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-account-service/src/main/java/com/liferay/commerce/account/service/impl/CommerceAccountUserRelLocalServiceImpl.java
@@ -46,7 +46,6 @@ import com.liferay.portal.kernel.util.Validator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Stream;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -187,18 +186,12 @@ public class CommerceAccountUserRelLocalServiceImpl
 			roles.add(role);
 		}
 
-		Stream<Role> stream = roles.stream();
-
-		long[] roleIds = stream.mapToLong(
-			Role::getRoleId
-		).toArray();
-
-		List<CommerceAccountUserRel> commerceAccountUserRels =
-			commerceAccountUserRelLocalService.
-				getCommerceAccountUserRelsByCommerceAccountUserId(userId);
+		long[] roleIds = TransformUtil.transformToLongArray(
+			roles, Role::getRoleId);
 
 		for (CommerceAccountUserRel commerceAccountUserRel :
-				commerceAccountUserRels) {
+				commerceAccountUserRelLocalService.
+					getCommerceAccountUserRelsByCommerceAccountUserId(userId)) {
 
 			CommerceAccount commerceAccount =
 				CommerceAccountImpl.fromAccountEntry(


### PR DESCRIPTION
@brianchandotcom The shortcuts in CommerceAccountHelperImpl and CommerceAccountGroupLocalServiceImpl are kept to avoid unnecessary local service invocation or array creation in ArrayUtil.sortedUnique().  FYI @shuyangzhou @tinatian