### PR TITLE
LPS-183745 The required fields are not requiring the user to fill in when switching languages ​​in instance settings

### DIFF
--- a/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/hooks/useForm.ts
+++ b/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/hooks/useForm.ts
@@ -14,10 +14,21 @@
 
 import {ChangeEventHandler, FormEvent, FormEventHandler, useState} from 'react';
 
+export function invalidateLocalizableLabelRequired(
+	labels: LocalizedValue<string> | undefined
+) {
+	const defaultLanguageId = Liferay.ThemeDisplay.getDefaultLanguageId();
+
+	if (!labels) {
+		return true;
+	}
+
+	return !labels[defaultLanguageId];
+}
+
 export function invalidateRequired(text: string | void) {
 	return !text?.trim();
 }
-
 interface IProps<T, P = {}, K extends Partial<T> = Partial<T>> {
 	initialValues: K;
 	onSubmit: (values: T) => void;

--- a/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/index.ts
+++ b/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/index.ts
@@ -48,7 +48,12 @@ export {
 	SidePanelForm,
 } from './components/SidePanelContent';
 export {Toggle} from './components/Toggle';
-export {invalidateRequired, useForm, FormError} from './hooks/useForm';
+export {
+	invalidateLocalizableLabelRequired,
+	invalidateRequired,
+	useForm,
+	FormError,
+} from './hooks/useForm';
 export {onActionDropdownItemClick} from './utils/fdsUtil';
 export {Panel} from './components/Panel/Panel';
 export {PanelBody, PanelSimpleBody} from './components/Panel/PanelBody';

--- a/modules/apps/object/object-js-components-web/types/src/main/resources/META-INF/resources/hooks/useForm.d.ts
+++ b/modules/apps/object/object-js-components-web/types/src/main/resources/META-INF/resources/hooks/useForm.d.ts
@@ -13,6 +13,9 @@
  */
 
 import {ChangeEventHandler, FormEventHandler} from 'react';
+export declare function invalidateLocalizableLabelRequired(
+	labels: LocalizedValue<string> | undefined
+): boolean;
 export declare function invalidateRequired(text: string | void): boolean;
 interface IProps<T, P = {}, K extends Partial<T> = Partial<T>> {
 	initialValues: K;

--- a/modules/apps/object/object-js-components-web/types/src/main/resources/META-INF/resources/index.d.ts
+++ b/modules/apps/object/object-js-components-web/types/src/main/resources/META-INF/resources/index.d.ts
@@ -47,7 +47,12 @@ export {
 	SidePanelForm,
 } from './components/SidePanelContent';
 export {Toggle} from './components/Toggle';
-export {invalidateRequired, useForm, FormError} from './hooks/useForm';
+export {
+	invalidateLocalizableLabelRequired,
+	invalidateRequired,
+	useForm,
+	FormError,
+} from './hooks/useForm';
 export {onActionDropdownItemClick} from './utils/fdsUtil';
 export {Panel} from './components/Panel/Panel';
 export {PanelBody, PanelSimpleBody} from './components/Panel/PanelBody';

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectDetails/useObjectDetailsForm.ts
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectDetails/useObjectDetailsForm.ts
@@ -14,7 +14,7 @@
 
 import {
 	FormError,
-	getLocalizableLabel,
+	invalidateLocalizableLabelRequired,
 	invalidateRequired,
 	useForm,
 } from '@liferay/object-js-components-web';
@@ -73,25 +73,11 @@ export function useObjectDetailsForm({
 	const validate = (objectDefinition: Partial<ObjectDefinition>) => {
 		const errors: ObjectDetailsErrors = {};
 
-		if (
-			invalidateRequired(
-				getLocalizableLabel(
-					objectDefinition.defaultLanguageId as Liferay.Language.Locale,
-					objectDefinition.label
-				)
-			)
-		) {
+		if (invalidateLocalizableLabelRequired(objectDefinition.label)) {
 			errors.label = REQUIRED_MSG;
 		}
 
-		if (
-			invalidateRequired(
-				getLocalizableLabel(
-					objectDefinition.defaultLanguageId as Liferay.Language.Locale,
-					objectDefinition.pluralLabel
-				)
-			)
-		) {
+		if (invalidateLocalizableLabelRequired(objectDefinition.pluralLabel)) {
 			errors.pluralLabel = REQUIRED_MSG;
 		}
 


### PR DESCRIPTION
Related issue : [LPS-183745](https://issues.liferay.com/browse/LPS-183745)
Original PR : https://github.com/liferay-objects/liferay-portal/pull/2079