### PR TITLE
Password History should check last n passwords

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/PasswordTrackerLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PasswordTrackerLocalServiceImpl.java
@@ -84,7 +84,7 @@ public class PasswordTrackerLocalServiceImpl
 			passwordTrackerPersistence.findByUserId(userId);
 
 		for (PasswordTracker passwordTracker : passwordTrackers) {
-			if (historyCount >= passwordPolicy.getHistoryCount()) {
+			if (historyCount > passwordPolicy.getHistoryCount()) {
 				break;
 			}
 


### PR DESCRIPTION
When enabling the password history with 2, the last 2 passwords of the user must be checked. For eg if user has 1st password apple, then it changes to ball and then it changes to cat. He should not allow to set apple. A same password validation restrict him to set "cat" again so the last two passwords would be ball and apple excluding the current one(cat).