### PR TITLE
LPS-176019 Add Integration Test for the OpenAPI that contains all the REST APIs of Liferay

### DIFF
--- a/modules/apps/headless/headless-discovery/headless-discovery-test/bnd.bnd
+++ b/modules/apps/headless/headless-discovery/headless-discovery-test/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Liferay Headless Discovery Test
+Bundle-SymbolicName: com.liferay.headless.discovery.test
+Bundle-Version: 1.0.0

--- a/modules/apps/headless/headless-discovery/headless-discovery-test/build.gradle
+++ b/modules/apps/headless/headless-discovery/headless-discovery-test/build.gradle
@@ -1,0 +1,5 @@
+dependencies {
+	testCompileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
+
+	testIntegrationCompile project(":test:arquillian-extension-junit-bridge")
+}

--- a/modules/apps/headless/headless-discovery/headless-discovery-test/build.gradle
+++ b/modules/apps/headless/headless-discovery/headless-discovery-test/build.gradle
@@ -1,5 +1,7 @@
 dependencies {
 	testCompileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 
+	testIntegrationCompile project(":apps:object:object-api")
+	testIntegrationCompile project(":apps:portal-vulcan:portal-vulcan-api")
 	testIntegrationCompile project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/headless/headless-discovery/headless-discovery-test/src/testIntegration/java/com/liferay/headless/discovery/jaxrs/resource/v1_0/test/HeadlessDiscoveryOpenAPIResourceTest.java
+++ b/modules/apps/headless/headless-discovery/headless-discovery-test/src/testIntegration/java/com/liferay/headless/discovery/jaxrs/resource/v1_0/test/HeadlessDiscoveryOpenAPIResourceTest.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.headless.discovery.jaxrs.resource.v1_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.servlet.HttpHeaders;
+import com.liferay.portal.kernel.util.Base64;
+import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.HttpUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.util.PropsUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Carlos Correa
+ */
+@RunWith(Arquillian.class)
+public class HeadlessDiscoveryOpenAPIResourceTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testGetGlobalOpenAPI() throws Exception {
+		_setFeatureFlag(true, "LPS-166216");
+
+		try {
+			JSONObject globalOpenAPIJSONObject = _invoke(
+				"openapi/openapi.json");
+
+			List<String> globalOpenAPIPaths = _getPaths(
+				globalOpenAPIJSONObject);
+
+			JSONObject openAPIEndpointsJSONObject = _invoke("openapi");
+
+			Map<String, Object> openAPIEndpointsMap =
+				openAPIEndpointsJSONObject.toMap();
+
+			for (Map.Entry<String, Object> entry :
+					openAPIEndpointsMap.entrySet()) {
+
+				for (String openAPIPath : (List<String>)entry.getValue()) {
+					JSONObject openAPIJSONObject = _invoke(
+						_getOpenAPISubpath(openAPIPath));
+
+					for (String path : _getPaths(openAPIJSONObject)) {
+						Assert.assertTrue(
+							globalOpenAPIPaths.remove(entry.getKey() + path));
+					}
+				}
+			}
+
+			Assert.assertTrue(
+				"The list of paths must be empty",
+				globalOpenAPIPaths.isEmpty());
+		}
+		finally {
+			_setFeatureFlag(false, "LPS-166216");
+		}
+	}
+
+	private String _getOpenAPISubpath(String openAPIPath) {
+		String openAPISubpath = StringUtil.removeFirst(
+			openAPIPath, "http://localhost:8080/o/");
+
+		return StringUtil.replaceLast(openAPISubpath, ".yaml", ".json");
+	}
+
+	private List<String> _getPaths(JSONObject openAPIJSONObject) {
+		JSONObject pathsJSONObject = openAPIJSONObject.getJSONObject("paths");
+
+		Map<String, Object> pathsMap = pathsJSONObject.toMap();
+
+		return new ArrayList<>(pathsMap.keySet());
+	}
+
+	private JSONObject _invoke(String endpoint) throws Exception {
+		Http.Options options = new Http.Options();
+
+		options.addHeader(
+			HttpHeaders.CONTENT_TYPE, ContentTypes.APPLICATION_JSON);
+		options.addHeader(
+			"Authorization",
+			"Basic " + Base64.encode("test@liferay.com:test".getBytes()));
+		options.setLocation("http://localhost:8080/o/" + endpoint);
+		options.setMethod(Http.Method.GET);
+
+		return JSONFactoryUtil.createJSONObject(HttpUtil.URLtoString(options));
+	}
+
+	private void _setFeatureFlag(boolean booleanValue, String featureFlag) {
+		PropsUtil.addProperties(
+			UnicodePropertiesBuilder.setProperty(
+				"feature.flag." + featureFlag, String.valueOf(booleanValue)
+			).build());
+	}
+
+}

