### PR TITLE
LPS-183903 Allow developers to retrieve different levels of the many/one to many related elements of a system object as nestedFields

### DIFF
--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -3126,27 +3126,28 @@ public class ObjectEntryResourceTest {
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
 		_testGetNestedFieldDetailsInRelationships(
-			_objectRelationship1.getName(),
+			_objectRelationship1.getName(), null,
+			_objectRelationship1.getName(), _objectDefinition1,
 			new String[][] {
 				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
 				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)}
 			},
-			null, _objectRelationship1.getName(), _objectDefinition1,
 			Type.ONE_TO_MANY);
 
 		_testGetNestedFieldDetailsInRelationships(
-			_objectRelationship1.getName(),
+			_objectRelationship1.getName(), 3, _objectRelationship1.getName(),
+			_objectDefinition1,
 			new String[][] {
 				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
 				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)},
 				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
 				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)}
 			},
-			3, _objectRelationship1.getName(), _objectDefinition1,
 			Type.ONE_TO_MANY);
 
 		_testGetNestedFieldDetailsInRelationships(
-			_objectRelationship1.getName(),
+			_objectRelationship1.getName(), 5, _objectRelationship1.getName(),
+			_objectDefinition1,
 			new String[][] {
 				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
 				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)},
@@ -3155,11 +3156,11 @@ public class ObjectEntryResourceTest {
 				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
 				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)}
 			},
-			5, _objectRelationship1.getName(), _objectDefinition1,
 			Type.ONE_TO_MANY);
 
 		_testGetNestedFieldDetailsInRelationships(
-			_objectRelationship1.getName(),
+			_objectRelationship1.getName(), 6, _objectRelationship1.getName(),
+			_objectDefinition1,
 			new String[][] {
 				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
 				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)},
@@ -3168,7 +3169,6 @@ public class ObjectEntryResourceTest {
 				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
 				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)}
 			},
-			6, _objectRelationship1.getName(), _objectDefinition1,
 			Type.ONE_TO_MANY);
 
 		// Many to many with custom object definition
@@ -3179,27 +3179,28 @@ public class ObjectEntryResourceTest {
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
 		_testGetNestedFieldDetailsInRelationships(
-			_objectRelationship2.getName(),
+			_objectRelationship2.getName(), null,
+			_objectRelationship2.getName(), _objectDefinition1,
 			new String[][] {
 				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
 				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)}
 			},
-			null, _objectRelationship2.getName(), _objectDefinition1,
 			Type.MANY_TO_MANY);
 
 		_testGetNestedFieldDetailsInRelationships(
-			_objectRelationship2.getName(),
+			_objectRelationship2.getName(), 3, _objectRelationship2.getName(),
+			_objectDefinition1,
 			new String[][] {
 				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
 				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)},
 				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
 				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)}
 			},
-			3, _objectRelationship2.getName(), _objectDefinition1,
 			Type.MANY_TO_MANY);
 
 		_testGetNestedFieldDetailsInRelationships(
-			_objectRelationship2.getName(),
+			_objectRelationship2.getName(), 5, _objectRelationship2.getName(),
+			_objectDefinition1,
 			new String[][] {
 				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
 				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)},
@@ -3208,11 +3209,11 @@ public class ObjectEntryResourceTest {
 				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
 				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)}
 			},
-			5, _objectRelationship2.getName(), _objectDefinition1,
 			Type.MANY_TO_MANY);
 
 		_testGetNestedFieldDetailsInRelationships(
-			_objectRelationship2.getName(),
+			_objectRelationship2.getName(), 6, _objectRelationship2.getName(),
+			_objectDefinition1,
 			new String[][] {
 				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
 				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)},
@@ -3221,7 +3222,6 @@ public class ObjectEntryResourceTest {
 				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
 				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)}
 			},
-			6, _objectRelationship2.getName(), _objectDefinition1,
 			Type.MANY_TO_MANY);
 
 		// Many to one with custom object definition
@@ -3237,12 +3237,13 @@ public class ObjectEntryResourceTest {
 			relationshipFieldName, "Id");
 
 		_testGetNestedFieldDetailsInRelationships(
-			relationshipFieldNameNestedFieldName,
+			relationshipFieldNameNestedFieldName, null, relationshipFieldName,
+			_objectDefinition2,
 			new String[][] {
 				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)},
 				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)}
 			},
-			null, relationshipFieldName, _objectDefinition2, Type.MANY_TO_ONE);
+			Type.MANY_TO_ONE);
 
 		String relatedObjectDefinitionName = StringUtil.removeFirst(
 			StringUtil.removeLast(
@@ -3250,48 +3251,50 @@ public class ObjectEntryResourceTest {
 			"c_");
 
 		_testGetNestedFieldDetailsInRelationships(
-			relationshipFieldNameNestedFieldName,
+			relationshipFieldNameNestedFieldName, null,
+			StringUtil.removeLast(relationshipFieldName, "Id"),
+			_objectDefinition2,
 			new String[][] {
 				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)},
 				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)}
 			},
-			null, StringUtil.removeLast(relationshipFieldName, "Id"),
-			_objectDefinition2, Type.MANY_TO_ONE);
-
-		_testGetNestedFieldDetailsInRelationships(
-			relationshipFieldNameNestedFieldName,
-			new String[][] {
-				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)},
-				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)}
-			},
-			null, relatedObjectDefinitionName, _objectDefinition2,
 			Type.MANY_TO_ONE);
 
 		_testGetNestedFieldDetailsInRelationships(
-			relationshipFieldNameNestedFieldName,
+			relationshipFieldNameNestedFieldName, null,
+			relatedObjectDefinitionName, _objectDefinition2,
 			new String[][] {
 				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)},
 				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)}
 			},
-			null, RandomTestUtil.randomString() + relatedObjectDefinitionName,
-			_objectDefinition2, Type.MANY_TO_ONE);
-
-		_testGetNestedFieldDetailsInRelationships(
-			relationshipFieldNameNestedFieldName,
-			new String[][] {
-				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)},
-				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)}
-			},
-			null, _objectRelationship3.getName(), _objectDefinition2,
 			Type.MANY_TO_ONE);
 
 		_testGetNestedFieldDetailsInRelationships(
-			_objectRelationship3.getName(),
+			relationshipFieldNameNestedFieldName, null,
+			RandomTestUtil.randomString() + relatedObjectDefinitionName,
+			_objectDefinition2,
 			new String[][] {
 				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)},
 				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)}
 			},
-			null, _objectRelationship3.getName(), _objectDefinition2,
+			Type.MANY_TO_ONE);
+
+		_testGetNestedFieldDetailsInRelationships(
+			relationshipFieldNameNestedFieldName, null,
+			_objectRelationship3.getName(), _objectDefinition2,
+			new String[][] {
+				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)},
+				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)}
+			},
+			Type.MANY_TO_ONE);
+
+		_testGetNestedFieldDetailsInRelationships(
+			_objectRelationship3.getName(), null,
+			_objectRelationship3.getName(), _objectDefinition2,
+			new String[][] {
+				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)},
+				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)}
+			},
 			Type.MANY_TO_ONE);
 	}
 
@@ -3308,12 +3311,12 @@ public class ObjectEntryResourceTest {
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
 		_testGetNestedFieldDetailsInRelationships(
-			_objectRelationship1.getName(),
+			_objectRelationship1.getName(), null,
+			_objectRelationship1.getName(), _objectDefinition1,
 			new String[][] {
 				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
 				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)}
 			},
-			null, _objectRelationship1.getName(), _objectDefinition1,
 			Type.ONE_TO_MANY);
 
 		// Many to many with system object definition
@@ -3324,27 +3327,28 @@ public class ObjectEntryResourceTest {
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
 		_testGetNestedFieldDetailsInRelationships(
-			_objectRelationship2.getName(),
+			_objectRelationship2.getName(), null,
+			_objectRelationship2.getName(), _objectDefinition1,
 			new String[][] {
 				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
 				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)}
 			},
-			null, _objectRelationship2.getName(), _objectDefinition1,
 			Type.MANY_TO_MANY);
 
 		_testGetNestedFieldDetailsInRelationships(
-			_objectRelationship2.getName(),
+			_objectRelationship2.getName(), 3, _objectRelationship2.getName(),
+			_objectDefinition1,
 			new String[][] {
 				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
 				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)},
 				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
 				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)}
 			},
-			3, _objectRelationship2.getName(), _objectDefinition1,
 			Type.MANY_TO_MANY);
 
 		_testGetNestedFieldDetailsInRelationships(
-			_objectRelationship2.getName(),
+			_objectRelationship2.getName(), 5, _objectRelationship2.getName(),
+			_objectDefinition1,
 			new String[][] {
 				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
 				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)},
@@ -3353,11 +3357,11 @@ public class ObjectEntryResourceTest {
 				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
 				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)}
 			},
-			5, _objectRelationship2.getName(), _objectDefinition1,
 			Type.MANY_TO_MANY);
 
 		_testGetNestedFieldDetailsInRelationships(
-			_objectRelationship2.getName(),
+			_objectRelationship2.getName(), 6, _objectRelationship2.getName(),
+			_objectDefinition1,
 			new String[][] {
 				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
 				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)},
@@ -3366,7 +3370,6 @@ public class ObjectEntryResourceTest {
 				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
 				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)}
 			},
-			6, _objectRelationship2.getName(), _objectDefinition1,
 			Type.MANY_TO_MANY);
 	}
 
