### PR TITLE
LPS-182579 Add integration test to validate the related object entries (custom and system) returned by using nestedFields query parameter

### DIFF
--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryRelatedObjectsResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryRelatedObjectsResourceTest.java
@@ -27,6 +27,7 @@ import com.liferay.object.rest.internal.resource.v1_0.test.util.ObjectDefinition
 import com.liferay.object.rest.internal.resource.v1_0.test.util.ObjectEntryTestUtil;
 import com.liferay.object.rest.internal.resource.v1_0.test.util.ObjectFieldTestUtil;
 import com.liferay.object.rest.internal.resource.v1_0.test.util.ObjectRelationshipTestUtil;
+import com.liferay.object.rest.internal.resource.v1_0.test.util.SystemObjectEntryTestUtil;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.object.system.JaxRsApplicationDescriptor;
@@ -908,44 +909,6 @@ public class ObjectEntryRelatedObjectsResourceTest {
 		return response.getResponseCode();
 	}
 
-	private UserAccount _randomUserAccount() throws Exception {
-		return new UserAccount() {
-			{
-				additionalName = StringUtil.toLowerCase(
-					RandomTestUtil.randomString());
-				alternateName = StringUtil.toLowerCase(
-					RandomTestUtil.randomString());
-				birthDate = RandomTestUtil.nextDate();
-				currentPassword = StringUtil.toLowerCase(
-					RandomTestUtil.randomString());
-				dashboardURL = StringUtil.toLowerCase(
-					RandomTestUtil.randomString());
-				dateCreated = RandomTestUtil.nextDate();
-				dateModified = RandomTestUtil.nextDate();
-				emailAddress =
-					StringUtil.toLowerCase(RandomTestUtil.randomString()) +
-						"@liferay.com";
-				familyName = StringUtil.toLowerCase(
-					RandomTestUtil.randomString());
-				givenName = StringUtil.toLowerCase(
-					RandomTestUtil.randomString());
-				honorificPrefix = StringUtil.toLowerCase(
-					RandomTestUtil.randomString());
-				honorificSuffix = StringUtil.toLowerCase(
-					RandomTestUtil.randomString());
-				image = StringUtil.toLowerCase(RandomTestUtil.randomString());
-				jobTitle = StringUtil.toLowerCase(
-					RandomTestUtil.randomString());
-				lastLoginDate = RandomTestUtil.nextDate();
-				name = StringUtil.toLowerCase(RandomTestUtil.randomString());
-				password = StringUtil.toLowerCase(
-					RandomTestUtil.randomString());
-				profileURL = StringUtil.toLowerCase(
-					RandomTestUtil.randomString());
-			}
-		};
-	}
-
 	private void _testDeleteCustomObjectDefinition1WithCustomObjectDefinition2(
 			String deleteEndpoint, String getEndpoint)
 		throws Exception {
@@ -1079,7 +1042,8 @@ public class ObjectEntryRelatedObjectsResourceTest {
 			_toBody(
 				manyToOne, objectRelationship,
 				JSONFactoryUtil.createJSONObject(
-					String.valueOf(_randomUserAccount()))),
+					String.valueOf(
+						SystemObjectEntryTestUtil.randomUserAccount()))),
 			_objectDefinition1.getRESTContextPath(), Http.Method.POST);
 
 		Assert.assertEquals("BAD_REQUEST", jsonObject.get("status"));
@@ -1089,7 +1053,7 @@ public class ObjectEntryRelatedObjectsResourceTest {
 			boolean manyToOne, ObjectRelationship objectRelationship)
 		throws Exception {
 
-		UserAccount userAccount = _randomUserAccount();
+		UserAccount userAccount = SystemObjectEntryTestUtil.randomUserAccount();
 
 		JSONObject jsonObject = HTTPTestUtil.invoke(
 			_toBody(
@@ -1133,13 +1097,14 @@ public class ObjectEntryRelatedObjectsResourceTest {
 				manyToOne, objectRelationship,
 				_createSystemObjectEntryJSONObject(
 					_SYSTEM_OBJECT_FIELD_NAME_2, _SYSTEM_OBJECT_FIELD_VALUE,
-					_randomUserAccount())),
+					SystemObjectEntryTestUtil.randomUserAccount())),
 			_objectDefinition1.getRESTContextPath(), Http.Method.POST);
 
 		String customObjectEntryId = customObjectEntryJSONObject.getString(
 			"id");
 
-		UserAccount putUserAccount = _randomUserAccount();
+		UserAccount putUserAccount =
+			SystemObjectEntryTestUtil.randomUserAccount();
 
 		putUserAccount.setExternalReferenceCode(
 			() -> {

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryRelatedObjectsResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryRelatedObjectsResourceTest.java
@@ -27,7 +27,7 @@ import com.liferay.object.rest.internal.resource.v1_0.test.util.ObjectDefinition
 import com.liferay.object.rest.internal.resource.v1_0.test.util.ObjectEntryTestUtil;
 import com.liferay.object.rest.internal.resource.v1_0.test.util.ObjectFieldTestUtil;
 import com.liferay.object.rest.internal.resource.v1_0.test.util.ObjectRelationshipTestUtil;
-import com.liferay.object.rest.internal.resource.v1_0.test.util.SystemObjectEntryTestUtil;
+import com.liferay.object.rest.internal.resource.v1_0.test.util.UserAccountTestUtil;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.object.system.JaxRsApplicationDescriptor;
@@ -1042,8 +1042,7 @@ public class ObjectEntryRelatedObjectsResourceTest {
 			_toBody(
 				manyToOne, objectRelationship,
 				JSONFactoryUtil.createJSONObject(
-					String.valueOf(
-						SystemObjectEntryTestUtil.randomUserAccount()))),
+					String.valueOf(UserAccountTestUtil.randomUserAccount()))),
 			_objectDefinition1.getRESTContextPath(), Http.Method.POST);
 
 		Assert.assertEquals("BAD_REQUEST", jsonObject.get("status"));
@@ -1053,7 +1052,7 @@ public class ObjectEntryRelatedObjectsResourceTest {
 			boolean manyToOne, ObjectRelationship objectRelationship)
 		throws Exception {
 
-		UserAccount userAccount = SystemObjectEntryTestUtil.randomUserAccount();
+		UserAccount userAccount = UserAccountTestUtil.randomUserAccount();
 
 		JSONObject jsonObject = HTTPTestUtil.invoke(
 			_toBody(
@@ -1097,14 +1096,13 @@ public class ObjectEntryRelatedObjectsResourceTest {
 				manyToOne, objectRelationship,
 				_createSystemObjectEntryJSONObject(
 					_SYSTEM_OBJECT_FIELD_NAME_2, _SYSTEM_OBJECT_FIELD_VALUE,
-					SystemObjectEntryTestUtil.randomUserAccount())),
+					UserAccountTestUtil.randomUserAccount())),
 			_objectDefinition1.getRESTContextPath(), Http.Method.POST);
 
 		String customObjectEntryId = customObjectEntryJSONObject.getString(
 			"id");
 
