### PR TITLE
LPS-179105 use getCompanyJobExecutorUnsafeConsumer instead getJobExecutorUnsafeRunnable because on DBPartition the Scheduler job is called several times

### DIFF
--- a/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/scheduler/test/CheckFileEntrySchedulerJobConfigurationTest.java
+++ b/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/scheduler/test/CheckFileEntrySchedulerJobConfigurationTest.java
@@ -80,7 +80,7 @@ public class CheckFileEntrySchedulerJobConfigurationTest {
 			ServiceContextTestUtil.getServiceContext(
 				_group.getGroupId(), TestPropsValues.getUserId()));
 
-		_dlFileEntryLocalService.checkFileEntries(1);
+		_dlFileEntryLocalService.checkFileEntries(_group.getCompanyId(), 1);
 
 		DLFileEntry dlFileEntry = _dlFileEntryLocalService.getFileEntry(
 			fileEntry.getFileEntryId());

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -369,11 +369,9 @@ public class DLFileEntryLocalServiceImpl
 
 		Date date = new Date();
 
-		if (_companyPreviousCheckDate.get(companyId) == null) {
-			_companyPreviousCheckDate.put(
-				companyId,
-				new Date(date.getTime() - (checkInterval * Time.MINUTE)));
-		}
+		_companyPreviousCheckDate.computeIfAbsent(
+			companyId,
+			key -> new Date(date.getTime() - (checkInterval * Time.MINUTE)));
 
 		_checkFileEntriesByExpirationDate(companyId, date);
 

--- a/portal-kernel/bnd.bnd
+++ b/portal-kernel/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 100.2.0
+Bundle-Version: 101.0.0
 Export-Package:\
 	!com.liferay.portal.kernel.internal.*,\
 	!com.liferay.portal.kernel.module.util,\

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryLocalService.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryLocalService.java
@@ -109,7 +109,8 @@ public interface DLFileEntryLocalService
 	public DLFileVersion cancelCheckOut(long userId, long fileEntryId)
 		throws PortalException;
 
-	public void checkFileEntries(long checkInterval) throws PortalException;
+	public void checkFileEntries(long companyId, long checkInterval)
+		throws PortalException;
 
 	public void checkInFileEntry(
 			long userId, long fileEntryId,

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryLocalServiceUtil.java
@@ -87,10 +87,10 @@ public class DLFileEntryLocalServiceUtil {
 		return getService().cancelCheckOut(userId, fileEntryId);
 	}
 
-	public static void checkFileEntries(long checkInterval)
+	public static void checkFileEntries(long companyId, long checkInterval)
 		throws PortalException {
 
-		getService().checkFileEntries(checkInterval);
+		getService().checkFileEntries(companyId, checkInterval);
 	}
 
 	public static void checkInFileEntry(

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryLocalServiceWrapper.java
@@ -85,10 +85,10 @@ public class DLFileEntryLocalServiceWrapper
 	}
 
 	@Override
-	public void checkFileEntries(long checkInterval)
+	public void checkFileEntries(long companyId, long checkInterval)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
-		_dlFileEntryLocalService.checkFileEntries(checkInterval);
+		_dlFileEntryLocalService.checkFileEntries(companyId, checkInterval);
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/packageinfo
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/packageinfo
@@ -1,1 +1,1 @@
-version 10.0.0
+version 11.0.0


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-179105

This is a fix to the user be able to work with Documents and Media when database partitioning is enabled.
On this fix the I used getCompanyJobExecutorUnsafeConsumer instead getJobExecutorUnsafeRunnable because on DB Partition the Scheduler job is called several times, one time by company id:
It seems that it is being called as many times as instances are instances in the system, which makes the method be called, in this case, 2 times.


- LPS-179105 check File Entries by company id that comes from the Scheduler Job Configuration
- LPS-179105 baseline
- LPS-179105 add the call to getCompanyJobExecutorUnsafeConsumer to be called instead n times getJobExecutorUnsafeRunnable when there are more than one instances

@brianchandotcom resending this pull directly to you since after a few retries we confirmed this pull is not related to any of the failing tests in https://github.com/liferay-lima/liferay-portal/pull/4123.
