### PR TITLE
LPS-168959 - Make current page focusable so it can be read by screen reader but not navigable.

### DIFF
--- a/portal-web/docroot/html/taglib/ui/page_iterator/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/page_iterator/start.jsp
@@ -158,7 +158,7 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 						<li class="page-item <%= (i == cur) ? "active" : StringPool.BLANK %>">
 							<c:choose>
 								<c:when test="<%= i == cur %>">
-									<a aria-current="page" class="page-link">
+									<a aria-current="page" class="page-link" tabindex="0">
 								</c:when>
 								<c:otherwise>
 									<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, i) : "" %>">
@@ -175,7 +175,7 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 				</c:when>
 				<c:when test="<%= cur == 1 %>">
 					<li class="active page-item">
-						<a aria-current="page" class="page-link"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span>1</a>
+						<a aria-current="page" class="page-link" tabindex="0"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span>1</a>
 					</li>
 					<li class="page-item">
 						<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, 2, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, 2) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span>2</a>
@@ -251,7 +251,7 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 						<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, pages - 1, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, pages - 1) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= pages - 1 %></a>
 					</li>
 					<li class="active page-item">
-						<a aria-current="page" class="page-link"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= pages %></a>
+						<a aria-current="page" class="page-link" tabindex="0"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= pages %></a>
 					</li>
 				</c:when>
 				<c:otherwise>
@@ -296,7 +296,7 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 					</c:if>
 
 					<li class="active page-item">
-						<a aria-current="page" class="page-link"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= cur %></a>
+						<a aria-current="page" class="page-link" tabindex="0"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= cur %></a>
 					</li>
 
 					<c:if test="<%= (cur + 1) < pages %>">


### PR DESCRIPTION
Manually Forwarding from: https://github.com/liferay-frontend/liferay-portal/pull/3106

### Reference
- https://issues.liferay.com/browse/LPS-168959

### What is the goal of this PR?
This PR is updating the pagination in the search container to make the current page focusable so that screen readers can announce the current page. It is intentionally not including an href so that it is not possible to navigate to the current page. This was discussed here: https://github.com/liferay/clay/pull/5290

### What does it look like?
![Screen Shot 2023-03-08 at 7 01 15 PM](https://user-images.githubusercontent.com/1609196/223748280-f1f52491-3f54-4262-9653-0bc777c04bbd.png)

### Steps to Reproduce

1. Open the URL
2. Go to Control panel - Sites
3. Sites page will be appear
4. Add a new site
5. Use Jaws
6. Change the Pagination to 4
7. Assert now we are at 1st page link
8. Attempt to press the tab key until the 1st page link is highlighted