### PR TITLE
LPS-169282

### DIFF
--- a/portal-web/docroot/html/taglib/aui/form/end.jsp
+++ b/portal-web/docroot/html/taglib/aui/form/end.jsp
@@ -21,7 +21,7 @@
 	</c:if>
 
 	<c:if test="<%= Validator.isNotNull(onSubmit) %>">
-		</fieldset>
+		</div>
 	</c:if>
 </form>
 

--- a/portal-web/docroot/html/taglib/aui/form/start.jsp
+++ b/portal-web/docroot/html/taglib/aui/form/start.jsp
@@ -22,8 +22,7 @@ String fullName = namespace.concat(HtmlUtil.escapeAttribute(name));
 
 <form action="<%= HtmlUtil.escapeAttribute(action) %>" class="form <%= cssClass %> <%= inlineLabels ? "field-labels-inline" : StringPool.BLANK %>" data-fm-namespace="<%= namespace %>" id="<%= fullName %>" method="<%= method %>" name="<%= fullName %>" <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %>>
 	<c:if test="<%= Validator.isNotNull(onSubmit) %>">
-		<fieldset class="input-container" disabled="disabled">
-			<legend class="sr-only"><%= HtmlUtil.escape(portletDisplay.getTitle()) %></legend>
+		<div aria-label="<%= HtmlUtil.escape(portletDisplay.getTitle()) %>" class="input-container" role="group">
 	</c:if>
 
 	<aui:input name="formDate" type="hidden" value="<%= System.currentTimeMillis() %>" />

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Panel.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Panel.macro
@@ -19,6 +19,8 @@ definition {
 	}
 
 	macro expandPanel {
+		SetWindowSize(value1 = "1920,1540");
+
 		Portlet.waitForForm();
 
 		var key_panel = ${panel};


### PR DESCRIPTION
[Original PR ](https://github.com/liferay-frontend/liferay-portal/pull/3267)

**Motivation**
JAWS read the hidden legend as a navigable element
Link to story or ticket

**Proposed Solution**
The solution is the same we did for #3228. We have replaced the `<fieldset>` element with` <div role=“group”>` , removed the legend element and added an aria-label to the <div role=“group”> with the text that the legend had.

**Steps to Verify:**

1. Navigate to Site Builder->Pages and add a page
2. Navigation to Global templates
3. Add a new Global template
4. Input the page name
5. Navigate to the General tab
6. Use jaws
7. Using the arrow key to traverse the page