### PR TITLE
LPS-175255 - Add API to access control panel spritemap

### DIFF
--- a/modules/apps/frontend-icons/frontend-icons-web/package.json
+++ b/modules/apps/frontend-icons/frontend-icons-web/package.json
@@ -1,7 +1,4 @@
 {
-	"dependencies": {
-		"frontend-js-web": "*"
-	},
 	"main": "js/index.js",
 	"name": "@liferay/frontend-icons-web",
 	"scripts": {

--- a/modules/apps/frontend-icons/frontend-icons-web/src/main/java/com/liferay/frontend/icons/web/internal/servlet/taglib/FrontendIconsSpritemapTopHeadDynamicInclude.java
+++ b/modules/apps/frontend-icons/frontend-icons-web/src/main/java/com/liferay/frontend/icons/web/internal/servlet/taglib/FrontendIconsSpritemapTopHeadDynamicInclude.java
@@ -55,6 +55,11 @@ public class FrontendIconsSpritemapTopHeadDynamicInclude
 
 		sb.append(
 			StringBundler.concat(
+				"Liferay.Icons.controlPanelSpritemap = '",
+				themeDisplay.getPathControlPanelSpritemap(), "';"));
+
+		sb.append(
+			StringBundler.concat(
 				"Liferay.Icons.spritemap = '",
 				themeDisplay.getPathThemeSpritemap(), "';"));
 

--- a/modules/apps/frontend-icons/frontend-icons-web/src/main/resources/META-INF/resources/js/index.ts
+++ b/modules/apps/frontend-icons/frontend-icons-web/src/main/resources/META-INF/resources/js/index.ts
@@ -13,5 +13,9 @@
  */
 
 export function getSpritemap(): string {
-	return Liferay.ThemeDisplay.getPathThemeSpritemap();
+	return Liferay.Icons.spritemap;
+}
+
+export function getControlPanelSpritemap(): string {
+	return Liferay.Icons.controlPanelSpritemap;
 }

--- a/modules/apps/frontend-icons/frontend-icons-web/src/main/resources/META-INF/resources/js/liferay.d.ts
+++ b/modules/apps/frontend-icons/frontend-icons-web/src/main/resources/META-INF/resources/js/liferay.d.ts
@@ -16,6 +16,7 @@
 
 declare module Liferay {
 	export const Icons: {
+		controlPanelSpritemap: string;
 		spritemap: string;
 	};
 }

--- a/modules/apps/frontend-icons/frontend-icons-web/tsconfig.json
+++ b/modules/apps/frontend-icons/frontend-icons-web/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "ef1cd2c35d9ff2d6f173ecd8973f049606ee42cd",
+	"@generated": "d8040a45557ab265b8f60f4099e72408f21f87e4",
 	"@overrides": {
 	},
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT OUTSIDE @overrides **",
@@ -13,9 +13,6 @@
 		"moduleResolution": "node",
 		"outDir": "./types",
 		"paths": {
-			"frontend-js-web": [
-				"../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts"
-			]
 		},
 		"sourceMap": false,
 		"strict": true,
@@ -35,8 +32,5 @@
 		"../../../global.d.ts"
 	],
 	"references": [
-		{
-			"path": "../../frontend-js/frontend-js-web"
-		}
 	]
 }

--- a/modules/apps/frontend-icons/frontend-icons-web/types/src/main/resources/META-INF/resources/js/index.d.ts
+++ b/modules/apps/frontend-icons/frontend-icons-web/types/src/main/resources/META-INF/resources/js/index.d.ts
@@ -13,3 +13,4 @@
  */
 
 export declare function getSpritemap(): string;
+export declare function getControlPanelSpritemap(): string;

--- a/portal-kernel/src/com/liferay/portal/kernel/theme/ThemeDisplay.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/theme/ThemeDisplay.java
@@ -593,6 +593,15 @@ public class ThemeDisplay
 	}
 
 	/**
+	 * Returns the URL for the control panel's spritemap.
+	 *
+	 * @return the URL for the control panel's spritemap
+	 */
+	public String getPathControlPanelSpritemap() {
+		return _pathControlPanelSpritemap;
+	}
+
+	/**
 	 * Returns the URL for the site's private layout set. This method typically
 	 * returns <code>/group</code>.
 	 *
@@ -1515,10 +1524,13 @@ public class ThemeDisplay
 			setPathThemeRoot(themeStaticResourcePath + rootPath);
 		}
 
-		setPathThemeSpritemap(
-			StringBundler.concat(
-				cdnBaseURL, themeStaticResourcePath, theme.getImagesPath(),
-				"/clay/icons.svg"));
+		String claySpritemapPath = StringBundler.concat(
+			cdnBaseURL, themeStaticResourcePath, theme.getImagesPath(),
+			"/clay/icons.svg");
+
+		setPathControlPanelSpritemap(claySpritemapPath);
+
+		setPathThemeSpritemap(claySpritemapPath);
 
 		setPathThemeTemplates(
 			cdnBaseURL + themeStaticResourcePath + theme.getTemplatesPath());
@@ -1550,6 +1562,10 @@ public class ThemeDisplay
 
 	public void setPathContext(String pathContext) {
 		_pathContext = pathContext;
+	}
+
+	public void setPathControlPanelSpritemap(String pathControlPanelSpritemap) {
+		_pathControlPanelSpritemap = pathControlPanelSpritemap;
 	}
 
 	public void setPathFriendlyURLPrivateGroup(
@@ -2009,6 +2025,7 @@ public class ThemeDisplay
 	private String _pathCms = StringPool.BLANK;
 	private String _pathColorSchemeImages = StringPool.BLANK;
 	private String _pathContext = StringPool.BLANK;
+	private String _pathControlPanelSpritemap = StringPool.BLANK;
 	private String _pathFriendlyURLPrivateGroup = StringPool.BLANK;
 	private String _pathFriendlyURLPrivateUser = StringPool.BLANK;
 	private String _pathFriendlyURLPublic = StringPool.BLANK;

--- a/portal-kernel/src/com/liferay/portal/kernel/theme/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/theme/packageinfo
@@ -1,1 +1,1 @@
-version 10.3.0
+version 10.4.0

--- a/portal-web/docroot/html/common/themes/top_js.jspf
+++ b/portal-web/docroot/html/common/themes/top_js.jspf
@@ -272,9 +272,6 @@
 			getPathThemeRoot: function() {
 				return '<%= themeDisplay.getPathThemeRoot() %>';
 			},
-			getPathThemeSpritemap: function() {
-				return '<%= themeDisplay.getPathThemeSpritemap() %>';
-			},
 			getPlid: function() {
 				return '<%= themeDisplay.getPlid() %>';
 			},


### PR DESCRIPTION
Manual forward from https://github.com/liferay-frontend/liferay-portal/pull/3097#issuecomment-1460169471

---------------

https://issues.liferay.com/browse/LPS-175255

I wasn't sure whether to call it `controlPanelSpritemap`, `systemSpritemap`, or `adminSpritemap`.

I settled with control panel since we already have "control panel" type wording in themeDisplay