### PR TITLE
Fix copy_images from liferay_jar_runner_set_up.sh

### DIFF
--- a/workspaces/liferay-learn-workspace/client-extensions/liferay-learn-etc-cron/assets/liferay_jar_runner_set_up.sh
+++ b/workspaces/liferay-learn-workspace/client-extensions/liferay-learn-etc-cron/assets/liferay_jar_runner_set_up.sh
@@ -32,7 +32,7 @@ function clone_repository {
 }
 
 function copy_images {
-	rsync --exclude=\"*\" --include=\"images/*\" --include=\"*/\" --prune-empty-dirs --recursive ~/liferay-learn/docs /public_html/images
+	rsync --include="images/*" --include="*/" --exclude="*" --prune-empty-dirs --recursive ~/liferay-learn/docs /public_html/images
 }
 
 function generate_zip_files {


### PR DESCRIPTION
The rsync's includes and excludes can't be sorted. In its current form it copies nearly everything, rather than just the images.

cc @allen-ziegenfus