### PR TITLE
LPS-172751 - Use latest npm-scripts to fix bug when building portal on windows machines

### DIFF
--- a/modules/apps/frontend-js/frontend-js-dependencies-web/npmscripts.config.js
+++ b/modules/apps/frontend-js/frontend-js-dependencies-web/npmscripts.config.js
@@ -17,6 +17,8 @@ module.exports = {
 		exports: [
 			'@liferay/js-api',
 			'@liferay/js-api/data-set',
+			'cropperjs',
+			'cropperjs/dist/cropper.css',
 			'date-fns',
 			'graphql-hooks-memcache',
 			'graphql-hooks',

--- a/modules/apps/frontend-js/frontend-js-dependencies-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-dependencies-web/package.json
@@ -3,6 +3,7 @@
 		"@liferay/js-api": "0.2.0-pre.0",
 		"axe-core": "4.2.0",
 		"clipboard": "2.0.4",
+		"cropperjs": "1.5.11",
 		"dagre": "0.8.2",
 		"date-fns": "2.29.3",
 		"dom-align": "1.12.2",

--- a/modules/npmscripts.config.js
+++ b/modules/npmscripts.config.js
@@ -65,6 +65,8 @@ module.exports = {
 						'/': '*',
 						'axe-core': '*',
 						'clipboard': '*',
+						'cropperjs': '*',
+						'cropperjs/dist/cropper.css': '*',
 						'dagre': '*',
 						'date-fns': '*',
 						'dom-align': '*',
@@ -463,6 +465,8 @@ module.exports = {
 				'@liferay/js-api/data-set',
 				'clipboard',
 				'axe-core',
+				'cropperjs',
+				'cropperjs/dist/cropper.css',
 				'dagre',
 				'date-fns',
 				'dom-align',
@@ -903,7 +907,6 @@ module.exports = {
 			// Needs to be removed
 
 			'axios',
-			'cropperjs',
 
 			// Causes bugs
 

--- a/modules/package.json
+++ b/modules/package.json
@@ -1,7 +1,7 @@
 {
 	"devDependencies": {
 		"@liferay/eslint-plugin": "1.4.0",
-		"@liferay/npm-scripts": "47.18.0",
+		"@liferay/npm-scripts": "47.18.1",
 		"@types/ckeditor4": "4.16.2",
 		"@types/codemirror": "^5.60.5",
 		"@types/react-router-dom": "^5.3.3",

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -1875,10 +1875,10 @@
     xml-js "^1.6.8"
     yargs "^14.0.0"
 
-"@liferay/npm-scripts@47.18.0":
-  version "47.18.0"
-  resolved "https://registry.yarnpkg.com/@liferay/npm-scripts/-/npm-scripts-47.18.0.tgz#ad6403891d4d70aaec0954403af1ec275eb3f6c8"
-  integrity sha512-neoAMG1ji0VIwFBFyPWTSx7rs2MevjcU4U9SHJMx4cTuwhhm18sYvSzx3RfzbmqttIQ9k9dK1dwULWzqX2FrsQ==
+"@liferay/npm-scripts@47.18.1":
+  version "47.18.1"
+  resolved "https://registry.yarnpkg.com/@liferay/npm-scripts/-/npm-scripts-47.18.1.tgz#b06c29d3a33c7839bb20c4ed1836948c80f99593"
+  integrity sha512-NBLW1Gu/fvJnVKYHAhua3Me0+Fj7c0zHxhfyA2qWRGwxje5Vbpo1BmLy0aO8KIweA3mYOL0zE3nbjW7kHGBB0Q==
   dependencies:
     "@babel/cli" "^7.2.3"
     "@babel/core" "^7.8.3"


### PR DESCRIPTION
This fixes the windows build issue for all .css files now by something we fixed in npm-scripts. I reverted the previous PR as that didn't fully fix it.