@@ -4884,7 +4887,7 @@ public class ObjectEntryResourceTest {
 
 	private void _assertNestedFieldsInRelationships(
 		int currentDepth, int depth, JSONObject jsonObject,
-		String[][] objectFieldNamesAndObjectFieldValues, String nestedFieldName,
+		String nestedFieldName, String[][] objectFieldNamesAndObjectFieldValues,
 		Type type) {
 
 		if (objectFieldNamesAndObjectFieldValues[currentDepth][0] == null) {
@@ -4912,7 +4915,7 @@ public class ObjectEntryResourceTest {
 		_assertNestedFieldsInRelationships(
 			currentDepth + 1, depth,
 			_getRelatedJSONObject(jsonObject, nestedFieldName, type),
-			objectFieldNamesAndObjectFieldValues, nestedFieldName,
+			nestedFieldName, objectFieldNamesAndObjectFieldValues,
 			_getReverseType(type));
 	}
 
@@ -5075,10 +5078,9 @@ public class ObjectEntryResourceTest {
 	}
 
 	private void _testGetNestedFieldDetailsInRelationships(
-			String expectedFieldName,
-			String[][] objectFieldNamesAndObjectFieldValues,
-			Integer nestedFieldDepth, String nestedFieldName,
-			ObjectDefinition objectDefinition, Type type)
+			String expectedFieldName, Integer nestedFieldDepth,
+			String nestedFieldName, ObjectDefinition objectDefinition,
+			String[][] objectFieldNamesAndObjectFieldValues, Type type)
 		throws Exception {
 
 		String endpoint = StringBundler.concat(
@@ -5100,7 +5102,7 @@ public class ObjectEntryResourceTest {
 
 		_assertNestedFieldsInRelationships(
 			0, GetterUtil.getInteger(nestedFieldDepth, 1), itemJSONObject,
-			objectFieldNamesAndObjectFieldValues, expectedFieldName, type);
+			expectedFieldName, objectFieldNamesAndObjectFieldValues, type);
 	}
 
 	private void

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -54,7 +54,6 @@ import com.liferay.object.system.SystemObjectDefinitionManagerRegistry;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
 import com.liferay.petra.function.transform.TransformUtil;
-import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.test.util.ConfigurationTemporarySwapper;
 import com.liferay.portal.kernel.json.JSONArray;
@@ -3877,8 +3876,9 @@ public class ObjectEntryResourceTest {
 
 		jsonObject = HTTPTestUtil.invoke(
 			null,
-			_objectDefinition1.getRESTContextPath() + StringPool.SLASH +
-				jsonObject.getString("id"),
+			String.format(
+				"%s/%d", _objectDefinition1.getRESTContextPath(),
+				jsonObject.getLong("id")),
 			Http.Method.GET);
 
 		JSONArray keywordsJSONArray = jsonObject.getJSONArray("keywords");
@@ -3894,8 +3894,9 @@ public class ObjectEntryResourceTest {
 
 		jsonObject = HTTPTestUtil.invoke(
 			null,
-			_objectDefinition1.getRESTContextPath() + StringPool.SLASH +
-				jsonObject.getString("id"),
+			String.format(
+				"%s/%d", _objectDefinition1.getRESTContextPath(),
+				jsonObject.getLong("id")),
 			Http.Method.GET);
 
 		keywordsJSONArray = jsonObject.getJSONArray("keywords");
@@ -3922,8 +3923,9 @@ public class ObjectEntryResourceTest {
 
 		jsonObject = HTTPTestUtil.invoke(
 			null,
-			_objectDefinition1.getRESTContextPath() + StringPool.SLASH +
-				jsonObject.getString("id"),
+			String.format(
+				"%s/%d", _objectDefinition1.getRESTContextPath(),
+				jsonObject.getLong("id")),
 			Http.Method.GET);
 
 		Assert.assertEquals(
@@ -3965,10 +3967,10 @@ public class ObjectEntryResourceTest {
 
 		jsonObject = HTTPTestUtil.invoke(
 			null,
-			StringBundler.concat(
-				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
-				jsonObject.getString("id"),
-				"?nestedFields=embeddedTaxonomyCategory"),
+			String.format(
+				"%s/%d?nestedFields=embeddedTaxonomyCategory",
+				_objectDefinition1.getRESTContextPath(),
+				jsonObject.getLong("id")),
 			Http.Method.GET);
 
 		Assert.assertEquals(
@@ -4027,8 +4029,8 @@ public class ObjectEntryResourceTest {
 
 		JSONObject jsonObject = HTTPTestUtil.invoke(
 			null,
-			StringBundler.concat(
-				_objectDefinition1.getRESTContextPath(), "?nestedFields=",
+			String.format(
+				"%s?nestedFields=%s", _objectDefinition1.getRESTContextPath(),
 				_objectRelationship1.getName()),
 			Http.Method.GET);
 
@@ -4099,14 +4101,16 @@ public class ObjectEntryResourceTest {
 			JSONUtil.put(
 				"keywords", JSONUtil.putAll("tag1", "tag2", "tag3")
 			).toString(),
-			_objectDefinition1.getRESTContextPath() + StringPool.SLASH +
-				jsonObject.getString("id"),
+			String.format(
+				"%s/%d", _objectDefinition1.getRESTContextPath(),
+				jsonObject.getLong("id")),
 			Http.Method.PATCH);
 
 		jsonObject = HTTPTestUtil.invoke(
 			null,
-			_objectDefinition1.getRESTContextPath() + StringPool.SLASH +
-				jsonObject.getString("id"),
+			String.format(
+				"%s/%d", _objectDefinition1.getRESTContextPath(),
+				jsonObject.getLong("id")),
 			Http.Method.GET);
 
 		JSONArray keywordsJSONArray = jsonObject.getJSONArray("keywords");
@@ -4140,8 +4144,9 @@ public class ObjectEntryResourceTest {
 					taxonomyCategory1.getId(), taxonomyCategory2.getId(),
 					taxonomyCategory3.getId())
 			).toString(),
-			_objectDefinition1.getRESTContextPath() + StringPool.SLASH +
-				jsonObject.getString("id"),
+			String.format(
+				"%s/%d", _objectDefinition1.getRESTContextPath(),
+				jsonObject.getLong("id")),
 			Http.Method.PATCH);
 
 		Assert.assertEquals(
@@ -4179,9 +4184,10 @@ public class ObjectEntryResourceTest {
 
 		JSONObject jsonObject = HTTPTestUtil.invoke(
 			objectEntryJSONObject.toString(),
-			StringBundler.concat(
-				_siteScopedObjectDefinition1.getRESTContextPath(), "/scopes/",
-				TestPropsValues.getGroupId(), "/by-external-reference-code/",
+			String.format(
+				"%s/scopes/%d/by-external-reference-code/%s",
+				_siteScopedObjectDefinition1.getRESTContextPath(),
+				TestPropsValues.getGroupId(),
 				_siteScopedObjectEntry1.getExternalReferenceCode()),
 			Http.Method.PATCH);
 
@@ -4290,13 +4296,13 @@ public class ObjectEntryResourceTest {
 			(JSONObject)nestedObjectEntriesJSONArray.get(1),
 			_OBJECT_FIELD_NAME_2, _NEW_OBJECT_FIELD_VALUE_2);
 
-		String objectEntryId = jsonObject.getString("id");
+		long objectEntryId = jsonObject.getLong("id");
 
 		jsonObject = HTTPTestUtil.invoke(
 			null,
-			StringBundler.concat(
-				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
-				objectEntryId, "?nestedFields=",
+			String.format(
+				"%s/%d?nestedFields=%s",
+				_objectDefinition1.getRESTContextPath(), objectEntryId,
 				_objectRelationship1.getName()),
 			Http.Method.GET);
 
@@ -4344,29 +4350,28 @@ public class ObjectEntryResourceTest {
 
 		_assertObjectEntryField(
 			jsonObject.getJSONObject(
-				StringBundler.concat(
-					"r_", _objectRelationship1.getName(), "_",
+				String.format(
+					"r_%s_%s", _objectRelationship1.getName(),
 					StringUtil.replaceLast(
 						_objectDefinition1.getPKObjectFieldName(), "Id", ""))),
 			_OBJECT_FIELD_NAME_1, _NEW_OBJECT_FIELD_VALUE_1);
 
-		String objectEntryId = jsonObject.getString("id");
+		long objectEntryId = jsonObject.getLong("id");
 
 		jsonObject = HTTPTestUtil.invoke(
 			null,
-			StringBundler.concat(
-				_objectDefinition2.getRESTContextPath(), StringPool.SLASH,
-				objectEntryId, "?nestedFields=",
-				StringBundler.concat(
-					"r_", _objectRelationship1.getName(), "_",
-					StringUtil.removeLast(
-						_objectDefinition1.getPKObjectFieldName(), "Id"))),
+			String.format(
+				"%s/%d?nestedFields=r_%s_%s",
+				_objectDefinition2.getRESTContextPath(), objectEntryId,
+				_objectRelationship1.getName(),
+				StringUtil.removeLast(
+					_objectDefinition1.getPKObjectFieldName(), "Id")),
 			Http.Method.GET);
 
 		_assertObjectEntryField(
 			jsonObject.getJSONObject(
-				StringBundler.concat(
-					"r_", _objectRelationship1.getName(), "_",
+				String.format(
+					"r_%s_%s", _objectRelationship1.getName(),
 					StringUtil.removeLast(
 						_objectDefinition1.getPKObjectFieldName(), "Id"))),
 			_OBJECT_FIELD_NAME_1, _NEW_OBJECT_FIELD_VALUE_1);
@@ -4412,13 +4417,13 @@ public class ObjectEntryResourceTest {
 			(JSONObject)nestedObjectEntriesJSONArray.get(1),
 			_OBJECT_FIELD_NAME_2, _NEW_OBJECT_FIELD_VALUE_2);
 
-		String objectEntryId = jsonObject.getString("id");
+		long objectEntryId = jsonObject.getLong("id");
 
 		jsonObject = HTTPTestUtil.invoke(
 			null,
-			StringBundler.concat(
-				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
-				objectEntryId, "?nestedFields=",
+			String.format(
+				"%s/%d?nestedFields=%s",
+				_objectDefinition1.getRESTContextPath(), objectEntryId,
 				_objectRelationship1.getName()),
 			Http.Method.GET);
 
@@ -4500,11 +4505,11 @@ public class ObjectEntryResourceTest {
 
 		JSONObject jsonObject = HTTPTestUtil.invoke(
 			null,
-			StringBundler.concat(
+			String.format(
+				"%s/by-external-reference-code/%s/%s/%s",
 				_objectDefinition1.getRESTContextPath(),
-				"/by-external-reference-code/",
-				_objectEntry1.getExternalReferenceCode(), StringPool.SLASH,
-				_objectRelationship1.getName(), StringPool.SLASH,
+				_objectEntry1.getExternalReferenceCode(),
+				_objectRelationship1.getName(),
 				_objectEntry2.getExternalReferenceCode()),
 			Http.Method.PUT);
 
@@ -4516,11 +4521,11 @@ public class ObjectEntryResourceTest {
 
 		jsonObject = HTTPTestUtil.invoke(
 			null,
-			StringBundler.concat(
+			String.format(
+				"%s/by-external-reference-code/%s/%s/%s",
 				_objectDefinition2.getRESTContextPath(),
-				"/by-external-reference-code/",
-				_objectEntry2.getExternalReferenceCode(), StringPool.SLASH,
-				_objectRelationship1.getName(), StringPool.SLASH,
+				_objectEntry2.getExternalReferenceCode(),
+				_objectRelationship1.getName(),
 				_objectEntry1.getExternalReferenceCode()),
 			Http.Method.PUT);
 
@@ -4532,12 +4537,11 @@ public class ObjectEntryResourceTest {
 
 		jsonObject = HTTPTestUtil.invoke(
 			null,
-			StringBundler.concat(
+			String.format(
+				"%s/by-external-reference-code/%s/%s/%s",
 				_objectDefinition2.getRESTContextPath(),
-				"/by-external-reference-code/",
-				_objectEntry2.getExternalReferenceCode(), StringPool.SLASH,
-				_objectRelationship1.getName(), StringPool.SLASH,
-				RandomTestUtil.randomString()),
+				_objectEntry2.getExternalReferenceCode(),
+				_objectRelationship1.getName(), RandomTestUtil.randomString()),
 			Http.Method.PUT);
 
 		Assert.assertThat(
@@ -4575,8 +4579,8 @@ public class ObjectEntryResourceTest {
 
 		JSONObject jsonObject = HTTPTestUtil.invoke(
 			newObjectEntryJSONObject.toString(),
-			StringBundler.concat(
-				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
+			String.format(
+				"%s/%d", _objectDefinition1.getRESTContextPath(),
 				_objectEntry1.getPrimaryKey()),
 			Http.Method.PUT);
 
@@ -4602,10 +4606,10 @@ public class ObjectEntryResourceTest {
 
 		jsonObject = HTTPTestUtil.invoke(
 			null,
-			StringBundler.concat(
-				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
-				_objectEntry1.getPrimaryKey(), "?nestedFields=",
-				_objectRelationship1.getName()),
+			String.format(
+				"%s/%d?nestedFields=%s",
+				_objectDefinition1.getRESTContextPath(),
+				_objectEntry1.getPrimaryKey(), _objectRelationship1.getName()),
 			Http.Method.GET);
 
 		nestedObjectEntriesJSONArray = jsonObject.getJSONArray(
@@ -4642,7 +4646,7 @@ public class ObjectEntryResourceTest {
 			objectEntryJSONObject.toString(),
 			_objectDefinition2.getRESTContextPath(), Http.Method.POST);
 
-		String objectEntryId = jsonObject.getString("id");
+		long objectEntryId = jsonObject.getLong("id");
 
 		JSONObject newObjectEntryJSONObject = JSONUtil.put(
 			_objectRelationship1.getName(),
@@ -4655,8 +4659,8 @@ public class ObjectEntryResourceTest {
 
 		jsonObject = HTTPTestUtil.invoke(
 			newObjectEntryJSONObject.toString(),
-			StringBundler.concat(
-				_objectDefinition2.getRESTContextPath(), StringPool.SLASH,
+			String.format(
+				"%s/%d", _objectDefinition2.getRESTContextPath(),
 				objectEntryId),
 			Http.Method.PUT);
 
@@ -4670,27 +4674,26 @@ public class ObjectEntryResourceTest {
 
 		_assertObjectEntryField(
 			jsonObject.getJSONObject(
-				StringBundler.concat(
-					"r_", _objectRelationship1.getName(), "_",
+				String.format(
+					"r_%s_%s", _objectRelationship1.getName(),
 					StringUtil.replaceLast(
 						_objectDefinition1.getPKObjectFieldName(), "Id", ""))),
 			_OBJECT_FIELD_NAME_1, _NEW_OBJECT_FIELD_VALUE_1);
 
 		jsonObject = HTTPTestUtil.invoke(
 			null,
-			StringBundler.concat(
-				_objectDefinition2.getRESTContextPath(), StringPool.SLASH,
-				objectEntryId, "?nestedFields=",
-				StringBundler.concat(
-					"r_", _objectRelationship1.getName(), "_",
-					StringUtil.removeLast(
-						_objectDefinition1.getPKObjectFieldName(), "Id"))),
+			String.format(
+				"%s/%d?nestedFields=r_%s_%s",
+				_objectDefinition2.getRESTContextPath(), objectEntryId,
+				_objectRelationship1.getName(),
+				StringUtil.removeLast(
+					_objectDefinition1.getPKObjectFieldName(), "Id")),
 			Http.Method.GET);
 
 		_assertObjectEntryField(
 			jsonObject.getJSONObject(
-				StringBundler.concat(
-					"r_", _objectRelationship1.getName(), "_",
+				String.format(
+					"r_%s_%s", _objectRelationship1.getName(),
 					StringUtil.removeLast(
 						_objectDefinition1.getPKObjectFieldName(), "Id"))),
 			_OBJECT_FIELD_NAME_1, _NEW_OBJECT_FIELD_VALUE_1);
@@ -4726,8 +4729,8 @@ public class ObjectEntryResourceTest {
 
 		JSONObject jsonObject = HTTPTestUtil.invoke(
 			newObjectEntryJSONObject.toString(),
-			StringBundler.concat(
-				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
+			String.format(
+				"%s/%d", _objectDefinition1.getRESTContextPath(),
 				_objectEntry1.getPrimaryKey()),
 			Http.Method.PUT);
 
@@ -4753,10 +4756,10 @@ public class ObjectEntryResourceTest {
 
 		jsonObject = HTTPTestUtil.invoke(
 			null,
-			StringBundler.concat(
-				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
-				_objectEntry1.getPrimaryKey(), "?nestedFields=",
-				_objectRelationship1.getName()),
+			String.format(
+				"%s/%d?nestedFields=%s",
+				_objectDefinition1.getRESTContextPath(),
+				_objectEntry1.getPrimaryKey(), _objectRelationship1.getName()),
 			Http.Method.GET);
 
 		nestedObjectEntriesJSONArray = jsonObject.getJSONArray(
@@ -4977,10 +4980,11 @@ public class ObjectEntryResourceTest {
 
 			ObjectEntryResource objectEntryResource =
 				serviceTrackerMap.getService(
-					StringBundler.concat(
+					String.format(
+						"%s#%s",
 						com.liferay.object.rest.dto.v1_0.ObjectEntry.class.
 							getName(),
-						StringPool.POUND, objectDefinition.getOSGiJaxRsName()));
+						objectDefinition.getOSGiJaxRsName()));
 
 			objectEntryResource.setContextAcceptLanguage(
 				new AcceptLanguage() {
@@ -5083,8 +5087,8 @@ public class ObjectEntryResourceTest {
 			String[][] objectFieldNamesAndObjectFieldValues, Type type)
 		throws Exception {
 
-		String endpoint = StringBundler.concat(
-			objectDefinition.getRESTContextPath(), "?nestedFields=",
+		String endpoint = String.format(
+			"%s?nestedFields=%s", objectDefinition.getRESTContextPath(),
 			nestedFieldName);
 
 		if (nestedFieldDepth != null) {

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/RelatedObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/RelatedObjectEntryResourceTest.java
@@ -23,6 +23,7 @@ import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.rest.internal.resource.v1_0.test.util.HTTPTestUtil;
 import com.liferay.object.rest.internal.resource.v1_0.test.util.ObjectDefinitionTestUtil;
 import com.liferay.object.rest.internal.resource.v1_0.test.util.ObjectEntryTestUtil;
+import com.liferay.object.rest.internal.resource.v1_0.test.util.ObjectRelationshipTestUtil;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.object.system.JaxRsApplicationDescriptor;
@@ -39,10 +40,8 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.Http;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
-import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
 import java.util.Collections;
 
@@ -101,11 +100,8 @@ public class RelatedObjectEntryResourceTest {
 			_userSystemObjectDefinitionManager.getJaxRsApplicationDescriptor();
 		Long irrelevantUserId = RandomTestUtil.randomLong();
 
-		String name = StringUtil.randomId();
-
 		_objectRelationship = _addObjectRelationship(
-			name, _objectDefinition.getObjectDefinitionId(),
-			_userSystemObjectDefinition.getObjectDefinitionId(),
+			_objectDefinition, _userSystemObjectDefinition,
 			_objectEntry.getPrimaryKey(), _user.getUserId(),
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
@@ -140,11 +136,8 @@ public class RelatedObjectEntryResourceTest {
 		JaxRsApplicationDescriptor jaxRsApplicationDescriptor =
 			_userSystemObjectDefinitionManager.getJaxRsApplicationDescriptor();
 
-		String name = StringUtil.randomId();
-
 		_objectRelationship = _addObjectRelationship(
-			name, _objectDefinition.getObjectDefinitionId(),
-			_userSystemObjectDefinition.getObjectDefinitionId(),
+			_objectDefinition, _userSystemObjectDefinition,
 			_objectEntry.getPrimaryKey(), _user.getUserId(),
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
@@ -189,11 +182,8 @@ public class RelatedObjectEntryResourceTest {
 		JaxRsApplicationDescriptor jaxRsApplicationDescriptor =
 			_userSystemObjectDefinitionManager.getJaxRsApplicationDescriptor();
 
-		String name = StringUtil.randomId();
-
 		_objectRelationship = _addObjectRelationship(
-			name, _objectDefinition.getObjectDefinitionId(),
-			_userSystemObjectDefinition.getObjectDefinitionId(),
+			_objectDefinition, _userSystemObjectDefinition,
 			_objectEntry.getPrimaryKey(), _user.getUserId(),
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
@@ -249,11 +239,8 @@ public class RelatedObjectEntryResourceTest {
 
 		Long irrelevantUserId = RandomTestUtil.randomLong();
 
-		String name = StringUtil.randomId();
-
 		_objectRelationship = _addObjectRelationship(
-			name, _userSystemObjectDefinition.getObjectDefinitionId(),
-			_objectDefinition.getObjectDefinitionId(), _user.getUserId(),
+			_userSystemObjectDefinition, _objectDefinition, _user.getUserId(),
 			_objectEntry.getPrimaryKey(),
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
@@ -305,11 +292,8 @@ public class RelatedObjectEntryResourceTest {
 		JaxRsApplicationDescriptor jaxRsApplicationDescriptor =
 			_userSystemObjectDefinitionManager.getJaxRsApplicationDescriptor();
 
-		String name = StringUtil.randomId();
-
 		_objectRelationship = _addObjectRelationship(
-			name, _userSystemObjectDefinition.getObjectDefinitionId(),
-			_objectDefinition.getObjectDefinitionId(), _user.getUserId(),
+			_userSystemObjectDefinition, _objectDefinition, _user.getUserId(),
 			_objectEntry.getPrimaryKey(),
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
@@ -354,11 +338,8 @@ public class RelatedObjectEntryResourceTest {
 		JaxRsApplicationDescriptor jaxRsApplicationDescriptor =
 			_userSystemObjectDefinitionManager.getJaxRsApplicationDescriptor();
 
-		String name = StringUtil.randomId();
-
 		_objectRelationship = _addObjectRelationship(
-			name, _userSystemObjectDefinition.getObjectDefinitionId(),
-			_objectDefinition.getObjectDefinitionId(), _user.getUserId(),
+			_userSystemObjectDefinition, _objectDefinition, _user.getUserId(),
 			_objectEntry.getPrimaryKey(),
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
@@ -390,8 +371,7 @@ public class RelatedObjectEntryResourceTest {
 		// Inactive object definition
 
 		_objectRelationship = _addObjectRelationship(
-			StringUtil.randomId(), _objectDefinition.getObjectDefinitionId(),
-			_userSystemObjectDefinition.getObjectDefinitionId(),
+			_objectDefinition, _userSystemObjectDefinition,
 			_objectEntry.getPrimaryKey(), _user.getUserId(),
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
@@ -418,11 +398,8 @@ public class RelatedObjectEntryResourceTest {
 			_userSystemObjectDefinitionManager.getJaxRsApplicationDescriptor();
 		Long irrelevantUserId = RandomTestUtil.randomLong();
 
-		String name = StringUtil.randomId();
-
 		_objectRelationship = _addObjectRelationship(
-			name, _objectDefinition.getObjectDefinitionId(),
-			_userSystemObjectDefinition.getObjectDefinitionId(),
+			_objectDefinition, _userSystemObjectDefinition,
 			_objectEntry.getPrimaryKey(), _user.getUserId(),
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
@@ -442,11 +419,8 @@ public class RelatedObjectEntryResourceTest {
 		JaxRsApplicationDescriptor jaxRsApplicationDescriptor =
 			_userSystemObjectDefinitionManager.getJaxRsApplicationDescriptor();
 
-		String name = StringUtil.randomId();
-
 		_objectRelationship = _addObjectRelationship(
-			name, _objectDefinition.getObjectDefinitionId(),
-			_userSystemObjectDefinition.getObjectDefinitionId(),
+			_objectDefinition, _userSystemObjectDefinition,
 			_objectEntry.getPrimaryKey(), _user.getUserId(),
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
@@ -476,8 +450,7 @@ public class RelatedObjectEntryResourceTest {
 			_userSystemObjectDefinitionManager.getJaxRsApplicationDescriptor();
 
 		_objectRelationship = _addObjectRelationship(
-			StringUtil.randomId(), _objectDefinition.getObjectDefinitionId(),
-			_userSystemObjectDefinition.getObjectDefinitionId(),
+			_objectDefinition, _userSystemObjectDefinition,
 			_objectEntry.getPrimaryKey(), _user.getUserId(),
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
@@ -506,8 +479,7 @@ public class RelatedObjectEntryResourceTest {
 	@Test
 	public void testPutSystemObjectRelatedObjectEntry() throws Exception {
 		_objectRelationship = _addObjectRelationship(
-			StringUtil.randomId(), _objectDefinition.getObjectDefinitionId(),
-			_userSystemObjectDefinition.getObjectDefinitionId(),
+			_objectDefinition, _userSystemObjectDefinition,
 			_objectEntry.getPrimaryKey(), _user.getUserId(),
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
@@ -517,9 +489,7 @@ public class RelatedObjectEntryResourceTest {
 			_objectRelationship);
 
 		_objectRelationship = _addObjectRelationship(
-			StringUtil.randomId(),
-			_userSystemObjectDefinition.getObjectDefinitionId(),
-			_objectDefinition.getObjectDefinitionId(), _user.getUserId(),
+			_userSystemObjectDefinition, _objectDefinition, _user.getUserId(),
 			_objectEntry.getPrimaryKey(),
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
@@ -531,11 +501,8 @@ public class RelatedObjectEntryResourceTest {
 		JaxRsApplicationDescriptor jaxRsApplicationDescriptor =
 			_userSystemObjectDefinitionManager.getJaxRsApplicationDescriptor();
 
-		String name = StringUtil.randomId();
-
 		_objectRelationship = _addObjectRelationship(
-			name, _objectDefinition.getObjectDefinitionId(),
-			_userSystemObjectDefinition.getObjectDefinitionId(),
+			_objectDefinition, _userSystemObjectDefinition,
 			_objectEntry.getPrimaryKey(), _user.getUserId(),
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
@@ -588,21 +555,17 @@ public class RelatedObjectEntryResourceTest {
 	}
 
 	private ObjectRelationship _addObjectRelationship(
-			String name, long objectDefinitionId1, long objectDefinitionId2,
-			long primaryKey1, long primaryKey2, String type)
+			ObjectDefinition objectDefinition1,
+			ObjectDefinition objectDefinition2, long primaryKey1,
+			long primaryKey2, String type)
 		throws Exception {
 
 		ObjectRelationship objectRelationship =
-			_objectRelationshipLocalService.addObjectRelationship(
-				_user.getUserId(), objectDefinitionId1, objectDefinitionId2, 0,
-				ObjectRelationshipConstants.DELETION_TYPE_PREVENT,
-				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
-				name, type);
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				objectDefinition1, objectDefinition2, _user.getUserId(), type);
 
-		_objectRelationshipLocalService.addObjectRelationshipMappingTableValues(
-			_user.getUserId(), objectRelationship.getObjectRelationshipId(),
-			primaryKey1, primaryKey2,
-			ServiceContextTestUtil.getServiceContext());
+		ObjectRelationshipTestUtil.relateObjectEntries(
+			primaryKey1, primaryKey2, objectRelationship, _user.getUserId());
 
 		return objectRelationship;
 	}

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/RelatedObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/RelatedObjectEntryResourceTest.java
@@ -29,8 +29,6 @@ import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.object.system.JaxRsApplicationDescriptor;
 import com.liferay.object.system.SystemObjectDefinitionManager;
 import com.liferay.object.system.SystemObjectDefinitionManagerRegistry;
-import com.liferay.petra.string.StringBundler;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.User;
@@ -107,10 +105,9 @@ public class RelatedObjectEntryResourceTest {
 
 		JSONObject jsonObject = HTTPTestUtil.invoke(
 			null,
-			StringBundler.concat(
-				jaxRsApplicationDescriptor.getRESTContextPath(),
-				StringPool.SLASH, irrelevantUserId, StringPool.SLASH,
-				_objectRelationship.getName(), StringPool.SLASH,
+			String.format(
+				"%s/%d/%s/%d", jaxRsApplicationDescriptor.getRESTContextPath(),
+				irrelevantUserId, _objectRelationship.getName(),
 				_objectEntry.getPrimaryKey()),
 			Http.Method.DELETE);
 
@@ -118,10 +115,9 @@ public class RelatedObjectEntryResourceTest {
 
 		jsonObject = HTTPTestUtil.invoke(
 			null,
-			StringBundler.concat(
-				jaxRsApplicationDescriptor.getRESTContextPath(),
-				StringPool.SLASH, _user.getUserId(), StringPool.SLASH,
-				_objectRelationship.getName()),
+			String.format(
+				"%s/%d/%s", jaxRsApplicationDescriptor.getRESTContextPath(),
+				_user.getUserId(), _objectRelationship.getName()),
 			Http.Method.GET);
 
 		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
@@ -143,10 +139,9 @@ public class RelatedObjectEntryResourceTest {
 
 		JSONObject jsonObject = HTTPTestUtil.invoke(
 			null,
-			StringBundler.concat(
-				jaxRsApplicationDescriptor.getRESTContextPath(),
-				StringPool.SLASH, _user.getUserId(), StringPool.SLASH,
-				_objectRelationship.getName()),
+			String.format(
+				"%s/%d/%s", jaxRsApplicationDescriptor.getRESTContextPath(),
+				_user.getUserId(), _objectRelationship.getName()),
 			Http.Method.GET);
 
 		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
@@ -155,19 +150,17 @@ public class RelatedObjectEntryResourceTest {
 
 		HTTPTestUtil.invoke(
 			null,
-			StringBundler.concat(
-				jaxRsApplicationDescriptor.getRESTContextPath(),
-				StringPool.SLASH, _user.getUserId(), StringPool.SLASH,
-				_objectRelationship.getName(), StringPool.SLASH,
+			String.format(
+				"%s/%d/%s/%d", jaxRsApplicationDescriptor.getRESTContextPath(),
+				_user.getUserId(), _objectRelationship.getName(),
 				_objectEntry.getPrimaryKey()),
 			Http.Method.DELETE);
 
 		jsonObject = HTTPTestUtil.invoke(
 			null,
-			StringBundler.concat(
-				jaxRsApplicationDescriptor.getRESTContextPath(),
-				StringPool.SLASH, _user.getUserId(), StringPool.SLASH,
-				_objectRelationship.getName()),
+			String.format(
+				"%s/%d/%s", jaxRsApplicationDescriptor.getRESTContextPath(),
+				_user.getUserId(), _objectRelationship.getName()),
 			Http.Method.GET);
 
 		itemsJSONArray = jsonObject.getJSONArray("items");
@@ -191,10 +184,9 @@ public class RelatedObjectEntryResourceTest {
 
 		JSONObject jsonObject = HTTPTestUtil.invoke(
 			null,
-			StringBundler.concat(
-				jaxRsApplicationDescriptor.getRESTContextPath(),
-				StringPool.SLASH, _user.getUserId(), StringPool.SLASH,
-				_objectRelationship.getName(), StringPool.SLASH,
+			String.format(
+				"%s/%d/%s/%d", jaxRsApplicationDescriptor.getRESTContextPath(),
+				_user.getUserId(), _objectRelationship.getName(),
 				irrelevantPrimaryKey),
 			Http.Method.DELETE);
 
@@ -202,10 +194,9 @@ public class RelatedObjectEntryResourceTest {
 
 		jsonObject = HTTPTestUtil.invoke(
 			null,
-			StringBundler.concat(
-				jaxRsApplicationDescriptor.getRESTContextPath(),
-				StringPool.SLASH, _user.getUserId(), StringPool.SLASH,
-				_objectRelationship.getName()),
+			String.format(
+				"%s/%d/%s", jaxRsApplicationDescriptor.getRESTContextPath(),
+				_user.getUserId(), _objectRelationship.getName()),
 			Http.Method.GET);
 
 		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
@@ -220,10 +211,9 @@ public class RelatedObjectEntryResourceTest {
 
 		jsonObject = HTTPTestUtil.invoke(
 			null,
-			StringBundler.concat(
-				jaxRsApplicationDescriptor.getRESTContextPath(),
-				StringPool.SLASH, _user.getUserId(), StringPool.SLASH,
-				_objectRelationship.getName(), StringPool.SLASH,
+			String.format(
+				"%s/%d/%s/%d", jaxRsApplicationDescriptor.getRESTContextPath(),
+				_user.getUserId(), _objectRelationship.getName(),
 				_objectEntry.getPrimaryKey()),
 			Http.Method.DELETE);
 
@@ -246,10 +236,9 @@ public class RelatedObjectEntryResourceTest {
 
 		JSONObject jsonObject = HTTPTestUtil.invoke(
 			null,
-			StringBundler.concat(
-				jaxRsApplicationDescriptor.getRESTContextPath(),
-				StringPool.SLASH, irrelevantUserId, StringPool.SLASH,
-				_objectRelationship.getName(), StringPool.SLASH,
+			String.format(
+				"%s/%d/%s/%d", jaxRsApplicationDescriptor.getRESTContextPath(),
+				irrelevantUserId, _objectRelationship.getName(),
 				_objectEntry.getPrimaryKey()),
 			Http.Method.DELETE);
 
@@ -257,10 +246,9 @@ public class RelatedObjectEntryResourceTest {
 
 		jsonObject = HTTPTestUtil.invoke(
 			null,
-			StringBundler.concat(
-				jaxRsApplicationDescriptor.getRESTContextPath(),
-				StringPool.SLASH, _user.getUserId(), StringPool.SLASH,
-				_objectRelationship.getName()),
+			String.format(
+				"%s/%d/%s", jaxRsApplicationDescriptor.getRESTContextPath(),
+				_user.getUserId(), _objectRelationship.getName()),
 			Http.Method.GET);
 
 		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
@@ -275,10 +263,9 @@ public class RelatedObjectEntryResourceTest {
 
 		jsonObject = HTTPTestUtil.invoke(
 			null,
-			StringBundler.concat(
-				jaxRsApplicationDescriptor.getRESTContextPath(),
-				StringPool.SLASH, _user.getUserId(), StringPool.SLASH,
-				_objectRelationship.getName(), StringPool.SLASH,
+			String.format(
+				"%s/%d/%s/%d", jaxRsApplicationDescriptor.getRESTContextPath(),
+				_user.getUserId(), _objectRelationship.getName(),
 				_objectEntry.getPrimaryKey()),
 			Http.Method.DELETE);
 
@@ -299,10 +286,9 @@ public class RelatedObjectEntryResourceTest {
 
 		JSONObject jsonObject = HTTPTestUtil.invoke(
 			null,
-			StringBundler.concat(
-				jaxRsApplicationDescriptor.getRESTContextPath(),
-				StringPool.SLASH, _user.getUserId(), StringPool.SLASH,
-				_objectRelationship.getName()),
+			String.format(
+				"%s/%d/%s", jaxRsApplicationDescriptor.getRESTContextPath(),
+				_user.getUserId(), _objectRelationship.getName()),
 			Http.Method.GET);
 
 		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
@@ -311,19 +297,17 @@ public class RelatedObjectEntryResourceTest {
 
 		HTTPTestUtil.invoke(
 			null,
-			StringBundler.concat(
-				jaxRsApplicationDescriptor.getRESTContextPath(),
-				StringPool.SLASH, _user.getUserId(), StringPool.SLASH,
-				_objectRelationship.getName(), StringPool.SLASH,
+			String.format(
+				"%s/%d/%s/%d", jaxRsApplicationDescriptor.getRESTContextPath(),
+				_user.getUserId(), _objectRelationship.getName(),
 				_objectEntry.getPrimaryKey()),
 			Http.Method.DELETE);
 
 		jsonObject = HTTPTestUtil.invoke(
 			null,
-			StringBundler.concat(
-				jaxRsApplicationDescriptor.getRESTContextPath(),
-				StringPool.SLASH, _user.getUserId(), StringPool.SLASH,
-				_objectRelationship.getName()),
+			String.format(
+				"%s/%d/%s", jaxRsApplicationDescriptor.getRESTContextPath(),
+				_user.getUserId(), _objectRelationship.getName()),
 			Http.Method.GET);
 
 		itemsJSONArray = jsonObject.getJSONArray("items");
@@ -347,10 +331,9 @@ public class RelatedObjectEntryResourceTest {
 
 		JSONObject jsonObject = HTTPTestUtil.invoke(
 			null,
-			StringBundler.concat(
-				jaxRsApplicationDescriptor.getRESTContextPath(),
-				StringPool.SLASH, _user.getUserId(), StringPool.SLASH,
-				_objectRelationship.getName(), StringPool.SLASH,
+			String.format(
+				"%s/%d/%s/%d", jaxRsApplicationDescriptor.getRESTContextPath(),
+				_user.getUserId(), _objectRelationship.getName(),
 				irrelevantPrimaryKey),
 			Http.Method.DELETE);
 
@@ -358,10 +341,9 @@ public class RelatedObjectEntryResourceTest {
 
 		jsonObject = HTTPTestUtil.invoke(
 			null,
-			StringBundler.concat(
-				jaxRsApplicationDescriptor.getRESTContextPath(),
-				StringPool.SLASH, _user.getUserId(), StringPool.SLASH,
-				_objectRelationship.getName()),
+			String.format(
+				"%s/%d/%s", jaxRsApplicationDescriptor.getRESTContextPath(),
+				_user.getUserId(), _objectRelationship.getName()),
 			Http.Method.GET);
 
 		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
@@ -381,10 +363,9 @@ public class RelatedObjectEntryResourceTest {
 
 		jsonObject = HTTPTestUtil.invoke(
 			null,
-			StringBundler.concat(
-				jaxRsApplicationDescriptor.getRESTContextPath(),
-				StringPool.SLASH, _user.getUserId(), StringPool.SLASH,
-				_objectRelationship.getName()),
+			String.format(
+				"%s/%d/%s", jaxRsApplicationDescriptor.getRESTContextPath(),
+				_user.getUserId(), _objectRelationship.getName()),
 			Http.Method.GET);
 
 		Assert.assertEquals("NOT_FOUND", jsonObject.getString("status"));
@@ -405,10 +386,9 @@ public class RelatedObjectEntryResourceTest {
 
 		JSONObject jsonObject = HTTPTestUtil.invoke(
 			null,
-			StringBundler.concat(
-				jaxRsApplicationDescriptor.getRESTContextPath(),
-				StringPool.SLASH, irrelevantUserId, StringPool.SLASH,
-				_objectRelationship.getName()),
+			String.format(
+				"%s/%d/%s", jaxRsApplicationDescriptor.getRESTContextPath(),
+				irrelevantUserId, _objectRelationship.getName()),
 			Http.Method.GET);
 
 		Assert.assertEquals("NOT_FOUND", jsonObject.getString("status"));
@@ -426,10 +406,9 @@ public class RelatedObjectEntryResourceTest {
 
 		JSONObject jsonObject = HTTPTestUtil.invoke(
 			null,
-			StringBundler.concat(
-				jaxRsApplicationDescriptor.getRESTContextPath(),
-				StringPool.SLASH, _user.getUserId(), StringPool.SLASH,
-				_objectRelationship.getName()),
+			String.format(
+				"%s/%d/%s", jaxRsApplicationDescriptor.getRESTContextPath(),
+				_user.getUserId(), _objectRelationship.getName()),
 			Http.Method.GET);
 
 		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
@@ -464,10 +443,10 @@ public class RelatedObjectEntryResourceTest {
 
 		JSONObject jsonObject = HTTPTestUtil.invoke(
 			null,
-			StringBundler.concat(
+			String.format(
+				"%s/%d/%s?page=1&pageSize=1",
 				jaxRsApplicationDescriptor.getRESTContextPath(),
-				StringPool.SLASH, _user.getUserId(), StringPool.SLASH,
-				_objectRelationship.getName(), "?page=1&pageSize=1"),
+				_user.getUserId(), _objectRelationship.getName()),
 			Http.Method.GET);
 
 		Assert.assertEquals(2, jsonObject.getLong("lastPage"));
@@ -510,10 +489,9 @@ public class RelatedObjectEntryResourceTest {
 
 		JSONObject jsonObject = HTTPTestUtil.invoke(
 			null,
-			StringBundler.concat(
-				jaxRsApplicationDescriptor.getRESTContextPath(),
-				StringPool.SLASH, _user.getUserId(), StringPool.SLASH,
-				_objectRelationship.getName(), StringPool.SLASH,
+			String.format(
+				"%s/%d/%s/%d", jaxRsApplicationDescriptor.getRESTContextPath(),
+				_user.getUserId(), _objectRelationship.getName(),
 				irrelevantPrimaryKey),
 			Http.Method.PUT);
 
@@ -521,10 +499,9 @@ public class RelatedObjectEntryResourceTest {
 
 		jsonObject = HTTPTestUtil.invoke(
 			null,
-			StringBundler.concat(
-				jaxRsApplicationDescriptor.getRESTContextPath(),
-				StringPool.SLASH, _user.getUserId(), StringPool.SLASH,
-				_objectRelationship.getName()),
+			String.format(
+				"%s/%d/%s", jaxRsApplicationDescriptor.getRESTContextPath(),
+				_user.getUserId(), _objectRelationship.getName()),
 			Http.Method.GET);
 
 		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
@@ -544,10 +521,9 @@ public class RelatedObjectEntryResourceTest {
 
 		jsonObject = HTTPTestUtil.invoke(
 			null,
-			StringBundler.concat(
-				jaxRsApplicationDescriptor.getRESTContextPath(),
-				StringPool.SLASH, _user.getUserId(), StringPool.SLASH,
-				_objectRelationship.getName(), StringPool.SLASH,
+			String.format(
+				"%s/%d/%s/%d", jaxRsApplicationDescriptor.getRESTContextPath(),
+				_user.getUserId(), _objectRelationship.getName(),
 				objectEntry.getPrimaryKey()),
 			Http.Method.PUT);
 
@@ -584,10 +560,9 @@ public class RelatedObjectEntryResourceTest {
 
 		JSONObject jsonObject = HTTPTestUtil.invoke(
 			null,
-			StringBundler.concat(
-				jaxRsApplicationDescriptor.getRESTContextPath(),
-				StringPool.SLASH, _user.getUserId(), StringPool.SLASH,
-				objectRelationship.getName(), StringPool.SLASH,
+			String.format(
+				"%s/%d/%s/%d", jaxRsApplicationDescriptor.getRESTContextPath(),
+				_user.getUserId(), objectRelationship.getName(),
 				objectEntry.getPrimaryKey()),
 			Http.Method.PUT);
 
@@ -596,10 +571,9 @@ public class RelatedObjectEntryResourceTest {
 
 		jsonObject = HTTPTestUtil.invoke(
 			null,
-			StringBundler.concat(
-				jaxRsApplicationDescriptor.getRESTContextPath(),
-				StringPool.SLASH, _user.getUserId(), StringPool.SLASH,
-				objectRelationship.getName()),
+			String.format(
+				"%s/%d/%s", jaxRsApplicationDescriptor.getRESTContextPath(),
+				_user.getUserId(), objectRelationship.getName()),
 			Http.Method.GET);
 
 		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/SystemObjectRelatedObjectEntriesTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/SystemObjectRelatedObjectEntriesTest.java
@@ -213,7 +213,7 @@ public class SystemObjectRelatedObjectEntriesTest {
 			_testPostSystemObjectEntryWithInvalidNestedCustomObjectEntries(
 				objectRelationship, false);
 
-			// Many to one
+			// Many to 1
 
 			objectRelationship =
 				ObjectRelationshipTestUtil.addObjectRelationship(
@@ -226,7 +226,7 @@ public class SystemObjectRelatedObjectEntriesTest {
 			_testPostSystemObjectEntryWithInvalidNestedCustomObjectEntries(
 				objectRelationship, true);
 
-			// One to many
+			// 1 to many
 
 			objectRelationship =
 				ObjectRelationshipTestUtil.addObjectRelationship(
@@ -256,7 +256,7 @@ public class SystemObjectRelatedObjectEntriesTest {
 		_testPostSystemObjectEntryWithNestedCustomObjectEntries(
 			objectRelationship);
 
-		// One to many
+		// 1 to many
 
 		objectRelationship = ObjectRelationshipTestUtil.addObjectRelationship(
 			_userSystemObjectDefinition, _objectDefinition, _user.getUserId(),
@@ -352,7 +352,7 @@ public class SystemObjectRelatedObjectEntriesTest {
 		_testPutSystemObjectEntryWithNestedCustomObjectEntries(
 			objectRelationship);
 
-		// One to many
+		// 1 to many
 
 		objectRelationship = ObjectRelationshipTestUtil.addObjectRelationship(
 			_userSystemObjectDefinition, _objectDefinition, _user.getUserId(),

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/SystemObjectRelatedObjectEntriesTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/SystemObjectRelatedObjectEntriesTest.java
@@ -31,7 +31,6 @@ import com.liferay.object.service.ObjectRelationshipLocalServiceUtil;
 import com.liferay.object.system.JaxRsApplicationDescriptor;
 import com.liferay.object.system.SystemObjectDefinitionManager;
 import com.liferay.object.system.SystemObjectDefinitionManagerRegistry;
-import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
@@ -295,14 +294,13 @@ public class SystemObjectRelatedObjectEntriesTest {
 
 		jsonObject = HTTPTestUtil.invoke(
 			null,
-			StringBundler.concat(
-				_getLocation(), StringPool.SLASH, jsonObject.getString("id")),
+			String.format("%s/%d", _getLocation(), jsonObject.getLong("id")),
 			Http.Method.GET);
 
 		Assert.assertEquals(
 			jsonObject.getString(
-				StringBundler.concat(
-					"r_", objectRelationship.getName(), "_",
+				String.format(
+					"r_%s_%s", objectRelationship.getName(),
 					StringUtil.replaceLast(
 						_objectDefinition.getPKObjectFieldName(), "Id",
 						"ERC"))),
@@ -480,16 +478,15 @@ public class SystemObjectRelatedObjectEntriesTest {
 		return jaxRsApplicationDescriptor.getRESTContextPath();
 	}
 
-	private String _getLocation(String name) {
-		return StringBundler.concat(
-			_getLocation(), StringPool.SLASH, _user.getUserId(),
-			"?nestedFields=", name);
+	private String _getLocation(long userId, String objectRelationshipName) {
+		return String.format(
+			"%s/%d?nestedFields=%s", _getLocation(), userId,
+			objectRelationshipName);
 	}
 
-	private String _getLocation(String userId, String objectRelationshipName) {
-		return StringBundler.concat(
-			_getLocation(), StringPool.SLASH, userId, "?nestedFields=",
-			objectRelationshipName);
+	private String _getLocation(String name) {
+		return String.format(
+			"%s/%d?nestedFields=%s", _getLocation(), _user.getUserId(), name);
 	}
 
 	private JSONObject _getObjectEntryByExternalReferenceCodeJSONObject(
@@ -498,9 +495,9 @@ public class SystemObjectRelatedObjectEntriesTest {
 
 		return HTTPTestUtil.invoke(
 			null,
-			StringBundler.concat(
-				_objectDefinition.getRESTContextPath(),
-				"/by-external-reference-code/", externalReferenceCode),
+			String.format(
+				"%s/by-external-reference-code/%s",
+				_objectDefinition.getRESTContextPath(), externalReferenceCode),
 			Http.Method.GET);
 	}
 
@@ -569,7 +566,7 @@ public class SystemObjectRelatedObjectEntriesTest {
 		jsonObject = HTTPTestUtil.invoke(
 			null,
 			_getLocation(
-				jsonObject.getString("id"), objectRelationship.getName()),
+				jsonObject.getLong("id"), objectRelationship.getName()),
 			Http.Method.GET);
 
 		nestedObjectEntriesJSONArray = jsonObject.getJSONArray(
@@ -629,7 +626,7 @@ public class SystemObjectRelatedObjectEntriesTest {
 		jsonObject = HTTPTestUtil.invoke(
 			null,
 			_getLocation(
-				jsonObject.getString("id"), objectRelationship.getName()),
+				jsonObject.getLong("id"), objectRelationship.getName()),
 			Http.Method.GET);
 
 		nestedObjectEntriesJSONArray = jsonObject.getJSONArray(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/SystemObjectRelatedObjectEntriesTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/SystemObjectRelatedObjectEntriesTest.java
@@ -41,6 +41,7 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.MapUtil;
@@ -50,10 +51,12 @@ import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.util.PropsValues;
 
 import java.io.Serializable;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -117,34 +120,122 @@ public class SystemObjectRelatedObjectEntriesTest {
 			_objectDefinition.getObjectDefinitionId());
 	}
 
+	@FeatureFlags("LPS-165819")
 	@Test
 	public void testGetManyToManySystemObjectRelatedObjectEntries()
 		throws Exception {
+
+		// Many to many with custom object definition
 
 		ObjectRelationship objectRelationship = _addObjectRelationship(
 			_objectDefinition, _userSystemObjectDefinition,
 			_objectEntry.getPrimaryKey(), _user.getUserId(),
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
-		JSONObject jsonObject = HTTPTestUtil.invoke(
-			null, _getLocation(objectRelationship.getName()), Http.Method.GET);
+		_testGetSystemObjectRelatedObjectEntries(
+			null, objectRelationship.getName(),
+			new String[][] {
+				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE}
+			},
+			Type.MANY_TO_MANY);
 
-		JSONArray jsonArray = jsonObject.getJSONArray(
-			objectRelationship.getName());
+		_testGetSystemObjectRelatedObjectEntries(
+			1, objectRelationship.getName(),
+			new String[][] {
+				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE}
+			},
+			Type.MANY_TO_MANY);
 
-		_assertEquals(jsonArray, _objectEntry);
+		_testGetSystemObjectRelatedObjectEntries(
+			2, objectRelationship.getName(),
+			new String[][] {
+				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE},
+				{"externalReferenceCode", _user.getExternalReferenceCode()}
+			},
+			Type.MANY_TO_MANY);
+
+		_testGetSystemObjectRelatedObjectEntries(
+			5, objectRelationship.getName(),
+			new String[][] {
+				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE},
+				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE},
+				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE}
+			},
+			Type.MANY_TO_MANY);
+
+		_testGetSystemObjectRelatedObjectEntries(
+			6, objectRelationship.getName(),
+			new String[][] {
+				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE},
+				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE},
+				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE}
+			},
+			Type.MANY_TO_MANY);
+
+		// Many to many with custom object definition (other side)
 
 		objectRelationship = _addObjectRelationship(
 			_userSystemObjectDefinition, _objectDefinition, _user.getUserId(),
 			_objectEntry.getPrimaryKey(),
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
-		jsonObject = HTTPTestUtil.invoke(
-			null, _getLocation(objectRelationship.getName()), Http.Method.GET);
+		_testGetSystemObjectRelatedObjectEntries(
+			null, objectRelationship.getName(),
+			new String[][] {
+				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE}
+			},
+			Type.MANY_TO_MANY);
 
-		jsonArray = jsonObject.getJSONArray(objectRelationship.getName());
+		_testGetSystemObjectRelatedObjectEntries(
+			1, objectRelationship.getName(),
+			new String[][] {
+				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE}
+			},
+			Type.MANY_TO_MANY);
 
-		_assertEquals(jsonArray, _objectEntry);
+		_testGetSystemObjectRelatedObjectEntries(
+			2, objectRelationship.getName(),
+			new String[][] {
+				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE},
+				{"externalReferenceCode", _user.getExternalReferenceCode()}
+			},
+			Type.MANY_TO_MANY);
+
+		_testGetSystemObjectRelatedObjectEntries(
+			5, objectRelationship.getName(),
+			new String[][] {
+				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE},
+				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE},
+				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE}
+			},
+			Type.MANY_TO_MANY);
+
+		_testGetSystemObjectRelatedObjectEntries(
+			6, objectRelationship.getName(),
+			new String[][] {
+				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE},
+				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE},
+				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE}
+			},
+			Type.MANY_TO_MANY);
 	}
 
 	@Test
@@ -183,12 +274,30 @@ public class SystemObjectRelatedObjectEntriesTest {
 			_objectEntry.getPrimaryKey(),
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
-		JSONObject jsonObject = HTTPTestUtil.invoke(
-			null, _getLocation(objectRelationship.getName()), Http.Method.GET);
+		_testGetSystemObjectRelatedObjectEntries(
+			null, objectRelationship.getName(),
+			new String[][] {
+				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE}
+			},
+			Type.ONE_TO_MANY);
 
-		_assertEquals(
-			jsonObject.getJSONArray(objectRelationship.getName()),
-			_objectEntry);
+		_testGetSystemObjectRelatedObjectEntries(
+			1, objectRelationship.getName(),
+			new String[][] {
+				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE}
+			},
+			Type.ONE_TO_MANY);
+
+		_testGetSystemObjectRelatedObjectEntries(
+			2, objectRelationship.getName(),
+			new String[][] {
+				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE},
+				{"externalReferenceCode", _user.getExternalReferenceCode()}
+			},
+			Type.ONE_TO_MANY);
 	}
 
 	@Test
@@ -427,13 +536,38 @@ public class SystemObjectRelatedObjectEntriesTest {
 		return objectRelationship;
 	}
 
-	private void _assertEquals(JSONArray jsonArray, ObjectEntry objectEntry) {
-		Assert.assertEquals(jsonArray.toString(), 1, jsonArray.length());
+	private void _assertNestedFieldsInRelationships(
+		int currentDepth, int depth, JSONObject jsonObject,
+		String nestedFieldName, String[][] objectFieldNamesAndObjectFieldValues,
+		Type type) {
 
-		JSONObject jsonObject = (JSONObject)jsonArray.get(0);
+		if (objectFieldNamesAndObjectFieldValues[currentDepth][0] == null) {
+			Assert.assertNull(jsonObject);
+		}
+		else {
+			Assert.assertEquals(
+				objectFieldNamesAndObjectFieldValues[currentDepth][1],
+				jsonObject.getString(
+					objectFieldNamesAndObjectFieldValues[currentDepth][0]));
+		}
 
-		Assert.assertEquals(
-			objectEntry.getObjectEntryId(), jsonObject.getLong("id"));
+		if ((currentDepth == depth) ||
+			(currentDepth ==
+				PropsValues.OBJECT_NESTED_FIELDS_MAX_QUERY_DEPTH)) {
+
+			Assert.assertEquals(
+				Arrays.toString(objectFieldNamesAndObjectFieldValues),
+				currentDepth + 1, objectFieldNamesAndObjectFieldValues.length);
+			Assert.assertNull(jsonObject.get(nestedFieldName));
+
+			return;
+		}
+
+		_assertNestedFieldsInRelationships(
+			currentDepth + 1, depth,
+			_getRelatedJSONObject(jsonObject, nestedFieldName, type),
+			nestedFieldName, objectFieldNamesAndObjectFieldValues,
+			_getReverseType(type));
 	}
 
 	private void _assertObjectEntryField(
@@ -499,6 +633,64 @@ public class SystemObjectRelatedObjectEntriesTest {
 				"%s/by-external-reference-code/%s",
 				_objectDefinition.getRESTContextPath(), externalReferenceCode),
 			Http.Method.GET);
+	}
+
+	private JSONObject _getRelatedJSONObject(
+		JSONObject jsonObject, String nestedFieldName, Type type) {
+
+		if (type == Type.MANY_TO_ONE) {
+			JSONObject nestedJSONObject = jsonObject.getJSONObject(
+				nestedFieldName);
+
+			Assert.assertNotNull(
+				"Missing field " + nestedFieldName, nestedJSONObject);
+
+			return jsonObject.getJSONObject(nestedFieldName);
+		}
+
+		JSONArray jsonArray = jsonObject.getJSONArray(nestedFieldName);
+
+		Assert.assertNotNull("Missing field " + nestedFieldName, jsonArray);
+
+		Assert.assertEquals(1, jsonArray.length());
+
+		return jsonArray.getJSONObject(0);
+	}
+
+	private Type _getReverseType(Type type) {
+		if (type == Type.MANY_TO_ONE) {
+			return Type.ONE_TO_MANY;
+		}
+		else if (type == Type.ONE_TO_MANY) {
+			return Type.MANY_TO_ONE;
+		}
+
+		return Type.MANY_TO_MANY;
+	}
+
+	private void _testGetSystemObjectRelatedObjectEntries(
+			Integer nestedFieldDepth, String nestedFieldName,
+			String[][] objectFieldNamesAndObjectFieldValues, Type type)
+		throws Exception {
+
+		JaxRsApplicationDescriptor jaxRsApplicationDescriptor =
+			_userSystemObjectDefinitionManager.getJaxRsApplicationDescriptor();
+
+		String endpoint = String.format(
+			"%s/%d?nestedFields=%s",
+			jaxRsApplicationDescriptor.getRESTContextPath(), _user.getUserId(),
+			nestedFieldName);
+
+		if (nestedFieldDepth != null) {
+			endpoint += "&nestedFieldsDepth=" + nestedFieldDepth;
+		}
+
+		JSONObject jsonObject = HTTPTestUtil.invoke(
+			null, endpoint, Http.Method.GET);
+
+		_assertNestedFieldsInRelationships(
+			0, GetterUtil.getInteger(nestedFieldDepth, 1), jsonObject,
+			nestedFieldName, objectFieldNamesAndObjectFieldValues, type);
 	}
 
 	private void _testPostSystemObjectEntryWithInvalidNestedCustomObjectEntries(
@@ -678,5 +870,11 @@ public class SystemObjectRelatedObjectEntriesTest {
 	private User _user;
 	private ObjectDefinition _userSystemObjectDefinition;
 	private SystemObjectDefinitionManager _userSystemObjectDefinitionManager;
+
+	private enum Type {
+
+		MANY_TO_MANY, MANY_TO_ONE, ONE_TO_MANY
+
+	}
 
 }

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/SystemObjectRelatedObjectEntriesTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/SystemObjectRelatedObjectEntriesTest.java
@@ -15,14 +15,17 @@
 package com.liferay.object.rest.internal.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.constants.ObjectRelationshipConstants;
 import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.rest.internal.resource.v1_0.test.util.HTTPTestUtil;
 import com.liferay.object.rest.internal.resource.v1_0.test.util.ObjectDefinitionTestUtil;
 import com.liferay.object.rest.internal.resource.v1_0.test.util.ObjectEntryTestUtil;
+import com.liferay.object.rest.internal.resource.v1_0.test.util.ObjectFieldTestUtil;
 import com.liferay.object.rest.internal.resource.v1_0.test.util.ObjectRelationshipTestUtil;
 import com.liferay.object.rest.internal.resource.v1_0.test.util.UserAccountTestUtil;
 import com.liferay.object.service.ObjectDefinitionLocalService;
@@ -38,6 +41,7 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -102,6 +106,18 @@ public class SystemObjectRelatedObjectEntriesTest {
 		_userSystemObjectDefinition =
 			_objectDefinitionLocalService.fetchSystemObjectDefinition(
 				_userSystemObjectDefinitionManager.getName());
+
+		_userSystemObjectField = ObjectFieldTestUtil.addCustomObjectField(
+			TestPropsValues.getUserId(),
+			ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+			ObjectFieldConstants.DB_TYPE_STRING, _userSystemObjectDefinition,
+			_SYSTEM_OBJECT_FIELD_NAME);
+
+		_userAccountJSONObject = UserAccountTestUtil.addUserAccountJSONObject(
+			_userSystemObjectDefinitionManager,
+			HashMapBuilder.<String, Serializable>put(
+				_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE
+			).build());
 	}
 
 	@After
@@ -110,7 +126,8 @@ public class SystemObjectRelatedObjectEntriesTest {
 			ObjectRelationshipLocalServiceUtil.
 				deleteObjectRelationshipMappingTableValues(
 					objectRelationship.getObjectRelationshipId(),
-					_objectEntry.getPrimaryKey(), _user.getUserId());
+					_objectEntry.getPrimaryKey(),
+					_userAccountJSONObject.getLong("id"));
 
 			ObjectRelationshipLocalServiceUtil.deleteObjectRelationship(
 				objectRelationship);
@@ -129,13 +146,13 @@ public class SystemObjectRelatedObjectEntriesTest {
 
 		ObjectRelationship objectRelationship = _addObjectRelationship(
 			_objectDefinition, _userSystemObjectDefinition,
-			_objectEntry.getPrimaryKey(), _user.getUserId(),
+			_objectEntry.getPrimaryKey(), _userAccountJSONObject.getLong("id"),
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
 		_testGetSystemObjectRelatedObjectEntries(
 			null, objectRelationship.getName(),
 			new String[][] {
-				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
 				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE}
 			},
 			Type.MANY_TO_MANY);
@@ -143,7 +160,7 @@ public class SystemObjectRelatedObjectEntriesTest {
 		_testGetSystemObjectRelatedObjectEntries(
 			1, objectRelationship.getName(),
 			new String[][] {
-				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
 				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE}
 			},
 			Type.MANY_TO_MANY);
@@ -151,20 +168,20 @@ public class SystemObjectRelatedObjectEntriesTest {
 		_testGetSystemObjectRelatedObjectEntries(
 			2, objectRelationship.getName(),
 			new String[][] {
-				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
 				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE},
-				{"externalReferenceCode", _user.getExternalReferenceCode()}
+				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE}
 			},
 			Type.MANY_TO_MANY);
 
 		_testGetSystemObjectRelatedObjectEntries(
 			5, objectRelationship.getName(),
 			new String[][] {
-				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
 				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE},
-				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
 				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE},
-				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
 				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE}
 			},
 			Type.MANY_TO_MANY);
@@ -172,11 +189,11 @@ public class SystemObjectRelatedObjectEntriesTest {
 		_testGetSystemObjectRelatedObjectEntries(
 			6, objectRelationship.getName(),
 			new String[][] {
-				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
 				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE},
-				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
 				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE},
-				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
 				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE}
 			},
 			Type.MANY_TO_MANY);
@@ -184,14 +201,14 @@ public class SystemObjectRelatedObjectEntriesTest {
 		// Many to many with custom object definition (other side)
 
 		objectRelationship = _addObjectRelationship(
-			_userSystemObjectDefinition, _objectDefinition, _user.getUserId(),
-			_objectEntry.getPrimaryKey(),
+			_userSystemObjectDefinition, _objectDefinition,
+			_userAccountJSONObject.getLong("id"), _objectEntry.getPrimaryKey(),
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
 		_testGetSystemObjectRelatedObjectEntries(
 			null, objectRelationship.getName(),
 			new String[][] {
-				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
 				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE}
 			},
 			Type.MANY_TO_MANY);
@@ -199,7 +216,7 @@ public class SystemObjectRelatedObjectEntriesTest {
 		_testGetSystemObjectRelatedObjectEntries(
 			1, objectRelationship.getName(),
 			new String[][] {
-				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
 				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE}
 			},
 			Type.MANY_TO_MANY);
@@ -207,20 +224,20 @@ public class SystemObjectRelatedObjectEntriesTest {
 		_testGetSystemObjectRelatedObjectEntries(
 			2, objectRelationship.getName(),
 			new String[][] {
-				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
 				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE},
-				{"externalReferenceCode", _user.getExternalReferenceCode()}
+				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE}
 			},
 			Type.MANY_TO_MANY);
 
 		_testGetSystemObjectRelatedObjectEntries(
 			5, objectRelationship.getName(),
 			new String[][] {
-				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
 				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE},
-				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
 				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE},
-				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
 				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE}
 			},
 			Type.MANY_TO_MANY);
@@ -228,11 +245,11 @@ public class SystemObjectRelatedObjectEntriesTest {
 		_testGetSystemObjectRelatedObjectEntries(
 			6, objectRelationship.getName(),
 			new String[][] {
-				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
 				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE},
-				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
 				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE},
-				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
 				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE}
 			},
 			Type.MANY_TO_MANY);
@@ -244,7 +261,7 @@ public class SystemObjectRelatedObjectEntriesTest {
 
 		ObjectRelationship objectRelationship = _addObjectRelationship(
 			_objectDefinition, _userSystemObjectDefinition,
-			_objectEntry.getPrimaryKey(), _user.getUserId(),
+			_objectEntry.getPrimaryKey(), _userAccountJSONObject.getLong("id"),
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
 		JSONObject jsonObject = HTTPTestUtil.invoke(
@@ -270,14 +287,14 @@ public class SystemObjectRelatedObjectEntriesTest {
 		throws Exception {
 
 		ObjectRelationship objectRelationship = _addObjectRelationship(
-			_userSystemObjectDefinition, _objectDefinition, _user.getUserId(),
-			_objectEntry.getPrimaryKey(),
+			_userSystemObjectDefinition, _objectDefinition,
+			_userAccountJSONObject.getLong("id"), _objectEntry.getPrimaryKey(),
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
 		_testGetSystemObjectRelatedObjectEntries(
 			null, objectRelationship.getName(),
 			new String[][] {
-				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
 				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE}
 			},
 			Type.ONE_TO_MANY);
@@ -285,7 +302,7 @@ public class SystemObjectRelatedObjectEntriesTest {
 		_testGetSystemObjectRelatedObjectEntries(
 			1, objectRelationship.getName(),
 			new String[][] {
-				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
 				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE}
 			},
 			Type.ONE_TO_MANY);
@@ -293,9 +310,9 @@ public class SystemObjectRelatedObjectEntriesTest {
 		_testGetSystemObjectRelatedObjectEntries(
 			2, objectRelationship.getName(),
 			new String[][] {
-				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
 				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE},
-				{"externalReferenceCode", _user.getExternalReferenceCode()}
+				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE}
 			},
 			Type.ONE_TO_MANY);
 	}
@@ -426,7 +443,7 @@ public class SystemObjectRelatedObjectEntriesTest {
 
 		ObjectRelationship objectRelationship = _addObjectRelationship(
 			_objectDefinition, _userSystemObjectDefinition,
-			_objectEntry.getPrimaryKey(), _user.getUserId(),
+			_objectEntry.getPrimaryKey(), _userAccountJSONObject.getLong("id"),
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
 		JSONObject jsonObject = UserAccountTestUtil.addUserAccountJSONObject(
@@ -620,7 +637,8 @@ public class SystemObjectRelatedObjectEntriesTest {
 
 	private String _getLocation(String name) {
 		return String.format(
-			"%s/%d?nestedFields=%s", _getLocation(), _user.getUserId(), name);
+			"%s/%d?nestedFields=%s", _getLocation(),
+			_userAccountJSONObject.getLong("id"), name);
 	}
 
 	private JSONObject _getObjectEntryByExternalReferenceCodeJSONObject(
@@ -678,8 +696,8 @@ public class SystemObjectRelatedObjectEntriesTest {
 
 		String endpoint = String.format(
 			"%s/%d?nestedFields=%s",
-			jaxRsApplicationDescriptor.getRESTContextPath(), _user.getUserId(),
-			nestedFieldName);
+			jaxRsApplicationDescriptor.getRESTContextPath(),
+			_userAccountJSONObject.getLong("id"), nestedFieldName);
 
 		if (nestedFieldDepth != null) {
 			endpoint += "&nestedFieldsDepth=" + nestedFieldDepth;
@@ -850,6 +868,12 @@ public class SystemObjectRelatedObjectEntriesTest {
 	private static final String _OBJECT_FIELD_VALUE =
 		RandomTestUtil.randomString();
 
+	private static final String _SYSTEM_OBJECT_FIELD_NAME =
+		"x" + RandomTestUtil.randomString();
+
+	private static final String _SYSTEM_OBJECT_FIELD_VALUE =
+		RandomTestUtil.randomString();
+
 	private ObjectDefinition _objectDefinition;
 
 	@Inject
@@ -868,8 +892,12 @@ public class SystemObjectRelatedObjectEntriesTest {
 		_systemObjectDefinitionManagerRegistry;
 
 	private User _user;
+	private JSONObject _userAccountJSONObject;
 	private ObjectDefinition _userSystemObjectDefinition;
 	private SystemObjectDefinitionManager _userSystemObjectDefinitionManager;
+
+	@DeleteAfterTestRun
+	private ObjectField _userSystemObjectField;
 
 	private enum Type {
 

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/util/UserAccountTestUtil.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/util/UserAccountTestUtil.java
@@ -17,8 +17,6 @@ package com.liferay.object.rest.internal.resource.v1_0.test.util;
 import com.liferay.headless.admin.user.dto.v1_0.UserAccount;
 import com.liferay.object.system.JaxRsApplicationDescriptor;
 import com.liferay.object.system.SystemObjectDefinitionManager;
-import com.liferay.petra.string.StringBundler;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -99,9 +97,9 @@ public class UserAccountTestUtil {
 
 		return HTTPTestUtil.invoke(
 			_toBody(userAccount, values),
-			StringBundler.concat(
-				jaxRsApplicationDescriptor.getRESTContextPath(),
-				StringPool.SLASH, userAccountJSONObject.get("id")),
+			String.format(
+				"%s/%d", jaxRsApplicationDescriptor.getRESTContextPath(),
+				userAccountJSONObject.getLong("id")),
 			Http.Method.PUT);
 	}
 


### PR DESCRIPTION
Followed-up PR from: https://github.com/brianchandotcom/liferay-portal/pull/134681

Related issue: https://issues.liferay.com/browse/LPS-183903

---

This PR contains the code to allow developers to retrieve different levels of the many to many and one to many related elements of a System Object.

Currently, it is already possible to retrieve the MtoM and 1toM of a System Object, as the functionality was included previously in [this other PR](https://github.com/brianchandotcom/liferay-portal/pull/133972). The reason is because when developing it in the Custom Objects side, when related to a System Object, some code was necessary to be included.

For that, the following changes have been included:

- A commit to modify the method used to check if the object definition is a system object, from `isSystem` to `isUnmodifiableSystemObject`, as the new method must be used when service builder system objects are involved.
- New integration "sub-tests" have been included in the `SystemObjectRelatedObjectEntriesTest` class over the tests `testGetManyToManySystemObjectRelatedObjectEntries` and `testGetOneToManySystemObjectRelatedObjectEntries`

**How to test it:**

- Set the feature flag `LPS-165819`
- Deploy the module `modules/apps/object/object-rest-impl`
- Launch the integration tests over the directory `modules/apps/object/object-rest-test`:
  - `gw tI --tests SystemObjectRelatedObjectEntriesTest.testGetManyToManySystemObjectRelatedObjectEntries`
  - `gw tI --tests SystemObjectRelatedObjectEntriesTest.testGetOneToManySystemObjectRelatedObjectEntries`