### PR TITLE
LPS-177720 HR_70 (scenario 2) Disabled checkbox should not be readable

### DIFF
--- a/portal-web/docroot/html/taglib/ui/input_permissions/horizontal.jspf
+++ b/portal-web/docroot/html/taglib/ui/input_permissions/horizontal.jspf
@@ -103,7 +103,7 @@ ServiceContext#deriveDefaultPermissions(long, String).
 						<label class="sr-only" for="<%= checkboxFieldId %>"><liferay-ui:message arguments="<%= new Object[] {ResourceActionsUtil.getAction(request, action), role.getTitle(themeDisplay.getLocale())} %>" key="give-x-permission-to-users-with-role-x" translateArguments="<%= false %>" /></label>
 
 						<c:if test="<%= action.equals(ActionKeys.VIEW) %>">
-							<input <%= checked ? "checked" : "" %> class="hide-accessible sr-only" id="<%= checkboxFieldId %>" name="<%= checkboxFieldName %>" type="checkbox" value="<%= action %>" />
+							<input <%= checked ? "checked" : "" %> class="hide" id="<%= checkboxFieldId %>" name="<%= checkboxFieldName %>" type="checkbox" value="<%= action %>" />
 
 							<%
 							disabled = true;

--- a/portal-web/docroot/html/taglib/ui/input_permissions/vertical.jspf
+++ b/portal-web/docroot/html/taglib/ui/input_permissions/vertical.jspf
@@ -103,7 +103,7 @@ ServiceContext#deriveDefaultPermissions(long, String).
 						<label class="hide-accessible sr-only" for="<%= checkboxFieldId %>"><liferay-ui:message arguments="<%= new Object[] {ResourceActionsUtil.getAction(request, action), role.getTitle(themeDisplay.getLocale())} %>" key="give-x-permission-to-users-with-role-x" translateArguments="<%= false %>" /></label>
 
 						<c:if test="<%= action.equals(ActionKeys.VIEW) %>">
-							<input <%= checked ? "checked" : "" %> class="hide-accessible sr-only" id="<%= checkboxFieldId %>" name="<%= checkboxFieldName %>" type="checkbox" value="<%= action %>" />
+							<input <%= checked ? "checked" : "" %> class="hide" id="<%= checkboxFieldId %>" name="<%= checkboxFieldName %>" type="checkbox" value="<%= action %>" />
 
 							<%
 							disabled = true;


### PR DESCRIPTION
Manual forward of [LPS-177720 HR_70 (scenario 2) Disabled checkbox should not be readable](https://github.com/liferay-frontend/liferay-portal/pull/3280) due to CI issues.

🟢 [Green light given by QA](https://github.com/liferay-frontend/liferay-portal/pull/3280#issuecomment-1538246087)

# Original description
In this PR we're hiding the internal checkbox to the eyes of the screen reader and the tab indexes by adding it display:none in the liferay-ui:input-permissions tag. This internal ckeckbox is added to the VIEW action behind a disabled checkbox to prevent modifications of VIEW permissions, but it was still being seen by assistive technologies.

cc/ @dsanz
