### PR TITLE
LPS-180399 It is more accurate to use _portal.getServletContextName()

### DIFF
--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/contributor/FragmentCollectionContributorRegistryImpl.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/contributor/FragmentCollectionContributorRegistryImpl.java
@@ -749,7 +749,7 @@ public class FragmentCollectionContributorRegistryImpl
 		@Override
 		public RequestDispatcher getRequestDispatcher(String path) {
 			return DirectRequestDispatcherFactoryUtil.getRequestDispatcher(
-				ServletContextPool.get(StringPool.BLANK), path);
+				ServletContextPool.get(_portal.getServletContextName()), path);
 		}
 
 		@Override
@@ -784,7 +784,7 @@ public class FragmentCollectionContributorRegistryImpl
 
 		@Override
 		public ServletContext getServletContext() {
-			return ServletContextPool.get(StringPool.BLANK);
+			return ServletContextPool.get(_portal.getServletContextName());
 		}
 
 		@Override
@@ -895,7 +895,8 @@ public class FragmentCollectionContributorRegistryImpl
 
 		private final Map<String, Object> _attributes =
 			ConcurrentHashMapBuilder.<String, Object>put(
-				WebKeys.CTX, ServletContextPool.get(StringPool.BLANK)
+				WebKeys.CTX,
+				ServletContextPool.get(_portal.getServletContextName())
 			).build();
 
 		private final HttpSession _httpSession = new HttpSession() {


### PR DESCRIPTION
rather than StringPool.BLANK here. _portal.getServletContextName() should work for all application servers, whereas StringPool.BLANK does not (for example, WebSphere).