### PR TITLE
LPS-178345 Allow developers to manage categories for object entries

### DIFF
--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/dto/v1_0/converter/TaxonomyCategoryDTOConverter.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/dto/v1_0/converter/TaxonomyCategoryDTOConverter.java
@@ -50,7 +50,11 @@ import org.osgi.service.component.annotations.Reference;
  * @author Víctor Galán
  */
 @Component(
-	property = "dto.class.name=com.liferay.asset.kernel.model.AssetCategory",
+	property = {
+		"application.name=Liferay.Headless.Admin.Taxonomy",
+		"dto.class.name=com.liferay.asset.kernel.model.AssetCategory",
+		"version=v1.0"
+	},
 	service = {DTOConverter.class, TaxonomyCategoryDTOConverter.class}
 )
 public class TaxonomyCategoryDTOConverter

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/util/TaxonomyCategoryBriefUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/util/TaxonomyCategoryBriefUtil.java
@@ -74,7 +74,8 @@ public class TaxonomyCategoryBriefUtil {
 
 			DTOConverter<?, ?> dtoConverter =
 				dtoConverterRegistry.getDTOConverter(
-					AssetCategory.class.getName());
+					"Liferay.Headless.Admin.Taxonomy",
+					AssetCategory.class.getName(), "v1.0");
 
 			if (dtoConverter == null) {
 				return null;

--- a/modules/apps/object/object-rest-api/bnd.bnd
+++ b/modules/apps/object/object-rest-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Object REST API
 Bundle-SymbolicName: com.liferay.object.rest.api
-Bundle-Version: 13.4.1
+Bundle-Version: 13.5.0
 Export-Package:\
 	com.liferay.object.rest.dto.v1_0,\
 	com.liferay.object.rest.dto.v1_0.util,\

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/ObjectEntry.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/ObjectEntry.java
@@ -354,6 +354,72 @@ public class ObjectEntry implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Status status;
 
+	@Schema(description = "The categories associated with this object entry.")
+	@Valid
+	public TaxonomyCategoryBrief[] getTaxonomyCategoryBriefs() {
+		return taxonomyCategoryBriefs;
+	}
+
+	public void setTaxonomyCategoryBriefs(
+		TaxonomyCategoryBrief[] taxonomyCategoryBriefs) {
+
+		this.taxonomyCategoryBriefs = taxonomyCategoryBriefs;
+	}
+
+	@JsonIgnore
+	public void setTaxonomyCategoryBriefs(
+		UnsafeSupplier<TaxonomyCategoryBrief[], Exception>
+			taxonomyCategoryBriefsUnsafeSupplier) {
+
+		try {
+			taxonomyCategoryBriefs = taxonomyCategoryBriefsUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField(
+		description = "The categories associated with this object entry."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected TaxonomyCategoryBrief[] taxonomyCategoryBriefs;
+
+	@Schema(
+		description = "A write-only field that adds `TaxonomyCategory` instances to the object entry."
+	)
+	public Long[] getTaxonomyCategoryIds() {
+		return taxonomyCategoryIds;
+	}
+
+	public void setTaxonomyCategoryIds(Long[] taxonomyCategoryIds) {
+		this.taxonomyCategoryIds = taxonomyCategoryIds;
+	}
+
+	@JsonIgnore
+	public void setTaxonomyCategoryIds(
+		UnsafeSupplier<Long[], Exception> taxonomyCategoryIdsUnsafeSupplier) {
+
+		try {
+			taxonomyCategoryIds = taxonomyCategoryIdsUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField(
+		description = "A write-only field that adds `TaxonomyCategory` instances to the object entry."
+	)
+	@JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+	protected Long[] taxonomyCategoryIds;
+
 	@Override
 	public boolean equals(Object object) {
 		if (this == object) {
@@ -512,6 +578,46 @@ public class ObjectEntry implements Serializable {
 			sb.append("\"status\": ");
 
 			sb.append(String.valueOf(status));
+		}
+
+		if (taxonomyCategoryBriefs != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"taxonomyCategoryBriefs\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < taxonomyCategoryBriefs.length; i++) {
+				sb.append(String.valueOf(taxonomyCategoryBriefs[i]));
+
+				if ((i + 1) < taxonomyCategoryBriefs.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
+		if (taxonomyCategoryIds != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"taxonomyCategoryIds\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < taxonomyCategoryIds.length; i++) {
+				sb.append(taxonomyCategoryIds[i]);
+
+				if ((i + 1) < taxonomyCategoryIds.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
 		}
 
 		sb.append("}");

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/TaxonomyCategoryBrief.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/TaxonomyCategoryBrief.java
@@ -1,0 +1,370 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.rest.dto.v1_0;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.util.ObjectMapperUtil;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.io.Serializable;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import javax.annotation.Generated;
+
+import javax.validation.Valid;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+@GraphQLName("TaxonomyCategoryBrief")
+@JsonFilter("Liferay.Vulcan")
+@XmlRootElement(name = "TaxonomyCategoryBrief")
+public class TaxonomyCategoryBrief implements Serializable {
+
+	public static TaxonomyCategoryBrief toDTO(String json) {
+		return ObjectMapperUtil.readValue(TaxonomyCategoryBrief.class, json);
+	}
+
+	public static TaxonomyCategoryBrief unsafeToDTO(String json) {
+		return ObjectMapperUtil.unsafeReadValue(
+			TaxonomyCategoryBrief.class, json);
+	}
+
+	@Schema(
+		description = "Optional field with the embedded taxonomy category, can be embedded with nestedFields"
+	)
+	@Valid
+	public Object getEmbeddedTaxonomyCategory() {
+		return embeddedTaxonomyCategory;
+	}
+
+	public void setEmbeddedTaxonomyCategory(Object embeddedTaxonomyCategory) {
+		this.embeddedTaxonomyCategory = embeddedTaxonomyCategory;
+	}
+
+	@JsonIgnore
+	public void setEmbeddedTaxonomyCategory(
+		UnsafeSupplier<Object, Exception>
+			embeddedTaxonomyCategoryUnsafeSupplier) {
+
+		try {
+			embeddedTaxonomyCategory =
+				embeddedTaxonomyCategoryUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField(
+		description = "Optional field with the embedded taxonomy category, can be embedded with nestedFields"
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Object embeddedTaxonomyCategory;
+
+	@Schema(
+		description = "The category's ID. This can be used to retrieve more information in the `TaxonomyCategory` API."
+	)
+	public Long getTaxonomyCategoryId() {
+		return taxonomyCategoryId;
+	}
+
+	public void setTaxonomyCategoryId(Long taxonomyCategoryId) {
+		this.taxonomyCategoryId = taxonomyCategoryId;
+	}
+
+	@JsonIgnore
+	public void setTaxonomyCategoryId(
+		UnsafeSupplier<Long, Exception> taxonomyCategoryIdUnsafeSupplier) {
+
+		try {
+			taxonomyCategoryId = taxonomyCategoryIdUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField(
+		description = "The category's ID. This can be used to retrieve more information in the `TaxonomyCategory` API."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Long taxonomyCategoryId;
+
+	@Schema(description = "The category's name.")
+	public String getTaxonomyCategoryName() {
+		return taxonomyCategoryName;
+	}
+
+	public void setTaxonomyCategoryName(String taxonomyCategoryName) {
+		this.taxonomyCategoryName = taxonomyCategoryName;
+	}
+
+	@JsonIgnore
+	public void setTaxonomyCategoryName(
+		UnsafeSupplier<String, Exception> taxonomyCategoryNameUnsafeSupplier) {
+
+		try {
+			taxonomyCategoryName = taxonomyCategoryNameUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField(description = "The category's name.")
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String taxonomyCategoryName;
+
+	@Schema(description = "The localized category's names.")
+	@Valid
+	public Map<String, String> getTaxonomyCategoryName_i18n() {
+		return taxonomyCategoryName_i18n;
+	}
+
+	public void setTaxonomyCategoryName_i18n(
+		Map<String, String> taxonomyCategoryName_i18n) {
+
+		this.taxonomyCategoryName_i18n = taxonomyCategoryName_i18n;
+	}
+
+	@JsonIgnore
+	public void setTaxonomyCategoryName_i18n(
+		UnsafeSupplier<Map<String, String>, Exception>
+			taxonomyCategoryName_i18nUnsafeSupplier) {
+
+		try {
+			taxonomyCategoryName_i18n =
+				taxonomyCategoryName_i18nUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField(description = "The localized category's names.")
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Map<String, String> taxonomyCategoryName_i18n;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof TaxonomyCategoryBrief)) {
+			return false;
+		}
+
+		TaxonomyCategoryBrief taxonomyCategoryBrief =
+			(TaxonomyCategoryBrief)object;
+
+		return Objects.equals(toString(), taxonomyCategoryBrief.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		if (embeddedTaxonomyCategory != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"embeddedTaxonomyCategory\": ");
+
+			if (embeddedTaxonomyCategory instanceof Map) {
+				sb.append(
+					JSONFactoryUtil.createJSONObject(
+						(Map<?, ?>)embeddedTaxonomyCategory));
+			}
+			else if (embeddedTaxonomyCategory instanceof String) {
+				sb.append("\"");
+				sb.append(_escape((String)embeddedTaxonomyCategory));
+				sb.append("\"");
+			}
+			else {
+				sb.append(embeddedTaxonomyCategory);
+			}
+		}
+
+		if (taxonomyCategoryId != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"taxonomyCategoryId\": ");
+
+			sb.append(taxonomyCategoryId);
+		}
+
+		if (taxonomyCategoryName != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"taxonomyCategoryName\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(taxonomyCategoryName));
+
+			sb.append("\"");
+		}
+
+		if (taxonomyCategoryName_i18n != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"taxonomyCategoryName_i18n\": ");
+
+			sb.append(_toJSON(taxonomyCategoryName_i18n));
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	@Schema(
+		accessMode = Schema.AccessMode.READ_ONLY,
+		defaultValue = "com.liferay.object.rest.dto.v1_0.TaxonomyCategoryBrief",
+		name = "x-class-name"
+	)
+	public String xClassName;
+
+	private static String _escape(Object object) {
+		return StringUtil.replace(
+			String.valueOf(object), _JSON_ESCAPE_STRINGS[0],
+			_JSON_ESCAPE_STRINGS[1]);
+	}
+
+	private static boolean _isArray(Object value) {
+		if (value == null) {
+			return false;
+		}
+
+		Class<?> clazz = value.getClass();
+
+		return clazz.isArray();
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(_escape(entry.getKey()));
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			if (_isArray(value)) {
+				sb.append("[");
+
+				Object[] valueArray = (Object[])value;
+
+				for (int i = 0; i < valueArray.length; i++) {
+					if (valueArray[i] instanceof String) {
+						sb.append("\"");
+						sb.append(valueArray[i]);
+						sb.append("\"");
+					}
+					else {
+						sb.append(valueArray[i]);
+					}
+
+					if ((i + 1) < valueArray.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof Map) {
+				sb.append(_toJSON((Map<String, ?>)value));
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(value));
+				sb.append("\"");
+			}
+			else {
+				sb.append(value);
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static final String[][] _JSON_ESCAPE_STRINGS = {
+		{"\\", "\"", "\b", "\f", "\n", "\r", "\t"},
+		{"\\\\", "\\\"", "\\b", "\\f", "\\n", "\\r", "\\t"}
+	};
+
+}

--- a/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/dto/v1_0/packageinfo
+++ b/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 1.5.0
+version 1.6.0

--- a/modules/apps/object/object-rest-impl/build.gradle
+++ b/modules/apps/object/object-rest-impl/build.gradle
@@ -15,6 +15,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:account:account-api")
+	compileOnly project(":apps:asset:asset-entry-rel-api")
 	compileOnly project(":apps:depot:depot-api")
 	compileOnly project(":apps:document-library:document-library-api")
 	compileOnly project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")

--- a/modules/apps/object/object-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-rest-impl/rest-openapi.yaml
@@ -71,6 +71,22 @@ components:
                 status:
                     $ref: "#/components/schemas/Status"
                     readOnly: true
+                taxonomyCategoryBriefs:
+                    description:
+                        The categories associated with this object entry.
+                    items:
+                        $ref: "#/components/schemas/TaxonomyCategoryBrief"
+                    readOnly: true
+                    type: array
+                taxonomyCategoryIds:
+                    # @review
+                    description:
+                        A write-only field that adds `TaxonomyCategory` instances to the object entry.
+                    items:
+                        format: int64
+                        type: integer
+                    type: array
+                    writeOnly: true
             type: object
         Status:
             properties:
@@ -82,6 +98,34 @@ components:
                     type: string
                 label_i18n:
                     type: string
+            type: object
+        TaxonomyCategoryBrief:
+            properties:
+                embeddedTaxonomyCategory:
+                    # @review
+                    description:
+                        Optional field with the embedded taxonomy category, can be embedded with nestedFields
+                    readOnly: true
+                    type: object
+                taxonomyCategoryId:
+                    description:
+                        The category's ID. This can be used to retrieve more information in the `TaxonomyCategory` API.
+                    format: int64
+                    readOnly: true
+                    type: integer
+                taxonomyCategoryName:
+                    description:
+                        The category's name.
+                    readOnly: true
+                    type: string
+                taxonomyCategoryName_i18n:
+                    additionalProperties:
+                        type: string
+                    # @review
+                    description:
+                        The localized category's names.
+                    readOnly: true
+                    type: object
             type: object
 info:
     license:

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -286,9 +286,10 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 
 	private ObjectEntryResourceImpl _createObjectEntryResourceImpl() {
 		return new ObjectEntryResourceImpl(
-			_objectDefinitionLocalService, _objectEntryLocalService,
-			_objectEntryManagerRegistry, _objectFieldLocalService,
-			_objectRelationshipService, _objectScopeProviderRegistry,
+			_dtoConverterRegistry, _objectDefinitionLocalService,
+			_objectEntryLocalService, _objectEntryManagerRegistry,
+			_objectFieldLocalService, _objectRelationshipService,
+			_objectScopeProviderRegistry,
 			_systemObjectDefinitionMetadataRegistry);
 	}
 

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
@@ -15,6 +15,7 @@
 package com.liferay.object.rest.internal.dto.v1_0.converter;
 
 import com.liferay.asset.kernel.model.AssetTag;
+import com.liferay.asset.kernel.service.AssetCategoryLocalService;
 import com.liferay.asset.kernel.service.AssetTagLocalService;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.service.DLAppService;
@@ -34,8 +35,10 @@ import com.liferay.object.rest.dto.v1_0.FileEntry;
 import com.liferay.object.rest.dto.v1_0.ListEntry;
 import com.liferay.object.rest.dto.v1_0.ObjectEntry;
 import com.liferay.object.rest.dto.v1_0.Status;
+import com.liferay.object.rest.dto.v1_0.TaxonomyCategoryBrief;
 import com.liferay.object.rest.dto.v1_0.util.CreatorUtil;
 import com.liferay.object.rest.dto.v1_0.util.LinkUtil;
+import com.liferay.object.rest.internal.dto.v1_0.util.TaxonomyCategoryBriefUtil;
 import com.liferay.object.rest.internal.util.DTOConverterUtil;
 import com.liferay.object.scope.ObjectScopeProvider;
 import com.liferay.object.scope.ObjectScopeProviderRegistry;
@@ -388,6 +391,17 @@ public class ObjectEntryDTOConverter
 								objectEntry.getStatus()));
 					}
 				};
+
+				if (FeatureFlagManagerUtil.isEnabled("LPS-176651")) {
+					taxonomyCategoryBriefs = TransformUtil.transformToArray(
+						_assetCategoryLocalService.getCategories(
+							objectDefinition.getClassName(),
+							objectEntry.getObjectEntryId()),
+						assetCategory ->
+							TaxonomyCategoryBriefUtil.toTaxonomyCategoryBrief(
+								assetCategory, dtoConverterContext),
+						TaxonomyCategoryBrief.class);
+				}
 			}
 		};
 	}
@@ -615,6 +629,9 @@ public class ObjectEntryDTOConverter
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		ObjectEntryDTOConverter.class);
+
+	@Reference
+	private AssetCategoryLocalService _assetCategoryLocalService;
 
 	@Reference
 	private AssetTagLocalService _assetTagLocalService;

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/util/TaxonomyCategoryBriefUtil.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/util/TaxonomyCategoryBriefUtil.java
@@ -75,7 +75,8 @@ public class TaxonomyCategoryBriefUtil {
 
 			DTOConverter<?, ?> dtoConverter =
 				dtoConverterRegistry.getDTOConverter(
-					AssetCategory.class.getName());
+					"Liferay.Headless.Admin.Taxonomy",
+					AssetCategory.class.getName(), "v1.0");
 
 			if (dtoConverter == null) {
 				return null;

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/util/TaxonomyCategoryBriefUtil.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/util/TaxonomyCategoryBriefUtil.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.rest.internal.dto.v1_0.util;
+
+import com.liferay.asset.kernel.model.AssetCategory;
+import com.liferay.object.rest.dto.v1_0.TaxonomyCategoryBrief;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.vulcan.dto.converter.DTOConverter;
+import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
+import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
+import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
+import com.liferay.portal.vulcan.util.LocalizedMapUtil;
+
+import java.util.Collections;
+
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.UriInfo;
+
+/**
+ * @author Javier Gamarra
+ */
+public class TaxonomyCategoryBriefUtil {
+
+	public static TaxonomyCategoryBrief toTaxonomyCategoryBrief(
+			AssetCategory assetCategory,
+			DTOConverterContext dtoConverterContext)
+		throws Exception {
+
+		return new TaxonomyCategoryBrief() {
+			{
+				embeddedTaxonomyCategory = _toTaxonomyCategory(
+					assetCategory.getCategoryId(), dtoConverterContext);
+				taxonomyCategoryId = assetCategory.getCategoryId();
+				taxonomyCategoryName = assetCategory.getTitle(
+					dtoConverterContext.getLocale());
+				taxonomyCategoryName_i18n = LocalizedMapUtil.getI18nMap(
+					dtoConverterContext.isAcceptAllLanguages(),
+					assetCategory.getTitleMap());
+			}
+		};
+	}
+
+	private static Object _toTaxonomyCategory(
+			long categoryId, DTOConverterContext dtoConverterContext)
+		throws Exception {
+
+		UriInfo uriInfo = dtoConverterContext.getUriInfo();
+
+		if (uriInfo == null) {
+			return null;
+		}
+
+		MultivaluedMap<String, String> queryParameters =
+			uriInfo.getQueryParameters();
+
+		String nestedFields = queryParameters.getFirst("nestedFields");
+
+		if (Validator.isNotNull(nestedFields) &&
+			nestedFields.contains("embeddedTaxonomyCategory")) {
+
+			DTOConverterRegistry dtoConverterRegistry =
+				dtoConverterContext.getDTOConverterRegistry();
+
+			DTOConverter<?, ?> dtoConverter =
+				dtoConverterRegistry.getDTOConverter(
+					AssetCategory.class.getName());
+
+			if (dtoConverter == null) {
+				return null;
+			}
+
+			return dtoConverter.toDTO(
+				new DefaultDTOConverterContext(
+					dtoConverterContext.isAcceptAllLanguages(),
+					Collections.emptyMap(), dtoConverterRegistry,
+					dtoConverterContext.getHttpServletRequest(), categoryId,
+					dtoConverterContext.getLocale(), uriInfo,
+					dtoConverterContext.getUser()));
+		}
+
+		return null;
+	}
+
+}

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -773,6 +773,14 @@ public class DefaultObjectEntryManagerImpl
 		serviceContext.setAddGroupPermissions(true);
 		serviceContext.setAddGuestPermissions(true);
 
+		if (Validator.isNotNull(objectEntry.getTaxonomyCategoryIds()) &&
+			FeatureFlagManagerUtil.isEnabled("LPS-176651")) {
+
+			serviceContext.setAssetCategoryIds(
+				ArrayUtil.toArray(objectEntry.getTaxonomyCategoryIds()));
+			serviceContext.setAssetTagNames(objectEntry.getKeywords());
+		}
+
 		Map<String, Object> properties = objectEntry.getProperties();
 
 		if (properties.get("categoryIds") != null) {

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/entity/v1_0/ObjectEntryEntityModel.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/entity/v1_0/ObjectEntryEntityModel.java
@@ -264,6 +264,18 @@ public class ObjectEntryEntityModel implements EntityModel {
 				new CollectionEntityField(
 					new IntegerEntityField("status", locale -> Field.STATUS))
 			).put(
+				"taxonomyCategoryIds",
+				() -> {
+					if (FeatureFlagManagerUtil.isEnabled("LPS-176651")) {
+						return new CollectionEntityField(
+							new IntegerEntityField(
+								"taxonomyCategoryIds",
+								locale -> "assetCategoryIds"));
+					}
+
+					return null;
+				}
+			).put(
 				"userId",
 				new IntegerEntityField("userId", locale -> Field.USER_ID)
 			).build();

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
@@ -472,6 +472,15 @@ public class PredicateExpressionVisitorImpl
 						rights, String::valueOf, Object.class)));
 		}
 
+		if (_isTaxonomyCategoryIds(left)) {
+			return _getTaxonomyCategoryIdsPredicate(
+				objectDefinitionId,
+				AssetEntryAssetCategoryRelTable.INSTANCE.assetCategoryId.in(
+					TransformUtil.transformToArray(
+						rights, assetCategoryId -> (Long)assetCategoryId,
+						Long.class)));
+		}
+
 		return _getColumn(
 			left, objectDefinitionId
 		).in(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseObjectEntryResourceImpl.java
@@ -351,6 +351,11 @@ public abstract class BaseObjectEntryResourceImpl
 			existingObjectEntry.setScopeKey(objectEntry.getScopeKey());
 		}
 
+		if (objectEntry.getTaxonomyCategoryIds() != null) {
+			existingObjectEntry.setTaxonomyCategoryIds(
+				objectEntry.getTaxonomyCategoryIds());
+		}
+
 		preparePatch(objectEntry, existingObjectEntry);
 
 		return putByExternalReferenceCode(
@@ -551,6 +556,11 @@ public abstract class BaseObjectEntryResourceImpl
 
 		if (objectEntry.getScopeKey() != null) {
 			existingObjectEntry.setScopeKey(objectEntry.getScopeKey());
+		}
+
+		if (objectEntry.getTaxonomyCategoryIds() != null) {
+			existingObjectEntry.setTaxonomyCategoryIds(
+				objectEntry.getTaxonomyCategoryIds());
 		}
 
 		preparePatch(objectEntry, existingObjectEntry);
@@ -777,6 +787,11 @@ public abstract class BaseObjectEntryResourceImpl
 
 		if (objectEntry.getScopeKey() != null) {
 			existingObjectEntry.setScopeKey(objectEntry.getScopeKey());
+		}
+
+		if (objectEntry.getTaxonomyCategoryIds() != null) {
+			existingObjectEntry.setTaxonomyCategoryIds(
+				objectEntry.getTaxonomyCategoryIds());
 		}
 
 		preparePatch(objectEntry, existingObjectEntry);

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
@@ -38,6 +38,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.vulcan.aggregation.Aggregation;
+import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
 import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
@@ -58,6 +59,7 @@ import javax.ws.rs.core.MultivaluedMap;
 public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 
 	public ObjectEntryResourceImpl(
+		DTOConverterRegistry dtoConverterRegistry,
 		ObjectDefinitionLocalService objectDefinitionLocalService,
 		ObjectEntryLocalService objectEntryLocalService,
 		ObjectEntryManagerRegistry objectEntryManagerRegistry,
@@ -67,6 +69,7 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 		SystemObjectDefinitionMetadataRegistry
 			systemObjectDefinitionMetadataRegistry) {
 
+		_dtoConverterRegistry = dtoConverterRegistry;
 		_objectDefinitionLocalService = objectDefinitionLocalService;
 		_objectEntryLocalService = objectEntryLocalService;
 		_objectEntryManagerRegistry = objectEntryManagerRegistry;
@@ -476,8 +479,8 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 		Long objectEntryId) {
 
 		return new DefaultDTOConverterContext(
-			contextAcceptLanguage.isAcceptAllLanguages(), null, null,
-			contextHttpServletRequest, objectEntryId,
+			contextAcceptLanguage.isAcceptAllLanguages(), null,
+			_dtoConverterRegistry, contextHttpServletRequest, objectEntryId,
 			contextAcceptLanguage.getPreferredLocale(), contextUriInfo,
 			contextUser);
 	}
@@ -576,6 +579,8 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 
 		throw new NotFoundException("Missing parameter \"objectDefinitionId\"");
 	}
+
+	private final DTOConverterRegistry _dtoConverterRegistry;
 
 	@Context
 	private ObjectDefinition _objectDefinition;

--- a/modules/apps/object/object-rest-test/bnd.bnd
+++ b/modules/apps/object/object-rest-test/bnd.bnd
@@ -1,3 +1,4 @@
 Bundle-Name: Liferay Object REST Test
 Bundle-SymbolicName: com.liferay.object.rest.test
 Bundle-Version: 1.0.0
+-includeresource: com.liferay.headless.admin.taxonomy.client.jar=com.liferay.headless.admin.taxonomy.client-*.jar;lib:=true

--- a/modules/apps/object/object-rest-test/build.gradle
+++ b/modules/apps/object/object-rest-test/build.gradle
@@ -6,6 +6,7 @@ dependencies {
 	testIntegrationCompile group: "org.apache.cxf", name: "cxf-core", version: "3.4.10"
 	testIntegrationCompile project(":apps:account:account-api")
 	testIntegrationCompile project(":apps:document-library:document-library-api")
+	testIntegrationCompile project(":apps:headless:headless-admin-taxonomy:headless-admin-taxonomy-client")
 	testIntegrationCompile project(":apps:headless:headless-admin-user:headless-admin-user-api")
 	testIntegrationCompile project(":apps:list-type:list-type-api")
 	testIntegrationCompile project(":apps:object:object-api")

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -32,6 +32,7 @@ import com.liferay.object.rest.internal.resource.v1_0.test.util.ObjectRelationsh
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
@@ -272,6 +273,124 @@ public class ObjectEntryResourceTest {
 		_assertFilteredObjectEntries(3, "keywords/any(k:k in ('tag1','tag2'))");
 		_assertFilteredObjectEntries(2, "keywords/any(k:k in ('tag2','tag3'))");
 		_assertFilteredObjectEntries(0, "keywords/any(k:k in ('1234','5678'))");
+	}
+
+	@Test
+	public void testGetObjectEntryFilteredByTaxonomyCategories()
+		throws Exception {
+
+		TaxonomyCategory taxonomyCategory1 = _addTaxonomyCategory();
+		TaxonomyCategory taxonomyCategory2 = _addTaxonomyCategory();
+		TaxonomyCategory taxonomyCategory3 = _addTaxonomyCategory();
+
+		_postObjectEntryWithTaxonomyCategories();
+		_postObjectEntryWithTaxonomyCategories(taxonomyCategory1);
+		_postObjectEntryWithTaxonomyCategories(
+			taxonomyCategory1, taxonomyCategory2);
+		_postObjectEntryWithTaxonomyCategories(
+			taxonomyCategory1, taxonomyCategory2, taxonomyCategory3);
+
+		_assertFilteredObjectEntries(
+			3,
+			String.format(
+				"taxonomyCategoryIds/any(k:k eq %s)",
+				taxonomyCategory1.getId()));
+		_assertFilteredObjectEntries(
+			3,
+			String.format(
+				"taxonomyCategoryIds/any(k:k eq %s)",
+				taxonomyCategory1.getId()));
+		_assertFilteredObjectEntries(
+			2,
+			String.format(
+				"taxonomyCategoryIds/any(k:k eq %s)",
+				taxonomyCategory2.getId()));
+		_assertFilteredObjectEntries(
+			1,
+			String.format(
+				"taxonomyCategoryIds/any(k:k eq %s)",
+				taxonomyCategory3.getId()));
+		_assertFilteredObjectEntries(0, "taxonomyCategoryIds/any(k:k eq 1234)");
+
+		_assertFilteredObjectEntries(
+			2,
+			String.format(
+				"taxonomyCategoryIds/any(k:k ne %s)",
+				taxonomyCategory1.getId()));
+		_assertFilteredObjectEntries(
+			3,
+			String.format(
+				"taxonomyCategoryIds/any(k:k ne %s)",
+				taxonomyCategory2.getId()));
+		_assertFilteredObjectEntries(
+			3,
+			String.format(
+				"taxonomyCategoryIds/any(k:k ne %s)",
+				taxonomyCategory3.getId()));
+
+		_assertFilteredObjectEntries(
+			2,
+			String.format(
+				"taxonomyCategoryIds/any(k:k gt %s)",
+				taxonomyCategory1.getId()));
+		_assertFilteredObjectEntries(
+			1,
+			String.format(
+				"taxonomyCategoryIds/any(k:k gt %s)",
+				taxonomyCategory2.getId()));
+		_assertFilteredObjectEntries(
+			0,
+			String.format(
+				"taxonomyCategoryIds/any(k:k gt %s)",
+				taxonomyCategory3.getId()));
+
+		_assertFilteredObjectEntries(
+			3,
+			String.format(
+				"taxonomyCategoryIds/any(k:k ge %s)",
+				taxonomyCategory1.getId()));
+		_assertFilteredObjectEntries(
+			2,
+			String.format(
+				"taxonomyCategoryIds/any(k:k ge %s)",
+				taxonomyCategory2.getId()));
+		_assertFilteredObjectEntries(
+			1,
+			String.format(
+				"taxonomyCategoryIds/any(k:k ge %s)",
+				taxonomyCategory3.getId()));
+
+		_assertFilteredObjectEntries(
+			0,
+			String.format(
+				"taxonomyCategoryIds/any(k:k lt %s)",
+				taxonomyCategory1.getId()));
+		_assertFilteredObjectEntries(
+			3,
+			String.format(
+				"taxonomyCategoryIds/any(k:k lt %s)",
+				taxonomyCategory2.getId()));
+		_assertFilteredObjectEntries(
+			3,
+			String.format(
+				"taxonomyCategoryIds/any(k:k lt %s)",
+				taxonomyCategory3.getId()));
+
+		_assertFilteredObjectEntries(
+			3,
+			String.format(
+				"taxonomyCategoryIds/any(k:k le %s)",
+				taxonomyCategory1.getId()));
+		_assertFilteredObjectEntries(
+			3,
+			String.format(
+				"taxonomyCategoryIds/any(k:k le %s)",
+				taxonomyCategory2.getId()));
+		_assertFilteredObjectEntries(
+			3,
+			String.format(
+				"taxonomyCategoryIds/any(k:k le %s)",
+				taxonomyCategory3.getId()));
 	}
 
 	@Test
@@ -1077,6 +1196,21 @@ public class ObjectEntryResourceTest {
 				_OBJECT_FIELD_NAME_1, RandomTestUtil.randomString()
 			).put(
 				"keywords", JSONUtil.putAll(keywords)
+			).toString(),
+			_objectDefinition1.getRESTContextPath(), Http.Method.POST);
+	}
+
+	private void _postObjectEntryWithTaxonomyCategories(
+			TaxonomyCategory... taxonomyCategories)
+		throws Exception {
+
+		HTTPTestUtil.invoke(
+			JSONUtil.put(
+				_OBJECT_FIELD_NAME_1, RandomTestUtil.randomString()
+			).put(
+				"taxonomyCategoryIds",
+				TransformUtil.transform(
+					taxonomyCategories, TaxonomyCategory::getId, String.class)
 			).toString(),
 			_objectDefinition1.getRESTContextPath(), Http.Method.POST);
 	}

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -488,6 +488,79 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
+	public void testGetObjectEntryWithTaxonomyCategoriesAndEmbeddedTaxonomyCategory()
+		throws Exception {
+
+		TaxonomyCategory taxonomyCategory1 = _addTaxonomyCategory();
+		TaxonomyCategory taxonomyCategory2 = _addTaxonomyCategory();
+
+		JSONObject jsonObject = HTTPTestUtil.invoke(
+			JSONUtil.put(
+				_OBJECT_FIELD_NAME_1, "value"
+			).put(
+				"taxonomyCategoryIds",
+				JSONUtil.putAll(
+					taxonomyCategory1.getId(), taxonomyCategory2.getId())
+			).toString(),
+			_objectDefinition1.getRESTContextPath(), Http.Method.POST);
+
+		jsonObject = HTTPTestUtil.invoke(
+			null,
+			StringBundler.concat(
+				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
+				jsonObject.getString("id"),
+				"?nestedFields=embeddedTaxonomyCategory"),
+			Http.Method.GET);
+
+		Assert.assertEquals(
+			JSONUtil.putAll(
+				JSONUtil.put(
+					"embeddedTaxonomyCategory",
+					JSONUtil.put(
+						"externalReferenceCode",
+						taxonomyCategory1.getExternalReferenceCode()
+					).put(
+						"id", Long.valueOf(taxonomyCategory1.getId())
+					).put(
+						"name", taxonomyCategory1.getName()
+					).put(
+						"siteId", taxonomyCategory1.getSiteId()
+					).put(
+						"vocabulary", _assetVocabulary.getName()
+					)
+				).put(
+					"taxonomyCategoryId",
+					Long.valueOf(taxonomyCategory1.getId())
+				).put(
+					"taxonomyCategoryName", taxonomyCategory1.getName()
+				),
+				JSONUtil.put(
+					"embeddedTaxonomyCategory",
+					JSONUtil.put(
+						"externalReferenceCode",
+						taxonomyCategory2.getExternalReferenceCode()
+					).put(
+						"id", Long.valueOf(taxonomyCategory2.getId())
+					).put(
+						"name", taxonomyCategory2.getName()
+					).put(
+						"siteId", taxonomyCategory2.getSiteId()
+					).put(
+						"vocabulary", _assetVocabulary.getName()
+					)
+				).put(
+					"taxonomyCategoryId",
+					Long.valueOf(taxonomyCategory2.getId())
+				).put(
+					"taxonomyCategoryName", taxonomyCategory2.getName()
+				)
+			).toString(),
+			jsonObject.getJSONArray(
+				"taxonomyCategoryBriefs"
+			).toString());
+	}
+
+	@Test
 	public void testGetObjectRelationshipERCFieldNameInOneToManyRelationship()
 		throws Exception {
 

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -58,6 +58,7 @@ import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.portal.util.PropsUtil;
 
 import java.util.Collections;
+import java.util.HashMap;
 
 import javax.ws.rs.NotSupportedException;
 
@@ -516,18 +517,7 @@ public class ObjectEntryResourceTest {
 			JSONUtil.putAll(
 				JSONUtil.put(
 					"embeddedTaxonomyCategory",
-					JSONUtil.put(
-						"externalReferenceCode",
-						taxonomyCategory1.getExternalReferenceCode()
-					).put(
-						"id", Long.valueOf(taxonomyCategory1.getId())
-					).put(
-						"name", taxonomyCategory1.getName()
-					).put(
-						"siteId", taxonomyCategory1.getSiteId()
-					).put(
-						"vocabulary", _assetVocabulary.getName()
-					)
+					_toEmbeddedTaxonomyCategoryJSONObject(taxonomyCategory1)
 				).put(
 					"taxonomyCategoryId",
 					Long.valueOf(taxonomyCategory1.getId())
@@ -536,18 +526,7 @@ public class ObjectEntryResourceTest {
 				),
 				JSONUtil.put(
 					"embeddedTaxonomyCategory",
-					JSONUtil.put(
-						"externalReferenceCode",
-						taxonomyCategory2.getExternalReferenceCode()
-					).put(
-						"id", Long.valueOf(taxonomyCategory2.getId())
-					).put(
-						"name", taxonomyCategory2.getName()
-					).put(
-						"siteId", taxonomyCategory2.getSiteId()
-					).put(
-						"vocabulary", _assetVocabulary.getName()
-					)
+					_toEmbeddedTaxonomyCategoryJSONObject(taxonomyCategory2)
 				).put(
 					"taxonomyCategoryId",
 					Long.valueOf(taxonomyCategory2.getId())
@@ -1540,6 +1519,18 @@ public class ObjectEntryResourceTest {
 			Http.Method.POST);
 
 		Assert.assertEquals("BAD_REQUEST", jsonObject.get("status"));
+	}
+
+	private JSONObject _toEmbeddedTaxonomyCategoryJSONObject(
+			TaxonomyCategory taxonomyCategory)
+		throws Exception {
+
+		TaxonomyCategory embeddedTaxonomyCategory = taxonomyCategory.clone();
+
+		embeddedTaxonomyCategory.setActions(new HashMap<>());
+
+		return JSONFactoryUtil.createJSONObject(
+			embeddedTaxonomyCategory.toString());
 	}
 
 	private static final String _ERC_VALUE_1 = RandomTestUtil.randomString();

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -391,6 +391,19 @@ public class ObjectEntryResourceTest {
 			String.format(
 				"taxonomyCategoryIds/any(k:k le %s)",
 				taxonomyCategory3.getId()));
+
+		_assertFilteredObjectEntries(
+			3,
+			String.format(
+				"taxonomyCategoryIds/any(k:k in (%s,%s))",
+				taxonomyCategory1.getId(), taxonomyCategory2.getId()));
+		_assertFilteredObjectEntries(
+			2,
+			String.format(
+				"taxonomyCategoryIds/any(k:k in (%s,%s))",
+				taxonomyCategory2.getId(), taxonomyCategory3.getId()));
+		_assertFilteredObjectEntries(
+			0, "taxonomyCategoryIds/any(k:k in (1234,5678))");
 	}
 
 	@Test

--- a/modules/apps/portal-odata/portal-odata-impl/build.gradle
+++ b/modules/apps/portal-odata/portal-odata-impl/build.gradle
@@ -1,9 +1,9 @@
 dependencies {
-	compileInclude group: "org.apache.olingo", name: "odata-commons-api", version: "4.7.1"
-	compileInclude group: "org.apache.olingo", name: "odata-commons-core", version: "4.7.1"
-	compileInclude group: "org.apache.olingo", name: "odata-server-api", version: "4.7.1"
-	compileInclude group: "org.apache.olingo", name: "odata-server-core", version: "4.7.1"
-	compileInclude group: "org.apache.olingo", name: "odata-server-core-ext", version: "4.7.1"
+	compileInclude group: "org.apache.olingo", name: "odata-commons-api", version: "4.9.0"
+	compileInclude group: "org.apache.olingo", name: "odata-commons-core", version: "4.9.0"
+	compileInclude group: "org.apache.olingo", name: "odata-server-api", version: "4.9.0"
+	compileInclude group: "org.apache.olingo", name: "odata-server-core", version: "4.9.0"
+	compileInclude group: "org.apache.olingo", name: "odata-server-core-ext", version: "4.9.0"
 
 	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.13.4.2"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"


### PR DESCRIPTION
Adding support for taxonomy categories in objects.

To test it use the automated tests, or the API explorer.

**Important:** I've used the same `if` approach to handle the `taxonomyCategoryIds` field, as in `keywords`. I have created https://issues.liferay.com/browse/LPS-178772 to unify in a common API that allows us to get rid of the `ifs`. I am starting to work on it now, but I want this to get reviewed and merged first.