-		UserAccount putUserAccount =
-			SystemObjectEntryTestUtil.randomUserAccount();
+		UserAccount putUserAccount = UserAccountTestUtil.randomUserAccount();
 
 		putUserAccount.setExternalReferenceCode(
 			() -> {

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryRelatedObjectsResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryRelatedObjectsResourceTest.java
@@ -21,16 +21,13 @@ import com.liferay.object.constants.ObjectRelationshipConstants;
 import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
-import com.liferay.object.model.ObjectField;
-import com.liferay.object.model.ObjectFieldSetting;
 import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.rest.internal.resource.v1_0.test.util.HTTPTestUtil;
 import com.liferay.object.rest.internal.resource.v1_0.test.util.ObjectDefinitionTestUtil;
 import com.liferay.object.rest.internal.resource.v1_0.test.util.ObjectEntryTestUtil;
+import com.liferay.object.rest.internal.resource.v1_0.test.util.ObjectFieldTestUtil;
 import com.liferay.object.rest.internal.resource.v1_0.test.util.ObjectRelationshipTestUtil;
 import com.liferay.object.service.ObjectDefinitionLocalService;
-import com.liferay.object.service.ObjectFieldLocalServiceUtil;
-import com.liferay.object.service.ObjectFieldSettingLocalServiceUtil;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.object.system.JaxRsApplicationDescriptor;
 import com.liferay.object.system.SystemObjectDefinitionManager;
@@ -60,12 +57,10 @@ import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
-import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -521,7 +516,7 @@ public class ObjectEntryRelatedObjectsResourceTest {
 
 		// Many to many
 
-		_addCustomObjectField(
+		ObjectFieldTestUtil.addCustomObjectField(
 			TestPropsValues.getUserId(),
 			ObjectFieldConstants.BUSINESS_TYPE_TEXT,
 			ObjectFieldConstants.DB_TYPE_STRING, _userSystemObjectDefinition,
@@ -556,7 +551,7 @@ public class ObjectEntryRelatedObjectsResourceTest {
 
 		// Many to many
 
-		_addCustomObjectField(
+		ObjectFieldTestUtil.addCustomObjectField(
 			TestPropsValues.getUserId(),
 			ObjectFieldConstants.BUSINESS_TYPE_TEXT,
 			ObjectFieldConstants.DB_TYPE_STRING, _userSystemObjectDefinition,
@@ -720,34 +715,6 @@ public class ObjectEntryRelatedObjectsResourceTest {
 		jsonArray = jsonObject.getJSONArray("items");
 
 		_assertEquals(_user1, jsonArray);
-	}
-
-	private ObjectField _addCustomObjectField(
-			long userId, String businessType, String dbType,
-			ObjectDefinition objectDefinition, String objectFieldName)
-		throws Exception {
-
-		List<ObjectFieldSetting> objectFieldSettings = null;
-
-		if (Objects.equals(
-				businessType, ObjectFieldConstants.BUSINESS_TYPE_LONG_TEXT) ||
-			Objects.equals(
-				businessType, ObjectFieldConstants.BUSINESS_TYPE_TEXT)) {
-
-			ObjectFieldSetting objectFieldSetting =
-				ObjectFieldSettingLocalServiceUtil.createObjectFieldSetting(0);
-
-			objectFieldSetting.setName("showCounter");
-			objectFieldSetting.setValue("false");
-
-			objectFieldSettings = Collections.singletonList(objectFieldSetting);
-		}
-
-		return ObjectFieldLocalServiceUtil.addCustomObjectField(
-			null, userId, 0, objectDefinition.getObjectDefinitionId(),
-			businessType, dbType, false, true, "",
-			LocalizedMapUtil.getLocalizedMap(objectFieldName), false,
-			objectFieldName, false, false, objectFieldSettings);
 	}
 
 	private ObjectRelationship _addObjectRelationship(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -44,7 +44,7 @@ import com.liferay.object.rest.internal.resource.v1_0.test.util.ObjectDefinition
 import com.liferay.object.rest.internal.resource.v1_0.test.util.ObjectEntryTestUtil;
 import com.liferay.object.rest.internal.resource.v1_0.test.util.ObjectFieldTestUtil;
 import com.liferay.object.rest.internal.resource.v1_0.test.util.ObjectRelationshipTestUtil;
-import com.liferay.object.rest.internal.resource.v1_0.test.util.SystemObjectEntryTestUtil;
+import com.liferay.object.rest.internal.resource.v1_0.test.util.UserAccountTestUtil;
 import com.liferay.object.rest.resource.v1_0.ObjectEntryResource;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
@@ -248,12 +248,11 @@ public class ObjectEntryResourceTest {
 			ObjectFieldConstants.DB_TYPE_STRING, _userSystemObjectDefinition,
 			_OBJECT_FIELD_NAME_2);
 
-		_userAccountJSONObject =
-			SystemObjectEntryTestUtil.addUserAccountJSONObject(
-				systemObjectDefinitionManager,
-				HashMapBuilder.<String, Serializable>put(
-					_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)
-				).build());
+		_userAccountJSONObject = UserAccountTestUtil.addUserAccountJSONObject(
+			systemObjectDefinitionManager,
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)
+			).build());
 	}
 
 	@After

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -3078,6 +3078,38 @@ public class ObjectEntryResourceTest {
 
 		_testGetNestedFieldDetailsInOneToManyRelationships(
 			StringBundler.concat(
+				_objectDefinition2.getRESTContextPath(), "?nestedFields=r_",
+				_objectRelationship1.getName(), "_",
+				StringUtil.removeLast(
+					_objectDefinition1.getPKObjectFieldName(), "Id")),
+			StringBundler.concat(
+				"r_", _objectRelationship1.getName(), "_",
+				StringUtil.removeLast(
+					_objectDefinition1.getPKObjectFieldName(), "Id")));
+
+		_testGetNestedFieldDetailsInOneToManyRelationships(
+			StringBundler.concat(
+				_objectDefinition2.getRESTContextPath(), "?nestedFields=",
+				StringUtil.removeLast(
+					StringUtil.removeFirst(
+						_objectDefinition1.getPKObjectFieldName(), "c_"),
+					"Id")),
+			StringBundler.concat(
+				"r_", _objectRelationship1.getName(), "_",
+				StringUtil.removeLast(
+					_objectDefinition1.getPKObjectFieldName(), "Id")));
+
+		_testGetNestedFieldDetailsInOneToManyRelationships(
+			StringBundler.concat(
+				_objectDefinition2.getRESTContextPath(), "?nestedFields=",
+				_objectRelationship1.getName()),
+			StringBundler.concat(
+				"r_", _objectRelationship1.getName(), "_",
+				StringUtil.removeLast(
+					_objectDefinition1.getPKObjectFieldName(), "Id")));
+
+		_testGetNestedFieldDetailsInOneToManyRelationships(
+			StringBundler.concat(
 				_objectDefinition2.getRESTContextPath(), "?nestedFields=",
 				_objectRelationship1.getName()),
 			_objectRelationship1.getName());

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -4922,10 +4922,18 @@ public class ObjectEntryResourceTest {
 		JSONObject jsonObject, String nestedFieldName, Type type) {
 
 		if (type == Type.MANY_TO_ONE) {
+			JSONObject nestedJSONObject = jsonObject.getJSONObject(
+				nestedFieldName);
+
+			Assert.assertNotNull(
+				"Missing field " + nestedFieldName, nestedJSONObject);
+
 			return jsonObject.getJSONObject(nestedFieldName);
 		}
 
 		JSONArray jsonArray = jsonObject.getJSONArray(nestedFieldName);
+
+		Assert.assertNotNull("Missing field " + nestedFieldName, jsonArray);
 
 		Assert.assertEquals(1, jsonArray.length());
 

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -25,6 +25,7 @@ import com.liferay.asset.kernel.service.AssetTagLocalServiceUtil;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalServiceUtil;
 import com.liferay.headless.admin.taxonomy.client.dto.v1_0.TaxonomyCategory;
 import com.liferay.headless.admin.taxonomy.client.resource.v1_0.TaxonomyCategoryResource;
+import com.liferay.headless.admin.user.dto.v1_0.UserAccount;
 import com.liferay.list.type.entry.util.ListTypeEntryUtil;
 import com.liferay.list.type.model.ListTypeDefinition;
 import com.liferay.list.type.service.ListTypeDefinitionLocalService;
@@ -37,15 +38,20 @@ import com.liferay.object.field.setting.builder.ObjectFieldSettingBuilder;
 import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.rest.internal.resource.v1_0.test.util.HTTPTestUtil;
 import com.liferay.object.rest.internal.resource.v1_0.test.util.ObjectDefinitionTestUtil;
 import com.liferay.object.rest.internal.resource.v1_0.test.util.ObjectEntryTestUtil;
+import com.liferay.object.rest.internal.resource.v1_0.test.util.ObjectFieldTestUtil;
 import com.liferay.object.rest.internal.resource.v1_0.test.util.ObjectRelationshipTestUtil;
+import com.liferay.object.rest.internal.resource.v1_0.test.util.SystemObjectEntryTestUtil;
 import com.liferay.object.rest.resource.v1_0.ObjectEntryResource;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.object.system.SystemObjectDefinitionManager;
+import com.liferay.object.system.SystemObjectDefinitionManagerRegistry;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
 import com.liferay.petra.function.transform.TransformUtil;
@@ -70,6 +76,7 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.service.permission.ModelPermissionsFactory;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -227,6 +234,26 @@ public class ObjectEntryResourceTest {
 		_siteScopedObjectEntry1 = ObjectEntryTestUtil.addObjectEntry(
 			_siteScopedObjectDefinition1, _OBJECT_FIELD_NAME_1,
 			_OBJECT_FIELD_VALUE_1);
+
+		SystemObjectDefinitionManager systemObjectDefinitionManager =
+			_systemObjectDefinitionManagerRegistry.
+				getSystemObjectDefinitionManager("User");
+
+		_userSystemObjectDefinition =
+			_objectDefinitionLocalService.fetchSystemObjectDefinition(
+				systemObjectDefinitionManager.getName());
+
+		_userSystemObjectField = ObjectFieldTestUtil.addCustomObjectField(
+			TestPropsValues.getUserId(),
+			ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+			ObjectFieldConstants.DB_TYPE_STRING, _userSystemObjectDefinition,
+			_OBJECT_FIELD_NAME_2);
+
+		_userAccount = SystemObjectEntryTestUtil.addUserAccount(
+			systemObjectDefinitionManager,
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)
+			).build());
 	}
 
 	@After
@@ -3089,7 +3116,8 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
-	public void testGetNestedFieldDetailsInRelationships() throws Exception {
+	public void testGetNestedFieldDetailsInRelationshipsWithCustomObjectDefinitions()
+		throws Exception {
 
 		// One to many with Custom Object Definition
 
@@ -3266,6 +3294,81 @@ public class ObjectEntryResourceTest {
 			},
 			null, _objectRelationship3.getName(), _objectDefinition2,
 			Type.MANY_TO_ONE);
+	}
+
+	@FeatureFlags("LPS-165819")
+	@Test
+	public void testGetNestedFieldDetailsInRelationshipsWithSystemObjectDefinitions()
+		throws Exception {
+
+		// One to many with System Object Definition
+
+		_objectRelationship1 = _addObjectRelationshipAndRelateObjectEntries(
+			_objectDefinition1, _userSystemObjectDefinition,
+			_objectEntry1.getPrimaryKey(), _userAccount.getId(),
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		_testGetNestedFieldDetailsInRelationships(
+			_objectRelationship1.getName(),
+			new String[][] {
+				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
+				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)}
+			},
+			null, _objectRelationship1.getName(), _objectDefinition1,
+			Type.ONE_TO_MANY);
+
+		// Many to many with System Object Definition
+
+		_objectRelationship2 = _addObjectRelationshipAndRelateObjectEntries(
+			_objectDefinition1, _userSystemObjectDefinition,
+			_objectEntry1.getPrimaryKey(), _userAccount.getId(),
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		_testGetNestedFieldDetailsInRelationships(
+			_objectRelationship2.getName(),
+			new String[][] {
+				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
+				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)}
+			},
+			null, _objectRelationship2.getName(), _objectDefinition1,
+			Type.MANY_TO_MANY);
+
+		_testGetNestedFieldDetailsInRelationships(
+			_objectRelationship2.getName(),
+			new String[][] {
+				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
+				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)},
+				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
+				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)}
+			},
+			3, _objectRelationship2.getName(), _objectDefinition1,
+			Type.MANY_TO_MANY);
+
+		_testGetNestedFieldDetailsInRelationships(
+			_objectRelationship2.getName(),
+			new String[][] {
+				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
+				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)},
+				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
+				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)},
+				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
+				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)}
+			},
+			5, _objectRelationship2.getName(), _objectDefinition1,
+			Type.MANY_TO_MANY);
+
+		_testGetNestedFieldDetailsInRelationships(
+			_objectRelationship2.getName(),
+			new String[][] {
+				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
+				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)},
+				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
+				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)},
+				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
+				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)}
+			},
+			6, _objectRelationship2.getName(), _objectDefinition1,
+			Type.MANY_TO_MANY);
 	}
 
 	@Test
