### PR TITLE
LPS-181757 Need to be protected in base class.

### DIFF
--- a/modules/apps/analytics/analytics-settings-web/src/main/java/com/liferay/analytics/settings/web/internal/portlet/action/BaseAnalyticsMVCActionCommand.java
+++ b/modules/apps/analytics/analytics-settings-web/src/main/java/com/liferay/analytics/settings/web/internal/portlet/action/BaseAnalyticsMVCActionCommand.java
@@ -201,6 +201,9 @@ public abstract class BaseAnalyticsMVCActionCommand
 	@Reference
 	protected SettingsFactory settingsFactory;
 
+	@Reference
+	protected SettingsLocatorHelper settingsLocatorHelper;
+
 	private void _checkPermissions(ThemeDisplay themeDisplay)
 		throws PrincipalException {
 
@@ -230,7 +233,7 @@ public abstract class BaseAnalyticsMVCActionCommand
 			new CompanyServiceSettingsLocator(scopePK, pid));
 
 		SettingsDescriptor settingsDescriptor =
-			_settingsLocatorHelper.getSettingsDescriptor(pid);
+			settingsLocatorHelper.getSettingsDescriptor(pid);
 
 		if (settingsDescriptor == null) {
 			return configurationProperties;
@@ -311,8 +314,5 @@ public abstract class BaseAnalyticsMVCActionCommand
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		BaseAnalyticsMVCActionCommand.class);
-
-	@Reference
-	private SettingsLocatorHelper _settingsLocatorHelper;
 
 }


### PR DESCRIPTION
@ ling-alan-huang can you add a SF check for this? For all base classes of Component(if the file contains @Reference, but it does not have @Component), all @Reference should be on protected fields, rather than private fields.