### PR TITLE
POSHI-465 Auto SF

### DIFF
--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testFunctional/macros/WorkflowMetrics.macro
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testFunctional/macros/WorkflowMetrics.macro
@@ -671,7 +671,7 @@ definition {
 
 		var scriptContent = TestCase.getFileContent(fileName = "addUsersWithRoles.groovy");
 
-		var scriptContent = StringUtil.regexReplaceFirst(${scriptContent}, numberOfUsers = 0, numberOfUsers = ${numberOfUsers});
+		var scriptContent = StringUtil.regexReplaceFirst(${scriptContent}, "numberOfUsers = 0", "numberOfUsers = ${numberOfUsers}");
 
 		ServerAdministration.executeScript(
 			language = "Groovy",


### PR DESCRIPTION
Fix SF error introduced by https://github.com/liferay/liferay-portal/commit/7f1b276d37008c02c3e6c7d48b538bcd2e1ec827

@ling-alan-huang How is an Auto SF commit introducing an SF error? As far as I can tell, the PoshiSourceProcessor has not been updated since the time you made that commit, so something seems wrong here.