@@ -5046,6 +5149,16 @@ public class ObjectEntryResourceTest {
 
 	private ObjectDefinition _siteScopedObjectDefinition1;
 	private ObjectEntry _siteScopedObjectEntry1;
+
+	@Inject
+	private SystemObjectDefinitionManagerRegistry
+		_systemObjectDefinitionManagerRegistry;
+
+	private UserAccount _userAccount;
+	private ObjectDefinition _userSystemObjectDefinition;
+
+	@DeleteAfterTestRun
+	private ObjectField _userSystemObjectField;
 
 	private enum Type {
 

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -76,6 +76,7 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.Http;
@@ -91,6 +92,7 @@ import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.util.PropsValues;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.fields.NestedFieldsContext;
 import com.liferay.portal.vulcan.fields.NestedFieldsContextThreadLocal;
@@ -237,6 +239,11 @@ public class ObjectEntryResourceTest {
 		if (_objectRelationship2 != null) {
 			_objectRelationshipLocalService.deleteObjectRelationship(
 				_objectRelationship2);
+		}
+
+		if (_objectRelationship3 != null) {
+			_objectRelationshipLocalService.deleteObjectRelationship(
+				_objectRelationship3);
 		}
 
 		_objectDefinitionLocalService.deleteObjectDefinition(
@@ -3060,49 +3067,181 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
-	public void testGetNestedFieldDetailsInOneToManyRelationships()
-		throws Exception {
+	public void testGetNestedFieldDetailsInRelationships() throws Exception {
+
+		// One to many with Custom Object Definition
 
 		_objectRelationship1 = _addObjectRelationshipAndRelateObjectEntries(
+			_objectDefinition1, _objectDefinition2, _objectEntry1,
+			_objectEntry2, ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		_testGetNestedFieldDetailsInRelationships(
+			_objectRelationship1.getName(),
+			new String[][] {
+				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
+				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)}
+			},
+			null, _objectRelationship1.getName(), _objectDefinition1,
+			Type.ONE_TO_MANY);
+
+		_testGetNestedFieldDetailsInRelationships(
+			_objectRelationship1.getName(),
+			new String[][] {
+				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
+				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)},
+				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
+				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)}
+			},
+			3, _objectRelationship1.getName(), _objectDefinition1,
+			Type.ONE_TO_MANY);
+
+		_testGetNestedFieldDetailsInRelationships(
+			_objectRelationship1.getName(),
+			new String[][] {
+				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
+				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)},
+				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
+				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)},
+				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
+				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)}
+			},
+			5, _objectRelationship1.getName(), _objectDefinition1,
+			Type.ONE_TO_MANY);
+
+		_testGetNestedFieldDetailsInRelationships(
+			_objectRelationship1.getName(),
+			new String[][] {
+				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
+				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)},
+				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
+				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)},
+				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
+				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)}
+			},
+			6, _objectRelationship1.getName(), _objectDefinition1,
+			Type.ONE_TO_MANY);
+
+		// Many to many with Custom Object Definition
+
+		_objectRelationship2 = _addObjectRelationshipAndRelateObjectEntries(
+			_objectDefinition1, _objectDefinition2, _objectEntry1,
+			_objectEntry2, ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		_testGetNestedFieldDetailsInRelationships(
+			_objectRelationship2.getName(),
+			new String[][] {
+				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
+				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)}
+			},
+			null, _objectRelationship2.getName(), _objectDefinition1,
+			Type.MANY_TO_MANY);
+
+		_testGetNestedFieldDetailsInRelationships(
+			_objectRelationship2.getName(),
+			new String[][] {
+				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
+				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)},
+				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
+				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)}
+			},
+			3, _objectRelationship2.getName(), _objectDefinition1,
+			Type.MANY_TO_MANY);
+
+		_testGetNestedFieldDetailsInRelationships(
+			_objectRelationship2.getName(),
+			new String[][] {
+				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
+				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)},
+				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
+				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)},
+				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
+				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)}
+			},
+			5, _objectRelationship2.getName(), _objectDefinition1,
+			Type.MANY_TO_MANY);
+
+		_testGetNestedFieldDetailsInRelationships(
+			_objectRelationship2.getName(),
+			new String[][] {
+				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
+				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)},
+				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
+				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)},
+				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
+				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)}
+			},
+			6, _objectRelationship2.getName(), _objectDefinition1,
+			Type.MANY_TO_MANY);
+
+		// Many to one with Custom Object Definition
+
+		_objectRelationship3 = _addObjectRelationshipAndRelateObjectEntries(
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
 		String relationshipFieldName = String.format(
-			"r_%s_%s", _objectRelationship1.getName(),
+			"r_%s_%s", _objectRelationship3.getName(),
 			_objectDefinition1.getPKObjectFieldName());
 
 		String relationshipFieldNestedFieldName = StringUtil.removeLast(
 			relationshipFieldName, "Id");
 
-		_testGetNestedFieldDetailsInOneToManyRelationships(
-			relationshipFieldNestedFieldName, relationshipFieldName,
-			_objectDefinition2);
-
-		_testGetNestedFieldDetailsInOneToManyRelationships(
+		_testGetNestedFieldDetailsInRelationships(
 			relationshipFieldNestedFieldName,
-			StringUtil.removeLast(relationshipFieldName, "Id"),
-			_objectDefinition2);
+			new String[][] {
+				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)},
+				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)}
+			},
+			null, relationshipFieldName, _objectDefinition2, Type.MANY_TO_ONE);
 
 		String relatedObjectDefinitionName = StringUtil.removeFirst(
 			StringUtil.removeLast(
 				_objectDefinition1.getPKObjectFieldName(), "Id"),
 			"c_");
 
-		_testGetNestedFieldDetailsInOneToManyRelationships(
-			relationshipFieldNestedFieldName, relatedObjectDefinitionName,
-			_objectDefinition2);
-
-		_testGetNestedFieldDetailsInOneToManyRelationships(
+		_testGetNestedFieldDetailsInRelationships(
 			relationshipFieldNestedFieldName,
-			RandomTestUtil.randomString() + relatedObjectDefinitionName,
-			_objectDefinition2);
+			new String[][] {
+				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)},
+				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)}
+			},
+			null, StringUtil.removeLast(relationshipFieldName, "Id"),
+			_objectDefinition2, Type.MANY_TO_ONE);
 
-		_testGetNestedFieldDetailsInOneToManyRelationships(
-			relationshipFieldNestedFieldName, _objectRelationship1.getName(),
-			_objectDefinition2);
+		_testGetNestedFieldDetailsInRelationships(
+			relationshipFieldNestedFieldName,
+			new String[][] {
+				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)},
+				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)}
+			},
+			null, relatedObjectDefinitionName, _objectDefinition2,
+			Type.MANY_TO_ONE);
 
-		_testGetNestedFieldDetailsInOneToManyRelationships(
-			_objectRelationship1.getName(), _objectRelationship1.getName(),
-			_objectDefinition2);
+		_testGetNestedFieldDetailsInRelationships(
+			relationshipFieldNestedFieldName,
+			new String[][] {
+				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)},
+				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)}
+			},
+			null, RandomTestUtil.randomString() + relatedObjectDefinitionName,
+			_objectDefinition2, Type.MANY_TO_ONE);
+
+		_testGetNestedFieldDetailsInRelationships(
+			relationshipFieldNestedFieldName,
+			new String[][] {
+				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)},
+				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)}
+			},
+			null, _objectRelationship3.getName(), _objectDefinition2,
+			Type.MANY_TO_ONE);
+
+		_testGetNestedFieldDetailsInRelationships(
+			_objectRelationship3.getName(),
+			new String[][] {
+				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)},
+				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)}
+			},
+			null, _objectRelationship3.getName(), _objectDefinition2,
+			Type.MANY_TO_ONE);
 	}
 
 	@Test
