### PR TITLE
LPS-183903 Allow developers to retrieve different levels of the many/one to many related elements of a system object as nestedFields

### DIFF
--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -3126,27 +3126,28 @@ public class ObjectEntryResourceTest {
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
 		_testGetNestedFieldDetailsInRelationships(
-			_objectRelationship1.getName(),
+			_objectRelationship1.getName(), null,
+			_objectRelationship1.getName(), _objectDefinition1,
 			new String[][] {
 				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
 				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)}
 			},
-			null, _objectRelationship1.getName(), _objectDefinition1,
 			Type.ONE_TO_MANY);
 
 		_testGetNestedFieldDetailsInRelationships(
-			_objectRelationship1.getName(),
+			_objectRelationship1.getName(), 3, _objectRelationship1.getName(),
+			_objectDefinition1,
 			new String[][] {
 				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
 				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)},
 				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
 				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)}
 			},
-			3, _objectRelationship1.getName(), _objectDefinition1,
 			Type.ONE_TO_MANY);
 
 		_testGetNestedFieldDetailsInRelationships(
-			_objectRelationship1.getName(),
+			_objectRelationship1.getName(), 5, _objectRelationship1.getName(),
+			_objectDefinition1,
 			new String[][] {
 				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
 				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)},
@@ -3155,11 +3156,11 @@ public class ObjectEntryResourceTest {
 				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
 				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)}
 			},
-			5, _objectRelationship1.getName(), _objectDefinition1,
 			Type.ONE_TO_MANY);
 
 		_testGetNestedFieldDetailsInRelationships(
-			_objectRelationship1.getName(),
+			_objectRelationship1.getName(), 6, _objectRelationship1.getName(),
+			_objectDefinition1,
 			new String[][] {
 				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
 				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)},
@@ -3168,7 +3169,6 @@ public class ObjectEntryResourceTest {
 				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
 				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)}
 			},
-			6, _objectRelationship1.getName(), _objectDefinition1,
 			Type.ONE_TO_MANY);
 
 		// Many to many with custom object definition
@@ -3179,27 +3179,28 @@ public class ObjectEntryResourceTest {
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
 		_testGetNestedFieldDetailsInRelationships(
-			_objectRelationship2.getName(),
+			_objectRelationship2.getName(), null,
+			_objectRelationship2.getName(), _objectDefinition1,
 			new String[][] {
 				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
 				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)}
 			},
-			null, _objectRelationship2.getName(), _objectDefinition1,
 			Type.MANY_TO_MANY);
 
 		_testGetNestedFieldDetailsInRelationships(
-			_objectRelationship2.getName(),
+			_objectRelationship2.getName(), 3, _objectRelationship2.getName(),
+			_objectDefinition1,
 			new String[][] {
 				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
 				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)},
 				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
 				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)}
 			},
-			3, _objectRelationship2.getName(), _objectDefinition1,
 			Type.MANY_TO_MANY);
 
 		_testGetNestedFieldDetailsInRelationships(
-			_objectRelationship2.getName(),
+			_objectRelationship2.getName(), 5, _objectRelationship2.getName(),
+			_objectDefinition1,
 			new String[][] {
 				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
 				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)},
@@ -3208,11 +3209,11 @@ public class ObjectEntryResourceTest {
 				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
 				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)}
 			},
-			5, _objectRelationship2.getName(), _objectDefinition1,
 			Type.MANY_TO_MANY);
 
 		_testGetNestedFieldDetailsInRelationships(
-			_objectRelationship2.getName(),
+			_objectRelationship2.getName(), 6, _objectRelationship2.getName(),
+			_objectDefinition1,
 			new String[][] {
 				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
 				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)},
@@ -3221,7 +3222,6 @@ public class ObjectEntryResourceTest {
 				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
 				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)}
 			},
-			6, _objectRelationship2.getName(), _objectDefinition1,
 			Type.MANY_TO_MANY);
 
 		// Many to one with custom object definition
@@ -3237,12 +3237,13 @@ public class ObjectEntryResourceTest {
 			relationshipFieldName, "Id");
 
 		_testGetNestedFieldDetailsInRelationships(
-			relationshipFieldNameNestedFieldName,
+			relationshipFieldNameNestedFieldName, null, relationshipFieldName,
+			_objectDefinition2,
 			new String[][] {
 				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)},
 				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)}
 			},
-			null, relationshipFieldName, _objectDefinition2, Type.MANY_TO_ONE);
+			Type.MANY_TO_ONE);
 
 		String relatedObjectDefinitionName = StringUtil.removeFirst(
 			StringUtil.removeLast(
@@ -3250,48 +3251,50 @@ public class ObjectEntryResourceTest {
 			"c_");
 
 		_testGetNestedFieldDetailsInRelationships(
-			relationshipFieldNameNestedFieldName,
+			relationshipFieldNameNestedFieldName, null,
+			StringUtil.removeLast(relationshipFieldName, "Id"),
+			_objectDefinition2,
 			new String[][] {
 				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)},
 				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)}
 			},
-			null, StringUtil.removeLast(relationshipFieldName, "Id"),
-			_objectDefinition2, Type.MANY_TO_ONE);
-
-		_testGetNestedFieldDetailsInRelationships(
-			relationshipFieldNameNestedFieldName,
-			new String[][] {
-				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)},
-				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)}
-			},
-			null, relatedObjectDefinitionName, _objectDefinition2,
 			Type.MANY_TO_ONE);
 
 		_testGetNestedFieldDetailsInRelationships(
-			relationshipFieldNameNestedFieldName,
+			relationshipFieldNameNestedFieldName, null,
+			relatedObjectDefinitionName, _objectDefinition2,
 			new String[][] {
 				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)},
 				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)}
 			},
