### PR TITLE
LPS-170415 Add integration test for filter parent custom entities with data from the related elements

### DIFF
--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -572,6 +572,179 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
+	public void testFilterByStringOperatorsObjectEntriesByRelatesObjectEntriesFields()
+		throws Exception {
+
+		String objectFieldValue1 = String.valueOf(_OBJECT_FIELD_VALUE_1);
+		String objectFieldValue2 = String.valueOf(_OBJECT_FIELD_VALUE_2);
+
+		_objectEntry1 = ObjectEntryTestUtil.addObjectEntry(
+			_objectDefinition1, _OBJECT_FIELD_NAME_1, objectFieldValue1);
+
+		_objectEntry2 = ObjectEntryTestUtil.addObjectEntry(
+			_objectDefinition2, _OBJECT_FIELD_NAME_2, objectFieldValue2);
+
+		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		// Custom fields
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			String.format(
+				"contains(%s/%s,'%s')", _objectRelationship.getName(),
+				_OBJECT_FIELD_NAME_2, objectFieldValue2.substring(1)),
+			_objectDefinition1);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			String.format(
+				"startswith(%s/%s,'%s')", _objectRelationship.getName(),
+				_OBJECT_FIELD_NAME_2, objectFieldValue2.substring(0, 2)),
+			_objectDefinition1);
+
+		// System field
+
+		String objectEntry2externalReferenceCode =
+			_objectEntry2.getExternalReferenceCode();
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			String.format(
+				"contains(%s/externalReferenceCode,'%s')",
+				_objectRelationship.getName(),
+				objectEntry2externalReferenceCode.substring(1)),
+			_objectDefinition1);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			String.format(
+				"startswith(%s/externalReferenceCode,'%s')",
+				_objectRelationship.getName(),
+				objectEntry2externalReferenceCode.substring(0, 2)),
+			_objectDefinition1);
+
+		// Other side of the relationship
+		// Custom field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			String.format(
+				"contains(%s/%s,'%s')", _objectRelationship.getName(),
+				_OBJECT_FIELD_NAME_1, objectFieldValue1.substring(1)),
+			_objectDefinition2);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			String.format(
+				"startswith(%s/%s,'%s')", _objectRelationship.getName(),
+				_OBJECT_FIELD_NAME_1, objectFieldValue1.substring(0, 2)),
+			_objectDefinition2);
+
+		// System field
+
+		String objectEntry1externalReferenceCode =
+			_objectEntry1.getExternalReferenceCode();
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			String.format(
+				"contains(%s/externalReferenceCode,'%s')",
+				_objectRelationship.getName(),
+				objectEntry1externalReferenceCode.substring(1)),
+			_objectDefinition2);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			String.format(
+				"startswith(%s/externalReferenceCode,'%s')",
+				_objectRelationship.getName(),
+				objectEntry1externalReferenceCode.substring(0, 2)),
+			_objectDefinition2);
+
+		_objectRelationshipLocalService.deleteObjectRelationship(
+			_objectRelationship);
+
+		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		// Custom fields
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			String.format(
+				"contains(%s/%s,'%s')", _objectRelationship.getName(),
+				_OBJECT_FIELD_NAME_2, objectFieldValue2.substring(1)),
+			_objectDefinition1);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			String.format(
+				"startswith(%s/%s,'%s')", _objectRelationship.getName(),
+				_OBJECT_FIELD_NAME_2, objectFieldValue2.substring(0, 2)),
+			_objectDefinition1);
+
+		// System field
+
+		objectEntry2externalReferenceCode =
+			_objectEntry2.getExternalReferenceCode();
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			String.format(
+				"contains(%s/externalReferenceCode,'%s')",
+				_objectRelationship.getName(),
+				objectEntry2externalReferenceCode.substring(1)),
+			_objectDefinition1);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			String.format(
+				"startswith(%s/externalReferenceCode,'%s')",
+				_objectRelationship.getName(),
+				objectEntry2externalReferenceCode.substring(0, 2)),
+			_objectDefinition1);
+
+		// Other side of the relationship
+		// Custom field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			String.format(
+				"contains(%s/%s,'%s')", _objectRelationship.getName(),
+				_OBJECT_FIELD_NAME_1, objectFieldValue1.substring(1)),
+			_objectDefinition2);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			String.format(
+				"startswith(%s/%s,'%s')", _objectRelationship.getName(),
+				_OBJECT_FIELD_NAME_1, objectFieldValue1.substring(0, 2)),
+			_objectDefinition2);
+
+		// System field
+
+		objectEntry1externalReferenceCode =
+			_objectEntry1.getExternalReferenceCode();
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			String.format(
+				"contains(%s/externalReferenceCode,'%s')",
+				_objectRelationship.getName(),
+				objectEntry1externalReferenceCode.substring(1)),
+			_objectDefinition2);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			String.format(
+				"startswith(%s/externalReferenceCode,'%s')",
+				_objectRelationship.getName(),
+				objectEntry1externalReferenceCode.substring(0, 2)),
+			_objectDefinition2);
+	}
+
+	@Test
 	public void testFilterObjectEntriesByRelatedObjectEntries()
 		throws Exception {
 

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -97,6 +97,10 @@ public class ObjectEntryResourceTest {
 			).build());
 		PropsUtil.addProperties(
 			UnicodePropertiesBuilder.setProperty(
+				"feature.flag.LPS-154672", "true"
+			).build());
+		PropsUtil.addProperties(
+			UnicodePropertiesBuilder.setProperty(
 				"feature.flag.LPS-164801", "true"
 			).build());
 		PropsUtil.addProperties(
@@ -125,6 +129,10 @@ public class ObjectEntryResourceTest {
 		PropsUtil.addProperties(
 			UnicodePropertiesBuilder.setProperty(
 				"feature.flag.LPS-153117", "false"
+			).build());
+		PropsUtil.addProperties(
+			UnicodePropertiesBuilder.setProperty(
+				"feature.flag.LPS-154672", "false"
 			).build());
 		PropsUtil.addProperties(
 			UnicodePropertiesBuilder.setProperty(
@@ -185,6 +193,382 @@ public class ObjectEntryResourceTest {
 			_objectDefinition2);
 		_objectDefinitionLocalService.deleteObjectDefinition(
 			_siteScopedObjectDefinition1);
+	}
+
+	@Test
+	public void testFilterByComparisonOperatorsObjectEntriesByRelatesObjectEntriesFields()
+		throws Exception {
+
+		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		// Custom field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s eq '%s'", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2)),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s ge '%s'", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2)),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s gt '%s'", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2 - 1)),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s le '%s'", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2)),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s lt '%s'", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2 + 1)),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s ne '%s'", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2 - 1)),
+			_objectDefinition1);
+
+		// System field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/id eq '%s'", _objectRelationship.getName(),
+					_objectEntry2.getObjectEntryId())),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/id ge '%s'", _objectRelationship.getName(),
+					_objectEntry2.getObjectEntryId())),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/id gt '%s'", _objectRelationship.getName(),
+					_objectEntry2.getObjectEntryId() - 1)),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/id le '%s'", _objectRelationship.getName(),
+					_objectEntry2.getObjectEntryId())),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/id lt '%s'", _objectRelationship.getName(),
+					_objectEntry2.getObjectEntryId() + 1)),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/id ne '%s'", _objectRelationship.getName(),
+					_objectEntry2.getObjectEntryId() - 1)),
+			_objectDefinition1);
+
+		// Other side of the relationship
+		// Custom field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/%s eq '%s'", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1)),
+			_objectDefinition2);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/%s ge '%s'", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1)),
+			_objectDefinition2);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/%s gt '%s'", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1 - 1)),
+			_objectDefinition2);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/%s le '%s'", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1)),
+			_objectDefinition2);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/%s lt '%s'", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1 + 1)),
+			_objectDefinition2);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/%s ne '%s'", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1 - 1)),
+			_objectDefinition2);
+
+		// System field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/id eq '%s'", _objectRelationship.getName(),
+					_objectEntry1.getObjectEntryId())),
+			_objectDefinition2);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/id ge '%s'", _objectRelationship.getName(),
+					_objectEntry1.getObjectEntryId())),
+			_objectDefinition2);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/id gt '%s'", _objectRelationship.getName(),
+					_objectEntry1.getObjectEntryId() - 1)),
+			_objectDefinition2);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/id le '%s'", _objectRelationship.getName(),
+					_objectEntry1.getObjectEntryId())),
+			_objectDefinition2);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/id lt '%s'", _objectRelationship.getName(),
+					_objectEntry1.getObjectEntryId() + 1)),
+			_objectDefinition2);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/id ne '%s'", _objectRelationship.getName(),
+					_objectEntry1.getObjectEntryId() - 1)),
+			_objectDefinition2);
+
+		_objectRelationshipLocalService.deleteObjectRelationship(
+			_objectRelationship);
+
+		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		// Custom field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s eq '%s'", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2)),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s ge '%s'", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2)),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s gt '%s'", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2 - 1)),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s le '%s'", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2)),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s lt '%s'", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2 + 1)),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s ne '%s'", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2 - 1)),
+			_objectDefinition1);
+
+		// System field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/id eq '%s'", _objectRelationship.getName(),
+					_objectEntry2.getObjectEntryId())),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/id ge '%s'", _objectRelationship.getName(),
+					_objectEntry2.getObjectEntryId())),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/id gt '%s'", _objectRelationship.getName(),
+					_objectEntry2.getObjectEntryId() - 1)),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/id le '%s'", _objectRelationship.getName(),
+					_objectEntry2.getObjectEntryId())),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/id lt '%s'", _objectRelationship.getName(),
+					_objectEntry2.getObjectEntryId() + 1)),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/id ne '%s'", _objectRelationship.getName(),
+					_objectEntry2.getObjectEntryId() - 1)),
+			_objectDefinition1);
+
+		// Other side of the relationship
+		// Custom field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/%s eq '%s'", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1)),
+			_objectDefinition2);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/%s ge '%s'", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1)),
+			_objectDefinition2);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/%s gt '%s'", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1 - 1)),
+			_objectDefinition2);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/%s le '%s'", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1)),
+			_objectDefinition2);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/%s lt '%s'", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1 + 1)),
+			_objectDefinition2);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/%s ne '%s'", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1 - 1)),
+			_objectDefinition2);
+
+		// System field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/id eq '%s'", _objectRelationship.getName(),
+					_objectEntry1.getObjectEntryId())),
+			_objectDefinition2);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/id ge '%s'", _objectRelationship.getName(),
+					_objectEntry1.getObjectEntryId())),
+			_objectDefinition2);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/id gt '%s'", _objectRelationship.getName(),
+					_objectEntry1.getObjectEntryId() - 1)),
+			_objectDefinition2);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/id le '%s'", _objectRelationship.getName(),
+					_objectEntry1.getObjectEntryId())),
+			_objectDefinition2);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/id lt '%s'", _objectRelationship.getName(),
+					_objectEntry1.getObjectEntryId() + 1)),
+			_objectDefinition2);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/id ne '%s'", _objectRelationship.getName(),
+					_objectEntry1.getObjectEntryId() - 1)),
+			_objectDefinition2);
 	}
 
 	@Test
