### PR TITLE
LPS-182826: Unable to create custom object and related system objects in a single request on a virtual host

### DIFF
--- a/modules/apps/object/object-rest-api/bnd.bnd
+++ b/modules/apps/object/object-rest-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Object REST API
 Bundle-SymbolicName: com.liferay.object.rest.api
-Bundle-Version: 13.6.1
+Bundle-Version: 14.0.0
 Export-Package:\
 	com.liferay.object.rest.dto.v1_0,\
 	com.liferay.object.rest.dto.v1_0.util,\

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/manager/v1_0/ObjectRelationshipElementsParser.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/manager/v1_0/ObjectRelationshipElementsParser.java
@@ -26,6 +26,8 @@ public interface ObjectRelationshipElementsParser<T> {
 
 	public String getClassName();
 
+	public long getCompanyId();
+
 	public String getObjectRelationshipType();
 
 	public List<T> parse(ObjectRelationship objectRelationship, Object value)

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/manager/v1_0/ObjectRelationshipElementsParserRegistry.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/manager/v1_0/ObjectRelationshipElementsParserRegistry.java
@@ -21,7 +21,7 @@ package com.liferay.object.rest.manager.v1_0;
 public interface ObjectRelationshipElementsParserRegistry {
 
 	public ObjectRelationshipElementsParser getObjectRelationshipElementsParser(
-			String className, String type)
+			String className, long companyId, String type)
 		throws Exception;
 
 }

--- a/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/manager/v1_0/packageinfo
+++ b/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/manager/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 8.2.0
+version 9.0.0

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/BaseObjectRelationshipElementsParserImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/BaseObjectRelationshipElementsParserImpl.java
@@ -43,6 +43,11 @@ public abstract class BaseObjectRelationshipElementsParserImpl<T>
 		return objectDefinition.getClassName();
 	}
 
+	@Override
+	public long getCompanyId() {
+		return objectDefinition.getCompanyId();
+	}
+
 	protected List<T> parseMany(Object object) {
 		List<T> objects = null;
 

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -728,6 +728,7 @@ public class DefaultObjectEntryManagerImpl
 				_objectRelationshipElementsParserRegistry.
 					getObjectRelationshipElementsParser(
 						relatedObjectDefinition.getClassName(),
+						relatedObjectDefinition.getCompanyId(),
 						objectRelationship.getType());
 
 			if (relatedObjectDefinition.isSystem()) {

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/ObjectRelationshipElementsParserRegistryImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/ObjectRelationshipElementsParserRegistryImpl.java
@@ -18,6 +18,7 @@ import com.liferay.object.rest.manager.v1_0.ObjectRelationshipElementsParser;
 import com.liferay.object.rest.manager.v1_0.ObjectRelationshipElementsParserRegistry;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 
 import org.osgi.framework.BundleContext;
@@ -35,10 +36,10 @@ public class ObjectRelationshipElementsParserRegistryImpl
 
 	@Override
 	public ObjectRelationshipElementsParser getObjectRelationshipElementsParser(
-			String className, String type)
+			String className, long companyId, String type)
 		throws Exception {
 
-		String key = _getKey(className, type);
+		String key = _getKey(className, companyId, type);
 
 		ObjectRelationshipElementsParser objectRelationshipManager =
 			_serviceTrackerMap.getService(key);
@@ -63,6 +64,7 @@ public class ObjectRelationshipElementsParserRegistryImpl
 				emitter.emit(
 					_getKey(
 						objectRelationshipElementsParser.getClassName(),
+						objectRelationshipElementsParser.getCompanyId(),
 						objectRelationshipElementsParser.
 							getObjectRelationshipType()));
 			});
@@ -73,8 +75,9 @@ public class ObjectRelationshipElementsParserRegistryImpl
 		_serviceTrackerMap.close();
 	}
 
-	private String _getKey(String className, String type) {
-		return className + StringPool.POUND + type;
+	private String _getKey(String className, long companyId, String type) {
+		return StringBundler.concat(
+			className, StringPool.POUND, companyId, StringPool.POUND, type);
 	}
 
 	private ServiceTrackerMap<String, ObjectRelationshipElementsParser>

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/ObjectRelationshipExtensionProvider.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/ObjectRelationshipExtensionProvider.java
@@ -205,6 +205,7 @@ public class ObjectRelationshipExtensionProvider
 				_objectRelationshipElementsParserRegistry.
 					getObjectRelationshipElementsParser(
 						relatedObjectDefinition.getClassName(),
+						relatedObjectDefinition.getCompanyId(),
 						objectRelationship.getType());
 
 			List<ObjectEntry> nestedObjectEntries =


### PR DESCRIPTION
**What is new?**
- Include a new parameter in `ObjectRelationshipElementsParserRegistryImpl` class to scoped by `companyId`.
- Define and implement `getConmapyId` method in `ObjectRelationshipElementsParser` which returns the related object definition's `companyId`
- Apply changes.
- The aim of this PR is to scope the `ObjectRelationshipElementsParser` implementation because it always the same instance of the default `companyId`

**NOTE**: Set f`eature.flag.LPS-153117=true`

**Steps to reproduce**
- Deploy `object-rest-api` and `object-rest-imp`l 
- Start portal and login, create a virtual host and login into it
- Create a new Custom Object and publish it.
- Set One-To-Many relationship between User and Custom Object created being User the parent
- Execute the following request:

```bash
curl -X POST -u 'test@liferay.com:test' -H 'Content-Type: application/json' -d '{"name": "Bob","userStudents": {
     "alternateName": "user1",
     "emailAddress": "user1@liferay.com",
     "familyName": "userfn1",
     "givenName": "usergn1"
     }}' http://test.com:8080/o/c/students
```
**JIRA Ticket**
https://issues.liferay.com/browse/LPS-182826