### PR TITLE
LPS-170503 Check for other Stream usages

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/IllegalImportsCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/IllegalImportsCheck.java
@@ -233,7 +233,7 @@ public class IllegalImportsCheck extends BaseFileCheck {
 				}
 
 				if (isAttributeValue(_AVOID_STREAM_KEY, absolutePath) &&
-					line.contains("java.util.stream.Stream")) {
+					line.contains("java.util.stream")) {
 
 					addMessage(
 						fileName,


### PR DESCRIPTION
Currently, `IllegalImportsCheck` does not check for other kinds of stream usages, like `java.util.stream.IntStream`.