-			null, RandomTestUtil.randomString() + relatedObjectDefinitionName,
-			_objectDefinition2, Type.MANY_TO_ONE);
-
-		_testGetNestedFieldDetailsInRelationships(
-			relationshipFieldNameNestedFieldName,
-			new String[][] {
-				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)},
-				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)}
-			},
-			null, _objectRelationship3.getName(), _objectDefinition2,
 			Type.MANY_TO_ONE);
 
 		_testGetNestedFieldDetailsInRelationships(
-			_objectRelationship3.getName(),
+			relationshipFieldNameNestedFieldName, null,
+			RandomTestUtil.randomString() + relatedObjectDefinitionName,
+			_objectDefinition2,
 			new String[][] {
 				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)},
 				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)}
 			},
-			null, _objectRelationship3.getName(), _objectDefinition2,
+			Type.MANY_TO_ONE);
+
+		_testGetNestedFieldDetailsInRelationships(
+			relationshipFieldNameNestedFieldName, null,
+			_objectRelationship3.getName(), _objectDefinition2,
+			new String[][] {
+				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)},
+				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)}
+			},
+			Type.MANY_TO_ONE);
+
+		_testGetNestedFieldDetailsInRelationships(
+			_objectRelationship3.getName(), null,
+			_objectRelationship3.getName(), _objectDefinition2,
+			new String[][] {
+				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)},
+				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)}
+			},
 			Type.MANY_TO_ONE);
 	}
 
@@ -3308,12 +3311,12 @@ public class ObjectEntryResourceTest {
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
 		_testGetNestedFieldDetailsInRelationships(
-			_objectRelationship1.getName(),
+			_objectRelationship1.getName(), null,
+			_objectRelationship1.getName(), _objectDefinition1,
 			new String[][] {
 				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
 				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)}
 			},
-			null, _objectRelationship1.getName(), _objectDefinition1,
 			Type.ONE_TO_MANY);
 
 		// Many to many with system object definition
@@ -3324,27 +3327,28 @@ public class ObjectEntryResourceTest {
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
 		_testGetNestedFieldDetailsInRelationships(
-			_objectRelationship2.getName(),
+			_objectRelationship2.getName(), null,
+			_objectRelationship2.getName(), _objectDefinition1,
 			new String[][] {
 				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
 				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)}
 			},
-			null, _objectRelationship2.getName(), _objectDefinition1,
 			Type.MANY_TO_MANY);
 
 		_testGetNestedFieldDetailsInRelationships(
-			_objectRelationship2.getName(),
+			_objectRelationship2.getName(), 3, _objectRelationship2.getName(),
+			_objectDefinition1,
 			new String[][] {
 				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
 				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)},
 				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
 				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)}
 			},
-			3, _objectRelationship2.getName(), _objectDefinition1,
 			Type.MANY_TO_MANY);
 
 		_testGetNestedFieldDetailsInRelationships(
-			_objectRelationship2.getName(),
+			_objectRelationship2.getName(), 5, _objectRelationship2.getName(),
+			_objectDefinition1,
 			new String[][] {
 				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
 				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)},
@@ -3353,11 +3357,11 @@ public class ObjectEntryResourceTest {
 				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
 				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)}
 			},
-			5, _objectRelationship2.getName(), _objectDefinition1,
 			Type.MANY_TO_MANY);
 
 		_testGetNestedFieldDetailsInRelationships(
-			_objectRelationship2.getName(),
+			_objectRelationship2.getName(), 6, _objectRelationship2.getName(),
+			_objectDefinition1,
 			new String[][] {
 				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
 				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)},
@@ -3366,7 +3370,6 @@ public class ObjectEntryResourceTest {
 				{_OBJECT_FIELD_NAME_1, String.valueOf(_OBJECT_FIELD_VALUE_1)},
 				{_OBJECT_FIELD_NAME_2, String.valueOf(_OBJECT_FIELD_VALUE_2)}
 			},
-			6, _objectRelationship2.getName(), _objectDefinition1,
 			Type.MANY_TO_MANY);
 	}
 
