### PR TITLE
LPS-178260 View button is not accessible through tab navigation

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/ActionsDropdown.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/ActionsDropdown.js
@@ -15,8 +15,8 @@
 import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
 import ClayDropDown from '@clayui/drop-down';
 import ClayIcon from '@clayui/icon';
-import ClayLink from '@clayui/link';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
+import {LinkOrButton} from '@clayui/shared';
 import {useIsMounted} from '@liferay/frontend-js-react-web';
 import PropTypes from 'prop-types';
 import React, {useContext} from 'react';
@@ -142,7 +142,7 @@ function ActionsDropdown({
 		}
 
 		return (
-			<ClayLink
+			<LinkOrButton
 				aria-label={action.label}
 				className="btn btn-secondary btn-sm"
 				href={
@@ -160,7 +160,7 @@ function ActionsDropdown({
 				title={action.label}
 			>
 				{action.icon ? <ClayIcon symbol={action.icon} /> : action.label}
-			</ClayLink>
+			</LinkOrButton>
 		);
 	}
 


### PR DESCRIPTION
Manual forward, after :green_circle: from QA in https://github.com/liferay-frontend/liferay-portal/pull/3149#issuecomment-1477879087

### References

- [LPS-178260 View button is not accessible through tab navigation](https://issues.liferay.com/browse/LPS-178260)

### What is the goal of this PR?

An accessibitly bugfix.

Note:
- I am intentionally not using `buttonDisplayType` and `linkDisplayType` [props](https://github.com/liferay/clay/blob/master/packages/clay-shared/src/LinkOrButton.tsx), because secondary link does not look the same as button. Instead, we are keeping CSS classes that drive how button and link look.
- The steps, as described in ticket, are technically no longer reproducible. We have two actions on dataset view, for the bug there needs to be one action. That is the case on Views page (see movie below), but that will no longer be the case after we add View deletion.

### What does it look like?

https://user-images.githubusercontent.com/5435511/226389653-5304f74f-8995-4cb8-911a-e20d2e9b78bf.mp4


### Steps to reproduce

1. Add `feature.flag.LPS-164563=true` to `portal-ext.properties`. This enables FDS Views Manager.
1. Open Global Menu > Control Panel > Object > Datasets

