### PR TITLE
COMMERCE-10086 Minor Refactor SF. Move to commerce/order

### DIFF
--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/order/CommerceOrderThreadLocal.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/order/CommerceOrderThreadLocal.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.commerce.util;
+package com.liferay.commerce.order;
 
 import com.liferay.petra.lang.CentralizedThreadLocal;
 

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/model/listener/CommerceOrderItemModelListener.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/model/listener/CommerceOrderItemModelListener.java
@@ -18,7 +18,7 @@ import com.liferay.commerce.constants.CommerceOrderConstants;
 import com.liferay.commerce.model.CommerceOrder;
 import com.liferay.commerce.model.CommerceOrderItem;
 import com.liferay.commerce.order.engine.CommerceOrderEngine;
-import com.liferay.commerce.util.CommerceOrderThreadLocal;
+import com.liferay.commerce.order.CommerceOrderThreadLocal;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderLocalServiceImpl.java
@@ -59,7 +59,7 @@ import com.liferay.commerce.service.base.CommerceOrderLocalServiceBaseImpl;
 import com.liferay.commerce.service.persistence.CommerceOrderItemPersistence;
 import com.liferay.commerce.term.model.CommerceTermEntry;
 import com.liferay.commerce.term.service.CommerceTermEntryLocalService;
-import com.liferay.commerce.util.CommerceOrderThreadLocal;
+import com.liferay.commerce.order.CommerceOrderThreadLocal;
 import com.liferay.commerce.util.CommerceShippingEngineRegistry;
 import com.liferay.commerce.util.CommerceShippingHelper;
 import com.liferay.commerce.util.CommerceUtil;


### PR DESCRIPTION
@brianchandotcom , sent from: https://github.com/brianchandotcom/liferay-portal/pull/131502 to fulfill request.


I took a look at this and discussed with the team:

```
commerce-api/src/main/java/com/liferay/commerce/context/CommerceContextThreadLocal.java
commerce-api/src/main/java/com/liferay/commerce/context/CommerceGroupThreadLocal.java
commerce-api/src/main/java/com/liferay/commerce/util/CommerceOrderThreadLocal.java

```
At best, I can move CommerceOrderThreadLocal to :

`commerce-api/src/main/java/com/liferay/commerce/order/CommerceOrderThreadLocal.java`

Originally, I put CommerceOrderThreadLocal in `/util` because the threadLocal was most likely going to be used everywhere in the future, but it looks like our general pattern (There are not that many, but still), is to follow the package

For example, AccountRolePermissionThreadLocal :

`modules/apps/account/account-api/src/main/java/com/liferay/account/role/AccountRolePermissionThreadLocal.java`