### PR TITLE
LPS-185020 Fix bugs on `XMLUpgradeDTDVersionCheck`

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/XMLDTDVersionCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/XMLDTDVersionCheck.java
@@ -31,36 +31,10 @@ import java.util.regex.Pattern;
  */
 public class XMLDTDVersionCheck extends BaseFileCheck {
 
-	@Override
-	protected String doProcess(
-			String fileName, String absolutePath, String content)
-		throws IOException {
-
-		if (fileName.endsWith(".xml")) {
-			return _checkDTDVersion(content);
-		}
-
-		return content;
-	}
-
-	protected String getLPVersion() {
-		return _releaseProperties.getProperty("lp.version");
-	}
-
-	protected String getLPVersionDTD() {
-		return _releaseProperties.getProperty("lp.version.dtd");
-	}
-
-	private String _checkDTDVersion(String content) throws IOException {
+	protected String checkDTDVersion(String content) throws IOException {
 		Matcher matcher = _doctypePattern.matcher(content);
 
 		if (!matcher.find()) {
-			return content;
-		}
-
-		_readReleaseProperties();
-
-		if (_releaseProperties == null) {
 			return content;
 		}
 
@@ -82,6 +56,28 @@ public class XMLDTDVersionCheck extends BaseFileCheck {
 				matcher.group(1), lpVersion, matcher.group(3), lpVersionDTD,
 				matcher.group(5)),
 			matcher.start());
+	}
+
+	@Override
+	protected String doProcess(
+			String fileName, String absolutePath, String content)
+		throws IOException {
+
+		_readReleaseProperties();
+
+		if ((_releaseProperties == null) || !fileName.endsWith(".xml")) {
+			return content;
+		}
+
+		return checkDTDVersion(content);
+	}
+
+	protected String getLPVersion() {
+		return _releaseProperties.getProperty("lp.version");
+	}
+
+	protected String getLPVersionDTD() {
+		return _releaseProperties.getProperty("lp.version.dtd");
 	}
 
 	private void _readReleaseProperties() throws IOException {

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/XMLUpgradeDTDVersionCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/XMLUpgradeDTDVersionCheck.java
@@ -34,11 +34,11 @@ public class XMLUpgradeDTDVersionCheck extends XMLDTDVersionCheck {
 		_upgradeToVersion = getAttributeValue(
 			SourceFormatterUtil.UPGRADE_TO_VERSION, absolutePath);
 
-		if (_upgradeToVersion == null) {
+		if ((_upgradeToVersion == null) || !fileName.endsWith(".xml")) {
 			return content;
 		}
 
-		return super.doProcess(fileName, absolutePath, content);
+		return checkDTDVersion(content);
 	}
 
 	@Override

--- a/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/UpgradeSourceProcessorTest.java
+++ b/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/UpgradeSourceProcessorTest.java
@@ -70,7 +70,7 @@ public class UpgradeSourceProcessorTest extends BaseSourceProcessorTestCase {
 
 	@Test
 	public void testXMLUpgradeDTDVersionCheck() throws Exception {
-		test("upgrade/GradleUpgradeReleaseDxpCheck.testgradle");
+		test("upgrade/XMLUpgradeDTDVersionCheck.testxml");
 	}
 
 	@Override


### PR DESCRIPTION
__Ticket:__ <https://issues.liferay.com/browse/LPS-185020>

Pull request tested here: <https://github.com/kevhlee/liferay-portal/pull/67>. Unrelated test failures.

Currently `XMLUpgradeDTDVersionCheck` does not work as it expects `release.properties` to exist in the project/directory, which is specific to `liferay-portal`. Also, the unit test for this check was incorrectly written.