@@ -4531,6 +4670,36 @@ public class ObjectEntryResourceTest {
 			String.valueOf(itemJSONObject.get(expectedObjectFieldName)));
 	}
 
+	private void _assertNestedFieldsInRelationships(
+		int currentDepth, int depth, JSONObject jsonObject,
+		String[][] keyValues, String nestedFieldName, Type type) {
+
+		if (keyValues[currentDepth][0] == null) {
+			Assert.assertNull(jsonObject);
+		}
+		else {
+			Assert.assertEquals(
+				keyValues[currentDepth][1],
+				jsonObject.getString(keyValues[currentDepth][0]));
+		}
+
+		if ((currentDepth == depth) ||
+			(currentDepth ==
+				PropsValues.OBJECT_NESTED_FIELDS_MAX_QUERY_DEPTH)) {
+
+			Assert.assertEquals(
+				Arrays.toString(keyValues), currentDepth + 1, keyValues.length);
+			Assert.assertNull(jsonObject.get(nestedFieldName));
+
+			return;
+		}
+
+		_assertNestedFieldsInRelationships(
+			currentDepth + 1, depth,
+			_getRelatedJSONObject(jsonObject, nestedFieldName, type), keyValues,
+			nestedFieldName, _getReverseType(type));
+	}
+
 	private void _assertObjectEntryField(
 		JSONObject objectEntryJSONObject, String objectFieldName,
 		String objectFieldValue) {
@@ -4629,6 +4798,31 @@ public class ObjectEntryResourceTest {
 		}
 	}
 
+	private JSONObject _getRelatedJSONObject(
+		JSONObject jsonObject, String nestedFieldName, Type type) {
+
+		if (type == Type.MANY_TO_ONE) {
+			return jsonObject.getJSONObject(nestedFieldName);
+		}
+
+		JSONArray jsonArray = jsonObject.getJSONArray(nestedFieldName);
+
+		Assert.assertEquals(1, jsonArray.length());
+
+		return jsonArray.getJSONObject(0);
+	}
+
+	private Type _getReverseType(Type type) {
+		if (type == Type.MANY_TO_ONE) {
+			return Type.ONE_TO_MANY;
+		}
+		else if (type == Type.ONE_TO_MANY) {
+			return Type.MANY_TO_ONE;
+		}
+
+		return Type.MANY_TO_MANY;
+	}
+
 	private void _postObjectEntryWithKeywords(String... keywords)
 		throws Exception {
 
@@ -4656,17 +4850,22 @@ public class ObjectEntryResourceTest {
 			_objectDefinition1.getRESTContextPath(), Http.Method.POST);
 	}
 
-	private void _testGetNestedFieldDetailsInOneToManyRelationships(
-			String expectedFieldName, String nestedFieldName,
-			ObjectDefinition objectDefinition)
+	private void _testGetNestedFieldDetailsInRelationships(
+			String expectedFieldName, String[][] keyValues,
+			Integer nestedFieldDepth, String nestedFieldName,
+			ObjectDefinition objectDefinition, Type type)
 		throws Exception {
 
+		String endpoint = StringBundler.concat(
+			objectDefinition.getRESTContextPath(), "?nestedFields=",
+			nestedFieldName);
+
+		if (nestedFieldDepth != null) {
+			endpoint += "&nestedFieldsDepth=" + nestedFieldDepth;
+		}
+
 		JSONObject jsonObject = HTTPTestUtil.invoke(
-			null,
-			StringBundler.concat(
-				objectDefinition.getRESTContextPath(), "?nestedFields=",
-				nestedFieldName),
-			Http.Method.GET);
+			null, endpoint, Http.Method.GET);
 
 		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
 
@@ -4674,15 +4873,9 @@ public class ObjectEntryResourceTest {
 
 		JSONObject itemJSONObject = itemsJSONArray.getJSONObject(0);
 
-		Assert.assertEquals(
-			_OBJECT_FIELD_VALUE_2, itemJSONObject.getInt(_OBJECT_FIELD_NAME_2));
-
-		JSONObject relatedObjectJSONObject = itemJSONObject.getJSONObject(
-			expectedFieldName);
-
-		Assert.assertEquals(
-			_OBJECT_FIELD_VALUE_1,
-			relatedObjectJSONObject.getInt(_OBJECT_FIELD_NAME_1));
+		_assertNestedFieldsInRelationships(
+			0, GetterUtil.getInteger(nestedFieldDepth, 1), itemJSONObject,
+			keyValues, expectedFieldName, type);
 	}
 
 	private void
@@ -4826,6 +5019,7 @@ public class ObjectEntryResourceTest {
 
 	private ObjectRelationship _objectRelationship1;
 	private ObjectRelationship _objectRelationship2;
+	private ObjectRelationship _objectRelationship3;
 
 	@Inject
 	private ObjectRelationshipLocalService _objectRelationshipLocalService;
@@ -4835,5 +5029,11 @@ public class ObjectEntryResourceTest {
 
 	private ObjectDefinition _siteScopedObjectDefinition1;
 	private ObjectEntry _siteScopedObjectEntry1;
+
+	private enum Type {
+
+		MANY_TO_MANY, MANY_TO_ONE, ONE_TO_MANY
+
+	}
 
 }

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -3066,66 +3066,43 @@ public class ObjectEntryResourceTest {
 		_objectRelationship1 = _addObjectRelationshipAndRelateObjectEntries(
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
-		_testGetNestedFieldDetailsInOneToManyRelationships(
-			StringBundler.concat(
-				_objectDefinition2.getRESTContextPath(), "?nestedFields=r_",
-				_objectRelationship1.getName(), "_",
-				_objectDefinition1.getPKObjectFieldName()),
-			StringBundler.concat(
-				"r_", _objectRelationship1.getName(), "_",
-				StringUtil.removeLast(
-					_objectDefinition1.getPKObjectFieldName(), "Id")));
+		String relationshipFieldName = String.format(
+			"r_%s_%s", _objectRelationship1.getName(),
+			_objectDefinition1.getPKObjectFieldName());
+
+		String relationshipFieldNestedFieldName = StringUtil.removeLast(
+			relationshipFieldName, "Id");
 
 		_testGetNestedFieldDetailsInOneToManyRelationships(
-			StringBundler.concat(
-				_objectDefinition2.getRESTContextPath(), "?nestedFields=r_",
-				_objectRelationship1.getName(), "_",
-				StringUtil.removeLast(
-					_objectDefinition1.getPKObjectFieldName(), "Id")),
-			StringBundler.concat(
-				"r_", _objectRelationship1.getName(), "_",
-				StringUtil.removeLast(
-					_objectDefinition1.getPKObjectFieldName(), "Id")));
+			relationshipFieldNestedFieldName, relationshipFieldName,
+			_objectDefinition2);
 
 		_testGetNestedFieldDetailsInOneToManyRelationships(
-			StringBundler.concat(
-				_objectDefinition2.getRESTContextPath(), "?nestedFields=",
-				StringUtil.removeLast(
-					StringUtil.removeFirst(
-						_objectDefinition1.getPKObjectFieldName(), "c_"),
-					"Id")),
-			StringBundler.concat(
-				"r_", _objectRelationship1.getName(), "_",
-				StringUtil.removeLast(
-					_objectDefinition1.getPKObjectFieldName(), "Id")));
+			relationshipFieldNestedFieldName,
+			StringUtil.removeLast(relationshipFieldName, "Id"),
+			_objectDefinition2);
+
+		String relatedObjectDefinitionName = StringUtil.removeFirst(
+			StringUtil.removeLast(
+				_objectDefinition1.getPKObjectFieldName(), "Id"),
+			"c_");
 
 		_testGetNestedFieldDetailsInOneToManyRelationships(
-			StringBundler.concat(
-				_objectDefinition2.getRESTContextPath(), "?nestedFields=",
-				_objectRelationship1.getName()),
-			StringBundler.concat(
-				"r_", _objectRelationship1.getName(), "_",
-				StringUtil.removeLast(
-					_objectDefinition1.getPKObjectFieldName(), "Id")));
+			relationshipFieldNestedFieldName, relatedObjectDefinitionName,
+			_objectDefinition2);
 
 		_testGetNestedFieldDetailsInOneToManyRelationships(
-			StringBundler.concat(
-				_objectDefinition2.getRESTContextPath(), "?nestedFields=",
-				_objectRelationship1.getName()),
-			_objectRelationship1.getName());
+			relationshipFieldNestedFieldName,
+			RandomTestUtil.randomString() + relatedObjectDefinitionName,
+			_objectDefinition2);
 
 		_testGetNestedFieldDetailsInOneToManyRelationships(
-			StringBundler.concat(
-				_objectDefinition2.getRESTContextPath(), "?nestedFields=",
-				RandomTestUtil.randomString(),
-				StringUtil.removeFirst(
-					StringUtil.removeLast(
-						_objectDefinition1.getPKObjectFieldName(), "Id"),
-					"c_")),
-			StringBundler.concat(
-				"r_", _objectRelationship1.getName(), "_",
-				StringUtil.replaceLast(
-					_objectDefinition1.getPKObjectFieldName(), "Id", "")));
+			relationshipFieldNestedFieldName, _objectRelationship1.getName(),
+			_objectDefinition2);
+
+		_testGetNestedFieldDetailsInOneToManyRelationships(
+			_objectRelationship1.getName(), _objectRelationship1.getName(),
+			_objectDefinition2);
 	}
 
 	@Test
