### PR TITLE
LPS-180466 Support group context for audit events - avoid company constant

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
@@ -440,7 +440,7 @@ public class ObjectEntryDTOConverter
 
 				return TransformUtil.transformToArray(
 					_auditEventLocalService.getAuditEvents(
-						0, 0, null, null, null, null, null,
+						0, 0, 0, null, null, null, null, null,
 						String.valueOf(objectEntry.getObjectEntryId()), null,
 						null, null, 0, null, false, QueryUtil.ALL_POS,
 						QueryUtil.ALL_POS),

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/model/listener/ObjectEntryModelListener.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/model/listener/ObjectEntryModelListener.java
@@ -179,7 +179,7 @@ public class ObjectEntryModelListener extends BaseModelListener<ObjectEntry> {
 		ObjectEntry objectEntry) {
 
 		AuditMessage auditMessage = AuditMessageBuilder.buildAuditMessage(
-			eventType, objectEntry.getModelClassName(),
+			objectEntry.getGroupId(), eventType, objectEntry.getModelClassName(),
 			objectEntry.getObjectEntryId(), null);
 
 		JSONObject additionalInfoJSONObject = auditMessage.getAdditionalInfo();
@@ -312,7 +312,8 @@ public class ObjectEntryModelListener extends BaseModelListener<ObjectEntry> {
 			if (StringUtil.equals(EventTypes.UPDATE, eventType)) {
 				_auditRouter.route(
 					AuditMessageBuilder.buildAuditMessage(
-						EventTypes.UPDATE, objectEntry.getModelClassName(),
+						objectEntry.getGroupId(), EventTypes.UPDATE,
+						objectEntry.getModelClassName(),
 						objectEntry.getObjectEntryId(),
 						_getModifiedAttributes(
 							objectDefinition, originalObjectEntry.getValues(),

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/model/listener/ObjectEntryModelListener.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/model/listener/ObjectEntryModelListener.java
@@ -179,8 +179,7 @@ public class ObjectEntryModelListener extends BaseModelListener<ObjectEntry> {
 		ObjectEntry objectEntry) {
 
 		AuditMessage auditMessage = AuditMessageBuilder.buildAuditMessage(
-			objectEntry.getGroupId(), eventType, objectEntry.getModelClassName(),
-			objectEntry.getObjectEntryId(), null);
+			eventType, objectEntry, null);
 
 		JSONObject additionalInfoJSONObject = auditMessage.getAdditionalInfo();
 
@@ -312,9 +311,7 @@ public class ObjectEntryModelListener extends BaseModelListener<ObjectEntry> {
 			if (StringUtil.equals(EventTypes.UPDATE, eventType)) {
 				_auditRouter.route(
 					AuditMessageBuilder.buildAuditMessage(
-						objectEntry.getGroupId(), EventTypes.UPDATE,
-						objectEntry.getModelClassName(),
-						objectEntry.getObjectEntryId(),
+						EventTypes.UPDATE, objectEntry,
 						_getModifiedAttributes(
 							objectDefinition, originalObjectEntry.getValues(),
 							objectEntry.getValues())));

--- a/modules/apps/portal-security-audit/portal-security-audit-api/bnd.bnd
+++ b/modules/apps/portal-security-audit/portal-security-audit-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Security Audit API
 Bundle-SymbolicName: com.liferay.portal.security.audit.api
-Bundle-Version: 7.0.1
+Bundle-Version: 8.0.0
 Export-Package:\
 	com.liferay.portal.security.audit,\
 	com.liferay.portal.security.audit.configuration,\

--- a/modules/apps/portal-security-audit/portal-security-audit-api/src/main/java/com/liferay/portal/security/audit/AuditEvent.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-api/src/main/java/com/liferay/portal/security/audit/AuditEvent.java
@@ -43,6 +43,8 @@ public interface AuditEvent {
 
 	public String getEventType();
 
+	public long getGroupId();
+
 	public String getMessage();
 
 	public long getPrimaryKey();

--- a/modules/apps/portal-security-audit/portal-security-audit-api/src/main/java/com/liferay/portal/security/audit/AuditEventManager.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-api/src/main/java/com/liferay/portal/security/audit/AuditEventManager.java
@@ -40,10 +40,11 @@ public interface AuditEventManager {
 				orderByComparator);
 
 	public List<AuditEvent> getAuditEvents(
-		long companyId, long userId, String userName, Date createDateGT,
-		Date createDateLT, String eventType, String className, String classPK,
-		String clientHost, String clientIP, String serverName, int serverPort,
-		String sessionID, boolean andSearch, int start, int end,
+		long companyId, long groupId, long userId, String userName,
+		Date createDateGT, Date createDateLT, String eventType,
+		String className, String classPK, String clientHost, String clientIP,
+		String serverName, int serverPort, String sessionID, boolean andSearch,
+		int start, int end,
 		OrderByComparator
 			<com.liferay.portal.security.audit.storage.model.AuditEvent>
 				orderByComparator);
@@ -51,9 +52,9 @@ public interface AuditEventManager {
 	public int getAuditEventsCount(long companyId);
 
 	public int getAuditEventsCount(
-		long companyId, long userId, String userName, Date createDateGT,
-		Date createDateLT, String eventType, String className, String classPK,
-		String clientHost, String clientIP, String serverName, int serverPort,
-		String sessionID, boolean andSearch);
+		long companyId, long groupId, long userId, String userName,
+		Date createDateGT, Date createDateLT, String eventType,
+		String className, String classPK, String clientHost, String clientIP,
+		String serverName, int serverPort, String sessionID, boolean andSearch);
 
 }

--- a/modules/apps/portal-security-audit/portal-security-audit-api/src/main/resources/com/liferay/portal/security/audit/packageinfo
+++ b/modules/apps/portal-security-audit/portal-security-audit-api/src/main/resources/com/liferay/portal/security/audit/packageinfo
@@ -1,1 +1,1 @@
-version 3.0.0
+version 4.0.0

--- a/modules/apps/portal-security-audit/portal-security-audit-event-generators-api/bnd.bnd
+++ b/modules/apps/portal-security-audit/portal-security-audit-event-generators-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Security Audit Event Generators API
 Bundle-SymbolicName: com.liferay.portal.security.audit.event.generators.api
-Bundle-Version: 6.0.1
+Bundle-Version: 6.1.0
 Export-Package:\
 	com.liferay.portal.security.audit.event.generators.constants,\
 	com.liferay.portal.security.audit.event.generators.util

--- a/modules/apps/portal-security-audit/portal-security-audit-event-generators-api/src/main/java/com/liferay/portal/security/audit/event/generators/util/AuditMessageBuilder.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-event-generators-api/src/main/java/com/liferay/portal/security/audit/event/generators/util/AuditMessageBuilder.java
@@ -22,7 +22,6 @@ import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.ClassedModel;
-import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
@@ -90,7 +89,7 @@ public class AuditMessageBuilder {
 		String eventType, ClassedModel classedModel,
 		List<Attribute> attributes) {
 
-		long groupId = CompanyConstants.SYSTEM;
+		long groupId = 0;
 
 		if (classedModel instanceof GroupedModel) {
 			GroupedModel groupedModel = (GroupedModel)classedModel;
@@ -107,8 +106,7 @@ public class AuditMessageBuilder {
 		String eventType, String className, long classPK,
 		List<Attribute> attributes) {
 
-		return buildAuditMessage(
-			CompanyConstants.SYSTEM, eventType, className, classPK, attributes);
+		return buildAuditMessage(0, eventType, className, classPK, attributes);
 	}
 
 	private static JSONArray _getAttributesJSONArray(

--- a/modules/apps/portal-security-audit/portal-security-audit-event-generators-api/src/main/java/com/liferay/portal/security/audit/event/generators/util/AuditMessageBuilder.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-event-generators-api/src/main/java/com/liferay/portal/security/audit/event/generators/util/AuditMessageBuilder.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -36,6 +37,14 @@ public class AuditMessageBuilder {
 
 	public static AuditMessage buildAuditMessage(
 		String eventType, String className, long classPK,
+		List<Attribute> attributes) {
+
+		return buildAuditMessage(
+			CompanyConstants.SYSTEM, eventType, className, classPK, attributes);
+	}
+
+	public static AuditMessage buildAuditMessage(
+		long groupId, String eventType, String className, long classPK,
 		List<Attribute> attributes) {
 
 		long companyId = CompanyThreadLocal.getCompanyId();
@@ -71,8 +80,8 @@ public class AuditMessageBuilder {
 		}
 
 		return new AuditMessage(
-			eventType, companyId, realUserId, realUserName, className,
-			String.valueOf(classPK), null, additionalInfoJSONObject);
+			eventType, companyId, groupId, realUserId, realUserName, className,
+			String.valueOf(classPK), null, null, additionalInfoJSONObject);
 	}
 
 	private static JSONArray _getAttributesJSONArray(

--- a/modules/apps/portal-security-audit/portal-security-audit-event-generators-api/src/main/java/com/liferay/portal/security/audit/event/generators/util/AuditMessageBuilder.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-event-generators-api/src/main/java/com/liferay/portal/security/audit/event/generators/util/AuditMessageBuilder.java
@@ -21,7 +21,9 @@ import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.ClassedModel;
 import com.liferay.portal.kernel.model.CompanyConstants;
+import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -36,15 +38,15 @@ import java.util.List;
 public class AuditMessageBuilder {
 
 	public static AuditMessage buildAuditMessage(
-		String eventType, String className, long classPK,
+		long groupId, String eventType, String className, long classPK,
 		List<Attribute> attributes) {
 
 		return buildAuditMessage(
-			CompanyConstants.SYSTEM, eventType, className, classPK, attributes);
+			groupId, eventType, className, String.valueOf(classPK), attributes);
 	}
 
 	public static AuditMessage buildAuditMessage(
-		long groupId, String eventType, String className, long classPK,
+		long groupId, String eventType, String className, String classPK,
 		List<Attribute> attributes) {
 
 		long companyId = CompanyThreadLocal.getCompanyId();
@@ -81,7 +83,32 @@ public class AuditMessageBuilder {
 
 		return new AuditMessage(
 			eventType, companyId, groupId, realUserId, realUserName, className,
-			String.valueOf(classPK), null, null, additionalInfoJSONObject);
+			classPK, null, null, additionalInfoJSONObject);
+	}
+
+	public static AuditMessage buildAuditMessage(
+		String eventType, ClassedModel classedModel,
+		List<Attribute> attributes) {
+
+		long groupId = CompanyConstants.SYSTEM;
+
+		if (classedModel instanceof GroupedModel) {
+			GroupedModel groupedModel = (GroupedModel)classedModel;
+
+			groupId = groupedModel.getGroupId();
+		}
+
+		return buildAuditMessage(
+			groupId, eventType, classedModel.getModelClassName(),
+			String.valueOf(classedModel.getPrimaryKeyObj()), attributes);
+	}
+
+	public static AuditMessage buildAuditMessage(
+		String eventType, String className, long classPK,
+		List<Attribute> attributes) {
+
+		return buildAuditMessage(
+			CompanyConstants.SYSTEM, eventType, className, classPK, attributes);
 	}
 
 	private static JSONArray _getAttributesJSONArray(

--- a/modules/apps/portal-security-audit/portal-security-audit-event-generators-api/src/main/resources/com/liferay/portal/security/audit/event/generators/util/packageinfo
+++ b/modules/apps/portal-security-audit/portal-security-audit-event-generators-api/src/main/resources/com/liferay/portal/security/audit/event/generators/util/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0

--- a/modules/apps/portal-security-audit/portal-security-audit-impl/src/main/java/com/liferay/portal/security/audit/internal/AuditMessageFactoryImpl.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-impl/src/main/java/com/liferay/portal/security/audit/internal/AuditMessageFactoryImpl.java
@@ -36,6 +36,17 @@ public class AuditMessageFactoryImpl implements AuditMessageFactory {
 
 	@Override
 	public AuditMessage getAuditMessage(
+		String eventType, long companyId, long groupId, long userId,
+		String userName, String className, String classPK, String message,
+		Date timestamp, JSONObject additionalInfoJSONObject) {
+
+		return new AuditMessage(
+			eventType, companyId, groupId, userId, userName, className, classPK,
+			message, timestamp, additionalInfoJSONObject);
+	}
+
+	@Override
+	public AuditMessage getAuditMessage(
 		String eventType, long companyId, long userId, String userName) {
 
 		return new AuditMessage(eventType, companyId, userId, userName);

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-api/bnd.bnd
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Security Audit Storage API
 Bundle-SymbolicName: com.liferay.portal.security.audit.storage.api
-Bundle-Version: 7.2.1
+Bundle-Version: 7.3.0
 Export-Package:\
 	com.liferay.portal.security.audit.storage.comparator,\
 	com.liferay.portal.security.audit.storage.exception,\

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-api/bnd.bnd
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Security Audit Storage API
 Bundle-SymbolicName: com.liferay.portal.security.audit.storage.api
-Bundle-Version: 7.3.0
+Bundle-Version: 8.0.0
 Export-Package:\
 	com.liferay.portal.security.audit.storage.comparator,\
 	com.liferay.portal.security.audit.storage.exception,\

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/model/AuditEventModel.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/model/AuditEventModel.java
@@ -87,6 +87,20 @@ public interface AuditEventModel extends BaseModel<AuditEvent>, ShardedModel {
 	public void setCompanyId(long companyId);
 
 	/**
+	 * Returns the group ID of this audit event.
+	 *
+	 * @return the group ID of this audit event
+	 */
+	public long getGroupId();
+
+	/**
+	 * Sets the group ID of this audit event.
+	 *
+	 * @param groupId the group ID of this audit event
+	 */
+	public void setGroupId(long groupId);
+
+	/**
 	 * Returns the user ID of this audit event.
 	 *
 	 * @return the user ID of this audit event

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/model/AuditEventModel.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/model/AuditEventModel.java
@@ -71,6 +71,20 @@ public interface AuditEventModel extends BaseModel<AuditEvent>, ShardedModel {
 	public void setAuditEventId(long auditEventId);
 
 	/**
+	 * Returns the group ID of this audit event.
+	 *
+	 * @return the group ID of this audit event
+	 */
+	public long getGroupId();
+
+	/**
+	 * Sets the group ID of this audit event.
+	 *
+	 * @param groupId the group ID of this audit event
+	 */
+	public void setGroupId(long groupId);
+
+	/**
 	 * Returns the company ID of this audit event.
 	 *
 	 * @return the company ID of this audit event
@@ -85,20 +99,6 @@ public interface AuditEventModel extends BaseModel<AuditEvent>, ShardedModel {
 	 */
 	@Override
 	public void setCompanyId(long companyId);
-
-	/**
-	 * Returns the group ID of this audit event.
-	 *
-	 * @return the group ID of this audit event
-	 */
-	public long getGroupId();
-
-	/**
-	 * Sets the group ID of this audit event.
-	 *
-	 * @param groupId the group ID of this audit event
-	 */
-	public void setGroupId(long groupId);
 
 	/**
 	 * Returns the user ID of this audit event.

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/model/AuditEventTable.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/model/AuditEventTable.java
@@ -37,6 +37,8 @@ public class AuditEventTable extends BaseTable<AuditEventTable> {
 		"auditEventId", Long.class, Types.BIGINT, Column.FLAG_PRIMARY);
 	public final Column<AuditEventTable, Long> companyId = createColumn(
 		"companyId", Long.class, Types.BIGINT, Column.FLAG_DEFAULT);
+	public final Column<AuditEventTable, Long> groupId = createColumn(
+		"groupId", Long.class, Types.BIGINT, Column.FLAG_DEFAULT);
 	public final Column<AuditEventTable, Long> userId = createColumn(
 		"userId", Long.class, Types.BIGINT, Column.FLAG_DEFAULT);
 	public final Column<AuditEventTable, String> userName = createColumn(

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/model/AuditEventTable.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/model/AuditEventTable.java
@@ -35,10 +35,10 @@ public class AuditEventTable extends BaseTable<AuditEventTable> {
 
 	public final Column<AuditEventTable, Long> auditEventId = createColumn(
 		"auditEventId", Long.class, Types.BIGINT, Column.FLAG_PRIMARY);
-	public final Column<AuditEventTable, Long> companyId = createColumn(
-		"companyId", Long.class, Types.BIGINT, Column.FLAG_DEFAULT);
 	public final Column<AuditEventTable, Long> groupId = createColumn(
 		"groupId", Long.class, Types.BIGINT, Column.FLAG_DEFAULT);
+	public final Column<AuditEventTable, Long> companyId = createColumn(
+		"companyId", Long.class, Types.BIGINT, Column.FLAG_DEFAULT);
 	public final Column<AuditEventTable, Long> userId = createColumn(
 		"userId", Long.class, Types.BIGINT, Column.FLAG_DEFAULT);
 	public final Column<AuditEventTable, String> userName = createColumn(

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/model/AuditEventWrapper.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/model/AuditEventWrapper.java
@@ -44,6 +44,7 @@ public class AuditEventWrapper
 
 		attributes.put("auditEventId", getAuditEventId());
 		attributes.put("companyId", getCompanyId());
+		attributes.put("groupId", getGroupId());
 		attributes.put("userId", getUserId());
 		attributes.put("userName", getUserName());
 		attributes.put("createDate", getCreateDate());
@@ -73,6 +74,12 @@ public class AuditEventWrapper
 
 		if (companyId != null) {
 			setCompanyId(companyId);
+		}
+
+		Long groupId = (Long)attributes.get("groupId");
+
+		if (groupId != null) {
+			setGroupId(groupId);
 		}
 
 		Long userId = (Long)attributes.get("userId");
@@ -250,6 +257,16 @@ public class AuditEventWrapper
 	}
 
 	/**
+	 * Returns the group ID of this audit event.
+	 *
+	 * @return the group ID of this audit event
+	 */
+	@Override
+	public long getGroupId() {
+		return model.getGroupId();
+	}
+
+	/**
 	 * Returns the message of this audit event.
 	 *
 	 * @return the message of this audit event
@@ -422,6 +439,16 @@ public class AuditEventWrapper
 	@Override
 	public void setEventType(String eventType) {
 		model.setEventType(eventType);
+	}
+
+	/**
+	 * Sets the group ID of this audit event.
+	 *
+	 * @param groupId the group ID of this audit event
+	 */
+	@Override
+	public void setGroupId(long groupId) {
+		model.setGroupId(groupId);
 	}
 
 	/**

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/model/AuditEventWrapper.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/model/AuditEventWrapper.java
@@ -43,8 +43,8 @@ public class AuditEventWrapper
 		Map<String, Object> attributes = new HashMap<String, Object>();
 
 		attributes.put("auditEventId", getAuditEventId());
-		attributes.put("companyId", getCompanyId());
 		attributes.put("groupId", getGroupId());
+		attributes.put("companyId", getCompanyId());
 		attributes.put("userId", getUserId());
 		attributes.put("userName", getUserName());
 		attributes.put("createDate", getCreateDate());
@@ -70,16 +70,16 @@ public class AuditEventWrapper
 			setAuditEventId(auditEventId);
 		}
 
-		Long companyId = (Long)attributes.get("companyId");
-
-		if (companyId != null) {
-			setCompanyId(companyId);
-		}
-
 		Long groupId = (Long)attributes.get("groupId");
 
 		if (groupId != null) {
 			setGroupId(groupId);
+		}
+
+		Long companyId = (Long)attributes.get("companyId");
+
+		if (companyId != null) {
+			setCompanyId(companyId);
 		}
 
 		Long userId = (Long)attributes.get("userId");

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/service/AuditEventLocalService.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/service/AuditEventLocalService.java
@@ -241,11 +241,29 @@ public interface AuditEventLocalService
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<AuditEvent> getAuditEvents(
+		long companyId, long groupId, long userId, String userName,
+		Date createDateGT, Date createDateLT, String eventType,
+		String className, String classPK, String clientHost, String clientIP,
+		String serverName, int serverPort, String sessionID, boolean andSearch,
+		int start, int end);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<AuditEvent> getAuditEvents(
+		long companyId, long groupId, long userId, String userName,
+		Date createDateGT, Date createDateLT, String eventType,
+		String className, String classPK, String clientHost, String clientIP,
+		String serverName, int serverPort, String sessionID, boolean andSearch,
+		int start, int end, OrderByComparator<AuditEvent> orderByComparator);
+
+	@Deprecated
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<AuditEvent> getAuditEvents(
 		long companyId, long userId, String userName, Date createDateGT,
 		Date createDateLT, String eventType, String className, String classPK,
 		String clientHost, String clientIP, String serverName, int serverPort,
 		String sessionID, boolean andSearch, int start, int end);
 
+	@Deprecated
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<AuditEvent> getAuditEvents(
 		long companyId, long userId, String userName, Date createDateGT,
@@ -265,6 +283,14 @@ public interface AuditEventLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getAuditEventsCount(long companyId);
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public int getAuditEventsCount(
+		long companyId, long groupId, long userId, String userName,
+		Date createDateGT, Date createDateLT, String eventType,
+		String className, String classPK, String clientHost, String clientIP,
+		String serverName, int serverPort, String sessionID, boolean andSearch);
+
+	@Deprecated
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getAuditEventsCount(
 		long companyId, long userId, String userName, Date createDateGT,

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/service/AuditEventLocalService.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/service/AuditEventLocalService.java
@@ -255,23 +255,6 @@ public interface AuditEventLocalService
 		String serverName, int serverPort, String sessionID, boolean andSearch,
 		int start, int end, OrderByComparator<AuditEvent> orderByComparator);
 
-	@Deprecated
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public List<AuditEvent> getAuditEvents(
-		long companyId, long userId, String userName, Date createDateGT,
-		Date createDateLT, String eventType, String className, String classPK,
-		String clientHost, String clientIP, String serverName, int serverPort,
-		String sessionID, boolean andSearch, int start, int end);
-
-	@Deprecated
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public List<AuditEvent> getAuditEvents(
-		long companyId, long userId, String userName, Date createDateGT,
-		Date createDateLT, String eventType, String className, String classPK,
-		String clientHost, String clientIP, String serverName, int serverPort,
-		String sessionID, boolean andSearch, int start, int end,
-		OrderByComparator<AuditEvent> orderByComparator);
-
 	/**
 	 * Returns the number of audit events.
 	 *
@@ -289,14 +272,6 @@ public interface AuditEventLocalService
 		Date createDateGT, Date createDateLT, String eventType,
 		String className, String classPK, String clientHost, String clientIP,
 		String serverName, int serverPort, String sessionID, boolean andSearch);
-
-	@Deprecated
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public int getAuditEventsCount(
-		long companyId, long userId, String userName, Date createDateGT,
-		Date createDateLT, String eventType, String className, String classPK,
-		String clientHost, String clientIP, String serverName, int serverPort,
-		String sessionID, boolean andSearch);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public IndexableActionableDynamicQuery getIndexableActionableDynamicQuery();

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/service/AuditEventLocalServiceUtil.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/service/AuditEventLocalServiceUtil.java
@@ -290,35 +290,6 @@ public class AuditEventLocalServiceUtil {
 			serverPort, sessionID, andSearch, start, end, orderByComparator);
 	}
 
-	@Deprecated
-	public static List<AuditEvent> getAuditEvents(
-		long companyId, long userId, String userName,
-		java.util.Date createDateGT, java.util.Date createDateLT,
-		String eventType, String className, String classPK, String clientHost,
-		String clientIP, String serverName, int serverPort, String sessionID,
-		boolean andSearch, int start, int end) {
-
-		return getService().getAuditEvents(
-			companyId, userId, userName, createDateGT, createDateLT, eventType,
-			className, classPK, clientHost, clientIP, serverName, serverPort,
-			sessionID, andSearch, start, end);
-	}
-
-	@Deprecated
-	public static List<AuditEvent> getAuditEvents(
-		long companyId, long userId, String userName,
-		java.util.Date createDateGT, java.util.Date createDateLT,
-		String eventType, String className, String classPK, String clientHost,
-		String clientIP, String serverName, int serverPort, String sessionID,
-		boolean andSearch, int start, int end,
-		OrderByComparator<AuditEvent> orderByComparator) {
-
-		return getService().getAuditEvents(
-			companyId, userId, userName, createDateGT, createDateLT, eventType,
-			className, classPK, clientHost, clientIP, serverName, serverPort,
-			sessionID, andSearch, start, end, orderByComparator);
-	}
-
 	/**
 	 * Returns the number of audit events.
 	 *
@@ -343,20 +314,6 @@ public class AuditEventLocalServiceUtil {
 			companyId, groupId, userId, userName, createDateGT, createDateLT,
 			eventType, className, classPK, clientHost, clientIP, serverName,
 			serverPort, sessionID, andSearch);
-	}
-
-	@Deprecated
-	public static int getAuditEventsCount(
-		long companyId, long userId, String userName,
-		java.util.Date createDateGT, java.util.Date createDateLT,
-		String eventType, String className, String classPK, String clientHost,
-		String clientIP, String serverName, int serverPort, String sessionID,
-		boolean andSearch) {
-
-		return getService().getAuditEventsCount(
-			companyId, userId, userName, createDateGT, createDateLT, eventType,
-			className, classPK, clientHost, clientIP, serverName, serverPort,
-			sessionID, andSearch);
 	}
 
 	public static

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/service/AuditEventLocalServiceUtil.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/service/AuditEventLocalServiceUtil.java
@@ -264,6 +264,34 @@ public class AuditEventLocalServiceUtil {
 	}
 
 	public static List<AuditEvent> getAuditEvents(
+		long companyId, long groupId, long userId, String userName,
+		java.util.Date createDateGT, java.util.Date createDateLT,
+		String eventType, String className, String classPK, String clientHost,
+		String clientIP, String serverName, int serverPort, String sessionID,
+		boolean andSearch, int start, int end) {
+
+		return getService().getAuditEvents(
+			companyId, groupId, userId, userName, createDateGT, createDateLT,
+			eventType, className, classPK, clientHost, clientIP, serverName,
+			serverPort, sessionID, andSearch, start, end);
+	}
+
+	public static List<AuditEvent> getAuditEvents(
+		long companyId, long groupId, long userId, String userName,
+		java.util.Date createDateGT, java.util.Date createDateLT,
+		String eventType, String className, String classPK, String clientHost,
+		String clientIP, String serverName, int serverPort, String sessionID,
+		boolean andSearch, int start, int end,
+		OrderByComparator<AuditEvent> orderByComparator) {
+
+		return getService().getAuditEvents(
+			companyId, groupId, userId, userName, createDateGT, createDateLT,
+			eventType, className, classPK, clientHost, clientIP, serverName,
+			serverPort, sessionID, andSearch, start, end, orderByComparator);
+	}
+
+	@Deprecated
+	public static List<AuditEvent> getAuditEvents(
 		long companyId, long userId, String userName,
 		java.util.Date createDateGT, java.util.Date createDateLT,
 		String eventType, String className, String classPK, String clientHost,
@@ -276,6 +304,7 @@ public class AuditEventLocalServiceUtil {
 			sessionID, andSearch, start, end);
 	}
 
+	@Deprecated
 	public static List<AuditEvent> getAuditEvents(
 		long companyId, long userId, String userName,
 		java.util.Date createDateGT, java.util.Date createDateLT,
@@ -303,6 +332,20 @@ public class AuditEventLocalServiceUtil {
 		return getService().getAuditEventsCount(companyId);
 	}
 
+	public static int getAuditEventsCount(
+		long companyId, long groupId, long userId, String userName,
+		java.util.Date createDateGT, java.util.Date createDateLT,
+		String eventType, String className, String classPK, String clientHost,
+		String clientIP, String serverName, int serverPort, String sessionID,
+		boolean andSearch) {
+
+		return getService().getAuditEventsCount(
+			companyId, groupId, userId, userName, createDateGT, createDateLT,
+			eventType, className, classPK, clientHost, clientIP, serverName,
+			serverPort, sessionID, andSearch);
+	}
+
+	@Deprecated
 	public static int getAuditEventsCount(
 		long companyId, long userId, String userName,
 		java.util.Date createDateGT, java.util.Date createDateLT,

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/service/AuditEventLocalServiceWrapper.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/service/AuditEventLocalServiceWrapper.java
@@ -311,6 +311,44 @@ public class AuditEventLocalServiceWrapper
 	public java.util.List
 		<com.liferay.portal.security.audit.storage.model.AuditEvent>
 			getAuditEvents(
+				long companyId, long groupId, long userId, String userName,
+				java.util.Date createDateGT, java.util.Date createDateLT,
+				String eventType, String className, String classPK,
+				String clientHost, String clientIP, String serverName,
+				int serverPort, String sessionID, boolean andSearch, int start,
+				int end) {
+
+		return _auditEventLocalService.getAuditEvents(
+			companyId, groupId, userId, userName, createDateGT, createDateLT,
+			eventType, className, classPK, clientHost, clientIP, serverName,
+			serverPort, sessionID, andSearch, start, end);
+	}
+
+	@Override
+	public java.util.List
+		<com.liferay.portal.security.audit.storage.model.AuditEvent>
+			getAuditEvents(
+				long companyId, long groupId, long userId, String userName,
+				java.util.Date createDateGT, java.util.Date createDateLT,
+				String eventType, String className, String classPK,
+				String clientHost, String clientIP, String serverName,
+				int serverPort, String sessionID, boolean andSearch, int start,
+				int end,
+				com.liferay.portal.kernel.util.OrderByComparator
+					<com.liferay.portal.security.audit.storage.model.AuditEvent>
+						orderByComparator) {
+
+		return _auditEventLocalService.getAuditEvents(
+			companyId, groupId, userId, userName, createDateGT, createDateLT,
+			eventType, className, classPK, clientHost, clientIP, serverName,
+			serverPort, sessionID, andSearch, start, end, orderByComparator);
+	}
+
+	@Deprecated
+	@Override
+	public java.util.List
+		<com.liferay.portal.security.audit.storage.model.AuditEvent>
+			getAuditEvents(
 				long companyId, long userId, String userName,
 				java.util.Date createDateGT, java.util.Date createDateLT,
 				String eventType, String className, String classPK,
@@ -324,6 +362,7 @@ public class AuditEventLocalServiceWrapper
 			sessionID, andSearch, start, end);
 	}
 
+	@Deprecated
 	@Override
 	public java.util.List
 		<com.liferay.portal.security.audit.storage.model.AuditEvent>
@@ -359,6 +398,21 @@ public class AuditEventLocalServiceWrapper
 		return _auditEventLocalService.getAuditEventsCount(companyId);
 	}
 
+	@Override
+	public int getAuditEventsCount(
+		long companyId, long groupId, long userId, String userName,
+		java.util.Date createDateGT, java.util.Date createDateLT,
+		String eventType, String className, String classPK, String clientHost,
+		String clientIP, String serverName, int serverPort, String sessionID,
+		boolean andSearch) {
+
+		return _auditEventLocalService.getAuditEventsCount(
+			companyId, groupId, userId, userName, createDateGT, createDateLT,
+			eventType, className, classPK, clientHost, clientIP, serverName,
+			serverPort, sessionID, andSearch);
+	}
+
+	@Deprecated
 	@Override
 	public int getAuditEventsCount(
 		long companyId, long userId, String userName,

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/service/AuditEventLocalServiceWrapper.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/service/AuditEventLocalServiceWrapper.java
@@ -344,45 +344,6 @@ public class AuditEventLocalServiceWrapper
 			serverPort, sessionID, andSearch, start, end, orderByComparator);
 	}
 
-	@Deprecated
-	@Override
-	public java.util.List
-		<com.liferay.portal.security.audit.storage.model.AuditEvent>
-			getAuditEvents(
-				long companyId, long userId, String userName,
-				java.util.Date createDateGT, java.util.Date createDateLT,
-				String eventType, String className, String classPK,
-				String clientHost, String clientIP, String serverName,
-				int serverPort, String sessionID, boolean andSearch, int start,
-				int end) {
-
-		return _auditEventLocalService.getAuditEvents(
-			companyId, userId, userName, createDateGT, createDateLT, eventType,
-			className, classPK, clientHost, clientIP, serverName, serverPort,
-			sessionID, andSearch, start, end);
-	}
-
-	@Deprecated
-	@Override
-	public java.util.List
-		<com.liferay.portal.security.audit.storage.model.AuditEvent>
-			getAuditEvents(
-				long companyId, long userId, String userName,
-				java.util.Date createDateGT, java.util.Date createDateLT,
-				String eventType, String className, String classPK,
-				String clientHost, String clientIP, String serverName,
-				int serverPort, String sessionID, boolean andSearch, int start,
-				int end,
-				com.liferay.portal.kernel.util.OrderByComparator
-					<com.liferay.portal.security.audit.storage.model.AuditEvent>
-						orderByComparator) {
-
-		return _auditEventLocalService.getAuditEvents(
-			companyId, userId, userName, createDateGT, createDateLT, eventType,
-			className, classPK, clientHost, clientIP, serverName, serverPort,
-			sessionID, andSearch, start, end, orderByComparator);
-	}
-
 	/**
 	 * Returns the number of audit events.
 	 *
@@ -410,21 +371,6 @@ public class AuditEventLocalServiceWrapper
 			companyId, groupId, userId, userName, createDateGT, createDateLT,
 			eventType, className, classPK, clientHost, clientIP, serverName,
 			serverPort, sessionID, andSearch);
-	}
-
-	@Deprecated
-	@Override
-	public int getAuditEventsCount(
-		long companyId, long userId, String userName,
-		java.util.Date createDateGT, java.util.Date createDateLT,
-		String eventType, String className, String classPK, String clientHost,
-		String clientIP, String serverName, int serverPort, String sessionID,
-		boolean andSearch) {
-
-		return _auditEventLocalService.getAuditEventsCount(
-			companyId, userId, userName, createDateGT, createDateLT, eventType,
-			className, classPK, clientHost, clientIP, serverName, serverPort,
-			sessionID, andSearch);
 	}
 
 	@Override

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/service/AuditEventService.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/service/AuditEventService.java
@@ -82,27 +82,6 @@ public interface AuditEventService extends BaseService {
 			OrderByComparator<AuditEvent> orderByComparator)
 		throws PortalException;
 
-	@Deprecated
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public List<AuditEvent> getAuditEvents(
-			long companyId, long userId, String userName, Date createDateGT,
-			Date createDateLT, String eventType, String className,
-			String classPK, String clientHost, String clientIP,
-			String serverName, int serverPort, String sessionID,
-			boolean andSearch, int start, int end)
-		throws PortalException;
-
-	@Deprecated
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public List<AuditEvent> getAuditEvents(
-			long companyId, long userId, String userName, Date createDateGT,
-			Date createDateLT, String eventType, String className,
-			String classPK, String clientHost, String clientIP,
-			String serverName, int serverPort, String sessionID,
-			boolean andSearch, int start, int end,
-			OrderByComparator<AuditEvent> orderByComparator)
-		throws PortalException;
-
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getAuditEventsCount(long companyId) throws PortalException;
 
@@ -113,16 +92,6 @@ public interface AuditEventService extends BaseService {
 			String className, String classPK, String clientHost,
 			String clientIP, String serverName, int serverPort,
 			String sessionID, boolean andSearch)
-		throws PortalException;
-
-	@Deprecated
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public int getAuditEventsCount(
-			long companyId, long userId, String userName, Date createDateGT,
-			Date createDateLT, String eventType, String className,
-			String classPK, String clientHost, String clientIP,
-			String serverName, int serverPort, String sessionID,
-			boolean andSearch)
 		throws PortalException;
 
 	/**

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/service/AuditEventService.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/service/AuditEventService.java
@@ -65,6 +65,26 @@ public interface AuditEventService extends BaseService {
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<AuditEvent> getAuditEvents(
+			long companyId, long groupId, long userId, String userName,
+			Date createDateGT, Date createDateLT, String eventType,
+			String className, String classPK, String clientHost,
+			String clientIP, String serverName, int serverPort,
+			String sessionID, boolean andSearch, int start, int end)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<AuditEvent> getAuditEvents(
+			long companyId, long groupId, long userId, String userName,
+			Date createDateGT, Date createDateLT, String eventType,
+			String className, String classPK, String clientHost,
+			String clientIP, String serverName, int serverPort,
+			String sessionID, boolean andSearch, int start, int end,
+			OrderByComparator<AuditEvent> orderByComparator)
+		throws PortalException;
+
+	@Deprecated
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<AuditEvent> getAuditEvents(
 			long companyId, long userId, String userName, Date createDateGT,
 			Date createDateLT, String eventType, String className,
 			String classPK, String clientHost, String clientIP,
@@ -72,6 +92,7 @@ public interface AuditEventService extends BaseService {
 			boolean andSearch, int start, int end)
 		throws PortalException;
 
+	@Deprecated
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<AuditEvent> getAuditEvents(
 			long companyId, long userId, String userName, Date createDateGT,
@@ -85,6 +106,16 @@ public interface AuditEventService extends BaseService {
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getAuditEventsCount(long companyId) throws PortalException;
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public int getAuditEventsCount(
+			long companyId, long groupId, long userId, String userName,
+			Date createDateGT, Date createDateLT, String eventType,
+			String className, String classPK, String clientHost,
+			String clientIP, String serverName, int serverPort,
+			String sessionID, boolean andSearch)
+		throws PortalException;
+
+	@Deprecated
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getAuditEventsCount(
 			long companyId, long userId, String userName, Date createDateGT,

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/service/AuditEventServiceUtil.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/service/AuditEventServiceUtil.java
@@ -85,38 +85,6 @@ public class AuditEventServiceUtil {
 			serverPort, sessionID, andSearch, start, end, orderByComparator);
 	}
 
-	@Deprecated
-	public static List<AuditEvent> getAuditEvents(
-			long companyId, long userId, String userName,
-			java.util.Date createDateGT, java.util.Date createDateLT,
-			String eventType, String className, String classPK,
-			String clientHost, String clientIP, String serverName,
-			int serverPort, String sessionID, boolean andSearch, int start,
-			int end)
-		throws PortalException {
-
-		return getService().getAuditEvents(
-			companyId, userId, userName, createDateGT, createDateLT, eventType,
-			className, classPK, clientHost, clientIP, serverName, serverPort,
-			sessionID, andSearch, start, end);
-	}
-
-	@Deprecated
-	public static List<AuditEvent> getAuditEvents(
-			long companyId, long userId, String userName,
-			java.util.Date createDateGT, java.util.Date createDateLT,
-			String eventType, String className, String classPK,
-			String clientHost, String clientIP, String serverName,
-			int serverPort, String sessionID, boolean andSearch, int start,
-			int end, OrderByComparator<AuditEvent> orderByComparator)
-		throws PortalException {
-
-		return getService().getAuditEvents(
-			companyId, userId, userName, createDateGT, createDateLT, eventType,
-			className, classPK, clientHost, clientIP, serverName, serverPort,
-			sessionID, andSearch, start, end, orderByComparator);
-	}
-
 	public static int getAuditEventsCount(long companyId)
 		throws PortalException {
 
@@ -135,21 +103,6 @@ public class AuditEventServiceUtil {
 			companyId, groupId, userId, userName, createDateGT, createDateLT,
 			eventType, className, classPK, clientHost, clientIP, serverName,
 			serverPort, sessionID, andSearch);
-	}
-
-	@Deprecated
-	public static int getAuditEventsCount(
-			long companyId, long userId, String userName,
-			java.util.Date createDateGT, java.util.Date createDateLT,
-			String eventType, String className, String classPK,
-			String clientHost, String clientIP, String serverName,
-			int serverPort, String sessionID, boolean andSearch)
-		throws PortalException {
-
-		return getService().getAuditEventsCount(
-			companyId, userId, userName, createDateGT, createDateLT, eventType,
-			className, classPK, clientHost, clientIP, serverName, serverPort,
-			sessionID, andSearch);
 	}
 
 	/**

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/service/AuditEventServiceUtil.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/service/AuditEventServiceUtil.java
@@ -56,6 +56,37 @@ public class AuditEventServiceUtil {
 	}
 
 	public static List<AuditEvent> getAuditEvents(
+			long companyId, long groupId, long userId, String userName,
+			java.util.Date createDateGT, java.util.Date createDateLT,
+			String eventType, String className, String classPK,
+			String clientHost, String clientIP, String serverName,
+			int serverPort, String sessionID, boolean andSearch, int start,
+			int end)
+		throws PortalException {
+
+		return getService().getAuditEvents(
+			companyId, groupId, userId, userName, createDateGT, createDateLT,
+			eventType, className, classPK, clientHost, clientIP, serverName,
+			serverPort, sessionID, andSearch, start, end);
+	}
+
+	public static List<AuditEvent> getAuditEvents(
+			long companyId, long groupId, long userId, String userName,
+			java.util.Date createDateGT, java.util.Date createDateLT,
+			String eventType, String className, String classPK,
+			String clientHost, String clientIP, String serverName,
+			int serverPort, String sessionID, boolean andSearch, int start,
+			int end, OrderByComparator<AuditEvent> orderByComparator)
+		throws PortalException {
+
+		return getService().getAuditEvents(
+			companyId, groupId, userId, userName, createDateGT, createDateLT,
+			eventType, className, classPK, clientHost, clientIP, serverName,
+			serverPort, sessionID, andSearch, start, end, orderByComparator);
+	}
+
+	@Deprecated
+	public static List<AuditEvent> getAuditEvents(
 			long companyId, long userId, String userName,
 			java.util.Date createDateGT, java.util.Date createDateLT,
 			String eventType, String className, String classPK,
@@ -70,6 +101,7 @@ public class AuditEventServiceUtil {
 			sessionID, andSearch, start, end);
 	}
 
+	@Deprecated
 	public static List<AuditEvent> getAuditEvents(
 			long companyId, long userId, String userName,
 			java.util.Date createDateGT, java.util.Date createDateLT,
@@ -91,6 +123,21 @@ public class AuditEventServiceUtil {
 		return getService().getAuditEventsCount(companyId);
 	}
 
+	public static int getAuditEventsCount(
+			long companyId, long groupId, long userId, String userName,
+			java.util.Date createDateGT, java.util.Date createDateLT,
+			String eventType, String className, String classPK,
+			String clientHost, String clientIP, String serverName,
+			int serverPort, String sessionID, boolean andSearch)
+		throws PortalException {
+
+		return getService().getAuditEventsCount(
+			companyId, groupId, userId, userName, createDateGT, createDateLT,
+			eventType, className, classPK, clientHost, clientIP, serverName,
+			serverPort, sessionID, andSearch);
+	}
+
+	@Deprecated
 	public static int getAuditEventsCount(
 			long companyId, long userId, String userName,
 			java.util.Date createDateGT, java.util.Date createDateLT,

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/service/AuditEventServiceWrapper.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/service/AuditEventServiceWrapper.java
@@ -96,47 +96,6 @@ public class AuditEventServiceWrapper
 			serverPort, sessionID, andSearch, start, end, orderByComparator);
 	}
 
-	@Deprecated
-	@Override
-	public java.util.List
-		<com.liferay.portal.security.audit.storage.model.AuditEvent>
-				getAuditEvents(
-					long companyId, long userId, String userName,
-					java.util.Date createDateGT, java.util.Date createDateLT,
-					String eventType, String className, String classPK,
-					String clientHost, String clientIP, String serverName,
-					int serverPort, String sessionID, boolean andSearch,
-					int start, int end)
-			throws com.liferay.portal.kernel.exception.PortalException {
-
-		return _auditEventService.getAuditEvents(
-			companyId, userId, userName, createDateGT, createDateLT, eventType,
-			className, classPK, clientHost, clientIP, serverName, serverPort,
-			sessionID, andSearch, start, end);
-	}
-
-	@Deprecated
-	@Override
-	public java.util.List
-		<com.liferay.portal.security.audit.storage.model.AuditEvent>
-				getAuditEvents(
-					long companyId, long userId, String userName,
-					java.util.Date createDateGT, java.util.Date createDateLT,
-					String eventType, String className, String classPK,
-					String clientHost, String clientIP, String serverName,
-					int serverPort, String sessionID, boolean andSearch,
-					int start, int end,
-					com.liferay.portal.kernel.util.OrderByComparator
-						<com.liferay.portal.security.audit.storage.model.
-							AuditEvent> orderByComparator)
-			throws com.liferay.portal.kernel.exception.PortalException {
-
-		return _auditEventService.getAuditEvents(
-			companyId, userId, userName, createDateGT, createDateLT, eventType,
-			className, classPK, clientHost, clientIP, serverName, serverPort,
-			sessionID, andSearch, start, end, orderByComparator);
-	}
-
 	@Override
 	public int getAuditEventsCount(long companyId)
 		throws com.liferay.portal.kernel.exception.PortalException {
@@ -157,22 +116,6 @@ public class AuditEventServiceWrapper
 			companyId, groupId, userId, userName, createDateGT, createDateLT,
 			eventType, className, classPK, clientHost, clientIP, serverName,
 			serverPort, sessionID, andSearch);
-	}
-
-	@Deprecated
-	@Override
-	public int getAuditEventsCount(
-			long companyId, long userId, String userName,
-			java.util.Date createDateGT, java.util.Date createDateLT,
-			String eventType, String className, String classPK,
-			String clientHost, String clientIP, String serverName,
-			int serverPort, String sessionID, boolean andSearch)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		return _auditEventService.getAuditEventsCount(
-			companyId, userId, userName, createDateGT, createDateLT, eventType,
-			className, classPK, clientHost, clientIP, serverName, serverPort,
-			sessionID, andSearch);
 	}
 
 	/**

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/service/AuditEventServiceWrapper.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/service/AuditEventServiceWrapper.java
@@ -61,6 +61,46 @@ public class AuditEventServiceWrapper
 	public java.util.List
 		<com.liferay.portal.security.audit.storage.model.AuditEvent>
 				getAuditEvents(
+					long companyId, long groupId, long userId, String userName,
+					java.util.Date createDateGT, java.util.Date createDateLT,
+					String eventType, String className, String classPK,
+					String clientHost, String clientIP, String serverName,
+					int serverPort, String sessionID, boolean andSearch,
+					int start, int end)
+			throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _auditEventService.getAuditEvents(
+			companyId, groupId, userId, userName, createDateGT, createDateLT,
+			eventType, className, classPK, clientHost, clientIP, serverName,
+			serverPort, sessionID, andSearch, start, end);
+	}
+
+	@Override
+	public java.util.List
+		<com.liferay.portal.security.audit.storage.model.AuditEvent>
+				getAuditEvents(
+					long companyId, long groupId, long userId, String userName,
+					java.util.Date createDateGT, java.util.Date createDateLT,
+					String eventType, String className, String classPK,
+					String clientHost, String clientIP, String serverName,
+					int serverPort, String sessionID, boolean andSearch,
+					int start, int end,
+					com.liferay.portal.kernel.util.OrderByComparator
+						<com.liferay.portal.security.audit.storage.model.
+							AuditEvent> orderByComparator)
+			throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _auditEventService.getAuditEvents(
+			companyId, groupId, userId, userName, createDateGT, createDateLT,
+			eventType, className, classPK, clientHost, clientIP, serverName,
+			serverPort, sessionID, andSearch, start, end, orderByComparator);
+	}
+
+	@Deprecated
+	@Override
+	public java.util.List
+		<com.liferay.portal.security.audit.storage.model.AuditEvent>
+				getAuditEvents(
 					long companyId, long userId, String userName,
 					java.util.Date createDateGT, java.util.Date createDateLT,
 					String eventType, String className, String classPK,
@@ -75,6 +115,7 @@ public class AuditEventServiceWrapper
 			sessionID, andSearch, start, end);
 	}
 
+	@Deprecated
 	@Override
 	public java.util.List
 		<com.liferay.portal.security.audit.storage.model.AuditEvent>
@@ -103,6 +144,22 @@ public class AuditEventServiceWrapper
 		return _auditEventService.getAuditEventsCount(companyId);
 	}
 
+	@Override
+	public int getAuditEventsCount(
+			long companyId, long groupId, long userId, String userName,
+			java.util.Date createDateGT, java.util.Date createDateLT,
+			String eventType, String className, String classPK,
+			String clientHost, String clientIP, String serverName,
+			int serverPort, String sessionID, boolean andSearch)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _auditEventService.getAuditEventsCount(
+			companyId, groupId, userId, userName, createDateGT, createDateLT,
+			eventType, className, classPK, clientHost, clientIP, serverName,
+			serverPort, sessionID, andSearch);
+	}
+
+	@Deprecated
 	@Override
 	public int getAuditEventsCount(
 			long companyId, long userId, String userName,

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/resources/com/liferay/portal/security/audit/storage/model/packageinfo
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/resources/com/liferay/portal/security/audit/storage/model/packageinfo
@@ -1,1 +1,1 @@
-version 3.1.0
+version 3.2.0

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/resources/com/liferay/portal/security/audit/storage/service/packageinfo
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/resources/com/liferay/portal/security/audit/storage/service/packageinfo
@@ -1,1 +1,1 @@
-version 1.6.0
+version 2.0.0

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-service/bnd.bnd
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-service/bnd.bnd
@@ -5,6 +5,6 @@ Import-Package:\
 	com.liferay.portal.security.audit.storage.comparator,\
 	\
 	*
-Liferay-Require-SchemaVersion: 2.0.1
+Liferay-Require-SchemaVersion: 2.1.0
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-service/service.xml
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-service/service.xml
@@ -9,10 +9,13 @@
 
 		<column name="auditEventId" primary="true" type="long" />
 
+		<!-- Group instance -->
+
+		<column name="groupId" type="long" />
+
 		<!-- Audit fields -->
 
 		<column name="companyId" type="long" />
-		<column name="groupId" type="long" />
 		<column name="userId" type="long" />
 		<column name="userName" type="String" />
 		<column name="createDate" type="Date" />

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-service/service.xml
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-service/service.xml
@@ -12,6 +12,7 @@
 		<!-- Audit fields -->
 
 		<column name="companyId" type="long" />
+		<column name="groupId" type="long" />
 		<column name="userId" type="long" />
 		<column name="userName" type="String" />
 		<column name="createDate" type="Date" />

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/internal/AuditEventManagerImpl.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/internal/AuditEventManagerImpl.java
@@ -60,20 +60,21 @@ public class AuditEventManagerImpl implements AuditEventManager {
 
 	@Override
 	public List<AuditEvent> getAuditEvents(
-		long companyId, long userId, String userName, Date createDateGT,
-		Date createDateLT, String eventType, String className, String classPK,
-		String clientHost, String clientIP, String serverName, int serverPort,
-		String sessionID, boolean andSearch, int start, int end,
+		long companyId, long groupId, long userId, String userName,
+		Date createDateGT, Date createDateLT, String eventType,
+		String className, String classPK, String clientHost, String clientIP,
+		String serverName, int serverPort, String sessionID, boolean andSearch,
+		int start, int end,
 		OrderByComparator
 			<com.liferay.portal.security.audit.storage.model.AuditEvent>
 				orderByComparator) {
 
 		return _translate(
 			_auditEventLocalService.getAuditEvents(
-				companyId, userId, userName, createDateGT, createDateLT,
-				eventType, className, classPK, clientHost, clientIP, serverName,
-				serverPort, sessionID, andSearch, start, end,
-				orderByComparator));
+				companyId, groupId, userId, userName, createDateGT,
+				createDateLT, eventType, className, classPK, clientHost,
+				clientIP, serverName, serverPort, sessionID, andSearch, start,
+				end, orderByComparator));
 	}
 
 	@Override
@@ -83,15 +84,16 @@ public class AuditEventManagerImpl implements AuditEventManager {
 
 	@Override
 	public int getAuditEventsCount(
-		long companyId, long userId, String userName, Date createDateGT,
-		Date createDateLT, String eventType, String className, String classPK,
-		String clientHost, String clientIP, String serverName, int serverPort,
-		String sessionID, boolean andSearch) {
+		long companyId, long groupId, long userId, String userName,
+		Date createDateGT, Date createDateLT, String eventType,
+		String className, String classPK, String clientHost, String clientIP,
+		String serverName, int serverPort, String sessionID,
+		boolean andSearch) {
 
 		return _auditEventLocalService.getAuditEventsCount(
-			companyId, userId, userName, createDateGT, createDateLT, eventType,
-			className, classPK, clientHost, clientIP, serverName, serverPort,
-			sessionID, andSearch);
+			companyId, groupId, userId, userName, createDateGT, createDateLT,
+			eventType, className, classPK, clientHost, clientIP, serverName,
+			serverPort, sessionID, andSearch);
 	}
 
 	private AuditEvent _createAuditEvent(

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/internal/upgrade/registry/AuditStorageServiceUpgradeStepRegistrator.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/internal/upgrade/registry/AuditStorageServiceUpgradeStepRegistrator.java
@@ -52,6 +52,11 @@ public class AuditStorageServiceUpgradeStepRegistrator
 				new Class<?>[] {AuditEventTable.class}));
 
 		registry.register("2.0.0", "2.0.1", new DummyUpgradeStep());
+
+		registry.register(
+			"2.0.1", "2.1.0",
+			UpgradeProcessFactory.addColumns(
+				"Audit_AuditEvent", "groupId LONG"));
 	}
 
 	@Reference

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/model/impl/AuditEventCacheModel.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/model/impl/AuditEventCacheModel.java
@@ -62,12 +62,14 @@ public class AuditEventCacheModel
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(31);
+		StringBundler sb = new StringBundler(33);
 
 		sb.append("{auditEventId=");
 		sb.append(auditEventId);
 		sb.append(", companyId=");
 		sb.append(companyId);
+		sb.append(", groupId=");
+		sb.append(groupId);
 		sb.append(", userId=");
 		sb.append(userId);
 		sb.append(", userName=");
@@ -105,6 +107,7 @@ public class AuditEventCacheModel
 
 		auditEventImpl.setAuditEventId(auditEventId);
 		auditEventImpl.setCompanyId(companyId);
+		auditEventImpl.setGroupId(groupId);
 		auditEventImpl.setUserId(userId);
 
 		if (userName == null) {
@@ -199,6 +202,8 @@ public class AuditEventCacheModel
 
 		companyId = objectInput.readLong();
 
+		groupId = objectInput.readLong();
+
 		userId = objectInput.readLong();
 		userName = objectInput.readUTF();
 		createDate = objectInput.readLong();
@@ -220,6 +225,8 @@ public class AuditEventCacheModel
 		objectOutput.writeLong(auditEventId);
 
 		objectOutput.writeLong(companyId);
+
+		objectOutput.writeLong(groupId);
 
 		objectOutput.writeLong(userId);
 
@@ -300,6 +307,7 @@ public class AuditEventCacheModel
 
 	public long auditEventId;
 	public long companyId;
+	public long groupId;
 	public long userId;
 	public String userName;
 	public long createDate;

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/model/impl/AuditEventCacheModel.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/model/impl/AuditEventCacheModel.java
@@ -66,10 +66,10 @@ public class AuditEventCacheModel
 
 		sb.append("{auditEventId=");
 		sb.append(auditEventId);
-		sb.append(", companyId=");
-		sb.append(companyId);
 		sb.append(", groupId=");
 		sb.append(groupId);
+		sb.append(", companyId=");
+		sb.append(companyId);
 		sb.append(", userId=");
 		sb.append(userId);
 		sb.append(", userName=");
@@ -106,8 +106,8 @@ public class AuditEventCacheModel
 		AuditEventImpl auditEventImpl = new AuditEventImpl();
 
 		auditEventImpl.setAuditEventId(auditEventId);
-		auditEventImpl.setCompanyId(companyId);
 		auditEventImpl.setGroupId(groupId);
+		auditEventImpl.setCompanyId(companyId);
 		auditEventImpl.setUserId(userId);
 
 		if (userName == null) {
@@ -200,9 +200,9 @@ public class AuditEventCacheModel
 
 		auditEventId = objectInput.readLong();
 
-		companyId = objectInput.readLong();
-
 		groupId = objectInput.readLong();
+
+		companyId = objectInput.readLong();
 
 		userId = objectInput.readLong();
 		userName = objectInput.readUTF();
@@ -224,9 +224,9 @@ public class AuditEventCacheModel
 	public void writeExternal(ObjectOutput objectOutput) throws IOException {
 		objectOutput.writeLong(auditEventId);
 
-		objectOutput.writeLong(companyId);
-
 		objectOutput.writeLong(groupId);
+
+		objectOutput.writeLong(companyId);
 
 		objectOutput.writeLong(userId);
 
@@ -306,8 +306,8 @@ public class AuditEventCacheModel
 	}
 
 	public long auditEventId;
-	public long companyId;
 	public long groupId;
+	public long companyId;
 	public long userId;
 	public String userName;
 	public long createDate;

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/model/impl/AuditEventModelImpl.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/model/impl/AuditEventModelImpl.java
@@ -72,8 +72,8 @@ public class AuditEventModelImpl
 	public static final String TABLE_NAME = "Audit_AuditEvent";
 
 	public static final Object[][] TABLE_COLUMNS = {
-		{"auditEventId", Types.BIGINT}, {"companyId", Types.BIGINT},
-		{"groupId", Types.BIGINT}, {"userId", Types.BIGINT},
+		{"auditEventId", Types.BIGINT}, {"groupId", Types.BIGINT},
+		{"companyId", Types.BIGINT}, {"userId", Types.BIGINT},
 		{"userName", Types.VARCHAR}, {"createDate", Types.TIMESTAMP},
 		{"eventType", Types.VARCHAR}, {"className", Types.VARCHAR},
 		{"classPK", Types.VARCHAR}, {"message", Types.VARCHAR},
@@ -87,8 +87,8 @@ public class AuditEventModelImpl
 
 	static {
 		TABLE_COLUMNS_MAP.put("auditEventId", Types.BIGINT);
-		TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
+		TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
@@ -105,7 +105,7 @@ public class AuditEventModelImpl
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table Audit_AuditEvent (auditEventId LONG not null primary key,companyId LONG,groupId LONG,userId LONG,userName VARCHAR(200) null,createDate DATE null,eventType VARCHAR(75) null,className VARCHAR(200) null,classPK VARCHAR(75) null,message STRING null,clientHost VARCHAR(255) null,clientIP VARCHAR(255) null,serverName VARCHAR(255) null,serverPort INTEGER,sessionID VARCHAR(255) null,additionalInfo TEXT null)";
+		"create table Audit_AuditEvent (auditEventId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(200) null,createDate DATE null,eventType VARCHAR(75) null,className VARCHAR(200) null,classPK VARCHAR(75) null,message STRING null,clientHost VARCHAR(255) null,clientIP VARCHAR(255) null,serverName VARCHAR(255) null,serverPort INTEGER,sessionID VARCHAR(255) null,additionalInfo TEXT null)";
 
 	public static final String TABLE_SQL_DROP = "drop table Audit_AuditEvent";
 
@@ -243,8 +243,8 @@ public class AuditEventModelImpl
 
 			attributeGetterFunctions.put(
 				"auditEventId", AuditEvent::getAuditEventId);
-			attributeGetterFunctions.put("companyId", AuditEvent::getCompanyId);
 			attributeGetterFunctions.put("groupId", AuditEvent::getGroupId);
+			attributeGetterFunctions.put("companyId", AuditEvent::getCompanyId);
 			attributeGetterFunctions.put("userId", AuditEvent::getUserId);
 			attributeGetterFunctions.put("userName", AuditEvent::getUserName);
 			attributeGetterFunctions.put(
@@ -283,11 +283,11 @@ public class AuditEventModelImpl
 				"auditEventId",
 				(BiConsumer<AuditEvent, Long>)AuditEvent::setAuditEventId);
 			attributeSetterBiConsumers.put(
-				"companyId",
-				(BiConsumer<AuditEvent, Long>)AuditEvent::setCompanyId);
-			attributeSetterBiConsumers.put(
 				"groupId",
 				(BiConsumer<AuditEvent, Long>)AuditEvent::setGroupId);
+			attributeSetterBiConsumers.put(
+				"companyId",
+				(BiConsumer<AuditEvent, Long>)AuditEvent::setCompanyId);
 			attributeSetterBiConsumers.put(
 				"userId", (BiConsumer<AuditEvent, Long>)AuditEvent::setUserId);
 			attributeSetterBiConsumers.put(
@@ -350,6 +350,21 @@ public class AuditEventModelImpl
 
 	@JSON
 	@Override
+	public long getGroupId() {
+		return _groupId;
+	}
+
+	@Override
+	public void setGroupId(long groupId) {
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
+		}
+
+		_groupId = groupId;
+	}
+
+	@JSON
+	@Override
 	public long getCompanyId() {
 		return _companyId;
 	}
@@ -371,21 +386,6 @@ public class AuditEventModelImpl
 	public long getOriginalCompanyId() {
 		return GetterUtil.getLong(
 			this.<Long>getColumnOriginalValue("companyId"));
-	}
-
-	@JSON
-	@Override
-	public long getGroupId() {
-		return _groupId;
-	}
-
-	@Override
-	public void setGroupId(long groupId) {
-		if (_columnOriginalValues == Collections.EMPTY_MAP) {
-			_setColumnOriginalValues();
-		}
-
-		_groupId = groupId;
 	}
 
 	@JSON
@@ -706,8 +706,8 @@ public class AuditEventModelImpl
 		AuditEventImpl auditEventImpl = new AuditEventImpl();
 
 		auditEventImpl.setAuditEventId(getAuditEventId());
-		auditEventImpl.setCompanyId(getCompanyId());
 		auditEventImpl.setGroupId(getGroupId());
+		auditEventImpl.setCompanyId(getCompanyId());
 		auditEventImpl.setUserId(getUserId());
 		auditEventImpl.setUserName(getUserName());
 		auditEventImpl.setCreateDate(getCreateDate());
@@ -733,9 +733,9 @@ public class AuditEventModelImpl
 
 		auditEventImpl.setAuditEventId(
 			this.<Long>getColumnOriginalValue("auditEventId"));
+		auditEventImpl.setGroupId(this.<Long>getColumnOriginalValue("groupId"));
 		auditEventImpl.setCompanyId(
 			this.<Long>getColumnOriginalValue("companyId"));
-		auditEventImpl.setGroupId(this.<Long>getColumnOriginalValue("groupId"));
 		auditEventImpl.setUserId(this.<Long>getColumnOriginalValue("userId"));
 		auditEventImpl.setUserName(
 			this.<String>getColumnOriginalValue("userName"));
@@ -838,9 +838,9 @@ public class AuditEventModelImpl
 
 		auditEventCacheModel.auditEventId = getAuditEventId();
 
-		auditEventCacheModel.companyId = getCompanyId();
-
 		auditEventCacheModel.groupId = getGroupId();
+
+		auditEventCacheModel.companyId = getCompanyId();
 
 		auditEventCacheModel.userId = getUserId();
 
@@ -997,8 +997,8 @@ public class AuditEventModelImpl
 	}
 
 	private long _auditEventId;
-	private long _companyId;
 	private long _groupId;
+	private long _companyId;
 	private long _userId;
 	private String _userName;
 	private Date _createDate;
@@ -1042,8 +1042,8 @@ public class AuditEventModelImpl
 		_columnOriginalValues = new HashMap<String, Object>();
 
 		_columnOriginalValues.put("auditEventId", _auditEventId);
-		_columnOriginalValues.put("companyId", _companyId);
 		_columnOriginalValues.put("groupId", _groupId);
+		_columnOriginalValues.put("companyId", _companyId);
 		_columnOriginalValues.put("userId", _userId);
 		_columnOriginalValues.put("userName", _userName);
 		_columnOriginalValues.put("createDate", _createDate);
@@ -1072,9 +1072,9 @@ public class AuditEventModelImpl
 
 		columnBitmasks.put("auditEventId", 1L);
 
-		columnBitmasks.put("companyId", 2L);
+		columnBitmasks.put("groupId", 2L);
 
-		columnBitmasks.put("groupId", 4L);
+		columnBitmasks.put("companyId", 4L);
 
 		columnBitmasks.put("userId", 8L);
 

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/model/impl/AuditEventModelImpl.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/model/impl/AuditEventModelImpl.java
@@ -73,13 +73,13 @@ public class AuditEventModelImpl
 
 	public static final Object[][] TABLE_COLUMNS = {
 		{"auditEventId", Types.BIGINT}, {"companyId", Types.BIGINT},
-		{"userId", Types.BIGINT}, {"userName", Types.VARCHAR},
-		{"createDate", Types.TIMESTAMP}, {"eventType", Types.VARCHAR},
-		{"className", Types.VARCHAR}, {"classPK", Types.VARCHAR},
-		{"message", Types.VARCHAR}, {"clientHost", Types.VARCHAR},
-		{"clientIP", Types.VARCHAR}, {"serverName", Types.VARCHAR},
-		{"serverPort", Types.INTEGER}, {"sessionID", Types.VARCHAR},
-		{"additionalInfo", Types.CLOB}
+		{"groupId", Types.BIGINT}, {"userId", Types.BIGINT},
+		{"userName", Types.VARCHAR}, {"createDate", Types.TIMESTAMP},
+		{"eventType", Types.VARCHAR}, {"className", Types.VARCHAR},
+		{"classPK", Types.VARCHAR}, {"message", Types.VARCHAR},
+		{"clientHost", Types.VARCHAR}, {"clientIP", Types.VARCHAR},
+		{"serverName", Types.VARCHAR}, {"serverPort", Types.INTEGER},
+		{"sessionID", Types.VARCHAR}, {"additionalInfo", Types.CLOB}
 	};
 
 	public static final Map<String, Integer> TABLE_COLUMNS_MAP =
@@ -88,6 +88,7 @@ public class AuditEventModelImpl
 	static {
 		TABLE_COLUMNS_MAP.put("auditEventId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+		TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
@@ -104,7 +105,7 @@ public class AuditEventModelImpl
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table Audit_AuditEvent (auditEventId LONG not null primary key,companyId LONG,userId LONG,userName VARCHAR(200) null,createDate DATE null,eventType VARCHAR(75) null,className VARCHAR(200) null,classPK VARCHAR(75) null,message STRING null,clientHost VARCHAR(255) null,clientIP VARCHAR(255) null,serverName VARCHAR(255) null,serverPort INTEGER,sessionID VARCHAR(255) null,additionalInfo TEXT null)";
+		"create table Audit_AuditEvent (auditEventId LONG not null primary key,companyId LONG,groupId LONG,userId LONG,userName VARCHAR(200) null,createDate DATE null,eventType VARCHAR(75) null,className VARCHAR(200) null,classPK VARCHAR(75) null,message STRING null,clientHost VARCHAR(255) null,clientIP VARCHAR(255) null,serverName VARCHAR(255) null,serverPort INTEGER,sessionID VARCHAR(255) null,additionalInfo TEXT null)";
 
 	public static final String TABLE_SQL_DROP = "drop table Audit_AuditEvent";
 
@@ -243,6 +244,7 @@ public class AuditEventModelImpl
 			attributeGetterFunctions.put(
 				"auditEventId", AuditEvent::getAuditEventId);
 			attributeGetterFunctions.put("companyId", AuditEvent::getCompanyId);
+			attributeGetterFunctions.put("groupId", AuditEvent::getGroupId);
 			attributeGetterFunctions.put("userId", AuditEvent::getUserId);
 			attributeGetterFunctions.put("userName", AuditEvent::getUserName);
 			attributeGetterFunctions.put(
@@ -283,6 +285,9 @@ public class AuditEventModelImpl
 			attributeSetterBiConsumers.put(
 				"companyId",
 				(BiConsumer<AuditEvent, Long>)AuditEvent::setCompanyId);
+			attributeSetterBiConsumers.put(
+				"groupId",
+				(BiConsumer<AuditEvent, Long>)AuditEvent::setGroupId);
 			attributeSetterBiConsumers.put(
 				"userId", (BiConsumer<AuditEvent, Long>)AuditEvent::setUserId);
 			attributeSetterBiConsumers.put(
@@ -366,6 +371,21 @@ public class AuditEventModelImpl
 	public long getOriginalCompanyId() {
 		return GetterUtil.getLong(
 			this.<Long>getColumnOriginalValue("companyId"));
+	}
+
+	@JSON
+	@Override
+	public long getGroupId() {
+		return _groupId;
+	}
+
+	@Override
+	public void setGroupId(long groupId) {
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
+		}
+
+		_groupId = groupId;
 	}
 
 	@JSON
@@ -687,6 +707,7 @@ public class AuditEventModelImpl
 
 		auditEventImpl.setAuditEventId(getAuditEventId());
 		auditEventImpl.setCompanyId(getCompanyId());
+		auditEventImpl.setGroupId(getGroupId());
 		auditEventImpl.setUserId(getUserId());
 		auditEventImpl.setUserName(getUserName());
 		auditEventImpl.setCreateDate(getCreateDate());
@@ -714,6 +735,7 @@ public class AuditEventModelImpl
 			this.<Long>getColumnOriginalValue("auditEventId"));
 		auditEventImpl.setCompanyId(
 			this.<Long>getColumnOriginalValue("companyId"));
+		auditEventImpl.setGroupId(this.<Long>getColumnOriginalValue("groupId"));
 		auditEventImpl.setUserId(this.<Long>getColumnOriginalValue("userId"));
 		auditEventImpl.setUserName(
 			this.<String>getColumnOriginalValue("userName"));
@@ -817,6 +839,8 @@ public class AuditEventModelImpl
 		auditEventCacheModel.auditEventId = getAuditEventId();
 
 		auditEventCacheModel.companyId = getCompanyId();
+
+		auditEventCacheModel.groupId = getGroupId();
 
 		auditEventCacheModel.userId = getUserId();
 
@@ -974,6 +998,7 @@ public class AuditEventModelImpl
 
 	private long _auditEventId;
 	private long _companyId;
+	private long _groupId;
 	private long _userId;
 	private String _userName;
 	private Date _createDate;
@@ -1018,6 +1043,7 @@ public class AuditEventModelImpl
 
 		_columnOriginalValues.put("auditEventId", _auditEventId);
 		_columnOriginalValues.put("companyId", _companyId);
+		_columnOriginalValues.put("groupId", _groupId);
 		_columnOriginalValues.put("userId", _userId);
 		_columnOriginalValues.put("userName", _userName);
 		_columnOriginalValues.put("createDate", _createDate);
@@ -1048,31 +1074,33 @@ public class AuditEventModelImpl
 
 		columnBitmasks.put("companyId", 2L);
 
-		columnBitmasks.put("userId", 4L);
+		columnBitmasks.put("groupId", 4L);
 
-		columnBitmasks.put("userName", 8L);
+		columnBitmasks.put("userId", 8L);
 
-		columnBitmasks.put("createDate", 16L);
+		columnBitmasks.put("userName", 16L);
 
-		columnBitmasks.put("eventType", 32L);
+		columnBitmasks.put("createDate", 32L);
 
-		columnBitmasks.put("className", 64L);
+		columnBitmasks.put("eventType", 64L);
 
-		columnBitmasks.put("classPK", 128L);
+		columnBitmasks.put("className", 128L);
 
-		columnBitmasks.put("message", 256L);
+		columnBitmasks.put("classPK", 256L);
 
-		columnBitmasks.put("clientHost", 512L);
+		columnBitmasks.put("message", 512L);
 
-		columnBitmasks.put("clientIP", 1024L);
+		columnBitmasks.put("clientHost", 1024L);
 
-		columnBitmasks.put("serverName", 2048L);
+		columnBitmasks.put("clientIP", 2048L);
 
-		columnBitmasks.put("serverPort", 4096L);
+		columnBitmasks.put("serverName", 4096L);
 
-		columnBitmasks.put("sessionID", 8192L);
+		columnBitmasks.put("serverPort", 8192L);
 
-		columnBitmasks.put("additionalInfo", 16384L);
+		columnBitmasks.put("sessionID", 16384L);
+
+		columnBitmasks.put("additionalInfo", 32768L);
 
 		_columnBitmasks = Collections.unmodifiableMap(columnBitmasks);
 	}

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/service/http/AuditEventServiceHttp.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/service/http/AuditEventServiceHttp.java
@@ -146,58 +146,6 @@ public class AuditEventServiceHttp {
 	public static java.util.List
 		<com.liferay.portal.security.audit.storage.model.AuditEvent>
 				getAuditEvents(
-					HttpPrincipal httpPrincipal, long companyId, long userId,
-					String userName, java.util.Date createDateGT,
-					java.util.Date createDateLT, String eventType,
-					String className, String classPK, String clientHost,
-					String clientIP, String serverName, int serverPort,
-					String sessionID, boolean andSearch, int start, int end)
-			throws com.liferay.portal.kernel.exception.PortalException {
-
-		try {
-			MethodKey methodKey = new MethodKey(
-				AuditEventServiceUtil.class, "getAuditEvents",
-				_getAuditEventsParameterTypes2);
-
-			MethodHandler methodHandler = new MethodHandler(
-				methodKey, companyId, userId, userName, createDateGT,
-				createDateLT, eventType, className, classPK, clientHost,
-				clientIP, serverName, serverPort, sessionID, andSearch, start,
-				end);
-
-			Object returnObj = null;
-
-			try {
-				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
-			}
-			catch (Exception exception) {
-				if (exception instanceof
-						com.liferay.portal.kernel.exception.PortalException) {
-
-					throw (com.liferay.portal.kernel.exception.PortalException)
-						exception;
-				}
-
-				throw new com.liferay.portal.kernel.exception.SystemException(
-					exception);
-			}
-
-			return (java.util.List
-				<com.liferay.portal.security.audit.storage.model.AuditEvent>)
-					returnObj;
-		}
-		catch (com.liferay.portal.kernel.exception.SystemException
-					systemException) {
-
-			_log.error(systemException, systemException);
-
-			throw systemException;
-		}
-	}
-
-	public static java.util.List
-		<com.liferay.portal.security.audit.storage.model.AuditEvent>
-				getAuditEvents(
 					HttpPrincipal httpPrincipal, long companyId, long groupId,
 					long userId, String userName, java.util.Date createDateGT,
 					java.util.Date createDateLT, String eventType,
@@ -209,7 +157,7 @@ public class AuditEventServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				AuditEventServiceUtil.class, "getAuditEvents",
-				_getAuditEventsParameterTypes3);
+				_getAuditEventsParameterTypes2);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, groupId, userId, userName, createDateGT,
@@ -250,61 +198,6 @@ public class AuditEventServiceHttp {
 	public static java.util.List
 		<com.liferay.portal.security.audit.storage.model.AuditEvent>
 				getAuditEvents(
-					HttpPrincipal httpPrincipal, long companyId, long userId,
-					String userName, java.util.Date createDateGT,
-					java.util.Date createDateLT, String eventType,
-					String className, String classPK, String clientHost,
-					String clientIP, String serverName, int serverPort,
-					String sessionID, boolean andSearch, int start, int end,
-					com.liferay.portal.kernel.util.OrderByComparator
-						<com.liferay.portal.security.audit.storage.model.
-							AuditEvent> orderByComparator)
-			throws com.liferay.portal.kernel.exception.PortalException {
-
-		try {
-			MethodKey methodKey = new MethodKey(
-				AuditEventServiceUtil.class, "getAuditEvents",
-				_getAuditEventsParameterTypes4);
-
-			MethodHandler methodHandler = new MethodHandler(
-				methodKey, companyId, userId, userName, createDateGT,
-				createDateLT, eventType, className, classPK, clientHost,
-				clientIP, serverName, serverPort, sessionID, andSearch, start,
-				end, orderByComparator);
-
-			Object returnObj = null;
-
-			try {
-				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
-			}
-			catch (Exception exception) {
-				if (exception instanceof
-						com.liferay.portal.kernel.exception.PortalException) {
-
-					throw (com.liferay.portal.kernel.exception.PortalException)
-						exception;
-				}
-
-				throw new com.liferay.portal.kernel.exception.SystemException(
-					exception);
-			}
-
-			return (java.util.List
-				<com.liferay.portal.security.audit.storage.model.AuditEvent>)
-					returnObj;
-		}
-		catch (com.liferay.portal.kernel.exception.SystemException
-					systemException) {
-
-			_log.error(systemException, systemException);
-
-			throw systemException;
-		}
-	}
-
-	public static java.util.List
-		<com.liferay.portal.security.audit.storage.model.AuditEvent>
-				getAuditEvents(
 					HttpPrincipal httpPrincipal, long companyId, long groupId,
 					long userId, String userName, java.util.Date createDateGT,
 					java.util.Date createDateLT, String eventType,
@@ -319,7 +212,7 @@ public class AuditEventServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				AuditEventServiceUtil.class, "getAuditEvents",
-				_getAuditEventsParameterTypes5);
+				_getAuditEventsParameterTypes3);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, groupId, userId, userName, createDateGT,
@@ -364,57 +257,10 @@ public class AuditEventServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				AuditEventServiceUtil.class, "getAuditEventsCount",
-				_getAuditEventsCountParameterTypes6);
+				_getAuditEventsCountParameterTypes4);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId);
-
-			Object returnObj = null;
-
-			try {
-				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
-			}
-			catch (Exception exception) {
-				if (exception instanceof
-						com.liferay.portal.kernel.exception.PortalException) {
-
-					throw (com.liferay.portal.kernel.exception.PortalException)
-						exception;
-				}
-
-				throw new com.liferay.portal.kernel.exception.SystemException(
-					exception);
-			}
-
-			return ((Integer)returnObj).intValue();
-		}
-		catch (com.liferay.portal.kernel.exception.SystemException
-					systemException) {
-
-			_log.error(systemException, systemException);
-
-			throw systemException;
-		}
-	}
-
-	public static int getAuditEventsCount(
-			HttpPrincipal httpPrincipal, long companyId, long userId,
-			String userName, java.util.Date createDateGT,
-			java.util.Date createDateLT, String eventType, String className,
-			String classPK, String clientHost, String clientIP,
-			String serverName, int serverPort, String sessionID,
-			boolean andSearch)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		try {
-			MethodKey methodKey = new MethodKey(
-				AuditEventServiceUtil.class, "getAuditEventsCount",
-				_getAuditEventsCountParameterTypes7);
-
-			MethodHandler methodHandler = new MethodHandler(
-				methodKey, companyId, userId, userName, createDateGT,
-				createDateLT, eventType, className, classPK, clientHost,
-				clientIP, serverName, serverPort, sessionID, andSearch);
 
 			Object returnObj = null;
 
@@ -456,7 +302,7 @@ public class AuditEventServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				AuditEventServiceUtil.class, "getAuditEventsCount",
-				_getAuditEventsCountParameterTypes8);
+				_getAuditEventsCountParameterTypes5);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, groupId, userId, userName, createDateGT,
@@ -503,10 +349,11 @@ public class AuditEventServiceHttp {
 		};
 	private static final Class<?>[] _getAuditEventsParameterTypes2 =
 		new Class[] {
-			long.class, long.class, String.class, java.util.Date.class,
-			java.util.Date.class, String.class, String.class, String.class,
-			String.class, String.class, String.class, int.class, String.class,
-			boolean.class, int.class, int.class
+			long.class, long.class, long.class, String.class,
+			java.util.Date.class, java.util.Date.class, String.class,
+			String.class, String.class, String.class, String.class,
+			String.class, int.class, String.class, boolean.class, int.class,
+			int.class
 		};
 	private static final Class<?>[] _getAuditEventsParameterTypes3 =
 		new Class[] {
@@ -514,34 +361,11 @@ public class AuditEventServiceHttp {
 			java.util.Date.class, java.util.Date.class, String.class,
 			String.class, String.class, String.class, String.class,
 			String.class, int.class, String.class, boolean.class, int.class,
-			int.class
-		};
-	private static final Class<?>[] _getAuditEventsParameterTypes4 =
-		new Class[] {
-			long.class, long.class, String.class, java.util.Date.class,
-			java.util.Date.class, String.class, String.class, String.class,
-			String.class, String.class, String.class, int.class, String.class,
-			boolean.class, int.class, int.class,
-			com.liferay.portal.kernel.util.OrderByComparator.class
-		};
-	private static final Class<?>[] _getAuditEventsParameterTypes5 =
-		new Class[] {
-			long.class, long.class, long.class, String.class,
-			java.util.Date.class, java.util.Date.class, String.class,
-			String.class, String.class, String.class, String.class,
-			String.class, int.class, String.class, boolean.class, int.class,
 			int.class, com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getAuditEventsCountParameterTypes6 =
+	private static final Class<?>[] _getAuditEventsCountParameterTypes4 =
 		new Class[] {long.class};
-	private static final Class<?>[] _getAuditEventsCountParameterTypes7 =
-		new Class[] {
-			long.class, long.class, String.class, java.util.Date.class,
-			java.util.Date.class, String.class, String.class, String.class,
-			String.class, String.class, String.class, int.class, String.class,
-			boolean.class
-		};
-	private static final Class<?>[] _getAuditEventsCountParameterTypes8 =
+	private static final Class<?>[] _getAuditEventsCountParameterTypes5 =
 		new Class[] {
 			long.class, long.class, long.class, String.class,
 			java.util.Date.class, java.util.Date.class, String.class,

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/service/http/AuditEventServiceHttp.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/service/http/AuditEventServiceHttp.java
@@ -198,6 +198,58 @@ public class AuditEventServiceHttp {
 	public static java.util.List
 		<com.liferay.portal.security.audit.storage.model.AuditEvent>
 				getAuditEvents(
+					HttpPrincipal httpPrincipal, long companyId, long groupId,
+					long userId, String userName, java.util.Date createDateGT,
+					java.util.Date createDateLT, String eventType,
+					String className, String classPK, String clientHost,
+					String clientIP, String serverName, int serverPort,
+					String sessionID, boolean andSearch, int start, int end)
+			throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				AuditEventServiceUtil.class, "getAuditEvents",
+				_getAuditEventsParameterTypes3);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, companyId, groupId, userId, userName, createDateGT,
+				createDateLT, eventType, className, classPK, clientHost,
+				clientIP, serverName, serverPort, sessionID, andSearch, start,
+				end);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (java.util.List
+				<com.liferay.portal.security.audit.storage.model.AuditEvent>)
+					returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static java.util.List
+		<com.liferay.portal.security.audit.storage.model.AuditEvent>
+				getAuditEvents(
 					HttpPrincipal httpPrincipal, long companyId, long userId,
 					String userName, java.util.Date createDateGT,
 					java.util.Date createDateLT, String eventType,
@@ -212,10 +264,65 @@ public class AuditEventServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				AuditEventServiceUtil.class, "getAuditEvents",
-				_getAuditEventsParameterTypes3);
+				_getAuditEventsParameterTypes4);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, userId, userName, createDateGT,
+				createDateLT, eventType, className, classPK, clientHost,
+				clientIP, serverName, serverPort, sessionID, andSearch, start,
+				end, orderByComparator);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (java.util.List
+				<com.liferay.portal.security.audit.storage.model.AuditEvent>)
+					returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static java.util.List
+		<com.liferay.portal.security.audit.storage.model.AuditEvent>
+				getAuditEvents(
+					HttpPrincipal httpPrincipal, long companyId, long groupId,
+					long userId, String userName, java.util.Date createDateGT,
+					java.util.Date createDateLT, String eventType,
+					String className, String classPK, String clientHost,
+					String clientIP, String serverName, int serverPort,
+					String sessionID, boolean andSearch, int start, int end,
+					com.liferay.portal.kernel.util.OrderByComparator
+						<com.liferay.portal.security.audit.storage.model.
+							AuditEvent> orderByComparator)
+			throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				AuditEventServiceUtil.class, "getAuditEvents",
+				_getAuditEventsParameterTypes5);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, companyId, groupId, userId, userName, createDateGT,
 				createDateLT, eventType, className, classPK, clientHost,
 				clientIP, serverName, serverPort, sessionID, andSearch, start,
 				end, orderByComparator);
@@ -257,7 +364,7 @@ public class AuditEventServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				AuditEventServiceUtil.class, "getAuditEventsCount",
-				_getAuditEventsCountParameterTypes4);
+				_getAuditEventsCountParameterTypes6);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId);
@@ -302,10 +409,57 @@ public class AuditEventServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				AuditEventServiceUtil.class, "getAuditEventsCount",
-				_getAuditEventsCountParameterTypes5);
+				_getAuditEventsCountParameterTypes7);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, userId, userName, createDateGT,
+				createDateLT, eventType, className, classPK, clientHost,
+				clientIP, serverName, serverPort, sessionID, andSearch);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return ((Integer)returnObj).intValue();
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static int getAuditEventsCount(
+			HttpPrincipal httpPrincipal, long companyId, long groupId,
+			long userId, String userName, java.util.Date createDateGT,
+			java.util.Date createDateLT, String eventType, String className,
+			String classPK, String clientHost, String clientIP,
+			String serverName, int serverPort, String sessionID,
+			boolean andSearch)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				AuditEventServiceUtil.class, "getAuditEventsCount",
+				_getAuditEventsCountParameterTypes8);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, companyId, groupId, userId, userName, createDateGT,
 				createDateLT, eventType, className, classPK, clientHost,
 				clientIP, serverName, serverPort, sessionID, andSearch);
 
@@ -356,20 +510,43 @@ public class AuditEventServiceHttp {
 		};
 	private static final Class<?>[] _getAuditEventsParameterTypes3 =
 		new Class[] {
+			long.class, long.class, long.class, String.class,
+			java.util.Date.class, java.util.Date.class, String.class,
+			String.class, String.class, String.class, String.class,
+			String.class, int.class, String.class, boolean.class, int.class,
+			int.class
+		};
+	private static final Class<?>[] _getAuditEventsParameterTypes4 =
+		new Class[] {
 			long.class, long.class, String.class, java.util.Date.class,
 			java.util.Date.class, String.class, String.class, String.class,
 			String.class, String.class, String.class, int.class, String.class,
 			boolean.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getAuditEventsCountParameterTypes4 =
+	private static final Class<?>[] _getAuditEventsParameterTypes5 =
+		new Class[] {
+			long.class, long.class, long.class, String.class,
+			java.util.Date.class, java.util.Date.class, String.class,
+			String.class, String.class, String.class, String.class,
+			String.class, int.class, String.class, boolean.class, int.class,
+			int.class, com.liferay.portal.kernel.util.OrderByComparator.class
+		};
+	private static final Class<?>[] _getAuditEventsCountParameterTypes6 =
 		new Class[] {long.class};
-	private static final Class<?>[] _getAuditEventsCountParameterTypes5 =
+	private static final Class<?>[] _getAuditEventsCountParameterTypes7 =
 		new Class[] {
 			long.class, long.class, String.class, java.util.Date.class,
 			java.util.Date.class, String.class, String.class, String.class,
 			String.class, String.class, String.class, int.class, String.class,
 			boolean.class
+		};
+	private static final Class<?>[] _getAuditEventsCountParameterTypes8 =
+		new Class[] {
+			long.class, long.class, long.class, String.class,
+			java.util.Date.class, java.util.Date.class, String.class,
+			String.class, String.class, String.class, String.class,
+			String.class, int.class, String.class, boolean.class
 		};
 
 }

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/service/impl/AuditEventLocalServiceImpl.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/service/impl/AuditEventLocalServiceImpl.java
@@ -51,8 +51,8 @@ public class AuditEventLocalServiceImpl extends AuditEventLocalServiceBaseImpl {
 
 		AuditEvent auditEvent = auditEventPersistence.create(auditEventId);
 
-		auditEvent.setCompanyId(auditMessage.getCompanyId());
 		auditEvent.setGroupId(auditMessage.getGroupId());
+		auditEvent.setCompanyId(auditMessage.getCompanyId());
 		auditEvent.setUserId(auditMessage.getUserId());
 		auditEvent.setUserName(auditMessage.getUserName());
 		auditEvent.setCreateDate(auditMessage.getTimestamp());

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/service/impl/AuditEventLocalServiceImpl.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/service/impl/AuditEventLocalServiceImpl.java
@@ -23,7 +23,6 @@ import com.liferay.portal.kernel.dao.orm.Junction;
 import com.liferay.portal.kernel.dao.orm.Property;
 import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
 import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
-import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -123,37 +122,6 @@ public class AuditEventLocalServiceImpl extends AuditEventLocalServiceBaseImpl {
 		return dynamicQuery(dynamicQuery, start, end, orderByComparator);
 	}
 
-	@Deprecated
-	@Override
-	public List<AuditEvent> getAuditEvents(
-		long companyId, long userId, String userName, Date createDateGT,
-		Date createDateLT, String eventType, String className, String classPK,
-		String clientHost, String clientIP, String serverName, int serverPort,
-		String sessionID, boolean andSearch, int start, int end) {
-
-		return getAuditEvents(
-			companyId, CompanyConstants.SYSTEM, userId, userName, createDateGT,
-			createDateLT, eventType, className, classPK, clientHost, clientIP,
-			serverName, serverPort, sessionID, andSearch, start, end,
-			new AuditEventCreateDateComparator());
-	}
-
-	@Deprecated
-	@Override
-	public List<AuditEvent> getAuditEvents(
-		long companyId, long userId, String userName, Date createDateGT,
-		Date createDateLT, String eventType, String className, String classPK,
-		String clientHost, String clientIP, String serverName, int serverPort,
-		String sessionID, boolean andSearch, int start, int end,
-		OrderByComparator<AuditEvent> orderByComparator) {
-
-		return getAuditEvents(
-			companyId, CompanyConstants.SYSTEM, userId, userName, createDateGT,
-			createDateLT, eventType, className, classPK, clientHost, clientIP,
-			serverName, serverPort, sessionID, andSearch, start, end,
-			new AuditEventCreateDateComparator());
-	}
-
 	@Override
 	public int getAuditEventsCount(long companyId) {
 		return auditEventPersistence.countByCompanyId(companyId);
@@ -173,20 +141,6 @@ public class AuditEventLocalServiceImpl extends AuditEventLocalServiceBaseImpl {
 			serverPort, sessionID, andSearch);
 
 		return (int)dynamicQueryCount(dynamicQuery);
-	}
-
-	@Deprecated
-	@Override
-	public int getAuditEventsCount(
-		long companyId, long userId, String userName, Date createDateGT,
-		Date createDateLT, String eventType, String className, String classPK,
-		String clientHost, String clientIP, String serverName, int serverPort,
-		String sessionID, boolean andSearch) {
-
-		return getAuditEventsCount(
-			companyId, CompanyConstants.SYSTEM, userId, userName, createDateGT,
-			createDateLT, eventType, className, classPK, clientHost, clientIP,
-			serverName, serverPort, sessionID, andSearch);
 	}
 
 	private DynamicQuery _buildDynamicQuery(

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/service/impl/AuditEventServiceImpl.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/service/impl/AuditEventServiceImpl.java
@@ -17,7 +17,6 @@ package com.liferay.portal.security.audit.storage.service.impl;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.change.tracking.CTAware;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
@@ -131,40 +130,6 @@ public class AuditEventServiceImpl extends AuditEventServiceBaseImpl {
 			serverPort, sessionID, andSearch, start, end, orderByComparator);
 	}
 
-	@Deprecated
-	@Override
-	public List<AuditEvent> getAuditEvents(
-			long companyId, long userId, String userName, Date createDateGT,
-			Date createDateLT, String eventType, String className,
-			String classPK, String clientHost, String clientIP,
-			String serverName, int serverPort, String sessionID,
-			boolean andSearch, int start, int end)
-		throws PortalException {
-
-		return getAuditEvents(
-			companyId, CompanyConstants.SYSTEM, userId, userName, createDateGT,
-			createDateLT, eventType, className, classPK, clientHost, clientIP,
-			serverName, serverPort, sessionID, andSearch, start, end);
-	}
-
-	@Deprecated
-	@Override
-	public List<AuditEvent> getAuditEvents(
-			long companyId, long userId, String userName, Date createDateGT,
-			Date createDateLT, String eventType, String className,
-			String classPK, String clientHost, String clientIP,
-			String serverName, int serverPort, String sessionID,
-			boolean andSearch, int start, int end,
-			OrderByComparator<AuditEvent> orderByComparator)
-		throws PortalException {
-
-		return getAuditEvents(
-			companyId, CompanyConstants.SYSTEM, userId, userName, createDateGT,
-			createDateLT, eventType, className, classPK, clientHost, clientIP,
-			serverName, serverPort, sessionID, andSearch, start, end,
-			orderByComparator);
-	}
-
 	@Override
 	public int getAuditEventsCount(long companyId) throws PortalException {
 		return auditEventLocalService.getAuditEventsCount(companyId);
@@ -182,22 +147,6 @@ public class AuditEventServiceImpl extends AuditEventServiceBaseImpl {
 			companyId, groupId, userId, userName, createDateGT, createDateLT,
 			eventType, className, classPK, clientHost, clientIP, serverName,
 			serverPort, sessionID, andSearch);
-	}
-
-	@Deprecated
-	@Override
-	public int getAuditEventsCount(
-			long companyId, long userId, String userName, Date createDateGT,
-			Date createDateLT, String eventType, String className,
-			String classPK, String clientHost, String clientIP,
-			String serverName, int serverPort, String sessionID,
-			boolean andSearch)
-		throws PortalException {
-
-		return getAuditEventsCount(
-			companyId, CompanyConstants.SYSTEM, userId, userName, createDateGT,
-			createDateLT, eventType, className, classPK, clientHost, clientIP,
-			serverName, serverPort, sessionID, andSearch);
 	}
 
 	@Reference

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/service/impl/AuditEventServiceImpl.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/service/impl/AuditEventServiceImpl.java
@@ -17,6 +17,7 @@ package com.liferay.portal.security.audit.storage.service.impl;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.change.tracking.CTAware;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
@@ -81,13 +82,12 @@ public class AuditEventServiceImpl extends AuditEventServiceBaseImpl {
 			companyId, start, end, orderByComparator);
 	}
 
-	@Override
 	public List<AuditEvent> getAuditEvents(
-			long companyId, long userId, String userName, Date createDateGT,
-			Date createDateLT, String eventType, String className,
-			String classPK, String clientHost, String clientIP,
-			String serverName, int serverPort, String sessionID,
-			boolean andSearch, int start, int end)
+			long companyId, long groupId, long userId, String userName,
+			Date createDateGT, Date createDateLT, String eventType,
+			String className, String classPK, String clientHost,
+			String clientIP, String serverName, int serverPort,
+			String sessionID, boolean andSearch, int start, int end)
 		throws PortalException {
 
 		PermissionChecker permissionChecker = getPermissionChecker();
@@ -101,18 +101,17 @@ public class AuditEventServiceImpl extends AuditEventServiceBaseImpl {
 		}
 
 		return auditEventLocalService.getAuditEvents(
-			companyId, userId, userName, createDateGT, createDateLT, eventType,
-			className, classPK, clientHost, clientIP, serverName, serverPort,
-			sessionID, andSearch, start, end);
+			companyId, groupId, userId, userName, createDateGT, createDateLT,
+			eventType, className, classPK, clientHost, clientIP, serverName,
+			serverPort, sessionID, andSearch, start, end);
 	}
 
-	@Override
 	public List<AuditEvent> getAuditEvents(
-			long companyId, long userId, String userName, Date createDateGT,
-			Date createDateLT, String eventType, String className,
-			String classPK, String clientHost, String clientIP,
-			String serverName, int serverPort, String sessionID,
-			boolean andSearch, int start, int end,
+			long companyId, long groupId, long userId, String userName,
+			Date createDateGT, Date createDateLT, String eventType,
+			String className, String classPK, String clientHost,
+			String clientIP, String serverName, int serverPort,
+			String sessionID, boolean andSearch, int start, int end,
 			OrderByComparator<AuditEvent> orderByComparator)
 		throws PortalException {
 
@@ -127,9 +126,43 @@ public class AuditEventServiceImpl extends AuditEventServiceBaseImpl {
 		}
 
 		return auditEventLocalService.getAuditEvents(
-			companyId, userId, userName, createDateGT, createDateLT, eventType,
-			className, classPK, clientHost, clientIP, serverName, serverPort,
-			sessionID, andSearch, start, end, orderByComparator);
+			companyId, groupId, userId, userName, createDateGT, createDateLT,
+			eventType, className, classPK, clientHost, clientIP, serverName,
+			serverPort, sessionID, andSearch, start, end, orderByComparator);
+	}
+
+	@Deprecated
+	@Override
+	public List<AuditEvent> getAuditEvents(
+			long companyId, long userId, String userName, Date createDateGT,
+			Date createDateLT, String eventType, String className,
+			String classPK, String clientHost, String clientIP,
+			String serverName, int serverPort, String sessionID,
+			boolean andSearch, int start, int end)
+		throws PortalException {
+
+		return getAuditEvents(
+			companyId, CompanyConstants.SYSTEM, userId, userName, createDateGT,
+			createDateLT, eventType, className, classPK, clientHost, clientIP,
+			serverName, serverPort, sessionID, andSearch, start, end);
+	}
+
+	@Deprecated
+	@Override
+	public List<AuditEvent> getAuditEvents(
+			long companyId, long userId, String userName, Date createDateGT,
+			Date createDateLT, String eventType, String className,
+			String classPK, String clientHost, String clientIP,
+			String serverName, int serverPort, String sessionID,
+			boolean andSearch, int start, int end,
+			OrderByComparator<AuditEvent> orderByComparator)
+		throws PortalException {
+
+		return getAuditEvents(
+			companyId, CompanyConstants.SYSTEM, userId, userName, createDateGT,
+			createDateLT, eventType, className, classPK, clientHost, clientIP,
+			serverName, serverPort, sessionID, andSearch, start, end,
+			orderByComparator);
 	}
 
 	@Override
@@ -137,6 +170,21 @@ public class AuditEventServiceImpl extends AuditEventServiceBaseImpl {
 		return auditEventLocalService.getAuditEventsCount(companyId);
 	}
 
+	public int getAuditEventsCount(
+			long companyId, long groupId, long userId, String userName,
+			Date createDateGT, Date createDateLT, String eventType,
+			String className, String classPK, String clientHost,
+			String clientIP, String serverName, int serverPort,
+			String sessionID, boolean andSearch)
+		throws PortalException {
+
+		return auditEventLocalService.getAuditEventsCount(
+			companyId, groupId, userId, userName, createDateGT, createDateLT,
+			eventType, className, classPK, clientHost, clientIP, serverName,
+			serverPort, sessionID, andSearch);
+	}
+
+	@Deprecated
 	@Override
 	public int getAuditEventsCount(
 			long companyId, long userId, String userName, Date createDateGT,
@@ -146,10 +194,10 @@ public class AuditEventServiceImpl extends AuditEventServiceBaseImpl {
 			boolean andSearch)
 		throws PortalException {
 
-		return auditEventLocalService.getAuditEventsCount(
-			companyId, userId, userName, createDateGT, createDateLT, eventType,
-			className, classPK, clientHost, clientIP, serverName, serverPort,
-			sessionID, andSearch);
+		return getAuditEventsCount(
+			companyId, CompanyConstants.SYSTEM, userId, userName, createDateGT,
+			createDateLT, eventType, className, classPK, clientHost, clientIP,
+			serverName, serverPort, sessionID, andSearch);
 	}
 
 	@Reference

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/resources/META-INF/module-hbm.xml
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/resources/META-INF/module-hbm.xml
@@ -7,8 +7,8 @@
 		<id access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="auditEventId" type="long">
 			<generator class="assigned" />
 		</id>
-		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="companyId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="groupId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="companyId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="userId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="userName" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="createDate" type="org.hibernate.type.TimestampType" />

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/resources/META-INF/module-hbm.xml
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/resources/META-INF/module-hbm.xml
@@ -8,6 +8,7 @@
 			<generator class="assigned" />
 		</id>
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="companyId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="groupId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="userId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="userName" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="createDate" type="org.hibernate.type.TimestampType" />

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -3,8 +3,8 @@
 <model-hints>
 	<model name="com.liferay.portal.security.audit.storage.model.AuditEvent">
 		<field name="auditEventId" type="long" />
-		<field name="companyId" type="long" />
 		<field name="groupId" type="long" />
+		<field name="companyId" type="long" />
 		<field name="userId" type="long" />
 		<field name="userName" type="String">
 			<hint name="max-length">200</hint>

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -4,6 +4,7 @@
 	<model name="com.liferay.portal.security.audit.storage.model.AuditEvent">
 		<field name="auditEventId" type="long" />
 		<field name="companyId" type="long" />
+		<field name="groupId" type="long" />
 		<field name="userId" type="long" />
 		<field name="userName" type="String">
 			<hint name="max-length">200</hint>

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/resources/META-INF/sql/tables.sql
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/resources/META-INF/sql/tables.sql
@@ -1,6 +1,7 @@
 create table Audit_AuditEvent (
 	auditEventId LONG not null primary key,
 	companyId LONG,
+	groupId LONG,
 	userId LONG,
 	userName VARCHAR(200) null,
 	createDate DATE null,

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/resources/META-INF/sql/tables.sql
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/resources/META-INF/sql/tables.sql
@@ -1,7 +1,7 @@
 create table Audit_AuditEvent (
 	auditEventId LONG not null primary key,
-	companyId LONG,
 	groupId LONG,
+	companyId LONG,
 	userId LONG,
 	userName VARCHAR(200) null,
 	createDate DATE null,

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-test/src/testIntegration/java/com/liferay/portal/security/audit/storage/service/persistence/test/AuditEventPersistenceTest.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-test/src/testIntegration/java/com/liferay/portal/security/audit/storage/service/persistence/test/AuditEventPersistenceTest.java
@@ -123,9 +123,9 @@ public class AuditEventPersistenceTest {
 
 		AuditEvent newAuditEvent = _persistence.create(pk);
 
-		newAuditEvent.setCompanyId(RandomTestUtil.nextLong());
-
 		newAuditEvent.setGroupId(RandomTestUtil.nextLong());
+
+		newAuditEvent.setCompanyId(RandomTestUtil.nextLong());
 
 		newAuditEvent.setUserId(RandomTestUtil.nextLong());
 
@@ -162,9 +162,9 @@ public class AuditEventPersistenceTest {
 			existingAuditEvent.getAuditEventId(),
 			newAuditEvent.getAuditEventId());
 		Assert.assertEquals(
-			existingAuditEvent.getCompanyId(), newAuditEvent.getCompanyId());
-		Assert.assertEquals(
 			existingAuditEvent.getGroupId(), newAuditEvent.getGroupId());
+		Assert.assertEquals(
+			existingAuditEvent.getCompanyId(), newAuditEvent.getCompanyId());
 		Assert.assertEquals(
 			existingAuditEvent.getUserId(), newAuditEvent.getUserId());
 		Assert.assertEquals(
@@ -227,8 +227,8 @@ public class AuditEventPersistenceTest {
 
 	protected OrderByComparator<AuditEvent> getOrderByComparator() {
 		return OrderByComparatorFactoryUtil.create(
-			"Audit_AuditEvent", "auditEventId", true, "companyId", true,
-			"groupId", true, "userId", true, "userName", true, "createDate",
+			"Audit_AuditEvent", "auditEventId", true, "groupId", true,
+			"companyId", true, "userId", true, "userName", true, "createDate",
 			true, "eventType", true, "className", true, "classPK", true,
 			"message", true, "clientHost", true, "clientIP", true, "serverName",
 			true, "serverPort", true, "sessionID", true);
@@ -448,9 +448,9 @@ public class AuditEventPersistenceTest {
 
 		AuditEvent auditEvent = _persistence.create(pk);
 
-		auditEvent.setCompanyId(RandomTestUtil.nextLong());
-
 		auditEvent.setGroupId(RandomTestUtil.nextLong());
+
+		auditEvent.setCompanyId(RandomTestUtil.nextLong());
 
 		auditEvent.setUserId(RandomTestUtil.nextLong());
 

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-test/src/testIntegration/java/com/liferay/portal/security/audit/storage/service/persistence/test/AuditEventPersistenceTest.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-test/src/testIntegration/java/com/liferay/portal/security/audit/storage/service/persistence/test/AuditEventPersistenceTest.java
@@ -125,6 +125,8 @@ public class AuditEventPersistenceTest {
 
 		newAuditEvent.setCompanyId(RandomTestUtil.nextLong());
 
+		newAuditEvent.setGroupId(RandomTestUtil.nextLong());
+
 		newAuditEvent.setUserId(RandomTestUtil.nextLong());
 
 		newAuditEvent.setUserName(RandomTestUtil.randomString());
@@ -161,6 +163,8 @@ public class AuditEventPersistenceTest {
 			newAuditEvent.getAuditEventId());
 		Assert.assertEquals(
 			existingAuditEvent.getCompanyId(), newAuditEvent.getCompanyId());
+		Assert.assertEquals(
+			existingAuditEvent.getGroupId(), newAuditEvent.getGroupId());
 		Assert.assertEquals(
 			existingAuditEvent.getUserId(), newAuditEvent.getUserId());
 		Assert.assertEquals(
@@ -224,10 +228,10 @@ public class AuditEventPersistenceTest {
 	protected OrderByComparator<AuditEvent> getOrderByComparator() {
 		return OrderByComparatorFactoryUtil.create(
 			"Audit_AuditEvent", "auditEventId", true, "companyId", true,
-			"userId", true, "userName", true, "createDate", true, "eventType",
-			true, "className", true, "classPK", true, "message", true,
-			"clientHost", true, "clientIP", true, "serverName", true,
-			"serverPort", true, "sessionID", true);
+			"groupId", true, "userId", true, "userName", true, "createDate",
+			true, "eventType", true, "className", true, "classPK", true,
+			"message", true, "clientHost", true, "clientIP", true, "serverName",
+			true, "serverPort", true, "sessionID", true);
 	}
 
 	@Test
@@ -445,6 +449,8 @@ public class AuditEventPersistenceTest {
 		AuditEvent auditEvent = _persistence.create(pk);
 
 		auditEvent.setCompanyId(RandomTestUtil.nextLong());
+
+		auditEvent.setGroupId(RandomTestUtil.nextLong());
 
 		auditEvent.setUserId(RandomTestUtil.nextLong());
 

--- a/modules/apps/roles/roles-test/src/testIntegration/java/com/liferay/roles/service/test/RoleLocalServiceSystemRolesTest.java
+++ b/modules/apps/roles/roles-test/src/testIntegration/java/com/liferay/roles/service/test/RoleLocalServiceSystemRolesTest.java
@@ -16,6 +16,7 @@ package com.liferay.roles.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Organization;
 import com.liferay.portal.kernel.model.ResourceConstants;
@@ -104,13 +105,14 @@ public class RoleLocalServiceSystemRolesTest {
 				QueryUtil.ALL_POS, null);
 			_auditEventService.getAuditEvents(
 				TestPropsValues.getCompanyId(), _user.getUserId(),
-				_user.getScreenName(), null, null, null, null, null, null, null,
-				null, 0, null, true, QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+				CompanyConstants.SYSTEM, _user.getScreenName(), null, null,
+				null, null, null, null, null, null, 0, null, true,
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 			_auditEventService.getAuditEvents(
 				TestPropsValues.getCompanyId(), _user.getUserId(),
-				_user.getScreenName(), null, null, null, null, null, null, null,
-				null, 0, null, true, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
-				null);
+				CompanyConstants.SYSTEM, _user.getScreenName(), null, null,
+				null, null, null, null, null, null, 0, null, true,
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
 		}
 		finally {
 			PermissionThreadLocal.setPermissionChecker(oldPermissionChecker);

--- a/modules/apps/roles/roles-test/src/testIntegration/java/com/liferay/roles/service/test/RoleLocalServiceSystemRolesTest.java
+++ b/modules/apps/roles/roles-test/src/testIntegration/java/com/liferay/roles/service/test/RoleLocalServiceSystemRolesTest.java
@@ -16,7 +16,6 @@ package com.liferay.roles.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
-import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Organization;
 import com.liferay.portal.kernel.model.ResourceConstants;
@@ -104,15 +103,14 @@ public class RoleLocalServiceSystemRolesTest {
 				TestPropsValues.getCompanyId(), QueryUtil.ALL_POS,
 				QueryUtil.ALL_POS, null);
 			_auditEventService.getAuditEvents(
-				TestPropsValues.getCompanyId(), _user.getUserId(),
-				CompanyConstants.SYSTEM, _user.getScreenName(), null, null,
-				null, null, null, null, null, null, 0, null, true,
-				QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+				TestPropsValues.getCompanyId(), 0, _user.getUserId(),
+				_user.getScreenName(), null, null, null, null, null, null, null,
+				null, 0, null, true, QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 			_auditEventService.getAuditEvents(
-				TestPropsValues.getCompanyId(), _user.getUserId(),
-				CompanyConstants.SYSTEM, _user.getScreenName(), null, null,
-				null, null, null, null, null, null, 0, null, true,
-				QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+				TestPropsValues.getCompanyId(), 0, _user.getUserId(),
+				_user.getScreenName(), null, null, null, null, null, null, null,
+				null, 0, null, true, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+				null);
 		}
 		finally {
 			PermissionThreadLocal.setPermissionChecker(oldPermissionChecker);

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/java/com/liferay/portal/security/audit/web/internal/AuditEventManagerUtil.java
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/java/com/liferay/portal/security/audit/web/internal/AuditEventManagerUtil.java
@@ -54,10 +54,11 @@ public class AuditEventManagerUtil {
 	}
 
 	public static List<AuditEvent> getAuditEvents(
-		long companyId, long userId, String userName, Date createDateGT,
-		Date createDateLT, String eventType, String className, String classPK,
-		String clientHost, String clientIP, String serverName, int serverPort,
-		String sessionID, boolean andSearch, int start, int end,
+		long companyId, long groupId, long userId, String userName,
+		Date createDateGT, Date createDateLT, String eventType,
+		String className, String classPK, String clientHost, String clientIP,
+		String serverName, int serverPort, String sessionID, boolean andSearch,
+		int start, int end,
 		OrderByComparator
 			<com.liferay.portal.security.audit.storage.model.AuditEvent>
 				orderByComparator) {
@@ -65,9 +66,9 @@ public class AuditEventManagerUtil {
 		AuditEventManager auditEventManager = _auditEventManagerSnapshot.get();
 
 		return auditEventManager.getAuditEvents(
-			companyId, userId, userName, createDateGT, createDateLT, eventType,
-			className, classPK, clientHost, clientIP, serverName, serverPort,
-			sessionID, andSearch, start, end, orderByComparator);
+			companyId, groupId, userId, userName, createDateGT, createDateLT,
+			eventType, className, classPK, clientHost, clientIP, serverName,
+			serverPort, sessionID, andSearch, start, end, orderByComparator);
 	}
 
 	public static int getAuditEventsCount(long companyId) {
@@ -77,17 +78,18 @@ public class AuditEventManagerUtil {
 	}
 
 	public static int getAuditEventsCount(
-		long companyId, long userId, String userName, Date createDateGT,
-		Date createDateLT, String eventType, String className, String classPK,
-		String clientHost, String clientIP, String serverName, int serverPort,
-		String sessionID, boolean andSearch) {
+		long companyId, long groupId, long userId, String userName,
+		Date createDateGT, Date createDateLT, String eventType,
+		String className, String classPK, String clientHost, String clientIP,
+		String serverName, int serverPort, String sessionID,
+		boolean andSearch) {
 
 		AuditEventManager auditEventManager = _auditEventManagerSnapshot.get();
 
 		return auditEventManager.getAuditEventsCount(
-			companyId, userId, userName, createDateGT, createDateLT, eventType,
-			className, classPK, clientHost, clientIP, serverName, serverPort,
-			sessionID, andSearch);
+			companyId, groupId, userId, userName, createDateGT, createDateLT,
+			eventType, className, classPK, clientHost, clientIP, serverName,
+			serverPort, sessionID, andSearch);
 	}
 
 	private static final Snapshot<AuditEventManager>

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/java/com/liferay/portal/security/audit/web/internal/display/context/AuditDisplayContext.java
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/java/com/liferay/portal/security/audit/web/internal/display/context/AuditDisplayContext.java
@@ -100,17 +100,17 @@ public class AuditDisplayContext {
 
 			_searchContainer.setResultsAndTotal(
 				() -> AuditEventManagerUtil.getAuditEvents(
-					_themeDisplay.getCompanyId(), _getUserId(), _getUserName(),
-					startDate, endDate, _getEventType(), _getClassName(),
-					_getClassPK(), _getClientHost(), _getClientIP(),
-					_getServerName(), _getServerPort(), null,
+					_themeDisplay.getCompanyId(), _getGroupId(), _getUserId(),
+					_getUserName(), startDate, endDate, _getEventType(),
+					_getClassName(), _getClassPK(), _getClientHost(),
+					_getClientIP(), _getServerName(), _getServerPort(), null,
 					displayTerms.isAndOperator(), range[0], range[1],
 					new AuditEventCreateDateComparator()),
 				AuditEventManagerUtil.getAuditEventsCount(
-					_themeDisplay.getCompanyId(), _getUserId(), _getUserName(),
-					startDate, endDate, _getEventType(), _getClassName(),
-					_getClassPK(), _getClientHost(), _getClientIP(),
-					_getServerName(), _getServerPort(), null,
+					_themeDisplay.getCompanyId(), _getGroupId(), _getUserId(),
+					_getUserName(), startDate, endDate, _getEventType(),
+					_getClassName(), _getClassPK(), _getClientHost(),
+					_getClientIP(), _getServerName(), _getServerPort(), null,
 					displayTerms.isAndOperator()));
 		}
 		else {
@@ -121,16 +121,16 @@ public class AuditDisplayContext {
 
 			_searchContainer.setResultsAndTotal(
 				() -> AuditEventManagerUtil.getAuditEvents(
-					_themeDisplay.getCompanyId(), Long.valueOf(number),
-					keywords, null, null, keywords, keywords, keywords,
-					keywords, keywords, keywords, Integer.valueOf(number), null,
-					false, range[0], range[1],
+					_themeDisplay.getCompanyId(), _getGroupId(),
+					Long.valueOf(number), keywords, null, null, keywords,
+					keywords, keywords, keywords, keywords, keywords,
+					Integer.valueOf(number), null, false, range[0], range[1],
 					new AuditEventCreateDateComparator()),
 				AuditEventManagerUtil.getAuditEventsCount(
-					_themeDisplay.getCompanyId(), Long.valueOf(number),
-					keywords, null, null, keywords, keywords, keywords,
-					keywords, keywords, keywords, Integer.valueOf(number), null,
-					false));
+					_themeDisplay.getCompanyId(), _getGroupId(),
+					Long.valueOf(number), keywords, null, null, keywords,
+					keywords, keywords, keywords, keywords, keywords,
+					Integer.valueOf(number), null, false));
 		}
 
 		return _searchContainer;
@@ -256,6 +256,16 @@ public class AuditDisplayContext {
 		return _eventType;
 	}
 
+	private long _getGroupId() {
+		if (_groupId != null) {
+			return _groupId;
+		}
+
+		_groupId = ParamUtil.getInteger(_httpServletRequest, "groupId");
+
+		return _groupId;
+	}
+
 	private PortletURL _getPortletURL() throws Exception {
 		if (_portletURL != null) {
 			return _portletURL;
@@ -288,6 +298,8 @@ public class AuditDisplayContext {
 			"endDateYear", _getEndDateYear()
 		).setParameter(
 			"eventType", _getEventType()
+		).setParameter(
+			"groupId", _getGroupId()
 		).setParameter(
 			"serverName", _getServerName()
 		).setParameter(
@@ -431,6 +443,7 @@ public class AuditDisplayContext {
 	private Integer _endDateMonth;
 	private Integer _endDateYear;
 	private String _eventType;
+	private Integer _groupId;
 	private final HttpServletRequest _httpServletRequest;
 	private final LiferayPortletRequest _liferayPortletRequest;
 	private final LiferayPortletResponse _liferayPortletResponse;

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/resources/META-INF/resources/event_search.jsp
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/resources/META-INF/resources/event_search.jsp
@@ -29,6 +29,8 @@ SearchContainer<?> searchContainer = (SearchContainer<?>)request.getAttribute("l
 
 	<aui:input label="user-name" name="userName" value="<%= userName %>" />
 
+	<aui:input label="group-id" name="groupId" value="<%= (groupId != 0) ? String.valueOf(groupId) : StringPool.BLANK %>" />
+
 	<aui:input label="resource-id" name="classPK" value="<%= classPK %>" />
 
 	<aui:input label="class-name" name="className" value="<%= className %>" />

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/resources/META-INF/resources/event_search.jsp
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/resources/META-INF/resources/event_search.jsp
@@ -29,7 +29,9 @@ SearchContainer<?> searchContainer = (SearchContainer<?>)request.getAttribute("l
 
 	<aui:input label="user-name" name="userName" value="<%= userName %>" />
 
-	<aui:input label="group-id" name="groupId" value="<%= (groupId != 0) ? String.valueOf(groupId) : StringPool.BLANK %>" />
+	<c:if test='<%= FeatureFlagManagerUtil.isEnabled("LPS-177194") %>'>
+		<aui:input label="group-id" name="groupId" value="<%= (groupId != 0) ? String.valueOf(groupId) : StringPool.BLANK %>" />
+	</c:if>
 
 	<aui:input label="resource-id" name="classPK" value="<%= classPK %>" />
 

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/resources/META-INF/resources/init.jsp
@@ -66,6 +66,7 @@ String clientIP = ParamUtil.getString(request, "clientIP");
 String eventType = ParamUtil.getString(request, "eventType");
 String serverName = ParamUtil.getString(request, "serverName");
 int serverPort = ParamUtil.getInteger(request, "serverPort");
+long groupId = ParamUtil.getLong(request, "groupId");
 long userId = ParamUtil.getLong(request, "userId");
 String userName = ParamUtil.getString(request, "userName");
 

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/resources/META-INF/resources/init.jsp
@@ -28,6 +28,7 @@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 <%@ page import="com.liferay.petra.lang.ClassResolverUtil" %><%@
 page import="com.liferay.petra.string.StringPool" %><%@
 page import="com.liferay.portal.kernel.dao.search.SearchContainer" %><%@
+page import="com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil" %><%@
 page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.portal.kernel.util.CalendarFactoryUtil" %><%@
 page import="com.liferay.portal.kernel.util.FastDateFormatFactoryUtil" %><%@

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/resources/META-INF/resources/view_audit_event.jsp
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/resources/META-INF/resources/view_audit_event.jsp
@@ -55,9 +55,11 @@ renderResponse.setTitle((auditEvent == null) ? "audit-event" : auditEvent.getEve
 				<%= dateFormatDateTime.format(auditEvent.getCreateDate()) %>
 			</aui:field-wrapper>
 
-			<aui:field-wrapper label="group-id">
-				<%= auditEvent.getGroupId() %>
-			</aui:field-wrapper>
+			<c:if test='<%= FeatureFlagManagerUtil.isEnabled("LPS-177194") %>'>
+				<aui:field-wrapper label="group-id">
+					<%= auditEvent.getGroupId() %>
+				</aui:field-wrapper>
+			</c:if>
 
 			<aui:field-wrapper label="resource-id">
 				<%= auditEvent.getClassPK() %>

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/resources/META-INF/resources/view_audit_event.jsp
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/resources/META-INF/resources/view_audit_event.jsp
@@ -55,6 +55,10 @@ renderResponse.setTitle((auditEvent == null) ? "audit-event" : auditEvent.getEve
 				<%= dateFormatDateTime.format(auditEvent.getCreateDate()) %>
 			</aui:field-wrapper>
 
+			<aui:field-wrapper label="group-id">
+				<%= auditEvent.getGroupId() %>
+			</aui:field-wrapper>
+
 			<aui:field-wrapper label="resource-id">
 				<%= auditEvent.getClassPK() %>
 			</aui:field-wrapper>

--- a/portal-impl/src/com/liferay/portal/action/LayoutAction.java
+++ b/portal-impl/src/com/liferay/portal/action/LayoutAction.java
@@ -326,9 +326,9 @@ public class LayoutAction implements Action {
 
 					AuditMessage auditMessage = new AuditMessage(
 						ActionKeys.VIEW, realUser.getCompanyId(),
-						realUser.getUserId(), realUser.getFullName(),
-						Layout.class.getName(),
-						String.valueOf(layout.getPlid()), null,
+						layout.getGroupId(), realUser.getUserId(),
+						realUser.getFullName(), Layout.class.getName(),
+						String.valueOf(layout.getPlid()), null, null,
 						additionalInfoJSONObject);
 
 					AuditRouterUtil.route(auditMessage);

--- a/portal-kernel/bnd.bnd
+++ b/portal-kernel/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 108.0.1
+Bundle-Version: 109.0.0
 Export-Package:\
 	!com.liferay.portal.kernel.internal.*,\
 	!com.liferay.portal.kernel.module.util,\

--- a/portal-kernel/src/com/liferay/portal/kernel/audit/AuditMessage.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/audit/AuditMessage.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PortalRunMode;
@@ -54,6 +55,7 @@ public class AuditMessage implements Serializable {
 		}
 
 		_companyId = jsonObject.getLong(_COMPANY_ID);
+		_groupId = jsonObject.getLong(_GROUP_ID);
 		_eventType = jsonObject.getString(_EVENT_TYPE);
 		_message = jsonObject.getString(_MESSAGE);
 
@@ -81,8 +83,8 @@ public class AuditMessage implements Serializable {
 		String eventType, long companyId, long userId, String userName) {
 
 		this(
-			eventType, companyId, userId, userName, null, null, null, null,
-			null);
+			eventType, companyId, CompanyConstants.SYSTEM, userId, userName,
+			null, null, null, null,null);
 	}
 
 	public AuditMessage(
@@ -90,8 +92,8 @@ public class AuditMessage implements Serializable {
 		String className, String classPK) {
 
 		this(
-			eventType, companyId, userId, userName, className, classPK, null,
-			null, null);
+			eventType, companyId, CompanyConstants.SYSTEM, userId, userName,
+			className, classPK, null,null, null);
 	}
 
 	public AuditMessage(
@@ -99,8 +101,8 @@ public class AuditMessage implements Serializable {
 		String className, String classPK, String message) {
 
 		this(
-			eventType, companyId, userId, userName, className, classPK, message,
-			null, null);
+			eventType, companyId, CompanyConstants.SYSTEM, userId, userName,
+			className, classPK, message,null, null);
 	}
 
 	public AuditMessage(
@@ -108,8 +110,19 @@ public class AuditMessage implements Serializable {
 		String className, String classPK, String message, Date timestamp,
 		JSONObject additionalInfoJSONObject) {
 
+		this(
+			eventType, companyId, CompanyConstants.SYSTEM, userId, userName,
+			className, classPK, message, timestamp, additionalInfoJSONObject);
+	}
+
+	public AuditMessage(
+		String eventType, long companyId, long groupId, long userId, String userName,
+		String className, String classPK, String message, Date timestamp,
+		JSONObject additionalInfoJSONObject) {
+
 		_eventType = eventType;
 		_companyId = companyId;
+		_groupId = groupId;
 		_userId = userId;
 		_userName = userName;
 		_className = className;
@@ -151,8 +164,8 @@ public class AuditMessage implements Serializable {
 		JSONObject additionalInfoJSONObject) {
 
 		this(
-			eventType, companyId, userId, userName, className, classPK, message,
-			null, additionalInfoJSONObject);
+			eventType, companyId, CompanyConstants.SYSTEM, userId, userName,
+			className, classPK, message,null, additionalInfoJSONObject);
 	}
 
 	public JSONObject getAdditionalInfo() {
@@ -181,6 +194,10 @@ public class AuditMessage implements Serializable {
 
 	public String getEventType() {
 		return _eventType;
+	}
+
+	public long getGroupId() {
+		return _groupId;
 	}
 
 	public String getMessage() {
@@ -249,6 +266,10 @@ public class AuditMessage implements Serializable {
 
 	public void setEventType(String eventType) {
 		_eventType = eventType;
+	}
+
+	public void setGroupId(long groupId) {
+		_groupId = groupId;
 	}
 
 	public void setMessage(String message) {
@@ -343,6 +364,8 @@ public class AuditMessage implements Serializable {
 
 	private static final String _EVENT_TYPE = "eventType";
 
+	private static final String _GROUP_ID = "groupId";
+
 	private static final String _MESSAGE = "message";
 
 	private static final String _SERVER_NAME = "serverName";
@@ -370,6 +393,7 @@ public class AuditMessage implements Serializable {
 	private String _clientIP;
 	private long _companyId = -1;
 	private String _eventType;
+	private long _groupId = -1;
 	private String _message;
 	private String _serverName;
 	private int _serverPort;

--- a/portal-kernel/src/com/liferay/portal/kernel/audit/AuditMessage.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/audit/AuditMessage.java
@@ -20,7 +20,6 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PortalRunMode;
@@ -126,8 +125,8 @@ public class AuditMessage implements Serializable {
 		String eventType, long companyId, long userId, String userName) {
 
 		this(
-			eventType, companyId, CompanyConstants.SYSTEM, userId, userName,
-			null, null, null, null, null);
+			eventType, companyId, 0, userId, userName, null, null, null, null,
+			null);
 	}
 
 	public AuditMessage(
@@ -135,8 +134,8 @@ public class AuditMessage implements Serializable {
 		String className, String classPK) {
 
 		this(
-			eventType, companyId, CompanyConstants.SYSTEM, userId, userName,
-			className, classPK, null, null, null);
+			eventType, companyId, 0, userId, userName, className, classPK, null,
+			null, null);
 	}
 
 	public AuditMessage(
@@ -144,8 +143,8 @@ public class AuditMessage implements Serializable {
 		String className, String classPK, String message) {
 
 		this(
-			eventType, companyId, CompanyConstants.SYSTEM, userId, userName,
-			className, classPK, message, null, null);
+			eventType, companyId, 0, userId, userName, className, classPK,
+			message, null, null);
 	}
 
 	public AuditMessage(
@@ -154,8 +153,8 @@ public class AuditMessage implements Serializable {
 		JSONObject additionalInfoJSONObject) {
 
 		this(
-			eventType, companyId, CompanyConstants.SYSTEM, userId, userName,
-			className, classPK, message, timestamp, additionalInfoJSONObject);
+			eventType, companyId, 0, userId, userName, className, classPK,
+			message, timestamp, additionalInfoJSONObject);
 	}
 
 	public AuditMessage(
@@ -164,8 +163,8 @@ public class AuditMessage implements Serializable {
 		JSONObject additionalInfoJSONObject) {
 
 		this(
-			eventType, companyId, CompanyConstants.SYSTEM, userId, userName,
-			className, classPK, message, null, additionalInfoJSONObject);
+			eventType, companyId, 0, userId, userName, className, classPK,
+			message, null, additionalInfoJSONObject);
 	}
 
 	public JSONObject getAdditionalInfo() {

--- a/portal-kernel/src/com/liferay/portal/kernel/audit/AuditMessage.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/audit/AuditMessage.java
@@ -80,45 +80,9 @@ public class AuditMessage implements Serializable {
 	}
 
 	public AuditMessage(
-		String eventType, long companyId, long userId, String userName) {
-
-		this(
-			eventType, companyId, CompanyConstants.SYSTEM, userId, userName,
-			null, null, null, null,null);
-	}
-
-	public AuditMessage(
-		String eventType, long companyId, long userId, String userName,
-		String className, String classPK) {
-
-		this(
-			eventType, companyId, CompanyConstants.SYSTEM, userId, userName,
-			className, classPK, null,null, null);
-	}
-
-	public AuditMessage(
-		String eventType, long companyId, long userId, String userName,
-		String className, String classPK, String message) {
-
-		this(
-			eventType, companyId, CompanyConstants.SYSTEM, userId, userName,
-			className, classPK, message,null, null);
-	}
-
-	public AuditMessage(
-		String eventType, long companyId, long userId, String userName,
-		String className, String classPK, String message, Date timestamp,
-		JSONObject additionalInfoJSONObject) {
-
-		this(
-			eventType, companyId, CompanyConstants.SYSTEM, userId, userName,
-			className, classPK, message, timestamp, additionalInfoJSONObject);
-	}
-
-	public AuditMessage(
-		String eventType, long companyId, long groupId, long userId, String userName,
-		String className, String classPK, String message, Date timestamp,
-		JSONObject additionalInfoJSONObject) {
+		String eventType, long companyId, long groupId, long userId,
+		String userName, String className, String classPK, String message,
+		Date timestamp, JSONObject additionalInfoJSONObject) {
 
 		_eventType = eventType;
 		_companyId = companyId;
@@ -159,13 +123,49 @@ public class AuditMessage implements Serializable {
 	}
 
 	public AuditMessage(
+		String eventType, long companyId, long userId, String userName) {
+
+		this(
+			eventType, companyId, CompanyConstants.SYSTEM, userId, userName,
+			null, null, null, null, null);
+	}
+
+	public AuditMessage(
+		String eventType, long companyId, long userId, String userName,
+		String className, String classPK) {
+
+		this(
+			eventType, companyId, CompanyConstants.SYSTEM, userId, userName,
+			className, classPK, null, null, null);
+	}
+
+	public AuditMessage(
+		String eventType, long companyId, long userId, String userName,
+		String className, String classPK, String message) {
+
+		this(
+			eventType, companyId, CompanyConstants.SYSTEM, userId, userName,
+			className, classPK, message, null, null);
+	}
+
+	public AuditMessage(
+		String eventType, long companyId, long userId, String userName,
+		String className, String classPK, String message, Date timestamp,
+		JSONObject additionalInfoJSONObject) {
+
+		this(
+			eventType, companyId, CompanyConstants.SYSTEM, userId, userName,
+			className, classPK, message, timestamp, additionalInfoJSONObject);
+	}
+
+	public AuditMessage(
 		String eventType, long companyId, long userId, String userName,
 		String className, String classPK, String message,
 		JSONObject additionalInfoJSONObject) {
 
 		this(
 			eventType, companyId, CompanyConstants.SYSTEM, userId, userName,
-			className, classPK, message,null, additionalInfoJSONObject);
+			className, classPK, message, null, additionalInfoJSONObject);
 	}
 
 	public JSONObject getAdditionalInfo() {

--- a/portal-kernel/src/com/liferay/portal/kernel/audit/AuditMessageFactory.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/audit/AuditMessageFactory.java
@@ -27,6 +27,11 @@ public interface AuditMessageFactory {
 	public AuditMessage getAuditMessage(String message) throws JSONException;
 
 	public AuditMessage getAuditMessage(
+		String eventType, long companyId, long groupId, long userId,
+		String userName, String className, String classPK, String message,
+		Date timestamp, JSONObject additionalInfoJSONObject);
+
+	public AuditMessage getAuditMessage(
 		String eventType, long companyId, long userId, String userName);
 
 	public AuditMessage getAuditMessage(

--- a/portal-kernel/src/com/liferay/portal/kernel/audit/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/audit/packageinfo
@@ -1,1 +1,1 @@
-version 7.1.1
+version 8.0.0


### PR DESCRIPTION
Hi Brian. Following up on https://github.com/brianchandotcom/liferay-portal/pull/135011#issuecomment-1553725943 .
Thanks for catching that RoleLocalServiceSystemRolesTest issue.

I change the use of `CompanyConstants.SYSTEM` to a hard coded 0 because that appears to be everywhere for system scoped Objects. 

I am sure we used to have a constant for the global scope of a company (`groupId=0`) before, not sure where that has gone.