@@ -1204,6 +1588,29 @@ public class ObjectEntryResourceTest {
 			});
 	}
 
+	private void _assertFilter(
+			String expectedObjectFieldName,
+			Serializable expectedObjectFieldValue, String filter,
+			ObjectDefinition objectDefinition)
+		throws Exception {
+
+		String endpoint =
+			objectDefinition.getRESTContextPath() + "?filter=" + filter;
+
+		JSONObject jsonObject = HTTPTestUtil.invoke(
+			null, endpoint, Http.Method.GET);
+
+		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
+
+		Assert.assertEquals(1, itemsJSONArray.length());
+
+		JSONObject itemJSONObject = itemsJSONArray.getJSONObject(0);
+
+		Assert.assertEquals(
+			String.valueOf(expectedObjectFieldValue),
+			String.valueOf(itemJSONObject.get(expectedObjectFieldName)));
+	}
+
 	private void _assertFilteredObjectEntries(
 			int expectedObjectEntryCount, String filter)
 		throws Exception {
@@ -1252,6 +1659,10 @@ public class ObjectEntryResourceTest {
 		}
 
 		return jsonArray;
+	}
+
+	private String _escape(String string) {
+		return URLCodec.encodeURL(string);
 	}
 
 	private void _postObjectEntryWithKeywords(String... keywords)

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -572,6 +572,110 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
+	public void testFilterByListOperatorsObjectEntriesByRelatesObjectEntriesFields()
+		throws Exception {
+
+		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		// Custom field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s in ('%s', '%s')", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+					RandomTestUtil.randomInt())),
+			_objectDefinition1);
+
+		// System field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/id in ('%s', '%s')", _objectRelationship.getName(),
+					_objectEntry2.getObjectEntryId(),
+					RandomTestUtil.randomInt())),
+			_objectDefinition1);
+
+		// Other side of the relationship
+		// Custom field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/%s in ('%s', '%s')", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+					RandomTestUtil.randomInt())),
+			_objectDefinition2);
+
+		// System field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/id in ('%s', '%s')", _objectRelationship.getName(),
+					_objectEntry1.getObjectEntryId(),
+					RandomTestUtil.randomInt())),
+			_objectDefinition2);
+
+		_objectRelationshipLocalService.deleteObjectRelationship(
+			_objectRelationship);
+
+		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		// Custom field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s in ('%s', '%s')", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+					RandomTestUtil.randomInt())),
+			_objectDefinition1);
+
+		// System field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/id in ('%s', '%s')", _objectRelationship.getName(),
+					_objectEntry2.getObjectEntryId(),
+					RandomTestUtil.randomInt())),
+			_objectDefinition1);
+
+		// Other side of the relationship
+		// Custom field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/%s in ('%s', '%s')", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+					RandomTestUtil.randomInt())),
+			_objectDefinition2);
+
+		// System field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/id in ('%s', '%s')", _objectRelationship.getName(),
+					_objectEntry1.getObjectEntryId(),
+					RandomTestUtil.randomInt())),
+			_objectDefinition2);
+	}
+
+	@Test
 	public void testFilterByLogicalOperatorsObjectEntriesByRelatesObjectEntriesFields()
 		throws Exception {
 

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -33,6 +33,7 @@ import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
@@ -46,7 +47,6 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
-import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.URLCodec;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
@@ -56,6 +56,8 @@ import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.portal.util.PropsUtil;
+
+import java.io.Serializable;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -723,8 +725,7 @@ public class ObjectEntryResourceTest {
 			objectEntryJSONObject.toString(),
 			StringBundler.concat(
 				_siteScopedObjectDefinition1.getRESTContextPath(), "/scopes/",
-				String.valueOf(TestPropsValues.getGroupId()),
-				"/by-external-reference-code/",
+				TestPropsValues.getGroupId(), "/by-external-reference-code/",
 				_siteScopedObjectEntry1.getExternalReferenceCode()),
 			Http.Method.PATCH);
 
@@ -937,7 +938,7 @@ public class ObjectEntryResourceTest {
 			_objectEntry2.getExternalReferenceCode(),
 			jsonObject.getString("externalReferenceCode"));
 		Assert.assertEquals(
-			_OBJECT_FIELD_VALUE_2, jsonObject.getString(_OBJECT_FIELD_NAME_2));
+			_OBJECT_FIELD_VALUE_2, jsonObject.getInt(_OBJECT_FIELD_NAME_2));
 
 		jsonObject = HTTPTestUtil.invoke(
 			null,
@@ -953,7 +954,7 @@ public class ObjectEntryResourceTest {
 			_objectEntry1.getExternalReferenceCode(),
 			jsonObject.getString("externalReferenceCode"));
 		Assert.assertEquals(
-			_OBJECT_FIELD_VALUE_1, jsonObject.getString(_OBJECT_FIELD_NAME_1));
+			_OBJECT_FIELD_VALUE_1, jsonObject.getInt(_OBJECT_FIELD_NAME_1));
 
 		jsonObject = HTTPTestUtil.invoke(
 			null,
@@ -1000,7 +1001,7 @@ public class ObjectEntryResourceTest {
 
 		JSONObject jsonObject = HTTPTestUtil.invoke(
 			newObjectEntryJSONObject.toString(),
-			com.liferay.petra.string.StringBundler.concat(
+			StringBundler.concat(
 				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
 				_objectEntry1.getPrimaryKey()),
 			Http.Method.PUT);
@@ -1015,7 +1016,7 @@ public class ObjectEntryResourceTest {
 
 		jsonObject = HTTPTestUtil.invoke(
 			null,
-			com.liferay.petra.string.StringBundler.concat(
+			StringBundler.concat(
 				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
 				_objectEntry1.getPrimaryKey(), "?nestedFields=",
 				_objectRelationship.getName()),
@@ -1068,7 +1069,7 @@ public class ObjectEntryResourceTest {
 
 		jsonObject = HTTPTestUtil.invoke(
 			newObjectEntryJSONObject.toString(),
-			com.liferay.petra.string.StringBundler.concat(
+			StringBundler.concat(
 				_objectDefinition2.getRESTContextPath(), StringPool.SLASH,
 				objectEntryId),
 			Http.Method.PUT);
@@ -1131,7 +1132,7 @@ public class ObjectEntryResourceTest {
 
 		JSONObject jsonObject = HTTPTestUtil.invoke(
 			newObjectEntryJSONObject.toString(),
-			com.liferay.petra.string.StringBundler.concat(
+			StringBundler.concat(
 				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
 				_objectEntry1.getPrimaryKey()),
 			Http.Method.PUT);
@@ -1146,7 +1147,7 @@ public class ObjectEntryResourceTest {
 
 		jsonObject = HTTPTestUtil.invoke(
 			null,
-			com.liferay.petra.string.StringBundler.concat(
+			StringBundler.concat(
 				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
 				_objectEntry1.getPrimaryKey(), "?nestedFields=",
 				_objectRelationship.getName()),
@@ -1297,7 +1298,8 @@ public class ObjectEntryResourceTest {
 	}
 
 	private void _testFilterByRelatedObjectDefinitionSystemObjectField(
-			String expectedObjectFieldName, String expectedObjectFieldValue,
+			String expectedObjectFieldName,
+			Serializable expectedObjectFieldValue,
 			FilterOperator filterOperator, ObjectDefinition objectDefinition,
 			ObjectRelationship objectRelationship, long relatedObjectEntryId)
 		throws Exception {
@@ -1305,8 +1307,7 @@ public class ObjectEntryResourceTest {
 		String endpoint = StringBundler.concat(
 			objectDefinition.getRESTContextPath(), "?filter=",
 			objectRelationship.getName(), "/id%20", filterOperator.getValue(),
-			"%20'", String.valueOf(relatedObjectEntryId),
-			StringPool.APOSTROPHE);
+			"%20'", relatedObjectEntryId, StringPool.APOSTROPHE);
 
 		_testFilterObjectEntriesByRelatedObjectEntriesUsingAFilterOperator(
 			endpoint, expectedObjectFieldName, expectedObjectFieldValue);
@@ -1353,23 +1354,28 @@ public class ObjectEntryResourceTest {
 
 	private void
 			_testFilterObjectEntriesByRelatedObjectEntriesUsingAFilterOperator(
-				String expectedObjectFieldName, String expectedObjectFieldValue,
+				String expectedObjectFieldName,
+				Serializable expectedObjectFieldValue,
 				FilterOperator filterOperator,
 				ObjectDefinition objectDefinition,
 				ObjectRelationship objectRelationship,
-				String relatedObjectFieldName, String relatedObjectFieldValue)
+				String relatedObjectFieldName,
+				Serializable relatedObjectFieldValue)
 		throws Exception {
 
 		String endpoint = objectDefinition.getRESTContextPath() + "?filter=";
 
 		if (filterOperator == FilterOperator.CONTAINS) {
+			String relatedObjectFieldString = String.valueOf(
+				relatedObjectFieldValue);
+
 			endpoint = endpoint.concat(
 				StringBundler.concat(
 					filterOperator.getValue(), StringPool.OPEN_PARENTHESIS,
 					objectRelationship.getName(), StringPool.SLASH,
 					relatedObjectFieldName, StringPool.COMMA,
 					StringPool.APOSTROPHE,
-					relatedObjectFieldValue.substring(1, 2),
+					relatedObjectFieldString.substring(1, 2),
 					StringPool.APOSTROPHE, StringPool.CLOSE_PARENTHESIS));
 		}
 		else if (filterOperator == FilterOperator.EQ) {
@@ -1393,13 +1399,16 @@ public class ObjectEntryResourceTest {
 					StringPool.APOSTROPHE, StringPool.CLOSE_PARENTHESIS));
 		}
 		else if (filterOperator == FilterOperator.STARTS_WITH) {
+			String relatedObjectFieldString = String.valueOf(
+				relatedObjectFieldValue);
+
 			endpoint = endpoint.concat(
 				StringBundler.concat(
 					filterOperator.getValue(), StringPool.OPEN_PARENTHESIS,
 					objectRelationship.getName(), StringPool.SLASH,
 					relatedObjectFieldName, StringPool.COMMA,
 					StringPool.APOSTROPHE,
-					relatedObjectFieldValue.substring(0, 1),
+					relatedObjectFieldString.substring(0, 1),
 					StringPool.APOSTROPHE, StringPool.CLOSE_PARENTHESIS));
 		}
 		else {
@@ -1414,7 +1423,7 @@ public class ObjectEntryResourceTest {
 	private void
 			_testFilterObjectEntriesByRelatedObjectEntriesUsingAFilterOperator(
 				String endpoint, String expectedObjectFieldName,
-				String expectedObjectFieldValue)
+				Serializable expectedObjectFieldValue)
 		throws Exception {
 
 		JSONObject jsonObject = HTTPTestUtil.invoke(
@@ -1428,7 +1437,7 @@ public class ObjectEntryResourceTest {
 
 		Assert.assertEquals(
 			expectedObjectFieldValue,
-			itemJSONObject.getString(expectedObjectFieldName));
+			itemJSONObject.getInt(expectedObjectFieldName));
 	}
 
 	private void _testGetNestedFieldDetailsInOneToManyRelationships(
@@ -1445,15 +1454,14 @@ public class ObjectEntryResourceTest {
 		JSONObject itemJSONObject = itemsJSONArray.getJSONObject(0);
 
 		Assert.assertEquals(
-			_OBJECT_FIELD_VALUE_2,
-			itemJSONObject.getString(_OBJECT_FIELD_NAME_2));
+			_OBJECT_FIELD_VALUE_2, itemJSONObject.getInt(_OBJECT_FIELD_NAME_2));
 
 		JSONObject relatedObjectJSONObject = itemJSONObject.getJSONObject(
 			expectedFieldName);
 
 		Assert.assertEquals(
 			_OBJECT_FIELD_VALUE_1,
-			relatedObjectJSONObject.getString(_OBJECT_FIELD_NAME_1));
+			relatedObjectJSONObject.getInt(_OBJECT_FIELD_NAME_1));
 	}
 
 	private void
@@ -1549,11 +1557,9 @@ public class ObjectEntryResourceTest {
 	private static final String _OBJECT_FIELD_NAME_2 =
 		"x" + RandomTestUtil.randomString();
 
-	private static final String _OBJECT_FIELD_VALUE_1 =
-		RandomTestUtil.randomString();
+	private static final int _OBJECT_FIELD_VALUE_1 = RandomTestUtil.randomInt();
 
-	private static final String _OBJECT_FIELD_VALUE_2 =
-		RandomTestUtil.randomString();
+	private static final int _OBJECT_FIELD_VALUE_2 = RandomTestUtil.randomInt();
 
 	private static AssetVocabulary _assetVocabulary;
 	private static TaxonomyCategoryResource _taxonomyCategoryResource;

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -572,6 +572,266 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
+	public void testFilterByLogicalOperatorsObjectEntriesByRelatesObjectEntriesFields()
+		throws Exception {
+
+		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		// Custom field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s le '%s' and %s/%s gt '%s'",
+					_objectRelationship.getName(), _OBJECT_FIELD_NAME_2,
+					_OBJECT_FIELD_VALUE_2, _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2 - 1)),
+			_objectDefinition1);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s le '%s' or %s/%s gt '%s'",
+					_objectRelationship.getName(), _OBJECT_FIELD_NAME_2,
+					_OBJECT_FIELD_VALUE_2, _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2 - 1)),
+			_objectDefinition1);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"not (%s/%s ge '%s')", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2 + 1)),
+			_objectDefinition1);
+
+		// System field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/id le '%s' and %s/id gt '%s'",
+					_objectRelationship.getName(),
+					_objectEntry2.getObjectEntryId(),
+					_objectRelationship.getName(),
+					_objectEntry2.getObjectEntryId() - 1)),
+			_objectDefinition1);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/id le '%s' or %s/id gt '%s'",
+					_objectRelationship.getName(), _OBJECT_FIELD_VALUE_2,
+					_objectRelationship.getName(),
+					_objectEntry2.getObjectEntryId() - 1)),
+			_objectDefinition1);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"not (%s/id ge '%s')", _objectRelationship.getName(),
+					_objectEntry2.getObjectEntryId() + 1)),
+			_objectDefinition1);
+
+		// Other side of the relationship
+		// Custom field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/%s le '%s' and %s/%s gt '%s'",
+					_objectRelationship.getName(), _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1, _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1 - 1)),
+			_objectDefinition2);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/%s le '%s' or %s/%s gt '%s'",
+					_objectRelationship.getName(), _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1, _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1 - 1)),
+			_objectDefinition2);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"not (%s/%s ge '%s')", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1 + 1)),
+			_objectDefinition2);
+
+		// System field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/id le '%s' and %s/id gt '%s'",
+					_objectRelationship.getName(),
+					_objectEntry1.getObjectEntryId(),
+					_objectRelationship.getName(),
+					_objectEntry1.getObjectEntryId() - 1)),
+			_objectDefinition2);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/id le '%s' or %s/id gt '%s'",
+					_objectRelationship.getName(), _OBJECT_FIELD_VALUE_1,
+					_objectRelationship.getName(),
+					_objectEntry1.getObjectEntryId() - 1)),
+			_objectDefinition2);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"not (%s/id ge '%s')", _objectRelationship.getName(),
+					_objectEntry1.getObjectEntryId() + 1)),
+			_objectDefinition2);
+
+		_objectRelationshipLocalService.deleteObjectRelationship(
+			_objectRelationship);
+
+		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		// Custom field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s le '%s' and %s/%s gt '%s'",
+					_objectRelationship.getName(), _OBJECT_FIELD_NAME_2,
+					_OBJECT_FIELD_VALUE_2, _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2 - 1)),
+			_objectDefinition1);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s le '%s' or %s/%s gt '%s'",
+					_objectRelationship.getName(), _OBJECT_FIELD_NAME_2,
+					_OBJECT_FIELD_VALUE_2, _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2 - 1)),
+			_objectDefinition1);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"not (%s/%s ge '%s')", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2 + 1)),
+			_objectDefinition1);
+
+		// System field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/id le '%s' and %s/id gt '%s'",
+					_objectRelationship.getName(),
+					_objectEntry2.getObjectEntryId(),
+					_objectRelationship.getName(),
+					_objectEntry2.getObjectEntryId() - 1)),
+			_objectDefinition1);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/id le '%s' or %s/id gt '%s'",
+					_objectRelationship.getName(), _OBJECT_FIELD_VALUE_2,
+					_objectRelationship.getName(),
+					_objectEntry2.getObjectEntryId() - 1)),
+			_objectDefinition1);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"not (%s/id ge '%s')", _objectRelationship.getName(),
+					_objectEntry2.getObjectEntryId() + 1)),
+			_objectDefinition1);
+
+		// Other side of the relationship
+		// Custom field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/%s le '%s' and %s/%s gt '%s'",
+					_objectRelationship.getName(), _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1, _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1 - 1)),
+			_objectDefinition2);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/%s le '%s' or %s/%s gt '%s'",
+					_objectRelationship.getName(), _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1, _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1 - 1)),
+			_objectDefinition2);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"not (%s/%s ge '%s')", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1 + 1)),
+			_objectDefinition2);
+
+		// System field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/id le '%s' and %s/id gt '%s'",
+					_objectRelationship.getName(),
+					_objectEntry1.getObjectEntryId(),
+					_objectRelationship.getName(),
+					_objectEntry1.getObjectEntryId() - 1)),
+			_objectDefinition2);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/id le '%s' or %s/id gt '%s'",
+					_objectRelationship.getName(), _OBJECT_FIELD_VALUE_1,
+					_objectRelationship.getName(),
+					_objectEntry1.getObjectEntryId() - 1)),
+			_objectDefinition2);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"not (%s/id ge '%s')", _objectRelationship.getName(),
+					_objectEntry1.getObjectEntryId() + 1)),
+			_objectDefinition2);
+	}
+
+	@Test
 	public void testFilterByStringOperatorsObjectEntriesByRelatesObjectEntriesFields()
 		throws Exception {
 

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/util/ObjectEntryTestUtil.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/util/ObjectEntryTestUtil.java
@@ -32,7 +32,7 @@ public class ObjectEntryTestUtil {
 
 	public static ObjectEntry addObjectEntry(
 			ObjectDefinition objectDefinition, String objectFieldName,
-			String objectFieldValue)
+			Serializable objectFieldValue)
 		throws Exception {
 
 		long groupId = 0;


### PR DESCRIPTION
Forwarded from: https://github.com/brianchandotcom/liferay-portal/pull/132299

Related ticket -> [LPS-170415](https://issues.liferay.com/browse/LPS-170415)
____
## Purpose of the PR

Add tests for most of the filter operators supported by Liferay when filtering by related element fields.