@@ -4680,11 +4657,16 @@ public class ObjectEntryResourceTest {
 	}
 
 	private void _testGetNestedFieldDetailsInOneToManyRelationships(
-			String endpoint, String expectedFieldName)
+			String expectedFieldName, String nestedFieldName,
+			ObjectDefinition objectDefinition)
 		throws Exception {
 
 		JSONObject jsonObject = HTTPTestUtil.invoke(
-			null, endpoint, Http.Method.GET);
+			null,
+			StringBundler.concat(
+				objectDefinition.getRESTContextPath(), "?nestedFields=",
+				nestedFieldName),
+			Http.Method.GET);
 
 		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
 

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -25,7 +25,6 @@ import com.liferay.asset.kernel.service.AssetTagLocalServiceUtil;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalServiceUtil;
 import com.liferay.headless.admin.taxonomy.client.dto.v1_0.TaxonomyCategory;
 import com.liferay.headless.admin.taxonomy.client.resource.v1_0.TaxonomyCategoryResource;
-import com.liferay.headless.admin.user.dto.v1_0.UserAccount;
 import com.liferay.list.type.entry.util.ListTypeEntryUtil;
 import com.liferay.list.type.model.ListTypeDefinition;
 import com.liferay.list.type.service.ListTypeDefinitionLocalService;
@@ -249,11 +248,12 @@ public class ObjectEntryResourceTest {
 			ObjectFieldConstants.DB_TYPE_STRING, _userSystemObjectDefinition,
 			_OBJECT_FIELD_NAME_2);
 
-		_userAccount = SystemObjectEntryTestUtil.addUserAccount(
-			systemObjectDefinitionManager,
-			HashMapBuilder.<String, Serializable>put(
-				_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)
-			).build());
+		_userAccountJSONObject =
+			SystemObjectEntryTestUtil.addUserAccountJSONObject(
+				systemObjectDefinitionManager,
+				HashMapBuilder.<String, Serializable>put(
+					_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)
+				).build());
 	}
 
 	@After