@@ -4884,7 +4887,7 @@ public class ObjectEntryResourceTest {
 
 	private void _assertNestedFieldsInRelationships(
 		int currentDepth, int depth, JSONObject jsonObject,
-		String[][] objectFieldNamesAndObjectFieldValues, String nestedFieldName,
+		String nestedFieldName, String[][] objectFieldNamesAndObjectFieldValues,
 		Type type) {
 
 		if (objectFieldNamesAndObjectFieldValues[currentDepth][0] == null) {
@@ -4912,7 +4915,7 @@ public class ObjectEntryResourceTest {
 		_assertNestedFieldsInRelationships(
 			currentDepth + 1, depth,
 			_getRelatedJSONObject(jsonObject, nestedFieldName, type),
-			objectFieldNamesAndObjectFieldValues, nestedFieldName,
+			nestedFieldName, objectFieldNamesAndObjectFieldValues,
 			_getReverseType(type));
 	}
 
@@ -5075,10 +5078,9 @@ public class ObjectEntryResourceTest {
 	}
 
 	private void _testGetNestedFieldDetailsInRelationships(
-			String expectedFieldName,
-			String[][] objectFieldNamesAndObjectFieldValues,
-			Integer nestedFieldDepth, String nestedFieldName,
-			ObjectDefinition objectDefinition, Type type)
+			String expectedFieldName, Integer nestedFieldDepth,
+			String nestedFieldName, ObjectDefinition objectDefinition,
+			String[][] objectFieldNamesAndObjectFieldValues, Type type)
 		throws Exception {
 
 		String endpoint = StringBundler.concat(
@@ -5100,7 +5102,7 @@ public class ObjectEntryResourceTest {
 
 		_assertNestedFieldsInRelationships(
 			0, GetterUtil.getInteger(nestedFieldDepth, 1), itemJSONObject,
-			objectFieldNamesAndObjectFieldValues, expectedFieldName, type);
+			expectedFieldName, objectFieldNamesAndObjectFieldValues, type);
 	}
 
 	private void

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/RelatedObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/RelatedObjectEntryResourceTest.java
@@ -23,6 +23,7 @@ import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.rest.internal.resource.v1_0.test.util.HTTPTestUtil;
 import com.liferay.object.rest.internal.resource.v1_0.test.util.ObjectDefinitionTestUtil;
 import com.liferay.object.rest.internal.resource.v1_0.test.util.ObjectEntryTestUtil;
+import com.liferay.object.rest.internal.resource.v1_0.test.util.ObjectRelationshipTestUtil;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.object.system.JaxRsApplicationDescriptor;
@@ -39,10 +40,8 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.Http;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
-import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
 import java.util.Collections;
 
@@ -101,11 +100,8 @@ public class RelatedObjectEntryResourceTest {
 			_userSystemObjectDefinitionManager.getJaxRsApplicationDescriptor();
 		Long irrelevantUserId = RandomTestUtil.randomLong();
 
-		String name = StringUtil.randomId();
-
 		_objectRelationship = _addObjectRelationship(
-			name, _objectDefinition.getObjectDefinitionId(),
-			_userSystemObjectDefinition.getObjectDefinitionId(),
+			_objectDefinition, _userSystemObjectDefinition,
 			_objectEntry.getPrimaryKey(), _user.getUserId(),
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
@@ -140,11 +136,8 @@ public class RelatedObjectEntryResourceTest {
 		JaxRsApplicationDescriptor jaxRsApplicationDescriptor =
 			_userSystemObjectDefinitionManager.getJaxRsApplicationDescriptor();
 
-		String name = StringUtil.randomId();
-
 		_objectRelationship = _addObjectRelationship(
-			name, _objectDefinition.getObjectDefinitionId(),
-			_userSystemObjectDefinition.getObjectDefinitionId(),
+			_objectDefinition, _userSystemObjectDefinition,
 			_objectEntry.getPrimaryKey(), _user.getUserId(),
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
@@ -189,11 +182,8 @@ public class RelatedObjectEntryResourceTest {
 		JaxRsApplicationDescriptor jaxRsApplicationDescriptor =
 			_userSystemObjectDefinitionManager.getJaxRsApplicationDescriptor();
 
-		String name = StringUtil.randomId();
-
 		_objectRelationship = _addObjectRelationship(
-			name, _objectDefinition.getObjectDefinitionId(),
-			_userSystemObjectDefinition.getObjectDefinitionId(),
+			_objectDefinition, _userSystemObjectDefinition,
 			_objectEntry.getPrimaryKey(), _user.getUserId(),
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
@@ -249,11 +239,8 @@ public class RelatedObjectEntryResourceTest {
 
 		Long irrelevantUserId = RandomTestUtil.randomLong();
 
-		String name = StringUtil.randomId();
-
 		_objectRelationship = _addObjectRelationship(
-			name, _userSystemObjectDefinition.getObjectDefinitionId(),
-			_objectDefinition.getObjectDefinitionId(), _user.getUserId(),
+			_userSystemObjectDefinition, _objectDefinition, _user.getUserId(),
 			_objectEntry.getPrimaryKey(),
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
@@ -305,11 +292,8 @@ public class RelatedObjectEntryResourceTest {
 		JaxRsApplicationDescriptor jaxRsApplicationDescriptor =
 			_userSystemObjectDefinitionManager.getJaxRsApplicationDescriptor();
 
-		String name = StringUtil.randomId();
-
 		_objectRelationship = _addObjectRelationship(
-			name, _userSystemObjectDefinition.getObjectDefinitionId(),
-			_objectDefinition.getObjectDefinitionId(), _user.getUserId(),
+			_userSystemObjectDefinition, _objectDefinition, _user.getUserId(),
 			_objectEntry.getPrimaryKey(),
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
@@ -354,11 +338,8 @@ public class RelatedObjectEntryResourceTest {
 		JaxRsApplicationDescriptor jaxRsApplicationDescriptor =
 			_userSystemObjectDefinitionManager.getJaxRsApplicationDescriptor();
 
-		String name = StringUtil.randomId();
-
 		_objectRelationship = _addObjectRelationship(
-			name, _userSystemObjectDefinition.getObjectDefinitionId(),
-			_objectDefinition.getObjectDefinitionId(), _user.getUserId(),
+			_userSystemObjectDefinition, _objectDefinition, _user.getUserId(),
 			_objectEntry.getPrimaryKey(),
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
@@ -390,8 +371,7 @@ public class RelatedObjectEntryResourceTest {
 		// Inactive object definition
 
 		_objectRelationship = _addObjectRelationship(
-			StringUtil.randomId(), _objectDefinition.getObjectDefinitionId(),
-			_userSystemObjectDefinition.getObjectDefinitionId(),
+			_objectDefinition, _userSystemObjectDefinition,
 			_objectEntry.getPrimaryKey(), _user.getUserId(),
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
@@ -418,11 +398,8 @@ public class RelatedObjectEntryResourceTest {
 			_userSystemObjectDefinitionManager.getJaxRsApplicationDescriptor();
 		Long irrelevantUserId = RandomTestUtil.randomLong();
 
-		String name = StringUtil.randomId();
-
 		_objectRelationship = _addObjectRelationship(
-			name, _objectDefinition.getObjectDefinitionId(),
-			_userSystemObjectDefinition.getObjectDefinitionId(),
+			_objectDefinition, _userSystemObjectDefinition,
 			_objectEntry.getPrimaryKey(), _user.getUserId(),
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
@@ -442,11 +419,8 @@ public class RelatedObjectEntryResourceTest {
 		JaxRsApplicationDescriptor jaxRsApplicationDescriptor =
 			_userSystemObjectDefinitionManager.getJaxRsApplicationDescriptor();
 
-		String name = StringUtil.randomId();
-
 		_objectRelationship = _addObjectRelationship(
-			name, _objectDefinition.getObjectDefinitionId(),
-			_userSystemObjectDefinition.getObjectDefinitionId(),
+			_objectDefinition, _userSystemObjectDefinition,
 			_objectEntry.getPrimaryKey(), _user.getUserId(),
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
@@ -476,8 +450,7 @@ public class RelatedObjectEntryResourceTest {
 			_userSystemObjectDefinitionManager.getJaxRsApplicationDescriptor();
 
 		_objectRelationship = _addObjectRelationship(
-			StringUtil.randomId(), _objectDefinition.getObjectDefinitionId(),
-			_userSystemObjectDefinition.getObjectDefinitionId(),
+			_objectDefinition, _userSystemObjectDefinition,
 			_objectEntry.getPrimaryKey(), _user.getUserId(),
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
@@ -506,8 +479,7 @@ public class RelatedObjectEntryResourceTest {
 	@Test
 	public void testPutSystemObjectRelatedObjectEntry() throws Exception {
 		_objectRelationship = _addObjectRelationship(
-			StringUtil.randomId(), _objectDefinition.getObjectDefinitionId(),
-			_userSystemObjectDefinition.getObjectDefinitionId(),
+			_objectDefinition, _userSystemObjectDefinition,
 			_objectEntry.getPrimaryKey(), _user.getUserId(),
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
@@ -517,9 +489,7 @@ public class RelatedObjectEntryResourceTest {
 			_objectRelationship);
 
 		_objectRelationship = _addObjectRelationship(
-			StringUtil.randomId(),
-			_userSystemObjectDefinition.getObjectDefinitionId(),
-			_objectDefinition.getObjectDefinitionId(), _user.getUserId(),
+			_userSystemObjectDefinition, _objectDefinition, _user.getUserId(),
 			_objectEntry.getPrimaryKey(),
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
@@ -531,11 +501,8 @@ public class RelatedObjectEntryResourceTest {
 		JaxRsApplicationDescriptor jaxRsApplicationDescriptor =
 			_userSystemObjectDefinitionManager.getJaxRsApplicationDescriptor();
 
-		String name = StringUtil.randomId();
-
 		_objectRelationship = _addObjectRelationship(
-			name, _objectDefinition.getObjectDefinitionId(),
-			_userSystemObjectDefinition.getObjectDefinitionId(),
+			_objectDefinition, _userSystemObjectDefinition,
 			_objectEntry.getPrimaryKey(), _user.getUserId(),
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
@@ -588,21 +555,17 @@ public class RelatedObjectEntryResourceTest {
 	}
 
 	private ObjectRelationship _addObjectRelationship(
-			String name, long objectDefinitionId1, long objectDefinitionId2,
-			long primaryKey1, long primaryKey2, String type)
+			ObjectDefinition objectDefinition1,
+			ObjectDefinition objectDefinition2, long primaryKey1,
+			long primaryKey2, String type)
 		throws Exception {
 
 		ObjectRelationship objectRelationship =
-			_objectRelationshipLocalService.addObjectRelationship(
-				_user.getUserId(), objectDefinitionId1, objectDefinitionId2, 0,
-				ObjectRelationshipConstants.DELETION_TYPE_PREVENT,
-				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
-				name, type);
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				objectDefinition1, objectDefinition2, _user.getUserId(), type);
 
-		_objectRelationshipLocalService.addObjectRelationshipMappingTableValues(
-			_user.getUserId(), objectRelationship.getObjectRelationshipId(),
-			primaryKey1, primaryKey2,
-			ServiceContextTestUtil.getServiceContext());
+		ObjectRelationshipTestUtil.relateObjectEntries(
+			primaryKey1, primaryKey2, objectRelationship, _user.getUserId());
 
 		return objectRelationship;
 	}

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/SystemObjectRelatedObjectEntriesTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/SystemObjectRelatedObjectEntriesTest.java
@@ -15,14 +15,17 @@
 package com.liferay.object.rest.internal.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.constants.ObjectRelationshipConstants;
 import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.rest.internal.resource.v1_0.test.util.HTTPTestUtil;
 import com.liferay.object.rest.internal.resource.v1_0.test.util.ObjectDefinitionTestUtil;
 import com.liferay.object.rest.internal.resource.v1_0.test.util.ObjectEntryTestUtil;
+import com.liferay.object.rest.internal.resource.v1_0.test.util.ObjectFieldTestUtil;
 import com.liferay.object.rest.internal.resource.v1_0.test.util.ObjectRelationshipTestUtil;
 import com.liferay.object.rest.internal.resource.v1_0.test.util.UserAccountTestUtil;
 import com.liferay.object.service.ObjectDefinitionLocalService;
@@ -39,6 +42,7 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -103,6 +107,18 @@ public class SystemObjectRelatedObjectEntriesTest {
 		_userSystemObjectDefinition =
 			_objectDefinitionLocalService.fetchSystemObjectDefinition(
 				_userSystemObjectDefinitionManager.getName());
+
+		_userSystemObjectField = ObjectFieldTestUtil.addCustomObjectField(
+			TestPropsValues.getUserId(),
+			ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+			ObjectFieldConstants.DB_TYPE_STRING, _userSystemObjectDefinition,
+			_SYSTEM_OBJECT_FIELD_NAME);
+
+		_userAccountJSONObject = UserAccountTestUtil.addUserAccountJSONObject(
+			_userSystemObjectDefinitionManager,
+			HashMapBuilder.<String, Serializable>put(
+				_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE
+			).build());
 	}
 
 	@After
@@ -111,7 +127,8 @@ public class SystemObjectRelatedObjectEntriesTest {
 			ObjectRelationshipLocalServiceUtil.
 				deleteObjectRelationshipMappingTableValues(
 					objectRelationship.getObjectRelationshipId(),
-					_objectEntry.getPrimaryKey(), _user.getUserId());
+					_objectEntry.getPrimaryKey(),
+					_userAccountJSONObject.getLong("id"));
 
 			ObjectRelationshipLocalServiceUtil.deleteObjectRelationship(
 				objectRelationship);
@@ -130,13 +147,13 @@ public class SystemObjectRelatedObjectEntriesTest {
 
 		ObjectRelationship objectRelationship = _addObjectRelationship(
 			_objectDefinition, _userSystemObjectDefinition,
-			_objectEntry.getPrimaryKey(), _user.getUserId(),
+			_objectEntry.getPrimaryKey(), _userAccountJSONObject.getLong("id"),
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
 		_testGetSystemObjectRelatedObjectEntries(
 			null, objectRelationship.getName(),
 			new String[][] {
-				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
 				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE}
 			},
 			Type.MANY_TO_MANY);
@@ -144,7 +161,7 @@ public class SystemObjectRelatedObjectEntriesTest {
 		_testGetSystemObjectRelatedObjectEntries(
 			1, objectRelationship.getName(),
 			new String[][] {
-				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
 				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE}
 			},
 			Type.MANY_TO_MANY);
@@ -152,20 +169,20 @@ public class SystemObjectRelatedObjectEntriesTest {
 		_testGetSystemObjectRelatedObjectEntries(
 			2, objectRelationship.getName(),
 			new String[][] {
-				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
 				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE},
-				{"externalReferenceCode", _user.getExternalReferenceCode()}
+				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE}
 			},
 			Type.MANY_TO_MANY);
 
 		_testGetSystemObjectRelatedObjectEntries(
 			5, objectRelationship.getName(),
 			new String[][] {
-				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
 				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE},
-				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
 				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE},
-				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
 				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE}
 			},
 			Type.MANY_TO_MANY);
@@ -173,11 +190,11 @@ public class SystemObjectRelatedObjectEntriesTest {
 		_testGetSystemObjectRelatedObjectEntries(
 			6, objectRelationship.getName(),
 			new String[][] {
-				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
 				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE},
-				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
 				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE},
-				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
 				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE}
 			},
 			Type.MANY_TO_MANY);
@@ -185,14 +202,14 @@ public class SystemObjectRelatedObjectEntriesTest {
 		// Many to many with custom object definition (other side)
 
 		objectRelationship = _addObjectRelationship(
-			_userSystemObjectDefinition, _objectDefinition, _user.getUserId(),
-			_objectEntry.getPrimaryKey(),
+			_userSystemObjectDefinition, _objectDefinition,
+			_userAccountJSONObject.getLong("id"), _objectEntry.getPrimaryKey(),
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
 		_testGetSystemObjectRelatedObjectEntries(
 			null, objectRelationship.getName(),
 			new String[][] {
-				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
 				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE}
 			},
 			Type.MANY_TO_MANY);
@@ -200,7 +217,7 @@ public class SystemObjectRelatedObjectEntriesTest {
 		_testGetSystemObjectRelatedObjectEntries(
 			1, objectRelationship.getName(),
 			new String[][] {
-				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
 				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE}
 			},
 			Type.MANY_TO_MANY);
@@ -208,20 +225,20 @@ public class SystemObjectRelatedObjectEntriesTest {
 		_testGetSystemObjectRelatedObjectEntries(
 			2, objectRelationship.getName(),
 			new String[][] {
-				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
 				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE},
-				{"externalReferenceCode", _user.getExternalReferenceCode()}
+				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE}
 			},
 			Type.MANY_TO_MANY);
 
 		_testGetSystemObjectRelatedObjectEntries(
 			5, objectRelationship.getName(),
 			new String[][] {
-				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
 				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE},
-				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
 				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE},
-				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
 				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE}
 			},
 			Type.MANY_TO_MANY);
@@ -229,11 +246,11 @@ public class SystemObjectRelatedObjectEntriesTest {
 		_testGetSystemObjectRelatedObjectEntries(
 			6, objectRelationship.getName(),
 			new String[][] {
-				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
 				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE},
-				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
 				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE},
-				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
 				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE}
 			},
 			Type.MANY_TO_MANY);
@@ -245,7 +262,7 @@ public class SystemObjectRelatedObjectEntriesTest {
 
 		ObjectRelationship objectRelationship = _addObjectRelationship(
 			_objectDefinition, _userSystemObjectDefinition,
-			_objectEntry.getPrimaryKey(), _user.getUserId(),
+			_objectEntry.getPrimaryKey(), _userAccountJSONObject.getLong("id"),
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
 		JSONObject jsonObject = HTTPTestUtil.invoke(
@@ -271,14 +288,14 @@ public class SystemObjectRelatedObjectEntriesTest {
 		throws Exception {
 
 		ObjectRelationship objectRelationship = _addObjectRelationship(
-			_userSystemObjectDefinition, _objectDefinition, _user.getUserId(),
-			_objectEntry.getPrimaryKey(),
+			_userSystemObjectDefinition, _objectDefinition,
+			_userAccountJSONObject.getLong("id"), _objectEntry.getPrimaryKey(),
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
 		_testGetSystemObjectRelatedObjectEntries(
 			null, objectRelationship.getName(),
 			new String[][] {
-				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
 				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE}
 			},
 			Type.ONE_TO_MANY);
@@ -286,7 +303,7 @@ public class SystemObjectRelatedObjectEntriesTest {
 		_testGetSystemObjectRelatedObjectEntries(
 			1, objectRelationship.getName(),
 			new String[][] {
-				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
 				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE}
 			},
 			Type.ONE_TO_MANY);
@@ -294,9 +311,9 @@ public class SystemObjectRelatedObjectEntriesTest {
 		_testGetSystemObjectRelatedObjectEntries(
 			2, objectRelationship.getName(),
 			new String[][] {
-				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
 				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE},
-				{"externalReferenceCode", _user.getExternalReferenceCode()}
+				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE}
 			},
 			Type.ONE_TO_MANY);
 	}
@@ -428,7 +445,7 @@ public class SystemObjectRelatedObjectEntriesTest {
 
 		ObjectRelationship objectRelationship = _addObjectRelationship(
 			_objectDefinition, _userSystemObjectDefinition,
-			_objectEntry.getPrimaryKey(), _user.getUserId(),
+			_objectEntry.getPrimaryKey(), _userAccountJSONObject.getLong("id"),
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
 		JSONObject jsonObject = UserAccountTestUtil.addUserAccountJSONObject(
@@ -616,8 +633,8 @@ public class SystemObjectRelatedObjectEntriesTest {
 
 	private String _getLocation(String name) {
 		return StringBundler.concat(
-			_getLocation(), StringPool.SLASH, _user.getUserId(),
-			"?nestedFields=", name);
+			_getLocation(), StringPool.SLASH,
+			_userAccountJSONObject.getLong("id"), "?nestedFields=", name);
 	}
 
 	private String _getLocation(String userId, String objectRelationshipName) {
@@ -681,7 +698,8 @@ public class SystemObjectRelatedObjectEntriesTest {
 
 		String endpoint = StringBundler.concat(
 			jaxRsApplicationDescriptor.getRESTContextPath(), StringPool.SLASH,
-			_user.getUserId(), "?nestedFields=", nestedFieldName);
+			_userAccountJSONObject.getLong("id"), "?nestedFields=",
+			nestedFieldName);
 
 		if (nestedFieldDepth != null) {
 			endpoint += "&nestedFieldsDepth=" + nestedFieldDepth;
@@ -852,6 +870,12 @@ public class SystemObjectRelatedObjectEntriesTest {
 	private static final String _OBJECT_FIELD_VALUE =
 		RandomTestUtil.randomString();
 
+	private static final String _SYSTEM_OBJECT_FIELD_NAME =
+		"x" + RandomTestUtil.randomString();
+
+	private static final String _SYSTEM_OBJECT_FIELD_VALUE =
+		RandomTestUtil.randomString();
+
 	private ObjectDefinition _objectDefinition;
 
 	@Inject
@@ -870,8 +894,12 @@ public class SystemObjectRelatedObjectEntriesTest {
 		_systemObjectDefinitionManagerRegistry;
 
 	private User _user;
+	private JSONObject _userAccountJSONObject;
 	private ObjectDefinition _userSystemObjectDefinition;
 	private SystemObjectDefinitionManager _userSystemObjectDefinitionManager;
+
+	@DeleteAfterTestRun
+	private ObjectField _userSystemObjectField;
 
 	private enum Type {
 

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/SystemObjectRelatedObjectEntriesTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/SystemObjectRelatedObjectEntriesTest.java
@@ -42,6 +42,7 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.MapUtil;
@@ -51,10 +52,12 @@ import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.util.PropsValues;
 
 import java.io.Serializable;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -118,34 +121,122 @@ public class SystemObjectRelatedObjectEntriesTest {
 			_objectDefinition.getObjectDefinitionId());
 	}
 
+	@FeatureFlags("LPS-165819")
 	@Test
 	public void testGetManyToManySystemObjectRelatedObjectEntries()
 		throws Exception {
+
+		// Many to many with custom object definition
 
 		ObjectRelationship objectRelationship = _addObjectRelationship(
 			_objectDefinition, _userSystemObjectDefinition,
 			_objectEntry.getPrimaryKey(), _user.getUserId(),
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
-		JSONObject jsonObject = HTTPTestUtil.invoke(
-			null, _getLocation(objectRelationship.getName()), Http.Method.GET);
+		_testGetSystemObjectRelatedObjectEntries(
+			null, objectRelationship.getName(),
+			new String[][] {
+				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE}
+			},
+			Type.MANY_TO_MANY);
 
-		JSONArray jsonArray = jsonObject.getJSONArray(
-			objectRelationship.getName());
+		_testGetSystemObjectRelatedObjectEntries(
+			1, objectRelationship.getName(),
+			new String[][] {
+				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE}
+			},
+			Type.MANY_TO_MANY);
 
-		_assertEquals(jsonArray, _objectEntry);
+		_testGetSystemObjectRelatedObjectEntries(
+			2, objectRelationship.getName(),
+			new String[][] {
+				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE},
+				{"externalReferenceCode", _user.getExternalReferenceCode()}
+			},
+			Type.MANY_TO_MANY);
+
+		_testGetSystemObjectRelatedObjectEntries(
+			5, objectRelationship.getName(),
+			new String[][] {
+				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE},
+				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE},
+				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE}
+			},
+			Type.MANY_TO_MANY);
+
+		_testGetSystemObjectRelatedObjectEntries(
+			6, objectRelationship.getName(),
+			new String[][] {
+				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE},
+				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE},
+				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE}
+			},
+			Type.MANY_TO_MANY);
+
+		// Many to many with custom object definition (other side)
 
 		objectRelationship = _addObjectRelationship(
 			_userSystemObjectDefinition, _objectDefinition, _user.getUserId(),
 			_objectEntry.getPrimaryKey(),
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
-		jsonObject = HTTPTestUtil.invoke(
-			null, _getLocation(objectRelationship.getName()), Http.Method.GET);
+		_testGetSystemObjectRelatedObjectEntries(
+			null, objectRelationship.getName(),
+			new String[][] {
+				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE}
+			},
+			Type.MANY_TO_MANY);
 
-		jsonArray = jsonObject.getJSONArray(objectRelationship.getName());
+		_testGetSystemObjectRelatedObjectEntries(
+			1, objectRelationship.getName(),
+			new String[][] {
+				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE}
+			},
+			Type.MANY_TO_MANY);
 
-		_assertEquals(jsonArray, _objectEntry);
+		_testGetSystemObjectRelatedObjectEntries(
+			2, objectRelationship.getName(),
+			new String[][] {
+				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE},
+				{"externalReferenceCode", _user.getExternalReferenceCode()}
+			},
+			Type.MANY_TO_MANY);
+
+		_testGetSystemObjectRelatedObjectEntries(
+			5, objectRelationship.getName(),
+			new String[][] {
+				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE},
+				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE},
+				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE}
+			},
+			Type.MANY_TO_MANY);
+
+		_testGetSystemObjectRelatedObjectEntries(
+			6, objectRelationship.getName(),
+			new String[][] {
+				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE},
+				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE},
+				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE}
+			},
+			Type.MANY_TO_MANY);
 	}
 
 	@Test
@@ -184,12 +275,30 @@ public class SystemObjectRelatedObjectEntriesTest {
 			_objectEntry.getPrimaryKey(),
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
-		JSONObject jsonObject = HTTPTestUtil.invoke(
-			null, _getLocation(objectRelationship.getName()), Http.Method.GET);
+		_testGetSystemObjectRelatedObjectEntries(
+			null, objectRelationship.getName(),
+			new String[][] {
+				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE}
+			},
+			Type.ONE_TO_MANY);
 
-		_assertEquals(
-			jsonObject.getJSONArray(objectRelationship.getName()),
-			_objectEntry);
+		_testGetSystemObjectRelatedObjectEntries(
+			1, objectRelationship.getName(),
+			new String[][] {
+				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE}
+			},
+			Type.ONE_TO_MANY);
+
+		_testGetSystemObjectRelatedObjectEntries(
+			2, objectRelationship.getName(),
+			new String[][] {
+				{"externalReferenceCode", _user.getExternalReferenceCode()},
+				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE},
+				{"externalReferenceCode", _user.getExternalReferenceCode()}
+			},
+			Type.ONE_TO_MANY);
 	}
 
 	@Test
@@ -429,13 +538,38 @@ public class SystemObjectRelatedObjectEntriesTest {
 		return objectRelationship;
 	}
 
-	private void _assertEquals(JSONArray jsonArray, ObjectEntry objectEntry) {
-		Assert.assertEquals(jsonArray.toString(), 1, jsonArray.length());
+	private void _assertNestedFieldsInRelationships(
+		int currentDepth, int depth, JSONObject jsonObject,
+		String nestedFieldName, String[][] objectFieldNamesAndObjectFieldValues,
+		Type type) {
 
-		JSONObject jsonObject = (JSONObject)jsonArray.get(0);
+		if (objectFieldNamesAndObjectFieldValues[currentDepth][0] == null) {
+			Assert.assertNull(jsonObject);
+		}
+		else {
+			Assert.assertEquals(
+				objectFieldNamesAndObjectFieldValues[currentDepth][1],
+				jsonObject.getString(
+					objectFieldNamesAndObjectFieldValues[currentDepth][0]));
+		}
 
-		Assert.assertEquals(
-			objectEntry.getObjectEntryId(), jsonObject.getLong("id"));
+		if ((currentDepth == depth) ||
+			(currentDepth ==
+				PropsValues.OBJECT_NESTED_FIELDS_MAX_QUERY_DEPTH)) {
+
+			Assert.assertEquals(
+				Arrays.toString(objectFieldNamesAndObjectFieldValues),
+				currentDepth + 1, objectFieldNamesAndObjectFieldValues.length);
+			Assert.assertNull(jsonObject.get(nestedFieldName));
+
+			return;
+		}
+
+		_assertNestedFieldsInRelationships(
+			currentDepth + 1, depth,
+			_getRelatedJSONObject(jsonObject, nestedFieldName, type),
+			nestedFieldName, objectFieldNamesAndObjectFieldValues,
+			_getReverseType(type));
 	}
 
 	private void _assertObjectEntryField(
@@ -502,6 +636,63 @@ public class SystemObjectRelatedObjectEntriesTest {
 				_objectDefinition.getRESTContextPath(),
 				"/by-external-reference-code/", externalReferenceCode),
 			Http.Method.GET);
+	}
+
+	private JSONObject _getRelatedJSONObject(
+		JSONObject jsonObject, String nestedFieldName, Type type) {
+
+		if (type == Type.MANY_TO_ONE) {
+			JSONObject nestedJSONObject = jsonObject.getJSONObject(
+				nestedFieldName);
+
+			Assert.assertNotNull(
+				"Missing field " + nestedFieldName, nestedJSONObject);
+
+			return jsonObject.getJSONObject(nestedFieldName);
+		}
+
+		JSONArray jsonArray = jsonObject.getJSONArray(nestedFieldName);
+
+		Assert.assertNotNull("Missing field " + nestedFieldName, jsonArray);
+
+		Assert.assertEquals(1, jsonArray.length());
+
+		return jsonArray.getJSONObject(0);
+	}
+
+	private Type _getReverseType(Type type) {
+		if (type == Type.MANY_TO_ONE) {
+			return Type.ONE_TO_MANY;
+		}
+		else if (type == Type.ONE_TO_MANY) {
+			return Type.MANY_TO_ONE;
+		}
+
+		return Type.MANY_TO_MANY;
+	}
+
+	private void _testGetSystemObjectRelatedObjectEntries(
+			Integer nestedFieldDepth, String nestedFieldName,
+			String[][] objectFieldNamesAndObjectFieldValues, Type type)
+		throws Exception {
+
+		JaxRsApplicationDescriptor jaxRsApplicationDescriptor =
+			_userSystemObjectDefinitionManager.getJaxRsApplicationDescriptor();
+
+		String endpoint = StringBundler.concat(
+			jaxRsApplicationDescriptor.getRESTContextPath(), StringPool.SLASH,
+			_user.getUserId(), "?nestedFields=", nestedFieldName);
+
+		if (nestedFieldDepth != null) {
+			endpoint += "&nestedFieldsDepth=" + nestedFieldDepth;
+		}
+
+		JSONObject jsonObject = HTTPTestUtil.invoke(
+			null, endpoint, Http.Method.GET);
+
+		_assertNestedFieldsInRelationships(
+			0, GetterUtil.getInteger(nestedFieldDepth, 1), jsonObject,
+			nestedFieldName, objectFieldNamesAndObjectFieldValues, type);
 	}
 
 	private void _testPostSystemObjectEntryWithInvalidNestedCustomObjectEntries(
@@ -681,5 +872,11 @@ public class SystemObjectRelatedObjectEntriesTest {
 	private User _user;
 	private ObjectDefinition _userSystemObjectDefinition;
 	private SystemObjectDefinitionManager _userSystemObjectDefinitionManager;
+
+	private enum Type {
+
+		MANY_TO_MANY, MANY_TO_ONE, ONE_TO_MANY
+
+	}
 
 }

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/SystemObjectRelatedObjectEntriesTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/SystemObjectRelatedObjectEntriesTest.java
@@ -214,7 +214,7 @@ public class SystemObjectRelatedObjectEntriesTest {
 			_testPostSystemObjectEntryWithInvalidNestedCustomObjectEntries(
 				objectRelationship, false);
 
-			// Many to one
+			// Many to 1
 
 			objectRelationship =
 				ObjectRelationshipTestUtil.addObjectRelationship(
@@ -227,7 +227,7 @@ public class SystemObjectRelatedObjectEntriesTest {
 			_testPostSystemObjectEntryWithInvalidNestedCustomObjectEntries(
 				objectRelationship, true);
 
-			// One to many
+			// 1 to many
 
 			objectRelationship =
 				ObjectRelationshipTestUtil.addObjectRelationship(
@@ -257,7 +257,7 @@ public class SystemObjectRelatedObjectEntriesTest {
 		_testPostSystemObjectEntryWithNestedCustomObjectEntries(
 			objectRelationship);
 
-		// One to many
+		// 1 to many
 
 		objectRelationship = ObjectRelationshipTestUtil.addObjectRelationship(
 			_userSystemObjectDefinition, _objectDefinition, _user.getUserId(),
@@ -354,7 +354,7 @@ public class SystemObjectRelatedObjectEntriesTest {
 		_testPutSystemObjectEntryWithNestedCustomObjectEntries(
 			objectRelationship);
 
-		// One to many
+		// 1 to many
 
 		objectRelationship = ObjectRelationshipTestUtil.addObjectRelationship(
 			_userSystemObjectDefinition, _objectDefinition, _user.getUserId(),


### PR DESCRIPTION
Followed-up PR from: https://github.com/brianchandotcom/liferay-portal/pull/134758

Related issue: https://issues.liferay.com/browse/LPS-183903

---

This PR contains the code to allow developers to retrieve different levels of the many to many and one to many related elements of a System Object.

Currently, it is already possible to retrieve the MtoM and 1toM of a System Object, as the functionality was included previously in [this other PR](https://github.com/brianchandotcom/liferay-portal/pull/133972). The reason is because when developing it in the Custom Objects side, when related to a System Object, some code was necessary to be included.

For that, the following changes have been included:

- A commit to modify the method used to check if the object definition is a system object, from `isSystem` to `isUnmodifiableSystemObject`, as the new method must be used when service builder system objects are involved.
- New integration "sub-tests" have been included in the `SystemObjectRelatedObjectEntriesTest` class over the tests `testGetManyToManySystemObjectRelatedObjectEntries` and `testGetOneToManySystemObjectRelatedObjectEntries`

**How to test it:**

- Set the feature flag `LPS-165819`
- Deploy the module `modules/apps/object/object-rest-impl`
- Launch the integration tests over the directory `modules/apps/object/object-rest-test`:
  - `gw tI --tests SystemObjectRelatedObjectEntriesTest.testGetManyToManySystemObjectRelatedObjectEntries`
  - `gw tI --tests SystemObjectRelatedObjectEntriesTest.testGetOneToManySystemObjectRelatedObjectEntries`