### PR TITLE
LPS-181320 Handled object relationships schema filter for multiple relationships between two objects

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/entity/v1_0/ObjectEntryEntityModel.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/entity/v1_0/ObjectEntryEntityModel.java
@@ -83,6 +83,8 @@ public class ObjectEntryEntityModel implements EntityModel {
 					objectRelationship.getName(),
 					_getRelatedObjectDefinitionEntityFields(
 						objectRelationship, objectDefinition)));
+
+			_handledObjectDefinitions.clear();
 		}
 	}
 
@@ -175,8 +177,7 @@ public class ObjectEntryEntityModel implements EntityModel {
 			ObjectDefinition objectDefinition)
 		throws Exception {
 
-		_relatedObjectRelationships.add(
-			objectRelationship.getObjectRelationshipId());
+		_handledObjectDefinitions.add(objectDefinition.getObjectDefinitionId());
 
 		ObjectDefinition relatedObjectDefinition = _getRelatedObjectDefinition(
 			objectDefinition, objectRelationship);
@@ -189,6 +190,15 @@ public class ObjectEntryEntityModel implements EntityModel {
 		List<EntityField> relatedObjectDefinitionEntityFields = new ArrayList<>(
 			relatedObjectDefinitionEntityFieldsMap.values());
 
+		if (_handledObjectDefinitions.contains(
+				relatedObjectDefinition.getObjectDefinitionId())) {
+
+			_handledObjectDefinitions.remove(
+				objectDefinition.getObjectDefinitionId());
+
+			return relatedObjectDefinitionEntityFields;
+		}
+
 		List<ObjectRelationship> relatedObjectDefinitionObjectRelationships =
 			ObjectRelationshipLocalServiceUtil.getAllObjectRelationships(
 				relatedObjectDefinition.getObjectDefinitionId());
@@ -198,8 +208,8 @@ public class ObjectEntryEntityModel implements EntityModel {
 
 			if ((relatedObjectRelationship.getObjectRelationshipId() ==
 					objectRelationship.getObjectRelationshipId()) ||
-				_relatedObjectRelationships.contains(
-					relatedObjectRelationship.getObjectRelationshipId())) {
+				_isObjectDefinitionHandled(
+					relatedObjectDefinition, relatedObjectRelationship)) {
 
 				continue;
 			}
@@ -319,8 +329,20 @@ public class ObjectEntryEntityModel implements EntityModel {
 		return entityFieldsMap;
 	}
 
+	private boolean _isObjectDefinitionHandled(
+			ObjectDefinition relatedObjectDefinition,
+			ObjectRelationship relatedObjectRelationship)
+		throws Exception {
+
+		ObjectDefinition objectDefinition = _getRelatedObjectDefinition(
+			relatedObjectDefinition, relatedObjectRelationship);
+
+		return _handledObjectDefinitions.contains(
+			objectDefinition.getObjectDefinitionId());
+	}
+
 	private final Map<String, EntityField> _entityFieldsMap;
-	private final List<Long> _relatedObjectRelationships = new ArrayList<>();
+	private final List<Long> _handledObjectDefinitions = new ArrayList<>();
 	private final Set<String> _unsupportedBusinessTypes = SetUtil.fromArray(
 		ObjectFieldConstants.BUSINESS_TYPE_AGGREGATION,
 		ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT,

--- a/modules/apps/portal-odata/portal-odata-impl/src/main/java/com/liferay/portal/odata/internal/filter/EntityModelSchemaBasedEdmProvider.java
+++ b/modules/apps/portal-odata/portal-odata-impl/src/main/java/com/liferay/portal/odata/internal/filter/EntityModelSchemaBasedEdmProvider.java
@@ -78,9 +78,9 @@ public class EntityModelSchemaBasedEdmProvider extends SchemaBasedEdmProvider {
 	}
 
 	private CsdlComplexType _createCsdlComplexType(
+		int depth, EntityField entityField, String namespace,
 		Map<String, ObjectValuePair<Integer, CsdlComplexType>>
-			complexTypeNameDepth,
-		EntityField entityField, String namespace, int depth) {
+			objectValuePairs) {
 
 		if (!Objects.equals(entityField.getType(), EntityField.Type.COMPLEX)) {
 			return null;
@@ -112,11 +112,10 @@ public class EntityModelSchemaBasedEdmProvider extends SchemaBasedEdmProvider {
 						(ComplexEntityField)curEntityField;
 
 					_handleComplexType(
-						complexTypeNameDepth,
 						_createCsdlComplexType(
-							complexTypeNameDepth, curComplexEntityField,
-							_NAMESPACE, depth++),
-						depth);
+							depth++, curComplexEntityField, _NAMESPACE,
+							objectValuePairs),
+						depth, objectValuePairs);
 
 					depth--;
 				}
@@ -132,21 +131,21 @@ public class EntityModelSchemaBasedEdmProvider extends SchemaBasedEdmProvider {
 		Map<String, EntityField> entityFieldsMap, String namespace) {
 
 		Map<String, ObjectValuePair<Integer, CsdlComplexType>>
-			complexTypeNameDepth = new HashMap<>();
+			objectValuePairs = new HashMap<>();
 
 		for (EntityField entityField : entityFieldsMap.values()) {
 			CsdlComplexType csdlComplexType = _createCsdlComplexType(
-				complexTypeNameDepth, entityField, namespace, 1);
+				1, entityField, namespace, objectValuePairs);
 
 			if (csdlComplexType != null) {
-				complexTypeNameDepth.put(
+				objectValuePairs.put(
 					csdlComplexType.getName(),
 					new ObjectValuePair<>(0, csdlComplexType));
 			}
 		}
 
 		return TransformUtil.transform(
-			complexTypeNameDepth.values(), ObjectValuePair::getValue);
+			objectValuePairs.values(), ObjectValuePair::getValue);
 	}
 
 	private CsdlEntityContainer _createCsdlEntityContainer(
@@ -342,11 +341,11 @@ public class EntityModelSchemaBasedEdmProvider extends SchemaBasedEdmProvider {
 	}
 
 	private void _handleComplexType(
+		CsdlComplexType csdlComplexType, int depth,
 		Map<String, ObjectValuePair<Integer, CsdlComplexType>>
-			complexTypeNameDepth,
-		CsdlComplexType csdlComplexType, int depth) {
+			objectValuePairs) {
 
-		complexTypeNameDepth.compute(
+		objectValuePairs.compute(
 			csdlComplexType.getName(),
 			(key, value) -> {
 				if ((value == null) || (value.getKey() >= depth)) {

--- a/modules/apps/portal-odata/portal-odata-impl/src/main/java/com/liferay/portal/odata/internal/filter/EntityModelSchemaBasedEdmProvider.java
+++ b/modules/apps/portal-odata/portal-odata-impl/src/main/java/com/liferay/portal/odata/internal/filter/EntityModelSchemaBasedEdmProvider.java
@@ -14,6 +14,8 @@
 
 package com.liferay.portal.odata.internal.filter;
 
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.odata.entity.CollectionEntityField;
 import com.liferay.portal.odata.entity.ComplexEntityField;
 import com.liferay.portal.odata.entity.EntityField;
@@ -21,6 +23,7 @@ import com.liferay.portal.odata.entity.EntityModel;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -75,8 +78,9 @@ public class EntityModelSchemaBasedEdmProvider extends SchemaBasedEdmProvider {
 	}
 
 	private CsdlComplexType _createCsdlComplexType(
-		List<CsdlComplexType> csdlComplexTypes, EntityField entityField,
-		String namespace) {
+		Map<String, ObjectValuePair<Integer, CsdlComplexType>>
+			complexTypeNameDepth,
+		EntityField entityField, String namespace, int depth) {
 
 		if (!Objects.equals(entityField.getType(), EntityField.Type.COMPLEX)) {
 			return null;
@@ -104,8 +108,17 @@ public class EntityModelSchemaBasedEdmProvider extends SchemaBasedEdmProvider {
 				if (Objects.equals(
 						curEntityField.getType(), EntityField.Type.COMPLEX)) {
 
-					csdlComplexTypes.addAll(
-						_createCsdlComplexTypes(entityFieldsMap, _NAMESPACE));
+					ComplexEntityField curComplexEntityField =
+						(ComplexEntityField)curEntityField;
+
+					_handleComplexType(
+						complexTypeNameDepth,
+						_createCsdlComplexType(
+							complexTypeNameDepth, curComplexEntityField,
+							_NAMESPACE, depth++),
+						depth);
+
+					depth--;
 				}
 			}
 		}
@@ -118,19 +131,22 @@ public class EntityModelSchemaBasedEdmProvider extends SchemaBasedEdmProvider {
 	private List<CsdlComplexType> _createCsdlComplexTypes(
 		Map<String, EntityField> entityFieldsMap, String namespace) {
 
-		List<CsdlComplexType> csdlComplexTypes = new ArrayList<>(
-			entityFieldsMap.size());
+		Map<String, ObjectValuePair<Integer, CsdlComplexType>>
+			complexTypeNameDepth = new HashMap<>();
 
 		for (EntityField entityField : entityFieldsMap.values()) {
 			CsdlComplexType csdlComplexType = _createCsdlComplexType(
-				csdlComplexTypes, entityField, namespace);
+				complexTypeNameDepth, entityField, namespace, 1);
 
 			if (csdlComplexType != null) {
-				csdlComplexTypes.add(csdlComplexType);
+				complexTypeNameDepth.put(
+					csdlComplexType.getName(),
+					new ObjectValuePair<>(0, csdlComplexType));
 			}
 		}
 
-		return csdlComplexTypes;
+		return TransformUtil.transform(
+			complexTypeNameDepth.values(), ObjectValuePair::getValue);
 	}
 
 	private CsdlEntityContainer _createCsdlEntityContainer(
@@ -323,6 +339,22 @@ public class EntityModelSchemaBasedEdmProvider extends SchemaBasedEdmProvider {
 
 	private FullQualifiedName _getFullQualifiedName(EntityModel entityModel) {
 		return new FullQualifiedName(_NAMESPACE + "." + entityModel.getName());
+	}
+
+	private void _handleComplexType(
+		Map<String, ObjectValuePair<Integer, CsdlComplexType>>
+			complexTypeNameDepth,
+		CsdlComplexType csdlComplexType, int depth) {
+
+		complexTypeNameDepth.compute(
+			csdlComplexType.getName(),
+			(key, value) -> {
+				if ((value == null) || (value.getKey() >= depth)) {
+					return new ObjectValuePair<>(depth, csdlComplexType);
+				}
+
+				return value;
+			});
 	}
 
 	private static final String _NAMESPACE = "HypermediaRestApis";


### PR DESCRIPTION
Original pull request comment:
Related ticket -> [LPS-181320](https://issues.liferay.com/browse/LPS-181320)
___
## Purpose of the PR
When there are multiple relationships between two objects, the filter parser fails. (see related ticket for more information)
This PR solves this problem. It is necessary to consider two main concepts here to understand what it is doing

### Building entity model
The entity model is the class where it is specified the fields that could be used on the filter. In order to allow filtering by relationships, it is necessary to get the relationships in the object definition. Of course, each object relationship has associated other object relationships, with its own fields. That fields are also needed to build the tree.

The way to do that is to handle the relationships as a `complex field,` as a `complex field` can contain other fields.
It means that if we have a relationship between students and subjects and we are in the students' endpoint, we will have a complex field that contains the subjects fields which we can filter by.

When there are multiple relationships between two objects, it is easy to end in an infinite loop. To avoid that, the PR builds the tree "from left to the right". That means if there are 3 objects: University, Students, and Subjects and there are relationships among them; when we are on the university endpoint, it will build the tree in these ways:
* `university->student->subjects`
* `university->subjects->students`

This means that it will take into account the university relationships first and then, depending on the related object, will take into account the student or subject relationships. If one the student and objects relationships is another relationship with the university, that will not be taken into account, because the university has already been handled.

### Building odata complex types
In order to be able to parser the tree, it is necessary to pass to odata the complex types of the entity model. The problem here is that there could be multiple complex types with the same name as there could be multiple relationships between two objects. If there are complex types with the same name, odata will take the first one founded. The problem is that the complex type could not have all the properties needed to parse the filter.

To solve this problem, the PR generates all the complex types that came from the entity model and, once created, handles them to avoid duplicity. The rule to avoid duplicity is to keep the complex types with more properties, as it assumes that the additional properties are the other relationships' complex types (and should be like this)

## How to test it
Deploy the following modules:
* `object-rest-impl`
* `portal-odata-impl`
* Follow the steps of the ticket to create the needed data