@@ -3305,7 +3305,7 @@ public class ObjectEntryResourceTest {
 
 		_objectRelationship1 = _addObjectRelationshipAndRelateObjectEntries(
 			_objectDefinition1, _userSystemObjectDefinition,
-			_objectEntry1.getPrimaryKey(), _userAccount.getId(),
+			_objectEntry1.getPrimaryKey(), _userAccountJSONObject.getLong("id"),
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
 		_testGetNestedFieldDetailsInRelationships(
@@ -3321,7 +3321,7 @@ public class ObjectEntryResourceTest {
 
 		_objectRelationship2 = _addObjectRelationshipAndRelateObjectEntries(
 			_objectDefinition1, _userSystemObjectDefinition,
-			_objectEntry1.getPrimaryKey(), _userAccount.getId(),
+			_objectEntry1.getPrimaryKey(), _userAccountJSONObject.getLong("id"),
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
 		_testGetNestedFieldDetailsInRelationships(
@@ -5162,7 +5162,7 @@ public class ObjectEntryResourceTest {
 	private SystemObjectDefinitionManagerRegistry
 		_systemObjectDefinitionManagerRegistry;
 
-	private UserAccount _userAccount;
+	private JSONObject _userAccountJSONObject;
 	private ObjectDefinition _userSystemObjectDefinition;
 
 	@DeleteAfterTestRun

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -640,12 +640,14 @@ public class ObjectEntryResourceTest {
 		// 1 to many relationship, custom object field
 
 		_objectRelationship1 = _addObjectRelationshipAndRelateObjectEntries(
-			_objectDefinition1, _objectDefinition2, _objectEntry1,
-			_objectEntry2, ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+			_objectDefinition1, _objectDefinition2,
+			_objectEntry1.getPrimaryKey(), _objectEntry2.getPrimaryKey(),
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
 		_objectRelationship2 = _addObjectRelationshipAndRelateObjectEntries(
-			_objectDefinition2, _objectDefinition3, _objectEntry2,
-			_objectEntry3, ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+			_objectDefinition2, _objectDefinition3,
+			_objectEntry2.getPrimaryKey(), _objectEntry3.getPrimaryKey(),
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
 		_assertFilterString(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
@@ -857,12 +859,14 @@ public class ObjectEntryResourceTest {
 		// Many to many relationship, custom object field
 
 		_objectRelationship1 = _addObjectRelationshipAndRelateObjectEntries(
-			_objectDefinition1, _objectDefinition2, _objectEntry1,
-			_objectEntry2, ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+			_objectDefinition1, _objectDefinition2,
+			_objectEntry1.getPrimaryKey(), _objectEntry2.getPrimaryKey(),
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
 		_objectRelationship2 = _addObjectRelationshipAndRelateObjectEntries(
-			_objectDefinition2, _objectDefinition3, _objectEntry2,
-			_objectEntry3, ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+			_objectDefinition2, _objectDefinition3,
+			_objectEntry2.getPrimaryKey(), _objectEntry3.getPrimaryKey(),
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
 		_assertFilterString(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
@@ -1188,12 +1192,14 @@ public class ObjectEntryResourceTest {
 		// 1 to many relationship, custom object field
 
 		_objectRelationship1 = _addObjectRelationshipAndRelateObjectEntries(
-			_objectDefinition1, _objectDefinition2, _objectEntry1,
-			_objectEntry2, ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+			_objectDefinition1, _objectDefinition2,
+			_objectEntry1.getPrimaryKey(), _objectEntry2.getPrimaryKey(),
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
 		_objectRelationship2 = _addObjectRelationshipAndRelateObjectEntries(
-			_objectDefinition2, _objectDefinition3, _objectEntry2,
-			_objectEntry3, ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+			_objectDefinition2, _objectDefinition3,
+			_objectEntry2.getPrimaryKey(), _objectEntry3.getPrimaryKey(),
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
 		_assertFilterString(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
@@ -1259,12 +1265,14 @@ public class ObjectEntryResourceTest {
 		// Many to many relationship, custom object field
 
 		_objectRelationship1 = _addObjectRelationshipAndRelateObjectEntries(
-			_objectDefinition1, _objectDefinition2, _objectEntry1,
-			_objectEntry2, ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+			_objectDefinition1, _objectDefinition2,
+			_objectEntry1.getPrimaryKey(), _objectEntry2.getPrimaryKey(),
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
 		_objectRelationship2 = _addObjectRelationshipAndRelateObjectEntries(
-			_objectDefinition2, _objectDefinition3, _objectEntry2,
-			_objectEntry3, ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+			_objectDefinition2, _objectDefinition3,
+			_objectEntry2.getPrimaryKey(), _objectEntry3.getPrimaryKey(),
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
 		_assertFilterString(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
@@ -1347,8 +1355,9 @@ public class ObjectEntryResourceTest {
 			_TAG_1);
 
 		_objectRelationship1 = _addObjectRelationshipAndRelateObjectEntries(
-			_objectDefinition1, _objectDefinition2, _objectEntry1,
-			_objectEntry2, ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+			_objectDefinition1, _objectDefinition2,
+			_objectEntry1.getPrimaryKey(), _objectEntry2.getPrimaryKey(),
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
 		_assertFilterString(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
@@ -1494,8 +1503,9 @@ public class ObjectEntryResourceTest {
 		// Many to many relationship, custom object field
 
 		_objectRelationship1 = _addObjectRelationshipAndRelateObjectEntries(
-			_objectDefinition1, _objectDefinition2, _objectEntry1,
-			_objectEntry2, ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+			_objectDefinition1, _objectDefinition2,
+			_objectEntry1.getPrimaryKey(), _objectEntry2.getPrimaryKey(),
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
 		_assertFilterString(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
@@ -1670,12 +1680,14 @@ public class ObjectEntryResourceTest {
 		// 1 to many relationship, custom object field
 
 		_objectRelationship1 = _addObjectRelationshipAndRelateObjectEntries(
-			_objectDefinition1, _objectDefinition2, _objectEntry1,
-			_objectEntry2, ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+			_objectDefinition1, _objectDefinition2,
+			_objectEntry1.getPrimaryKey(), _objectEntry2.getPrimaryKey(),
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
 		_objectRelationship2 = _addObjectRelationshipAndRelateObjectEntries(
-			_objectDefinition2, _objectDefinition3, _objectEntry2,
-			_objectEntry3, ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+			_objectDefinition2, _objectDefinition3,
+			_objectEntry2.getPrimaryKey(), _objectEntry3.getPrimaryKey(),
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
 		_assertFilterString(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
@@ -1851,12 +1863,14 @@ public class ObjectEntryResourceTest {
 		// Many to many relationship, custom object field
 
 		_objectRelationship1 = _addObjectRelationshipAndRelateObjectEntries(
-			_objectDefinition1, _objectDefinition2, _objectEntry1,
-			_objectEntry2, ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+			_objectDefinition1, _objectDefinition2,
+			_objectEntry1.getPrimaryKey(), _objectEntry2.getPrimaryKey(),
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
 		_objectRelationship2 = _addObjectRelationshipAndRelateObjectEntries(
-			_objectDefinition2, _objectDefinition3, _objectEntry2,
-			_objectEntry3, ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+			_objectDefinition2, _objectDefinition3,
+			_objectEntry2.getPrimaryKey(), _objectEntry3.getPrimaryKey(),
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
 		_assertFilterString(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
@@ -2374,12 +2388,14 @@ public class ObjectEntryResourceTest {
 		throws Exception {
 
 		_objectRelationship1 = _addObjectRelationshipAndRelateObjectEntries(
-			_objectDefinition1, _objectDefinition2, _objectEntry1,
-			_objectEntry2, ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+			_objectDefinition1, _objectDefinition2,
+			_objectEntry1.getPrimaryKey(), _objectEntry2.getPrimaryKey(),
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
 		_objectRelationship2 = _addObjectRelationshipAndRelateObjectEntries(
-			_objectDefinition2, _objectDefinition3, _objectEntry2,
-			_objectEntry3, ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+			_objectDefinition2, _objectDefinition3,
+			_objectEntry2.getPrimaryKey(), _objectEntry3.getPrimaryKey(),
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
 		// 1 to many relationship, custom object field
 
@@ -2533,12 +2549,14 @@ public class ObjectEntryResourceTest {
 		// Many to many relationship, custom object field
 
 		_objectRelationship1 = _addObjectRelationshipAndRelateObjectEntries(
-			_objectDefinition1, _objectDefinition2, _objectEntry1,
-			_objectEntry2, ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+			_objectDefinition1, _objectDefinition2,
+			_objectEntry1.getPrimaryKey(), _objectEntry2.getPrimaryKey(),
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
 		_objectRelationship2 = _addObjectRelationshipAndRelateObjectEntries(
-			_objectDefinition2, _objectDefinition3, _objectEntry2,
-			_objectEntry3, ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+			_objectDefinition2, _objectDefinition3,
+			_objectEntry2.getPrimaryKey(), _objectEntry3.getPrimaryKey(),
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
 		_assertFilterString(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
@@ -2867,12 +2885,14 @@ public class ObjectEntryResourceTest {
 		// 1 to many relationship, custom object field
 
 		_objectRelationship1 = _addObjectRelationshipAndRelateObjectEntries(
-			_objectDefinition1, _objectDefinition2, _objectEntry1,
-			_objectEntry2, ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+			_objectDefinition1, _objectDefinition2,
+			_objectEntry1.getPrimaryKey(), _objectEntry2.getPrimaryKey(),
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
 		_objectRelationship2 = _addObjectRelationshipAndRelateObjectEntries(
-			_objectDefinition2, _objectDefinition3, _objectEntry2,
-			_objectEntry3, ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+			_objectDefinition2, _objectDefinition3,
+			_objectEntry2.getPrimaryKey(), _objectEntry3.getPrimaryKey(),
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
 		_assertFilterString(
 			_OBJECT_FIELD_NAME_1, objectFieldValue1,
@@ -2970,12 +2990,14 @@ public class ObjectEntryResourceTest {
 		// Many to many relationship, custom object field
 
 		_objectRelationship1 = _addObjectRelationshipAndRelateObjectEntries(
-			_objectDefinition1, _objectDefinition2, _objectEntry1,
-			_objectEntry2, ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+			_objectDefinition1, _objectDefinition2,
+			_objectEntry1.getPrimaryKey(), _objectEntry2.getPrimaryKey(),
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
 		_objectRelationship2 = _addObjectRelationshipAndRelateObjectEntries(
-			_objectDefinition2, _objectDefinition3, _objectEntry2,
-			_objectEntry3, ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+			_objectDefinition2, _objectDefinition3,
+			_objectEntry2.getPrimaryKey(), _objectEntry3.getPrimaryKey(),
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
 		_assertFilterString(
 			_OBJECT_FIELD_NAME_1, objectFieldValue1,
@@ -3072,8 +3094,9 @@ public class ObjectEntryResourceTest {
 		// One to many with Custom Object Definition
 
 		_objectRelationship1 = _addObjectRelationshipAndRelateObjectEntries(
-			_objectDefinition1, _objectDefinition2, _objectEntry1,
-			_objectEntry2, ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+			_objectDefinition1, _objectDefinition2,
+			_objectEntry1.getPrimaryKey(), _objectEntry2.getPrimaryKey(),
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
 		_testGetNestedFieldDetailsInRelationships(
 			_objectRelationship1.getName(),
@@ -3124,8 +3147,9 @@ public class ObjectEntryResourceTest {
 		// Many to many with Custom Object Definition
 
 		_objectRelationship2 = _addObjectRelationshipAndRelateObjectEntries(
-			_objectDefinition1, _objectDefinition2, _objectEntry1,
-			_objectEntry2, ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+			_objectDefinition1, _objectDefinition2,
+			_objectEntry1.getPrimaryKey(), _objectEntry2.getPrimaryKey(),
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
 		_testGetNestedFieldDetailsInRelationships(
 			_objectRelationship2.getName(),
@@ -4567,8 +4591,8 @@ public class ObjectEntryResourceTest {
 
 	private ObjectRelationship _addObjectRelationshipAndRelateObjectEntries(
 			ObjectDefinition objectDefinition1,
-			ObjectDefinition objectDefinition2, ObjectEntry objectEntry1,
-			ObjectEntry objectEntry2, String type)
+			ObjectDefinition objectDefinition2, long primaryKey1,
+			long primaryKey2, String type)
 		throws Exception {
 
 		ObjectRelationship objectRelationship =
@@ -4577,8 +4601,8 @@ public class ObjectEntryResourceTest {
 				TestPropsValues.getUserId(), type);
 
 		ObjectRelationshipTestUtil.relateObjectEntries(
-			objectEntry1.getPrimaryKey(), objectEntry2.getPrimaryKey(),
-			objectRelationship, TestPropsValues.getUserId());
+			primaryKey1, primaryKey2, objectRelationship,
+			TestPropsValues.getUserId());
 
 		return objectRelationship;
 	}
@@ -4587,16 +4611,9 @@ public class ObjectEntryResourceTest {
 			String type)
 		throws Exception {
 
-		ObjectRelationship objectRelationship =
-			ObjectRelationshipTestUtil.addObjectRelationship(
-				_objectDefinition1, _objectDefinition2,
-				TestPropsValues.getUserId(), type);
-
-		ObjectRelationshipTestUtil.relateObjectEntries(
-			_objectEntry1.getPrimaryKey(), _objectEntry2.getPrimaryKey(),
-			objectRelationship, TestPropsValues.getUserId());
-
-		return objectRelationship;
+		return _addObjectRelationshipAndRelateObjectEntries(
+			_objectDefinition1, _objectDefinition2,
+			_objectEntry1.getPrimaryKey(), _objectEntry2.getPrimaryKey(), type);
 	}
 
 	private TaxonomyCategory _addTaxonomyCategory() throws Exception {

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -3073,8 +3073,8 @@ public class ObjectEntryResourceTest {
 				_objectDefinition1.getPKObjectFieldName()),
 			StringBundler.concat(
 				"r_", _objectRelationship1.getName(), "_",
-				StringUtil.replaceLast(
-					_objectDefinition1.getPKObjectFieldName(), "Id", "")));
+				StringUtil.removeLast(
+					_objectDefinition1.getPKObjectFieldName(), "Id")));
 
 		_testGetNestedFieldDetailsInOneToManyRelationships(
 			StringBundler.concat(
@@ -4033,16 +4033,16 @@ public class ObjectEntryResourceTest {
 				objectEntryId, "?nestedFields=",
 				StringBundler.concat(
 					"r_", _objectRelationship1.getName(), "_",
-					StringUtil.replaceLast(
-						_objectDefinition1.getPKObjectFieldName(), "Id", ""))),
+					StringUtil.removeLast(
+						_objectDefinition1.getPKObjectFieldName(), "Id"))),
 			Http.Method.GET);
 
 		_assertObjectEntryField(
 			jsonObject.getJSONObject(
 				StringBundler.concat(
 					"r_", _objectRelationship1.getName(), "_",
-					StringUtil.replaceLast(
-						_objectDefinition1.getPKObjectFieldName(), "Id", ""))),
+					StringUtil.removeLast(
+						_objectDefinition1.getPKObjectFieldName(), "Id"))),
 			_OBJECT_FIELD_NAME_1, _NEW_OBJECT_FIELD_VALUE_1);
 	}
 
@@ -4325,16 +4325,16 @@ public class ObjectEntryResourceTest {
 				objectEntryId, "?nestedFields=",
 				StringBundler.concat(
 					"r_", _objectRelationship1.getName(), "_",
-					StringUtil.replaceLast(
-						_objectDefinition1.getPKObjectFieldName(), "Id", ""))),
+					StringUtil.removeLast(
+						_objectDefinition1.getPKObjectFieldName(), "Id"))),
 			Http.Method.GET);
 
 		_assertObjectEntryField(
 			jsonObject.getJSONObject(
 				StringBundler.concat(
 					"r_", _objectRelationship1.getName(), "_",
-					StringUtil.replaceLast(
-						_objectDefinition1.getPKObjectFieldName(), "Id", ""))),
+					StringUtil.removeLast(
+						_objectDefinition1.getPKObjectFieldName(), "Id"))),
 			_OBJECT_FIELD_NAME_1, _NEW_OBJECT_FIELD_VALUE_1);
 	}
 

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/SystemObjectRelatedObjectEntriesTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/SystemObjectRelatedObjectEntriesTest.java
@@ -24,7 +24,7 @@ import com.liferay.object.rest.internal.resource.v1_0.test.util.HTTPTestUtil;
 import com.liferay.object.rest.internal.resource.v1_0.test.util.ObjectDefinitionTestUtil;
 import com.liferay.object.rest.internal.resource.v1_0.test.util.ObjectEntryTestUtil;
 import com.liferay.object.rest.internal.resource.v1_0.test.util.ObjectRelationshipTestUtil;
-import com.liferay.object.rest.internal.resource.v1_0.test.util.SystemObjectEntryTestUtil;
+import com.liferay.object.rest.internal.resource.v1_0.test.util.UserAccountTestUtil;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalServiceUtil;
@@ -281,18 +281,17 @@ public class SystemObjectRelatedObjectEntriesTest {
 
 		_objectRelationships.add(objectRelationship);
 
-		JSONObject jsonObject =
-			SystemObjectEntryTestUtil.addUserAccountJSONObject(
-				_userSystemObjectDefinitionManager,
-				HashMapBuilder.<String, Serializable>put(
-					objectRelationship.getName(),
-					JSONFactoryUtil.createJSONObject(
-						JSONUtil.put(
-							_OBJECT_FIELD_NAME, _NEW_OBJECT_FIELD_VALUE_1
-						).put(
-							"externalReferenceCode", _ERC_VALUE_1
-						).toString())
-				).build());
+		JSONObject jsonObject = UserAccountTestUtil.addUserAccountJSONObject(
+			_userSystemObjectDefinitionManager,
+			HashMapBuilder.<String, Serializable>put(
+				objectRelationship.getName(),
+				JSONFactoryUtil.createJSONObject(
+					JSONUtil.put(
+						_OBJECT_FIELD_NAME, _NEW_OBJECT_FIELD_VALUE_1
+					).put(
+						"externalReferenceCode", _ERC_VALUE_1
+					).toString())
+			).build());
 
 		jsonObject = HTTPTestUtil.invoke(
 			null,
@@ -323,13 +322,11 @@ public class SystemObjectRelatedObjectEntriesTest {
 			_objectEntry.getPrimaryKey(), _user.getUserId(),
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
-		JSONObject jsonObject =
-			SystemObjectEntryTestUtil.addUserAccountJSONObject(
-				_userSystemObjectDefinitionManager,
-				HashMapBuilder.<String, Serializable>put(
-					objectRelationship.getName(),
-					JSONFactoryUtil.createJSONArray()
-				).build());
+		JSONObject jsonObject = UserAccountTestUtil.addUserAccountJSONObject(
+			_userSystemObjectDefinitionManager,
+			HashMapBuilder.<String, Serializable>put(
+				objectRelationship.getName(), JSONFactoryUtil.createJSONArray()
+			).build());
 
 		Assert.assertEquals(
 			HttpStatus.BAD_REQUEST.getReasonPhrase(
@@ -381,20 +378,19 @@ public class SystemObjectRelatedObjectEntriesTest {
 
 		_objectRelationships.add(objectRelationship);
 
-		JSONObject jsonObject =
-			SystemObjectEntryTestUtil.addUserAccountJSONObject(
-				_userSystemObjectDefinitionManager,
-				HashMapBuilder.<String, Serializable>put(
-					objectRelationship.getName(),
-					JSONFactoryUtil.createJSONObject(
-						JSONUtil.put(
-							_OBJECT_FIELD_NAME, RandomTestUtil.randomString()
-						).put(
-							"externalReferenceCode", _ERC_VALUE_1
-						).toString())
-				).build());
+		JSONObject jsonObject = UserAccountTestUtil.addUserAccountJSONObject(
+			_userSystemObjectDefinitionManager,
+			HashMapBuilder.<String, Serializable>put(
+				objectRelationship.getName(),
+				JSONFactoryUtil.createJSONObject(
+					JSONUtil.put(
+						_OBJECT_FIELD_NAME, RandomTestUtil.randomString()
+					).put(
+						"externalReferenceCode", _ERC_VALUE_1
+					).toString())
+			).build());
 
-		SystemObjectEntryTestUtil.updateUserAccountJSONObject(
+		UserAccountTestUtil.updateUserAccountJSONObject(
 			jsonObject, _userSystemObjectDefinitionManager,
 			HashMapBuilder.<String, Serializable>put(
 				objectRelationship.getName(),
@@ -515,7 +511,7 @@ public class SystemObjectRelatedObjectEntriesTest {
 		JSONObject jsonObject;
 
 		if (manyToOne) {
-			jsonObject = SystemObjectEntryTestUtil.addUserAccountJSONObject(
+			jsonObject = UserAccountTestUtil.addUserAccountJSONObject(
 				_userSystemObjectDefinitionManager,
 				HashMapBuilder.<String, Serializable>put(
 					objectRelationship.getName(),
@@ -528,7 +524,7 @@ public class SystemObjectRelatedObjectEntriesTest {
 				).build());
 		}
 		else {
-			jsonObject = SystemObjectEntryTestUtil.addUserAccountJSONObject(
+			jsonObject = UserAccountTestUtil.addUserAccountJSONObject(
 				_userSystemObjectDefinitionManager,
 				HashMapBuilder.<String, Serializable>put(
 					objectRelationship.getName(),
@@ -546,18 +542,17 @@ public class SystemObjectRelatedObjectEntriesTest {
 			ObjectRelationship objectRelationship)
 		throws Exception {
 
-		JSONObject jsonObject =
-			SystemObjectEntryTestUtil.addUserAccountJSONObject(
-				_userSystemObjectDefinitionManager,
-				HashMapBuilder.<String, Serializable>put(
-					objectRelationship.getName(),
-					_createObjectEntriesJSONArray(
-						new String[] {_ERC_VALUE_1, _ERC_VALUE_2},
-						_OBJECT_FIELD_NAME,
-						new String[] {
-							_NEW_OBJECT_FIELD_VALUE_1, _NEW_OBJECT_FIELD_VALUE_2
-						})
-				).build());
+		JSONObject jsonObject = UserAccountTestUtil.addUserAccountJSONObject(
+			_userSystemObjectDefinitionManager,
+			HashMapBuilder.<String, Serializable>put(
+				objectRelationship.getName(),
+				_createObjectEntriesJSONArray(
+					new String[] {_ERC_VALUE_1, _ERC_VALUE_2},
+					_OBJECT_FIELD_NAME,
+					new String[] {
+						_NEW_OBJECT_FIELD_VALUE_1, _NEW_OBJECT_FIELD_VALUE_2
+					})
+			).build());
 
 		jsonObject = HTTPTestUtil.invoke(
 			null,
@@ -582,21 +577,20 @@ public class SystemObjectRelatedObjectEntriesTest {
 			ObjectRelationship objectRelationship)
 		throws Exception {
 
-		JSONObject jsonObject =
-			SystemObjectEntryTestUtil.addUserAccountJSONObject(
-				_userSystemObjectDefinitionManager,
-				HashMapBuilder.<String, Serializable>put(
-					objectRelationship.getName(),
-					_createObjectEntriesJSONArray(
-						new String[] {_ERC_VALUE_1, _ERC_VALUE_2},
-						_OBJECT_FIELD_NAME,
-						new String[] {
-							RandomTestUtil.randomString(),
-							RandomTestUtil.randomString()
-						})
-				).build());
+		JSONObject jsonObject = UserAccountTestUtil.addUserAccountJSONObject(
+			_userSystemObjectDefinitionManager,
+			HashMapBuilder.<String, Serializable>put(
+				objectRelationship.getName(),
+				_createObjectEntriesJSONArray(
+					new String[] {_ERC_VALUE_1, _ERC_VALUE_2},
+					_OBJECT_FIELD_NAME,
+					new String[] {
+						RandomTestUtil.randomString(),
+						RandomTestUtil.randomString()
+					})
+			).build());
 
-		jsonObject = SystemObjectEntryTestUtil.updateUserAccountJSONObject(
+		jsonObject = UserAccountTestUtil.updateUserAccountJSONObject(
 			jsonObject, _userSystemObjectDefinitionManager,
 			HashMapBuilder.<String, Serializable>put(
 				objectRelationship.getName(),

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/util/ObjectFieldTestUtil.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/util/ObjectFieldTestUtil.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.rest.internal.resource.v1_0.test.util;
+
+import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectField;
+import com.liferay.object.model.ObjectFieldSetting;
+import com.liferay.object.service.ObjectFieldLocalServiceUtil;
+import com.liferay.object.service.ObjectFieldSettingLocalServiceUtil;
+import com.liferay.portal.vulcan.util.LocalizedMapUtil;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * @author Carlos Correa
+ */
+public class ObjectFieldTestUtil {
+
+	public static ObjectField addCustomObjectField(
+			long userId, String businessType, String dbType,
+			ObjectDefinition objectDefinition, String objectFieldName)
+		throws Exception {
+
+		List<ObjectFieldSetting> objectFieldSettings = null;
+
+		if (Objects.equals(
+				businessType, ObjectFieldConstants.BUSINESS_TYPE_LONG_TEXT) ||
+			Objects.equals(
+				businessType, ObjectFieldConstants.BUSINESS_TYPE_TEXT)) {
+
+			ObjectFieldSetting objectFieldSetting =
+				ObjectFieldSettingLocalServiceUtil.createObjectFieldSetting(0);
+
+			objectFieldSetting.setName("showCounter");
+			objectFieldSetting.setValue("false");
+
+			objectFieldSettings = Collections.singletonList(objectFieldSetting);
+		}
+
+		return ObjectFieldLocalServiceUtil.addCustomObjectField(
+			null, userId, 0, objectDefinition.getObjectDefinitionId(),
+			businessType, dbType, false, true, "",
+			LocalizedMapUtil.getLocalizedMap(objectFieldName), false,
+			objectFieldName, false, false, objectFieldSettings);
+	}
+
+}

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/util/SystemObjectEntryTestUtil.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/util/SystemObjectEntryTestUtil.java
@@ -17,6 +17,8 @@ package com.liferay.object.rest.internal.resource.v1_0.test.util;
 import com.liferay.headless.admin.user.dto.v1_0.UserAccount;
 import com.liferay.object.system.JaxRsApplicationDescriptor;
 import com.liferay.object.system.SystemObjectDefinitionManager;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -32,26 +34,22 @@ import java.util.Map;
  */
 public class SystemObjectEntryTestUtil {
 
-	public static UserAccount addUserAccount(
+	public static JSONObject addUserAccountJSONObject(
 			SystemObjectDefinitionManager systemObjectDefinitionManager,
 			Map<String, Serializable> values)
 		throws Exception {
 
-		UserAccount userAccount = _randomUserAccount();
+		UserAccount userAccount = randomUserAccount();
 
 		JaxRsApplicationDescriptor jaxRsApplicationDescriptor =
 			systemObjectDefinitionManager.getJaxRsApplicationDescriptor();
 
-		JSONObject jsonObject = HTTPTestUtil.invoke(
+		return HTTPTestUtil.invoke(
 			_toBody(values, userAccount),
 			jaxRsApplicationDescriptor.getRESTContextPath(), Http.Method.POST);
-
-		userAccount.setId(jsonObject.getLong("id"));
-
-		return userAccount;
 	}
 
-	private static UserAccount _randomUserAccount() throws Exception {
+	public static UserAccount randomUserAccount() {
 		return new UserAccount() {
 			{
 				additionalName = StringUtil.toLowerCase(
@@ -89,6 +87,25 @@ public class SystemObjectEntryTestUtil {
 		};
 	}
 
+	public static JSONObject updateUserAccountJSONObject(
+			JSONObject userAccountJSONObject,
+			SystemObjectDefinitionManager systemObjectDefinitionManager,
+			Map<String, Serializable> values)
+		throws Exception {
+
+		UserAccount userAccount = randomUserAccount();
+
+		JaxRsApplicationDescriptor jaxRsApplicationDescriptor =
+			systemObjectDefinitionManager.getJaxRsApplicationDescriptor();
+
+		return HTTPTestUtil.invoke(
+			_toBody(values, userAccount),
+			StringBundler.concat(
+				jaxRsApplicationDescriptor.getRESTContextPath(),
+				StringPool.SLASH, userAccountJSONObject.get("id")),
+			Http.Method.PUT);
+	}
+
 	private static String _toBody(
 			Map<String, Serializable> values, UserAccount userAccount)
 		throws Exception {
@@ -96,8 +113,10 @@ public class SystemObjectEntryTestUtil {
 		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
 			userAccount.toString());
 
-		for (Map.Entry<String, Serializable> entry : values.entrySet()) {
-			jsonObject.put(entry.getKey(), entry.getValue());
+		if (values != null) {
+			for (Map.Entry<String, Serializable> entry : values.entrySet()) {
+				jsonObject.put(entry.getKey(), entry.getValue());
+			}
 		}
 
 		return jsonObject.toString();

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/util/SystemObjectEntryTestUtil.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/util/SystemObjectEntryTestUtil.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.rest.internal.resource.v1_0.test.util;
+
+import com.liferay.headless.admin.user.dto.v1_0.UserAccount;
+import com.liferay.object.system.JaxRsApplicationDescriptor;
+import com.liferay.object.system.SystemObjectDefinitionManager;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.StringUtil;
+
+import java.io.Serializable;
+
+import java.util.Map;
+
+/**
+ * @author Carlos Correa
+ */
+public class SystemObjectEntryTestUtil {
+
+	public static UserAccount addUserAccount(
+			SystemObjectDefinitionManager systemObjectDefinitionManager,
+			Map<String, Serializable> values)
+		throws Exception {
+
+		UserAccount userAccount = _randomUserAccount();
+
+		JaxRsApplicationDescriptor jaxRsApplicationDescriptor =
+			systemObjectDefinitionManager.getJaxRsApplicationDescriptor();
+
+		JSONObject jsonObject = HTTPTestUtil.invoke(
+			_toBody(values, userAccount),
+			jaxRsApplicationDescriptor.getRESTContextPath(), Http.Method.POST);
+
+		userAccount.setId(jsonObject.getLong("id"));
+
+		return userAccount;
+	}
+
+	private static UserAccount _randomUserAccount() throws Exception {
+		return new UserAccount() {
+			{
+				additionalName = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				alternateName = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				birthDate = RandomTestUtil.nextDate();
+				currentPassword = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				dashboardURL = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				dateCreated = RandomTestUtil.nextDate();
+				dateModified = RandomTestUtil.nextDate();
+				emailAddress =
+					StringUtil.toLowerCase(RandomTestUtil.randomString()) +
+						"@liferay.com";
+				familyName = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				givenName = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				honorificPrefix = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				honorificSuffix = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				image = StringUtil.toLowerCase(RandomTestUtil.randomString());
+				jobTitle = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				lastLoginDate = RandomTestUtil.nextDate();
+				name = StringUtil.toLowerCase(RandomTestUtil.randomString());
+				password = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				profileURL = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+			}
+		};
+	}
+
+	private static String _toBody(
+			Map<String, Serializable> values, UserAccount userAccount)
+		throws Exception {
+
+		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
+			userAccount.toString());
+
+		for (Map.Entry<String, Serializable> entry : values.entrySet()) {
+			jsonObject.put(entry.getKey(), entry.getValue());
+		}
+
+		return jsonObject.toString();
+	}
+
+}

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/util/UserAccountTestUtil.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/util/UserAccountTestUtil.java
@@ -32,7 +32,7 @@ import java.util.Map;
 /**
  * @author Carlos Correa
  */
-public class SystemObjectEntryTestUtil {
+public class UserAccountTestUtil {
 
 	public static JSONObject addUserAccountJSONObject(
 			SystemObjectDefinitionManager systemObjectDefinitionManager,

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/test/ObjectRelationshipExtensionProviderTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/test/ObjectRelationshipExtensionProviderTest.java
@@ -107,6 +107,9 @@ public class ObjectRelationshipExtensionProviderTest {
 				_objectRelationship.getObjectRelationshipId(),
 				_objectEntry.getPrimaryKey(), _user.getUserId(),
 				ServiceContextTestUtil.getServiceContext());
+
+		_originalNestedFieldsContext =
+			NestedFieldsContextThreadLocal.getNestedFieldsContext();
 	}
 
 	@After
@@ -121,6 +124,9 @@ public class ObjectRelationshipExtensionProviderTest {
 
 		_objectDefinitionLocalService.deleteObjectDefinition(
 			_objectDefinition.getObjectDefinitionId());
+
+		NestedFieldsContextThreadLocal.setNestedFieldsContext(
+			_originalNestedFieldsContext);
 	}
 
 	@Test
@@ -130,6 +136,8 @@ public class ObjectRelationshipExtensionProviderTest {
 				id = _user.getUserId();
 			}
 		};
+
+		NestedFieldsContextThreadLocal.setNestedFieldsContext(null);
 
 		Map<String, Serializable> extendedProperties =
 			_extensionProvider.getExtendedProperties(
@@ -249,6 +257,7 @@ public class ObjectRelationshipExtensionProviderTest {
 	private ObjectDefinition _objectDefinition;
 	private ObjectEntry _objectEntry;
 	private ObjectRelationship _objectRelationship;
+	private NestedFieldsContext _originalNestedFieldsContext;
 
 	@Inject
 	private SystemObjectDefinitionManagerRegistry


### PR DESCRIPTION
Forwarded from: https://github.com/brianchandotcom/liferay-portal/pull/134400

---

This PR contains the integration test to validate:

- Related Custom Object Entries related to a Custom Object by using `nestedFields` and `nestedFieldsDepth` query parameters.
- Related System Object Entries related to a Custom Object by using `nestedFields` and `nestedFieldsDepth` query parameters (under the FF `LPS-165819`).

Furthermore, two classes have been added:

- `ObjectFieldTestUtil`: Test Util class to manage custom object fields
- `UserAccountTestUtil`: Test Util class to generate random UserAccount and to manage the creation and update of a UserAccount

---

How to launch the tests:

- `cd modules/apps/object/object-rest-test`
- `gw tI --tests ObjectEntryRelatedObjectsResourceTest`
- `gw tI --tests ObjectEntryResourceTest`