### PR TITLE
LPS-171436 Make TemplateHandlerServiceTrackerCustomizer an EagerServi…

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/template/TemplateHandlerRegistryImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/template/TemplateHandlerRegistryImpl.java
@@ -18,6 +18,7 @@ import com.liferay.dynamic.data.mapping.internal.util.ResourceBundleLoaderProvid
 import com.liferay.dynamic.data.mapping.kernel.DDMTemplateManager;
 import com.liferay.dynamic.data.mapping.model.DDMTemplate;
 import com.liferay.dynamic.data.mapping.service.DDMTemplateLocalService;
+import com.liferay.osgi.service.tracker.collections.EagerServiceTrackerCustomizer;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
 import com.liferay.petra.string.StringBundler;
@@ -62,7 +63,6 @@ import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.util.tracker.ServiceTrackerCustomizer;
 
 /**
  * @author Michael C. Han
@@ -332,7 +332,8 @@ public class TemplateHandlerRegistryImpl implements TemplateHandlerRegistry {
 	}
 
 	private class TemplateHandlerServiceTrackerCustomizer
-		implements ServiceTrackerCustomizer<TemplateHandler, TemplateHandler> {
+		implements EagerServiceTrackerCustomizer
+			<TemplateHandler, TemplateHandler> {
 
 		@Override
 		public TemplateHandler addingService(


### PR DESCRIPTION
…ceTrackerCustomizer in TemplateHandlerRegistryImpl since the ServiceTrackerMapFactory.openSingleValueMap open the tracker in a lazy way. It is necessary to register TemplateHandler when the portal is started for the first time and populate database using the TemplateHandlerPortalInstanceLifecycleListener