--- a/modules/apps/headless/headless-discovery/headless-discovery-test/src/testIntegration/java/com/liferay/headless/discovery/jaxrs/resource/v1_0/test/HeadlessDiscoveryOpenAPIResourceTest.java
+++ b/modules/apps/headless/headless-discovery/headless-discovery-test/src/testIntegration/java/com/liferay/headless/discovery/jaxrs/resource/v1_0/test/HeadlessDiscoveryOpenAPIResourceTest.java
@@ -22,6 +22,7 @@ import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.servlet.HttpHeaders;
+import com.liferay.portal.kernel.test.rule.DataGuard;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.Base64;
@@ -40,7 +41,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -51,6 +51,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Carlos Correa
  */
+@DataGuard(scope = DataGuard.Scope.METHOD)
 @RunWith(Arquillian.class)
 public class HeadlessDiscoveryOpenAPIResourceTest {
 
@@ -65,14 +66,6 @@ public class HeadlessDiscoveryOpenAPIResourceTest {
 			ObjectDefinitionConstants.SCOPE_COMPANY);
 		_objectDefinition2 = _publishObjectDefinition(
 			ObjectDefinitionConstants.SCOPE_SITE);
-	}
-
-	@After
-	public void tearDown() throws Exception {
-		_objectDefinitionLocalService.deleteObjectDefinition(
-			_objectDefinition1.getObjectDefinitionId());
-		_objectDefinitionLocalService.deleteObjectDefinition(
-			_objectDefinition2.getObjectDefinitionId());
 	}
 
 	@Test

--- a/modules/apps/headless/headless-discovery/headless-discovery-test/src/testIntegration/java/com/liferay/headless/discovery/jaxrs/resource/v1_0/test/HeadlessDiscoveryOpenAPIResourceTest.java
+++ b/modules/apps/headless/headless-discovery/headless-discovery-test/src/testIntegration/java/com/liferay/headless/discovery/jaxrs/resource/v1_0/test/HeadlessDiscoveryOpenAPIResourceTest.java
@@ -15,23 +15,34 @@
 package com.liferay.headless.discovery.jaxrs.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.field.util.ObjectFieldUtil;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.servlet.HttpHeaders;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.HttpUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
+import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.util.PropsUtil;
+import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -47,6 +58,22 @@ public class HeadlessDiscoveryOpenAPIResourceTest {
 	@Rule
 	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
 		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_objectDefinition1 = _publishObjectDefinition(
+			ObjectDefinitionConstants.SCOPE_COMPANY);
+		_objectDefinition2 = _publishObjectDefinition(
+			ObjectDefinitionConstants.SCOPE_SITE);
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			_objectDefinition1.getObjectDefinitionId());
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			_objectDefinition2.getObjectDefinitionId());
+	}
 
 	@Test
 	public void testGetGlobalOpenAPI() throws Exception {
@@ -72,6 +99,10 @@ public class HeadlessDiscoveryOpenAPIResourceTest {
 						_getOpenAPISubpath(openAPIPath));
 
 					for (String path : _getPaths(openAPIJSONObject)) {
+						if (path.endsWith("/")) {
+							path = path.substring(0, path.lastIndexOf("/"));
+						}
+
 						Assert.assertTrue(
 							globalOpenAPIPaths.remove(entry.getKey() + path));
 					}
@@ -116,11 +147,38 @@ public class HeadlessDiscoveryOpenAPIResourceTest {
 		return JSONFactoryUtil.createJSONObject(HttpUtil.URLtoString(options));
 	}
 
+	private ObjectDefinition _publishObjectDefinition(String scope)
+		throws Exception {
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.addCustomObjectDefinition(
+				TestPropsValues.getUserId(), false,
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				"A" + RandomTestUtil.randomString(), null, null,
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				scope, ObjectDefinitionConstants.STORAGE_TYPE_DEFAULT,
+				Collections.singletonList(
+					ObjectFieldUtil.createObjectField(
+						"Text", "String", true, true, null,
+						RandomTestUtil.randomString(),
+						"x" + RandomTestUtil.randomString(), false)));
+
+		return _objectDefinitionLocalService.publishCustomObjectDefinition(
+			TestPropsValues.getUserId(),
+			objectDefinition.getObjectDefinitionId());
+	}
+
 	private void _setFeatureFlag(boolean booleanValue, String featureFlag) {
 		PropsUtil.addProperties(
 			UnicodePropertiesBuilder.setProperty(
 				"feature.flag." + featureFlag, String.valueOf(booleanValue)
 			).build());
 	}
+
+	private ObjectDefinition _objectDefinition1;
+	private ObjectDefinition _objectDefinition2;
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
 
 }


### PR DESCRIPTION
PR forwarded manually from: https://github.com/liferay-headless/liferay-portal/pull/1063 (ci:forward:force didn't work as expected)

---

This PR contains a new Integration Test to validate the OpenAPI that contains all the REST APIs.

In order to validate also that the Global OpenAPI contains the Object REST APIs generated dynamically, two Object Definitions has been created in the tests.

---

How to test:

- Move to the folder `modules/apps/headless/headless-discovery/headless-discovery-test`
- Execute the integration test with the command `gw testIntegration`