### PR TITLE
LPS-184020 Add new test conditions for checking new behaviour + fix of entities that didn't follow the pattern

### DIFF
--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountEntryServiceImpl.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountEntryServiceImpl.java
@@ -160,16 +160,15 @@ public class AccountEntryServiceImpl extends AccountEntryServiceBaseImpl {
 
 	@Override
 	public void deleteAccountEntry(long accountEntryId) throws PortalException {
-
-		AccountEntry accountEntry = accountEntryLocalService.
-			getAccountEntry(accountEntryId);
+		AccountEntry accountEntry = accountEntryLocalService.getAccountEntry(
+			accountEntryId);
 
 		_accountEntryModelResourcePermission.check(
 			getPermissionChecker(), accountEntry.getAccountEntryId(),
 			ActionKeys.DELETE);
 
-		accountEntryLocalService.deleteAccountEntry(accountEntry.
-			getAccountEntryId());
+		accountEntryLocalService.deleteAccountEntry(
+			accountEntry.getAccountEntryId());
 	}
 
 	@Override

--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountEntryServiceImpl.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountEntryServiceImpl.java
@@ -160,10 +160,16 @@ public class AccountEntryServiceImpl extends AccountEntryServiceBaseImpl {
 
 	@Override
 	public void deleteAccountEntry(long accountEntryId) throws PortalException {
-		_accountEntryModelResourcePermission.check(
-			getPermissionChecker(), accountEntryId, ActionKeys.DELETE);
 
-		accountEntryLocalService.deleteAccountEntry(accountEntryId);
+		AccountEntry accountEntry = accountEntryLocalService.
+			getAccountEntry(accountEntryId);
+
+		_accountEntryModelResourcePermission.check(
+			getPermissionChecker(), accountEntry.getAccountEntryId(),
+			ActionKeys.DELETE);
+
+		accountEntryLocalService.deleteAccountEntry(accountEntry.
+			getAccountEntryId());
 	}
 
 	@Override

--- a/modules/apps/batch-planner/batch-planner-rest-test/src/testIntegration/java/com/liferay/batch/planner/rest/resource/v1_0/test/BasePlanResourceTestCase.java
+++ b/modules/apps/batch-planner/batch-planner-rest-test/src/testIntegration/java/com/liferay/batch/planner/rest/resource/v1_0/test/BasePlanResourceTestCase.java
@@ -29,6 +29,7 @@ import com.liferay.batch.planner.rest.client.pagination.Page;
 import com.liferay.batch.planner.rest.client.pagination.Pagination;
 import com.liferay.batch.planner.rest.client.resource.v1_0.PlanResource;
 import com.liferay.batch.planner.rest.client.serdes.v1_0.PlanSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -298,8 +299,12 @@ public abstract class BasePlanResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		Plan plan = testDeletePlan_addPlan();
 
-		assertHttpResponseStatusCode(
-			204, planResource.deletePlanHttpResponse(plan.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> planResource.deletePlanHttpResponse(plan.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404, planResource.getPlanHttpResponse(plan.getId()));

--- a/modules/apps/commerce/commerce-order-rule-service/src/main/java/com/liferay/commerce/order/rule/service/impl/COREntryServiceImpl.java
+++ b/modules/apps/commerce/commerce-order-rule-service/src/main/java/com/liferay/commerce/order/rule/service/impl/COREntryServiceImpl.java
@@ -69,10 +69,14 @@ public class COREntryServiceImpl extends COREntryServiceBaseImpl {
 
 	@Override
 	public COREntry deleteCOREntry(long corEntryId) throws PortalException {
-		_corEntryModelResourcePermission.check(
-			getPermissionChecker(), corEntryId, ActionKeys.DELETE);
 
-		return corEntryLocalService.deleteCOREntry(corEntryId);
+		COREntry corEntry = corEntryLocalService.getCOREntry(corEntryId);
+
+		_corEntryModelResourcePermission.check(
+			getPermissionChecker(), corEntry.getCOREntryId(),
+			ActionKeys.DELETE);
+
+		return corEntryLocalService.deleteCOREntry(corEntry.getCOREntryId());
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-order-rule-service/src/main/java/com/liferay/commerce/order/rule/service/impl/COREntryServiceImpl.java
+++ b/modules/apps/commerce/commerce-order-rule-service/src/main/java/com/liferay/commerce/order/rule/service/impl/COREntryServiceImpl.java
@@ -69,7 +69,6 @@ public class COREntryServiceImpl extends COREntryServiceBaseImpl {
 
 	@Override
 	public COREntry deleteCOREntry(long corEntryId) throws PortalException {
-
 		COREntry corEntry = corEntryLocalService.getCOREntry(corEntryId);
 
 		_corEntryModelResourcePermission.check(

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CommerceChannelServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CommerceChannelServiceImpl.java
@@ -88,11 +88,14 @@ public class CommerceChannelServiceImpl extends CommerceChannelServiceBaseImpl {
 	public CommerceChannel deleteCommerceChannel(long commerceChannelId)
 		throws PortalException {
 
+		CommerceChannel commerceChannel = commerceChannelLocalService.
+			getCommerceChannel(commerceChannelId);
+
 		_commerceChannelModelResourcePermission.check(
-			getPermissionChecker(), commerceChannelId, ActionKeys.DELETE);
+			getPermissionChecker(), commerceChannel.getCommerceChannelId(), ActionKeys.DELETE);
 
 		return commerceChannelLocalService.deleteCommerceChannel(
-			commerceChannelId);
+			commerceChannel.getCommerceChannelId());
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CommerceChannelServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CommerceChannelServiceImpl.java
@@ -88,11 +88,12 @@ public class CommerceChannelServiceImpl extends CommerceChannelServiceBaseImpl {
 	public CommerceChannel deleteCommerceChannel(long commerceChannelId)
 		throws PortalException {
 
-		CommerceChannel commerceChannel = commerceChannelLocalService.
-			getCommerceChannel(commerceChannelId);
+		CommerceChannel commerceChannel =
+			commerceChannelLocalService.getCommerceChannel(commerceChannelId);
 
 		_commerceChannelModelResourcePermission.check(
-			getPermissionChecker(), commerceChannel.getCommerceChannelId(), ActionKeys.DELETE);
+			getPermissionChecker(), commerceChannel.getCommerceChannelId(),
+			ActionKeys.DELETE);
 
 		return commerceChannelLocalService.deleteCommerceChannel(
 			commerceChannel.getCommerceChannelId());

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderTypeServiceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderTypeServiceImpl.java
@@ -77,11 +77,15 @@ public class CommerceOrderTypeServiceImpl
 	public CommerceOrderType deleteCommerceOrderType(long commerceOrderTypeId)
 		throws PortalException {
 
+		CommerceOrderType commerceOrderType = commerceOrderTypeLocalService.
+			getCommerceOrderType(commerceOrderTypeId);
+
 		_commerceOrderTypeModelResourcePermission.check(
-			getPermissionChecker(), commerceOrderTypeId, ActionKeys.DELETE);
+			getPermissionChecker(), commerceOrderType.getCommerceOrderTypeId(),
+			ActionKeys.DELETE);
 
 		return commerceOrderTypeLocalService.deleteCommerceOrderType(
-			commerceOrderTypeId);
+			commerceOrderType.getCommerceOrderTypeId());
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderTypeServiceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderTypeServiceImpl.java
@@ -77,8 +77,9 @@ public class CommerceOrderTypeServiceImpl
 	public CommerceOrderType deleteCommerceOrderType(long commerceOrderTypeId)
 		throws PortalException {
 
-		CommerceOrderType commerceOrderType = commerceOrderTypeLocalService.
-			getCommerceOrderType(commerceOrderTypeId);
+		CommerceOrderType commerceOrderType =
+			commerceOrderTypeLocalService.getCommerceOrderType(
+				commerceOrderTypeId);
 
 		_commerceOrderTypeModelResourcePermission.check(
 			getPermissionChecker(), commerceOrderType.getCommerceOrderTypeId(),

--- a/modules/apps/commerce/commerce-term-service/src/main/java/com/liferay/commerce/term/service/impl/CommerceTermEntryServiceImpl.java
+++ b/modules/apps/commerce/commerce-term-service/src/main/java/com/liferay/commerce/term/service/impl/CommerceTermEntryServiceImpl.java
@@ -80,8 +80,9 @@ public class CommerceTermEntryServiceImpl
 	public CommerceTermEntry deleteCommerceTermEntry(long commerceTermEntryId)
 		throws PortalException {
 
-		CommerceTermEntry commerceTermEntry = commerceTermEntryLocalService.
-			getCommerceTermEntry(commerceTermEntryId);
+		CommerceTermEntry commerceTermEntry =
+			commerceTermEntryLocalService.getCommerceTermEntry(
+				commerceTermEntryId);
 
 		_commerceTermEntryModelResourcePermission.check(
 			getPermissionChecker(), commerceTermEntry.getCommerceTermEntryId(),

--- a/modules/apps/commerce/commerce-term-service/src/main/java/com/liferay/commerce/term/service/impl/CommerceTermEntryServiceImpl.java
+++ b/modules/apps/commerce/commerce-term-service/src/main/java/com/liferay/commerce/term/service/impl/CommerceTermEntryServiceImpl.java
@@ -80,11 +80,15 @@ public class CommerceTermEntryServiceImpl
 	public CommerceTermEntry deleteCommerceTermEntry(long commerceTermEntryId)
 		throws PortalException {
 
+		CommerceTermEntry commerceTermEntry = commerceTermEntryLocalService.
+			getCommerceTermEntry(commerceTermEntryId);
+
 		_commerceTermEntryModelResourcePermission.check(
-			getPermissionChecker(), commerceTermEntryId, ActionKeys.DELETE);
+			getPermissionChecker(), commerceTermEntry.getCommerceTermEntryId(),
+			ActionKeys.DELETE);
 
 		return commerceTermEntryLocalService.deleteCommerceTermEntry(
-			commerceTermEntryId);
+			commerceTermEntry.getCommerceTermEntryId());
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/rest-openapi.yaml
@@ -569,7 +569,7 @@ info:
         name: Commerce Team
     description:
         "Liferay Commerce Admin Account API. A Java client JAR is available for use with the group ID 'com.liferay',
-        artifact ID 'com.liferay.headless.commerce.admin.account.client', and version '4.0.25'."
+        artifact ID 'com.liferay.headless.commerce.admin.account.client', and version '4.0.26'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Liferay Commerce Admin Account API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.account.client', and version '4.0.25'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Account API", version = "v1.0")
+	info = @Info(description = "Liferay Commerce Admin Account API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.account.client', and version '4.0.26'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Account API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountAddressResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountAddressResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.admin.account.client.pagination.Page;
 import com.liferay.headless.commerce.admin.account.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.account.client.resource.v1_0.AccountAddressResource;
 import com.liferay.headless.commerce.admin.account.client.serdes.v1_0.AccountAddressSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -220,11 +221,15 @@ public abstract class BaseAccountAddressResourceTestCase {
 		AccountAddress accountAddress =
 			testDeleteAccountAddressByExternalReferenceCode_addAccountAddress();
 
-		assertHttpResponseStatusCode(
-			204,
-			accountAddressResource.
-				deleteAccountAddressByExternalReferenceCodeHttpResponse(
-					accountAddress.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				accountAddressResource.
+					deleteAccountAddressByExternalReferenceCodeHttpResponse(
+						accountAddress.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -345,10 +350,13 @@ public abstract class BaseAccountAddressResourceTestCase {
 		AccountAddress accountAddress =
 			testDeleteAccountAddress_addAccountAddress();
 
-		assertHttpResponseStatusCode(
-			204,
-			accountAddressResource.deleteAccountAddressHttpResponse(
-				accountAddress.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> accountAddressResource.deleteAccountAddressHttpResponse(
+				accountAddress.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountChannelEntryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountChannelEntryResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.admin.account.client.pagination.Page;
 import com.liferay.headless.commerce.admin.account.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.account.client.resource.v1_0.AccountChannelEntryResource;
 import com.liferay.headless.commerce.admin.account.client.serdes.v1_0.AccountChannelEntrySerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -205,11 +206,15 @@ public abstract class BaseAccountChannelEntryResourceTestCase {
 		AccountChannelEntry accountChannelEntry =
 			testDeleteAccountChannelBillingAddressId_addAccountChannelEntry();
 
-		assertHttpResponseStatusCode(
-			204,
-			accountChannelEntryResource.
-				deleteAccountChannelBillingAddressIdHttpResponse(
-					accountChannelEntry.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				accountChannelEntryResource.
+					deleteAccountChannelBillingAddressIdHttpResponse(
+						accountChannelEntry.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -349,11 +354,15 @@ public abstract class BaseAccountChannelEntryResourceTestCase {
 		AccountChannelEntry accountChannelEntry =
 			testDeleteAccountChannelCurrencyId_addAccountChannelEntry();
 
-		assertHttpResponseStatusCode(
-			204,
-			accountChannelEntryResource.
-				deleteAccountChannelCurrencyIdHttpResponse(
-					accountChannelEntry.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				accountChannelEntryResource.
+					deleteAccountChannelCurrencyIdHttpResponse(
+						accountChannelEntry.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -489,11 +498,15 @@ public abstract class BaseAccountChannelEntryResourceTestCase {
 		AccountChannelEntry accountChannelEntry =
 			testDeleteAccountChannelDeliveryTermId_addAccountChannelEntry();
 
-		assertHttpResponseStatusCode(
-			204,
-			accountChannelEntryResource.
-				deleteAccountChannelDeliveryTermIdHttpResponse(
-					accountChannelEntry.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				accountChannelEntryResource.
+					deleteAccountChannelDeliveryTermIdHttpResponse(
+						accountChannelEntry.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -631,11 +644,15 @@ public abstract class BaseAccountChannelEntryResourceTestCase {
 		AccountChannelEntry accountChannelEntry =
 			testDeleteAccountChannelDiscountId_addAccountChannelEntry();
 
-		assertHttpResponseStatusCode(
-			204,
-			accountChannelEntryResource.
-				deleteAccountChannelDiscountIdHttpResponse(
-					accountChannelEntry.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				accountChannelEntryResource.
+					deleteAccountChannelDiscountIdHttpResponse(
+						accountChannelEntry.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -771,11 +788,15 @@ public abstract class BaseAccountChannelEntryResourceTestCase {
 		AccountChannelEntry accountChannelEntry =
 			testDeleteAccountChannelPaymentMethodId_addAccountChannelEntry();
 
-		assertHttpResponseStatusCode(
-			204,
-			accountChannelEntryResource.
-				deleteAccountChannelPaymentMethodIdHttpResponse(
-					accountChannelEntry.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				accountChannelEntryResource.
+					deleteAccountChannelPaymentMethodIdHttpResponse(
+						accountChannelEntry.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -913,11 +934,15 @@ public abstract class BaseAccountChannelEntryResourceTestCase {
 		AccountChannelEntry accountChannelEntry =
 			testDeleteAccountChannelPaymentTermId_addAccountChannelEntry();
 
-		assertHttpResponseStatusCode(
-			204,
-			accountChannelEntryResource.
-				deleteAccountChannelPaymentTermIdHttpResponse(
-					accountChannelEntry.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				accountChannelEntryResource.
+					deleteAccountChannelPaymentTermIdHttpResponse(
+						accountChannelEntry.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -1055,11 +1080,15 @@ public abstract class BaseAccountChannelEntryResourceTestCase {
 		AccountChannelEntry accountChannelEntry =
 			testDeleteAccountChannelPriceListId_addAccountChannelEntry();
 
-		assertHttpResponseStatusCode(
-			204,
-			accountChannelEntryResource.
-				deleteAccountChannelPriceListIdHttpResponse(
-					accountChannelEntry.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				accountChannelEntryResource.
+					deleteAccountChannelPriceListIdHttpResponse(
+						accountChannelEntry.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -1197,11 +1226,15 @@ public abstract class BaseAccountChannelEntryResourceTestCase {
 		AccountChannelEntry accountChannelEntry =
 			testDeleteAccountChannelShippingAddressId_addAccountChannelEntry();
 
-		assertHttpResponseStatusCode(
-			204,
-			accountChannelEntryResource.
-				deleteAccountChannelShippingAddressIdHttpResponse(
-					accountChannelEntry.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				accountChannelEntryResource.
+					deleteAccountChannelShippingAddressIdHttpResponse(
+						accountChannelEntry.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -1341,10 +1374,15 @@ public abstract class BaseAccountChannelEntryResourceTestCase {
 		AccountChannelEntry accountChannelEntry =
 			testDeleteAccountChannelUserId_addAccountChannelEntry();
 
-		assertHttpResponseStatusCode(
-			204,
-			accountChannelEntryResource.deleteAccountChannelUserIdHttpResponse(
-				accountChannelEntry.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				accountChannelEntryResource.
+					deleteAccountChannelUserIdHttpResponse(
+						accountChannelEntry.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountChannelShippingOptionResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountChannelShippingOptionResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.admin.account.client.pagination.Page;
 import com.liferay.headless.commerce.admin.account.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.account.client.resource.v1_0.AccountChannelShippingOptionResource;
 import com.liferay.headless.commerce.admin.account.client.serdes.v1_0.AccountChannelShippingOptionSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -221,11 +222,15 @@ public abstract class BaseAccountChannelShippingOptionResourceTestCase {
 		AccountChannelShippingOption accountChannelShippingOption =
 			testDeleteAccountChannelShippingOption_addAccountChannelShippingOption();
 
-		assertHttpResponseStatusCode(
-			204,
-			accountChannelShippingOptionResource.
-				deleteAccountChannelShippingOptionHttpResponse(
-					accountChannelShippingOption.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				accountChannelShippingOptionResource.
+					deleteAccountChannelShippingOptionHttpResponse(
+						accountChannelShippingOption.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.admin.account.client.pagination.Page;
 import com.liferay.headless.commerce.admin.account.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.account.client.resource.v1_0.AccountResource;
 import com.liferay.headless.commerce.admin.account.client.serdes.v1_0.AccountSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -217,12 +218,16 @@ public abstract class BaseAccountResourceTestCase {
 		Account account =
 			testDeleteAccountGroupByExternalReferenceCodeAccount_addAccount();
 
-		assertHttpResponseStatusCode(
-			204,
-			accountResource.
-				deleteAccountGroupByExternalReferenceCodeAccountHttpResponse(
-					testDeleteAccountGroupByExternalReferenceCodeAccount_getAccountExternalReferenceCode(),
-					account.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				accountResource.
+					deleteAccountGroupByExternalReferenceCodeAccountHttpResponse(
+						testDeleteAccountGroupByExternalReferenceCodeAccount_getAccountExternalReferenceCode(),
+						account.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 	}
 
 	protected String
@@ -583,10 +588,15 @@ public abstract class BaseAccountResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		Account account = testDeleteAccountByExternalReferenceCode_addAccount();
 
-		assertHttpResponseStatusCode(
-			204,
-			accountResource.deleteAccountByExternalReferenceCodeHttpResponse(
-				account.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				accountResource.
+					deleteAccountByExternalReferenceCodeHttpResponse(
+						account.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -701,8 +711,12 @@ public abstract class BaseAccountResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		Account account = testDeleteAccount_addAccount();
 
-		assertHttpResponseStatusCode(
-			204, accountResource.deleteAccountHttpResponse(account.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> accountResource.deleteAccountHttpResponse(account.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404, accountResource.getAccountHttpResponse(account.getId()));

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAdminAccountGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAdminAccountGroupResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.admin.account.client.pagination.Page;
 import com.liferay.headless.commerce.admin.account.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.account.client.resource.v1_0.AdminAccountGroupResource;
 import com.liferay.headless.commerce.admin.account.client.serdes.v1_0.AdminAccountGroupSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -552,11 +553,15 @@ public abstract class BaseAdminAccountGroupResourceTestCase {
 		AdminAccountGroup adminAccountGroup =
 			testDeleteAccountGroupByExternalReferenceCode_addAdminAccountGroup();
 
-		assertHttpResponseStatusCode(
-			204,
-			adminAccountGroupResource.
-				deleteAccountGroupByExternalReferenceCodeHttpResponse(
-					adminAccountGroup.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				adminAccountGroupResource.
+					deleteAccountGroupByExternalReferenceCodeHttpResponse(
+						adminAccountGroup.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -675,10 +680,13 @@ public abstract class BaseAdminAccountGroupResourceTestCase {
 		AdminAccountGroup adminAccountGroup =
 			testDeleteAccountGroup_addAdminAccountGroup();
 
-		assertHttpResponseStatusCode(
-			204,
-			adminAccountGroupResource.deleteAccountGroupHttpResponse(
-				adminAccountGroup.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> adminAccountGroupResource.deleteAccountGroupHttpResponse(
+				adminAccountGroup.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseCatalogResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseCatalogResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.admin.catalog.client.pagination.Page;
 import com.liferay.headless.commerce.admin.catalog.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.catalog.client.resource.v1_0.CatalogResource;
 import com.liferay.headless.commerce.admin.catalog.client.serdes.v1_0.CatalogSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -207,10 +208,15 @@ public abstract class BaseCatalogResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		Catalog catalog = testDeleteCatalogByExternalReferenceCode_addCatalog();
 
-		assertHttpResponseStatusCode(
-			204,
-			catalogResource.deleteCatalogByExternalReferenceCodeHttpResponse(
-				catalog.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				catalogResource.
+					deleteCatalogByExternalReferenceCodeHttpResponse(
+						catalog.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -320,8 +326,12 @@ public abstract class BaseCatalogResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		Catalog catalog = testDeleteCatalog_addCatalog();
 
-		assertHttpResponseStatusCode(
-			204, catalogResource.deleteCatalogHttpResponse(catalog.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> catalogResource.deleteCatalogHttpResponse(catalog.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404, catalogResource.getCatalogHttpResponse(catalog.getId()));

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseGroupedProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseGroupedProductResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.admin.catalog.client.pagination.Page;
 import com.liferay.headless.commerce.admin.catalog.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.catalog.client.resource.v1_0.GroupedProductResource;
 import com.liferay.headless.commerce.admin.catalog.client.serdes.v1_0.GroupedProductSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -201,10 +202,13 @@ public abstract class BaseGroupedProductResourceTestCase {
 		GroupedProduct groupedProduct =
 			testDeleteGroupedProduct_addGroupedProduct();
 
-		assertHttpResponseStatusCode(
-			204,
-			groupedProductResource.deleteGroupedProductHttpResponse(
-				groupedProduct.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> groupedProductResource.deleteGroupedProductHttpResponse(
+				groupedProduct.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 	}
 
 	protected GroupedProduct testDeleteGroupedProduct_addGroupedProduct()

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseMappedProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseMappedProductResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.admin.catalog.client.pagination.Page;
 import com.liferay.headless.commerce.admin.catalog.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.catalog.client.resource.v1_0.MappedProductResource;
 import com.liferay.headless.commerce.admin.catalog.client.serdes.v1_0.MappedProductSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -206,10 +207,13 @@ public abstract class BaseMappedProductResourceTestCase {
 		MappedProduct mappedProduct =
 			testDeleteMappedProduct_addMappedProduct();
 
-		assertHttpResponseStatusCode(
-			204,
-			mappedProductResource.deleteMappedProductHttpResponse(
-				mappedProduct.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> mappedProductResource.deleteMappedProductHttpResponse(
+				mappedProduct.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 	}
 
 	protected MappedProduct testDeleteMappedProduct_addMappedProduct()

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseOptionCategoryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseOptionCategoryResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.admin.catalog.client.pagination.Page;
 import com.liferay.headless.commerce.admin.catalog.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.catalog.client.resource.v1_0.OptionCategoryResource;
 import com.liferay.headless.commerce.admin.catalog.client.serdes.v1_0.OptionCategorySerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -594,10 +595,13 @@ public abstract class BaseOptionCategoryResourceTestCase {
 		OptionCategory optionCategory =
 			testDeleteOptionCategory_addOptionCategory();
 
-		assertHttpResponseStatusCode(
-			204,
-			optionCategoryResource.deleteOptionCategoryHttpResponse(
-				optionCategory.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> optionCategoryResource.deleteOptionCategoryHttpResponse(
+				optionCategory.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseOptionResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseOptionResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.admin.catalog.client.pagination.Page;
 import com.liferay.headless.commerce.admin.catalog.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.catalog.client.resource.v1_0.OptionResource;
 import com.liferay.headless.commerce.admin.catalog.client.serdes.v1_0.OptionSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -538,10 +539,14 @@ public abstract class BaseOptionResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		Option option = testDeleteOptionByExternalReferenceCode_addOption();
 
-		assertHttpResponseStatusCode(
-			204,
-			optionResource.deleteOptionByExternalReferenceCodeHttpResponse(
-				option.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				optionResource.deleteOptionByExternalReferenceCodeHttpResponse(
+					option.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -647,8 +652,12 @@ public abstract class BaseOptionResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		Option option = testDeleteOption_addOption();
 
-		assertHttpResponseStatusCode(
-			204, optionResource.deleteOptionHttpResponse(option.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> optionResource.deleteOptionHttpResponse(option.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404, optionResource.getOptionHttpResponse(option.getId()));

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseOptionValueResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseOptionValueResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.admin.catalog.client.pagination.Page;
 import com.liferay.headless.commerce.admin.catalog.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.catalog.client.resource.v1_0.OptionValueResource;
 import com.liferay.headless.commerce.admin.catalog.client.serdes.v1_0.OptionValueSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -204,11 +205,15 @@ public abstract class BaseOptionValueResourceTestCase {
 		OptionValue optionValue =
 			testDeleteOptionValueByExternalReferenceCode_addOptionValue();
 
-		assertHttpResponseStatusCode(
-			204,
-			optionValueResource.
-				deleteOptionValueByExternalReferenceCodeHttpResponse(
-					optionValue.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				optionValueResource.
+					deleteOptionValueByExternalReferenceCodeHttpResponse(
+						optionValue.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -324,10 +329,13 @@ public abstract class BaseOptionValueResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		OptionValue optionValue = testDeleteOptionValue_addOptionValue();
 
-		assertHttpResponseStatusCode(
-			204,
-			optionValueResource.deleteOptionValueHttpResponse(
-				optionValue.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> optionValueResource.deleteOptionValueHttpResponse(
+				optionValue.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BasePinResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BasePinResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.admin.catalog.client.pagination.Page;
 import com.liferay.headless.commerce.admin.catalog.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.catalog.client.resource.v1_0.PinResource;
 import com.liferay.headless.commerce.admin.catalog.client.serdes.v1_0.PinSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -198,8 +199,12 @@ public abstract class BasePinResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		Pin pin = testDeletePin_addPin();
 
-		assertHttpResponseStatusCode(
-			204, pinResource.deletePinHttpResponse(pin.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> pinResource.deletePinHttpResponse(pin.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 	}
 
 	protected Pin testDeletePin_addPin() throws Exception {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductAccountGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductAccountGroupResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.admin.catalog.client.pagination.Page;
 import com.liferay.headless.commerce.admin.catalog.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.catalog.client.resource.v1_0.ProductAccountGroupResource;
 import com.liferay.headless.commerce.admin.catalog.client.serdes.v1_0.ProductAccountGroupSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -202,10 +203,15 @@ public abstract class BaseProductAccountGroupResourceTestCase {
 		ProductAccountGroup productAccountGroup =
 			testDeleteProductAccountGroup_addProductAccountGroup();
 
-		assertHttpResponseStatusCode(
-			204,
-			productAccountGroupResource.deleteProductAccountGroupHttpResponse(
-				productAccountGroup.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				productAccountGroupResource.
+					deleteProductAccountGroupHttpResponse(
+						productAccountGroup.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductChannelResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductChannelResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.admin.catalog.client.pagination.Page;
 import com.liferay.headless.commerce.admin.catalog.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.catalog.client.resource.v1_0.ProductChannelResource;
 import com.liferay.headless.commerce.admin.catalog.client.serdes.v1_0.ProductChannelSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -204,10 +205,13 @@ public abstract class BaseProductChannelResourceTestCase {
 		ProductChannel productChannel =
 			testDeleteProductChannel_addProductChannel();
 
-		assertHttpResponseStatusCode(
-			204,
-			productChannelResource.deleteProductChannelHttpResponse(
-				productChannel.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> productChannelResource.deleteProductChannelHttpResponse(
+				productChannel.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductGroupProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductGroupProductResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.admin.catalog.client.pagination.Page;
 import com.liferay.headless.commerce.admin.catalog.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.catalog.client.resource.v1_0.ProductGroupProductResource;
 import com.liferay.headless.commerce.admin.catalog.client.serdes.v1_0.ProductGroupProductSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -206,10 +207,15 @@ public abstract class BaseProductGroupProductResourceTestCase {
 		ProductGroupProduct productGroupProduct =
 			testDeleteProductGroupProduct_addProductGroupProduct();
 
-		assertHttpResponseStatusCode(
-			204,
-			productGroupProductResource.deleteProductGroupProductHttpResponse(
-				productGroupProduct.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				productGroupProductResource.
+					deleteProductGroupProductHttpResponse(
+						productGroupProduct.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 	}
 
 	protected ProductGroupProduct

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductGroupResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.admin.catalog.client.pagination.Page;
 import com.liferay.headless.commerce.admin.catalog.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.catalog.client.resource.v1_0.ProductGroupResource;
 import com.liferay.headless.commerce.admin.catalog.client.serdes.v1_0.ProductGroupSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -575,11 +576,15 @@ public abstract class BaseProductGroupResourceTestCase {
 		ProductGroup productGroup =
 			testDeleteProductGroupByExternalReferenceCode_addProductGroup();
 
-		assertHttpResponseStatusCode(
-			204,
-			productGroupResource.
-				deleteProductGroupByExternalReferenceCodeHttpResponse(
-					productGroup.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				productGroupResource.
+					deleteProductGroupByExternalReferenceCodeHttpResponse(
+						productGroup.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -697,10 +702,13 @@ public abstract class BaseProductGroupResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		ProductGroup productGroup = testDeleteProductGroup_addProductGroup();
 
-		assertHttpResponseStatusCode(
-			204,
-			productGroupResource.deleteProductGroupHttpResponse(
-				productGroup.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> productGroupResource.deleteProductGroupHttpResponse(
+				productGroup.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductOptionResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductOptionResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.admin.catalog.client.pagination.Page;
 import com.liferay.headless.commerce.admin.catalog.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.catalog.client.resource.v1_0.ProductOptionResource;
 import com.liferay.headless.commerce.admin.catalog.client.serdes.v1_0.ProductOptionSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -202,10 +203,13 @@ public abstract class BaseProductOptionResourceTestCase {
 		ProductOption productOption =
 			testDeleteProductOption_addProductOption();
 
-		assertHttpResponseStatusCode(
-			204,
-			productOptionResource.deleteProductOptionHttpResponse(
-				productOption.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> productOptionResource.deleteProductOptionHttpResponse(
+				productOption.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.admin.catalog.client.pagination.Page;
 import com.liferay.headless.commerce.admin.catalog.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.catalog.client.resource.v1_0.ProductResource;
 import com.liferay.headless.commerce.admin.catalog.client.serdes.v1_0.ProductSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -548,10 +549,15 @@ public abstract class BaseProductResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		Product product = testDeleteProductByExternalReferenceCode_addProduct();
 
-		assertHttpResponseStatusCode(
-			204,
-			productResource.deleteProductByExternalReferenceCodeHttpResponse(
-				product.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				productResource.
+					deleteProductByExternalReferenceCodeHttpResponse(
+						product.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -664,11 +670,16 @@ public abstract class BaseProductResourceTestCase {
 		Product product =
 			testDeleteProductByExternalReferenceCodeByVersion_addProduct();
 
-		assertHttpResponseStatusCode(
-			204,
-			productResource.
-				deleteProductByExternalReferenceCodeByVersionHttpResponse(
-					product.getExternalReferenceCode(), product.getVersion()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				productResource.
+					deleteProductByExternalReferenceCodeByVersionHttpResponse(
+						product.getExternalReferenceCode(),
+						product.getVersion());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -806,8 +817,12 @@ public abstract class BaseProductResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		Product product = testDeleteProduct_addProduct();
 
-		assertHttpResponseStatusCode(
-			204, productResource.deleteProductHttpResponse(product.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> productResource.deleteProductHttpResponse(product.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404, productResource.getProductHttpResponse(product.getId()));
@@ -925,10 +940,13 @@ public abstract class BaseProductResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		Product product = testDeleteProductByVersion_addProduct();
 
-		assertHttpResponseStatusCode(
-			204,
-			productResource.deleteProductByVersionHttpResponse(
-				product.getId(), product.getVersion()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> productResource.deleteProductByVersionHttpResponse(
+				product.getId(), product.getVersion());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductSpecificationResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductSpecificationResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.admin.catalog.client.pagination.Page;
 import com.liferay.headless.commerce.admin.catalog.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.catalog.client.resource.v1_0.ProductSpecificationResource;
 import com.liferay.headless.commerce.admin.catalog.client.serdes.v1_0.ProductSpecificationSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -202,10 +203,15 @@ public abstract class BaseProductSpecificationResourceTestCase {
 		ProductSpecification productSpecification =
 			testDeleteProductSpecification_addProductSpecification();
 
-		assertHttpResponseStatusCode(
-			204,
-			productSpecificationResource.deleteProductSpecificationHttpResponse(
-				productSpecification.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				productSpecificationResource.
+					deleteProductSpecificationHttpResponse(
+						productSpecification.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseRelatedProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseRelatedProductResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.admin.catalog.client.pagination.Page;
 import com.liferay.headless.commerce.admin.catalog.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.catalog.client.resource.v1_0.RelatedProductResource;
 import com.liferay.headless.commerce.admin.catalog.client.serdes.v1_0.RelatedProductSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -534,10 +535,13 @@ public abstract class BaseRelatedProductResourceTestCase {
 		RelatedProduct relatedProduct =
 			testDeleteRelatedProduct_addRelatedProduct();
 
-		assertHttpResponseStatusCode(
-			204,
-			relatedProductResource.deleteRelatedProductHttpResponse(
-				relatedProduct.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> relatedProductResource.deleteRelatedProductHttpResponse(
+				relatedProduct.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseSkuResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseSkuResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.admin.catalog.client.pagination.Page;
 import com.liferay.headless.commerce.admin.catalog.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.catalog.client.resource.v1_0.SkuResource;
 import com.liferay.headless.commerce.admin.catalog.client.serdes.v1_0.SkuSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -781,10 +782,13 @@ public abstract class BaseSkuResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		Sku sku = testDeleteSkuByExternalReferenceCode_addSku();
 
-		assertHttpResponseStatusCode(
-			204,
-			skuResource.deleteSkuByExternalReferenceCodeHttpResponse(
-				sku.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> skuResource.deleteSkuByExternalReferenceCodeHttpResponse(
+				sku.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -910,8 +914,12 @@ public abstract class BaseSkuResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		Sku sku = testDeleteSku_addSku();
 
-		assertHttpResponseStatusCode(
-			204, skuResource.deleteSkuHttpResponse(sku.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> skuResource.deleteSkuHttpResponse(sku.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404, skuResource.getSkuHttpResponse(sku.getId()));

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseSpecificationResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseSpecificationResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.admin.catalog.client.pagination.Page;
 import com.liferay.headless.commerce.admin.catalog.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.catalog.client.resource.v1_0.SpecificationResource;
 import com.liferay.headless.commerce.admin.catalog.client.serdes.v1_0.SpecificationSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -581,10 +582,13 @@ public abstract class BaseSpecificationResourceTestCase {
 		Specification specification =
 			testDeleteSpecification_addSpecification();
 
-		assertHttpResponseStatusCode(
-			204,
-			specificationResource.deleteSpecificationHttpResponse(
-				specification.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> specificationResource.deleteSpecificationHttpResponse(
+				specification.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/rest-openapi.yaml
@@ -361,7 +361,7 @@ components:
 info:
     description:
         "Liferay Commerce Admin Channel API. A Java client JAR is available for use with the group ID 'com.liferay',
-        artifact ID 'com.liferay.headless.commerce.admin.channel.client', and version '4.0.23'."
+        artifact ID 'com.liferay.headless.commerce.admin.channel.client', and version '4.0.24'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Liferay Commerce Admin Channel API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.channel.client', and version '4.0.23'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Channel API", version = "v1.0")
+	info = @Info(description = "Liferay Commerce Admin Channel API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.channel.client', and version '4.0.24'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Channel API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseChannelResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseChannelResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.admin.channel.client.pagination.Page;
 import com.liferay.headless.commerce.admin.channel.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.channel.client.resource.v1_0.ChannelResource;
 import com.liferay.headless.commerce.admin.channel.client.serdes.v1_0.ChannelSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -544,10 +545,15 @@ public abstract class BaseChannelResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		Channel channel = testDeleteChannelByExternalReferenceCode_addChannel();
 
-		assertHttpResponseStatusCode(
-			204,
-			channelResource.deleteChannelByExternalReferenceCodeHttpResponse(
-				channel.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				channelResource.
+					deleteChannelByExternalReferenceCodeHttpResponse(
+						channel.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -733,8 +739,12 @@ public abstract class BaseChannelResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		Channel channel = testDeleteChannel_addChannel();
 
-		assertHttpResponseStatusCode(
-			204, channelResource.deleteChannelHttpResponse(channel.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> channelResource.deleteChannelHttpResponse(channel.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404, channelResource.getChannelHttpResponse(channel.getId()));

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-test/src/testIntegration/java/com/liferay/headless/commerce/admin/inventory/resource/v1_0/test/BaseReplenishmentItemResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-test/src/testIntegration/java/com/liferay/headless/commerce/admin/inventory/resource/v1_0/test/BaseReplenishmentItemResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.admin.inventory.client.pagination.Page;
 import com.liferay.headless.commerce.admin.inventory.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.inventory.client.resource.v1_0.ReplenishmentItemResource;
 import com.liferay.headless.commerce.admin.inventory.client.serdes.v1_0.ReplenishmentItemSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -206,11 +207,15 @@ public abstract class BaseReplenishmentItemResourceTestCase {
 		ReplenishmentItem replenishmentItem =
 			testDeleteReplenishmentItemByExternalReferenceCode_addReplenishmentItem();
 
-		assertHttpResponseStatusCode(
-			204,
-			replenishmentItemResource.
-				deleteReplenishmentItemByExternalReferenceCodeHttpResponse(
-					replenishmentItem.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				replenishmentItemResource.
+					deleteReplenishmentItemByExternalReferenceCodeHttpResponse(
+						replenishmentItem.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -365,10 +370,13 @@ public abstract class BaseReplenishmentItemResourceTestCase {
 		ReplenishmentItem replenishmentItem =
 			testDeleteReplenishmentItem_addReplenishmentItem();
 
-		assertHttpResponseStatusCode(
-			204,
-			replenishmentItemResource.deleteReplenishmentItemHttpResponse(
-				replenishmentItem.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> replenishmentItemResource.deleteReplenishmentItemHttpResponse(
+				replenishmentItem.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-test/src/testIntegration/java/com/liferay/headless/commerce/admin/inventory/resource/v1_0/test/BaseWarehouseItemResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-test/src/testIntegration/java/com/liferay/headless/commerce/admin/inventory/resource/v1_0/test/BaseWarehouseItemResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.admin.inventory.client.pagination.Page;
 import com.liferay.headless.commerce.admin.inventory.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.inventory.client.resource.v1_0.WarehouseItemResource;
 import com.liferay.headless.commerce.admin.inventory.client.serdes.v1_0.WarehouseItemSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -207,11 +208,15 @@ public abstract class BaseWarehouseItemResourceTestCase {
 		WarehouseItem warehouseItem =
 			testDeleteWarehouseItemByExternalReferenceCode_addWarehouseItem();
 
-		assertHttpResponseStatusCode(
-			204,
-			warehouseItemResource.
-				deleteWarehouseItemByExternalReferenceCodeHttpResponse(
-					warehouseItem.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				warehouseItemResource.
+					deleteWarehouseItemByExternalReferenceCodeHttpResponse(
+						warehouseItem.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -455,10 +460,13 @@ public abstract class BaseWarehouseItemResourceTestCase {
 		WarehouseItem warehouseItem =
 			testDeleteWarehouseItem_addWarehouseItem();
 
-		assertHttpResponseStatusCode(
-			204,
-			warehouseItemResource.deleteWarehouseItemHttpResponse(
-				warehouseItem.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> warehouseItemResource.deleteWarehouseItemHttpResponse(
+				warehouseItem.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-test/src/testIntegration/java/com/liferay/headless/commerce/admin/inventory/resource/v1_0/test/BaseWarehouseResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-test/src/testIntegration/java/com/liferay/headless/commerce/admin/inventory/resource/v1_0/test/BaseWarehouseResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.admin.inventory.client.pagination.Page;
 import com.liferay.headless.commerce.admin.inventory.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.inventory.client.resource.v1_0.WarehouseResource;
 import com.liferay.headless.commerce.admin.inventory.client.serdes.v1_0.WarehouseSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -566,11 +567,15 @@ public abstract class BaseWarehouseResourceTestCase {
 		Warehouse warehouse =
 			testDeleteWarehouseByExternalReferenceCode_addWarehouse();
 
-		assertHttpResponseStatusCode(
-			204,
-			warehouseResource.
-				deleteWarehouseByExternalReferenceCodeHttpResponse(
-					warehouse.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				warehouseResource.
+					deleteWarehouseByExternalReferenceCodeHttpResponse(
+						warehouse.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -683,9 +688,13 @@ public abstract class BaseWarehouseResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		Warehouse warehouse = testDeleteWarehouseId_addWarehouse();
 
-		assertHttpResponseStatusCode(
-			204,
-			warehouseResource.deleteWarehouseIdHttpResponse(warehouse.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> warehouseResource.deleteWarehouseIdHttpResponse(
+				warehouse.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/rest-openapi.yaml
@@ -1375,7 +1375,7 @@ info:
         name: Commerce Team
     description:
         "Liferay Commerce Admin Order API. A Java client JAR is available for use with the group ID 'com.liferay',
-        artifact ID 'com.liferay.headless.commerce.admin.order.client', and version '4.0.30'."
+        artifact ID 'com.liferay.headless.commerce.admin.order.client', and version '4.0.31'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Liferay Commerce Admin Order API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.order.client', and version '4.0.30'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Order API", version = "v1.0")
+	info = @Info(description = "Liferay Commerce Admin Order API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.order.client', and version '4.0.31'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Order API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderItemResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderItemResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.admin.order.client.pagination.Page;
 import com.liferay.headless.commerce.admin.order.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.order.client.resource.v1_0.OrderItemResource;
 import com.liferay.headless.commerce.admin.order.client.serdes.v1_0.OrderItemSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -557,11 +558,15 @@ public abstract class BaseOrderItemResourceTestCase {
 		OrderItem orderItem =
 			testDeleteOrderItemByExternalReferenceCode_addOrderItem();
 
-		assertHttpResponseStatusCode(
-			204,
-			orderItemResource.
-				deleteOrderItemByExternalReferenceCodeHttpResponse(
-					orderItem.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				orderItemResource.
+					deleteOrderItemByExternalReferenceCodeHttpResponse(
+						orderItem.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -728,9 +733,13 @@ public abstract class BaseOrderItemResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		OrderItem orderItem = testDeleteOrderItem_addOrderItem();
 
-		assertHttpResponseStatusCode(
-			204,
-			orderItemResource.deleteOrderItemHttpResponse(orderItem.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> orderItemResource.deleteOrderItemHttpResponse(
+				orderItem.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404, orderItemResource.getOrderItemHttpResponse(orderItem.getId()));

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderNoteResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderNoteResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.admin.order.client.pagination.Page;
 import com.liferay.headless.commerce.admin.order.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.order.client.resource.v1_0.OrderNoteResource;
 import com.liferay.headless.commerce.admin.order.client.serdes.v1_0.OrderNoteSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -203,11 +204,15 @@ public abstract class BaseOrderNoteResourceTestCase {
 		OrderNote orderNote =
 			testDeleteOrderNoteByExternalReferenceCode_addOrderNote();
 
-		assertHttpResponseStatusCode(
-			204,
-			orderNoteResource.
-				deleteOrderNoteByExternalReferenceCodeHttpResponse(
-					orderNote.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				orderNoteResource.
+					deleteOrderNoteByExternalReferenceCodeHttpResponse(
+						orderNote.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -320,9 +325,13 @@ public abstract class BaseOrderNoteResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		OrderNote orderNote = testDeleteOrderNote_addOrderNote();
 
-		assertHttpResponseStatusCode(
-			204,
-			orderNoteResource.deleteOrderNoteHttpResponse(orderNote.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> orderNoteResource.deleteOrderNoteHttpResponse(
+				orderNote.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404, orderNoteResource.getOrderNoteHttpResponse(orderNote.getId()));

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.admin.order.client.pagination.Page;
 import com.liferay.headless.commerce.admin.order.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.order.client.resource.v1_0.OrderResource;
 import com.liferay.headless.commerce.admin.order.client.serdes.v1_0.OrderSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -595,10 +596,13 @@ public abstract class BaseOrderResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		Order order = testDeleteOrderByExternalReferenceCode_addOrder();
 
-		assertHttpResponseStatusCode(
-			204,
-			orderResource.deleteOrderByExternalReferenceCodeHttpResponse(
-				order.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> orderResource.deleteOrderByExternalReferenceCodeHttpResponse(
+				order.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -704,8 +708,12 @@ public abstract class BaseOrderResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		Order order = testDeleteOrder_addOrder();
 
-		assertHttpResponseStatusCode(
-			204, orderResource.deleteOrderHttpResponse(order.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> orderResource.deleteOrderHttpResponse(order.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404, orderResource.getOrderHttpResponse(order.getId()));

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderRuleResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderRuleResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.admin.order.client.pagination.Page;
 import com.liferay.headless.commerce.admin.order.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.order.client.resource.v1_0.OrderRuleResource;
 import com.liferay.headless.commerce.admin.order.client.serdes.v1_0.OrderRuleSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -567,11 +568,15 @@ public abstract class BaseOrderRuleResourceTestCase {
 		OrderRule orderRule =
 			testDeleteOrderRuleByExternalReferenceCode_addOrderRule();
 
-		assertHttpResponseStatusCode(
-			204,
-			orderRuleResource.
-				deleteOrderRuleByExternalReferenceCodeHttpResponse(
-					orderRule.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				orderRuleResource.
+					deleteOrderRuleByExternalReferenceCodeHttpResponse(
+						orderRule.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -711,9 +716,13 @@ public abstract class BaseOrderRuleResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		OrderRule orderRule = testDeleteOrderRule_addOrderRule();
 
-		assertHttpResponseStatusCode(
-			204,
-			orderRuleResource.deleteOrderRuleHttpResponse(orderRule.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> orderRuleResource.deleteOrderRuleHttpResponse(
+				orderRule.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404, orderRuleResource.getOrderRuleHttpResponse(orderRule.getId()));

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderTypeResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderTypeResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.admin.order.client.pagination.Page;
 import com.liferay.headless.commerce.admin.order.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.order.client.resource.v1_0.OrderTypeResource;
 import com.liferay.headless.commerce.admin.order.client.serdes.v1_0.OrderTypeSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -647,11 +648,15 @@ public abstract class BaseOrderTypeResourceTestCase {
 		OrderType orderType =
 			testDeleteOrderTypeByExternalReferenceCode_addOrderType();
 
-		assertHttpResponseStatusCode(
-			204,
-			orderTypeResource.
-				deleteOrderTypeByExternalReferenceCodeHttpResponse(
-					orderType.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				orderTypeResource.
+					deleteOrderTypeByExternalReferenceCodeHttpResponse(
+						orderType.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -791,9 +796,13 @@ public abstract class BaseOrderTypeResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		OrderType orderType = testDeleteOrderType_addOrderType();
 
-		assertHttpResponseStatusCode(
-			204,
-			orderTypeResource.deleteOrderTypeHttpResponse(orderType.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> orderTypeResource.deleteOrderTypeHttpResponse(
+				orderType.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404, orderTypeResource.getOrderTypeHttpResponse(orderType.getId()));

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseTermResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseTermResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.admin.order.client.pagination.Page;
 import com.liferay.headless.commerce.admin.order.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.order.client.resource.v1_0.TermResource;
 import com.liferay.headless.commerce.admin.order.client.serdes.v1_0.TermSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -536,10 +537,13 @@ public abstract class BaseTermResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		Term term = testDeleteTermByExternalReferenceCode_addTerm();
 
-		assertHttpResponseStatusCode(
-			204,
-			termResource.deleteTermByExternalReferenceCodeHttpResponse(
-				term.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> termResource.deleteTermByExternalReferenceCodeHttpResponse(
+				term.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -668,8 +672,12 @@ public abstract class BaseTermResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		Term term = testDeleteTerm_addTerm();
 
-		assertHttpResponseStatusCode(
-			204, termResource.deleteTermHttpResponse(term.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> termResource.deleteTermHttpResponse(term.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404, termResource.getTermHttpResponse(term.getId()));

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/rest-openapi-v2.0.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/rest-openapi-v2.0.yaml
@@ -1470,7 +1470,7 @@ info:
         name: Commerce Team
     description:
         "Liferay Commerce Admin Pricing API. A Java client JAR is available for use with the group ID 'com.liferay',
-        artifact ID 'com.liferay.headless.commerce.admin.pricing.client', and version '4.0.23'."
+        artifact ID 'com.liferay.headless.commerce.admin.pricing.client', and version '4.0.25'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/rest-openapi.yaml
@@ -484,7 +484,7 @@ info:
         name: Commerce Team
     description:
         "Liferay Commerce Admin Pricing API. A Java client JAR is available for use with the group ID 'com.liferay',
-        artifact ID 'com.liferay.headless.commerce.admin.pricing.client', and version '4.0.23'."
+        artifact ID 'com.liferay.headless.commerce.admin.pricing.client', and version '4.0.25'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Liferay Commerce Admin Pricing API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.pricing.client', and version '4.0.23'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Pricing API", version = "v1.0")
+	info = @Info(description = "Liferay Commerce Admin Pricing API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.pricing.client', and version '4.0.25'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Pricing API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/OpenAPIResourceImpl.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Liferay Commerce Admin Pricing API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.pricing.client', and version '4.0.23'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Pricing API", version = "v2.0")
+	info = @Info(description = "Liferay Commerce Admin Pricing API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.pricing.client', and version '4.0.25'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Pricing API", version = "v2.0")
 )
 @Path("/v2.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseDiscountAccountGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseDiscountAccountGroupResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.admin.pricing.client.pagination.Page;
 import com.liferay.headless.commerce.admin.pricing.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.pricing.client.resource.v1_0.DiscountAccountGroupResource;
 import com.liferay.headless.commerce.admin.pricing.client.serdes.v1_0.DiscountAccountGroupSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -205,10 +206,15 @@ public abstract class BaseDiscountAccountGroupResourceTestCase {
 		DiscountAccountGroup discountAccountGroup =
 			testDeleteDiscountAccountGroup_addDiscountAccountGroup();
 
-		assertHttpResponseStatusCode(
-			204,
-			discountAccountGroupResource.deleteDiscountAccountGroupHttpResponse(
-				discountAccountGroup.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				discountAccountGroupResource.
+					deleteDiscountAccountGroupHttpResponse(
+						discountAccountGroup.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 	}
 
 	protected DiscountAccountGroup

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseDiscountCategoryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseDiscountCategoryResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.admin.pricing.client.pagination.Page;
 import com.liferay.headless.commerce.admin.pricing.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.pricing.client.resource.v1_0.DiscountCategoryResource;
 import com.liferay.headless.commerce.admin.pricing.client.serdes.v1_0.DiscountCategorySerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -201,10 +202,13 @@ public abstract class BaseDiscountCategoryResourceTestCase {
 		DiscountCategory discountCategory =
 			testDeleteDiscountCategory_addDiscountCategory();
 
-		assertHttpResponseStatusCode(
-			204,
-			discountCategoryResource.deleteDiscountCategoryHttpResponse(
-				discountCategory.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> discountCategoryResource.deleteDiscountCategoryHttpResponse(
+				discountCategory.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 	}
 
 	protected DiscountCategory testDeleteDiscountCategory_addDiscountCategory()

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseDiscountProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseDiscountProductResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.admin.pricing.client.pagination.Page;
 import com.liferay.headless.commerce.admin.pricing.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.pricing.client.resource.v1_0.DiscountProductResource;
 import com.liferay.headless.commerce.admin.pricing.client.serdes.v1_0.DiscountProductSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -201,10 +202,13 @@ public abstract class BaseDiscountProductResourceTestCase {
 		DiscountProduct discountProduct =
 			testDeleteDiscountProduct_addDiscountProduct();
 
-		assertHttpResponseStatusCode(
-			204,
-			discountProductResource.deleteDiscountProductHttpResponse(
-				discountProduct.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> discountProductResource.deleteDiscountProductHttpResponse(
+				discountProduct.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 	}
 
 	protected DiscountProduct testDeleteDiscountProduct_addDiscountProduct()

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseDiscountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseDiscountResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.admin.pricing.client.pagination.Page;
 import com.liferay.headless.commerce.admin.pricing.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.pricing.client.resource.v1_0.DiscountResource;
 import com.liferay.headless.commerce.admin.pricing.client.serdes.v1_0.DiscountSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -347,10 +348,15 @@ public abstract class BaseDiscountResourceTestCase {
 		Discount discount =
 			testDeleteDiscountByExternalReferenceCode_addDiscount();
 
-		assertHttpResponseStatusCode(
-			204,
-			discountResource.deleteDiscountByExternalReferenceCodeHttpResponse(
-				discount.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				discountResource.
+					deleteDiscountByExternalReferenceCodeHttpResponse(
+						discount.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -462,8 +468,12 @@ public abstract class BaseDiscountResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		Discount discount = testDeleteDiscount_addDiscount();
 
-		assertHttpResponseStatusCode(
-			204, discountResource.deleteDiscountHttpResponse(discount.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> discountResource.deleteDiscountHttpResponse(discount.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404, discountResource.getDiscountHttpResponse(discount.getId()));

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseDiscountRuleResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseDiscountRuleResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.admin.pricing.client.pagination.Page;
 import com.liferay.headless.commerce.admin.pricing.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.pricing.client.resource.v1_0.DiscountRuleResource;
 import com.liferay.headless.commerce.admin.pricing.client.serdes.v1_0.DiscountRuleSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -374,10 +375,13 @@ public abstract class BaseDiscountRuleResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		DiscountRule discountRule = testDeleteDiscountRule_addDiscountRule();
 
-		assertHttpResponseStatusCode(
-			204,
-			discountRuleResource.deleteDiscountRuleHttpResponse(
-				discountRule.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> discountRuleResource.deleteDiscountRuleHttpResponse(
+				discountRule.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BasePriceEntryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BasePriceEntryResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.admin.pricing.client.pagination.Page;
 import com.liferay.headless.commerce.admin.pricing.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.pricing.client.resource.v1_0.PriceEntryResource;
 import com.liferay.headless.commerce.admin.pricing.client.serdes.v1_0.PriceEntrySerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -204,11 +205,15 @@ public abstract class BasePriceEntryResourceTestCase {
 		PriceEntry priceEntry =
 			testDeletePriceEntryByExternalReferenceCode_addPriceEntry();
 
-		assertHttpResponseStatusCode(
-			204,
-			priceEntryResource.
-				deletePriceEntryByExternalReferenceCodeHttpResponse(
-					priceEntry.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				priceEntryResource.
+					deletePriceEntryByExternalReferenceCodeHttpResponse(
+						priceEntry.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -322,10 +327,13 @@ public abstract class BasePriceEntryResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		PriceEntry priceEntry = testDeletePriceEntry_addPriceEntry();
 
-		assertHttpResponseStatusCode(
-			204,
-			priceEntryResource.deletePriceEntryHttpResponse(
-				priceEntry.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> priceEntryResource.deletePriceEntryHttpResponse(
+				priceEntry.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BasePriceListAccountGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BasePriceListAccountGroupResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.admin.pricing.client.pagination.Page;
 import com.liferay.headless.commerce.admin.pricing.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.pricing.client.resource.v1_0.PriceListAccountGroupResource;
 import com.liferay.headless.commerce.admin.pricing.client.serdes.v1_0.PriceListAccountGroupSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -208,11 +209,15 @@ public abstract class BasePriceListAccountGroupResourceTestCase {
 		PriceListAccountGroup priceListAccountGroup =
 			testDeletePriceListAccountGroup_addPriceListAccountGroup();
 
-		assertHttpResponseStatusCode(
-			204,
-			priceListAccountGroupResource.
-				deletePriceListAccountGroupHttpResponse(
-					priceListAccountGroup.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				priceListAccountGroupResource.
+					deletePriceListAccountGroupHttpResponse(
+						priceListAccountGroup.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 	}
 
 	protected PriceListAccountGroup

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BasePriceListResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BasePriceListResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.admin.pricing.client.pagination.Page;
 import com.liferay.headless.commerce.admin.pricing.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.pricing.client.resource.v1_0.PriceListResource;
 import com.liferay.headless.commerce.admin.pricing.client.serdes.v1_0.PriceListSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -559,11 +560,15 @@ public abstract class BasePriceListResourceTestCase {
 		PriceList priceList =
 			testDeletePriceListByExternalReferenceCode_addPriceList();
 
-		assertHttpResponseStatusCode(
-			204,
-			priceListResource.
-				deletePriceListByExternalReferenceCodeHttpResponse(
-					priceList.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				priceListResource.
+					deletePriceListByExternalReferenceCodeHttpResponse(
+						priceList.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -676,9 +681,13 @@ public abstract class BasePriceListResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		PriceList priceList = testDeletePriceList_addPriceList();
 
-		assertHttpResponseStatusCode(
-			204,
-			priceListResource.deletePriceListHttpResponse(priceList.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> priceListResource.deletePriceListHttpResponse(
+				priceList.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404, priceListResource.getPriceListHttpResponse(priceList.getId()));

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseTierPriceResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseTierPriceResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.admin.pricing.client.pagination.Page;
 import com.liferay.headless.commerce.admin.pricing.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.pricing.client.resource.v1_0.TierPriceResource;
 import com.liferay.headless.commerce.admin.pricing.client.serdes.v1_0.TierPriceSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -509,11 +510,15 @@ public abstract class BaseTierPriceResourceTestCase {
 		TierPrice tierPrice =
 			testDeleteTierPriceByExternalReferenceCode_addTierPrice();
 
-		assertHttpResponseStatusCode(
-			204,
-			tierPriceResource.
-				deleteTierPriceByExternalReferenceCodeHttpResponse(
-					tierPrice.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				tierPriceResource.
+					deleteTierPriceByExternalReferenceCodeHttpResponse(
+						tierPrice.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -626,9 +631,13 @@ public abstract class BaseTierPriceResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		TierPrice tierPrice = testDeleteTierPrice_addTierPrice();
 
-		assertHttpResponseStatusCode(
-			204,
-			tierPriceResource.deleteTierPriceHttpResponse(tierPrice.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> tierPriceResource.deleteTierPriceHttpResponse(
+				tierPrice.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404, tierPriceResource.getTierPriceHttpResponse(tierPrice.getId()));

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.admin.pricing.client.pagination.Page;
 import com.liferay.headless.commerce.admin.pricing.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.pricing.client.resource.v2_0.DiscountResource;
 import com.liferay.headless.commerce.admin.pricing.client.serdes.v2_0.DiscountSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -555,10 +556,15 @@ public abstract class BaseDiscountResourceTestCase {
 		Discount discount =
 			testDeleteDiscountByExternalReferenceCode_addDiscount();
 
-		assertHttpResponseStatusCode(
-			204,
-			discountResource.deleteDiscountByExternalReferenceCodeHttpResponse(
-				discount.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				discountResource.
+					deleteDiscountByExternalReferenceCodeHttpResponse(
+						discount.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -696,8 +702,12 @@ public abstract class BaseDiscountResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		Discount discount = testDeleteDiscount_addDiscount();
 
-		assertHttpResponseStatusCode(
-			204, discountResource.deleteDiscountHttpResponse(discount.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> discountResource.deleteDiscountHttpResponse(discount.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404, discountResource.getDiscountHttpResponse(discount.getId()));

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountRuleResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountRuleResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.admin.pricing.client.pagination.Page;
 import com.liferay.headless.commerce.admin.pricing.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.pricing.client.resource.v2_0.DiscountRuleResource;
 import com.liferay.headless.commerce.admin.pricing.client.serdes.v2_0.DiscountRuleSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -204,10 +205,13 @@ public abstract class BaseDiscountRuleResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		DiscountRule discountRule = testDeleteDiscountRule_addDiscountRule();
 
-		assertHttpResponseStatusCode(
-			204,
-			discountRuleResource.deleteDiscountRuleHttpResponse(
-				discountRule.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> discountRuleResource.deleteDiscountRuleHttpResponse(
+				discountRule.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.admin.pricing.client.pagination.Page;
 import com.liferay.headless.commerce.admin.pricing.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.pricing.client.resource.v2_0.PriceListResource;
 import com.liferay.headless.commerce.admin.pricing.client.serdes.v2_0.PriceListSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -565,11 +566,15 @@ public abstract class BasePriceListResourceTestCase {
 		PriceList priceList =
 			testDeletePriceListByExternalReferenceCode_addPriceList();
 
-		assertHttpResponseStatusCode(
-			204,
-			priceListResource.
-				deletePriceListByExternalReferenceCodeHttpResponse(
-					priceList.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				priceListResource.
+					deletePriceListByExternalReferenceCodeHttpResponse(
+						priceList.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -709,9 +714,13 @@ public abstract class BasePriceListResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		PriceList priceList = testDeletePriceList_addPriceList();
 
-		assertHttpResponseStatusCode(
-			204,
-			priceListResource.deletePriceListHttpResponse(priceList.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> priceListResource.deletePriceListHttpResponse(
+				priceList.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404, priceListResource.getPriceListHttpResponse(priceList.getId()));

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceModifierResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceModifierResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.admin.pricing.client.pagination.Page;
 import com.liferay.headless.commerce.admin.pricing.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.pricing.client.resource.v2_0.PriceModifierResource;
 import com.liferay.headless.commerce.admin.pricing.client.serdes.v2_0.PriceModifierSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -788,11 +789,15 @@ public abstract class BasePriceModifierResourceTestCase {
 		PriceModifier priceModifier =
 			testDeletePriceModifierByExternalReferenceCode_addPriceModifier();
 
-		assertHttpResponseStatusCode(
-			204,
-			priceModifierResource.
-				deletePriceModifierByExternalReferenceCodeHttpResponse(
-					priceModifier.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				priceModifierResource.
+					deletePriceModifierByExternalReferenceCodeHttpResponse(
+						priceModifier.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -911,10 +916,13 @@ public abstract class BasePriceModifierResourceTestCase {
 		PriceModifier priceModifier =
 			testDeletePriceModifier_addPriceModifier();
 
-		assertHttpResponseStatusCode(
-			204,
-			priceModifierResource.deletePriceModifierHttpResponse(
-				priceModifier.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> priceModifierResource.deletePriceModifierHttpResponse(
+				priceModifier.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseTierPriceResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseTierPriceResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.admin.pricing.client.pagination.Page;
 import com.liferay.headless.commerce.admin.pricing.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.pricing.client.resource.v2_0.TierPriceResource;
 import com.liferay.headless.commerce.admin.pricing.client.serdes.v2_0.TierPriceSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -527,11 +528,15 @@ public abstract class BaseTierPriceResourceTestCase {
 		TierPrice tierPrice =
 			testDeleteTierPriceByExternalReferenceCode_addTierPrice();
 
-		assertHttpResponseStatusCode(
-			204,
-			tierPriceResource.
-				deleteTierPriceByExternalReferenceCodeHttpResponse(
-					tierPrice.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				tierPriceResource.
+					deleteTierPriceByExternalReferenceCodeHttpResponse(
+						tierPrice.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -644,9 +649,13 @@ public abstract class BaseTierPriceResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		TierPrice tierPrice = testDeleteTierPrice_addTierPrice();
 
-		assertHttpResponseStatusCode(
-			204,
-			tierPriceResource.deleteTierPriceHttpResponse(tierPrice.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> tierPriceResource.deleteTierPriceHttpResponse(
+				tierPrice.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404, tierPriceResource.getTierPriceHttpResponse(tierPrice.getId()));

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-test/src/testIntegration/java/com/liferay/headless/commerce/admin/shipment/resource/v1_0/test/BaseShipmentItemResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-test/src/testIntegration/java/com/liferay/headless/commerce/admin/shipment/resource/v1_0/test/BaseShipmentItemResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.admin.shipment.client.pagination.Page;
 import com.liferay.headless.commerce.admin.shipment.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.shipment.client.resource.v1_0.ShipmentItemResource;
 import com.liferay.headless.commerce.admin.shipment.client.serdes.v1_0.ShipmentItemSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -206,11 +207,15 @@ public abstract class BaseShipmentItemResourceTestCase {
 		ShipmentItem shipmentItem =
 			testDeleteShipmentItemByExternalReferenceCode_addShipmentItem();
 
-		assertHttpResponseStatusCode(
-			204,
-			shipmentItemResource.
-				deleteShipmentItemByExternalReferenceCodeHttpResponse(
-					shipmentItem.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				shipmentItemResource.
+					deleteShipmentItemByExternalReferenceCodeHttpResponse(
+						shipmentItem.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 	}
 
 	protected ShipmentItem
@@ -316,10 +321,13 @@ public abstract class BaseShipmentItemResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		ShipmentItem shipmentItem = testDeleteShipmentItem_addShipmentItem();
 
-		assertHttpResponseStatusCode(
-			204,
-			shipmentItemResource.deleteShipmentItemHttpResponse(
-				shipmentItem.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> shipmentItemResource.deleteShipmentItemHttpResponse(
+				shipmentItem.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-test/src/testIntegration/java/com/liferay/headless/commerce/admin/shipment/resource/v1_0/test/BaseShipmentResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-test/src/testIntegration/java/com/liferay/headless/commerce/admin/shipment/resource/v1_0/test/BaseShipmentResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.admin.shipment.client.pagination.Page;
 import com.liferay.headless.commerce.admin.shipment.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.shipment.client.resource.v1_0.ShipmentResource;
 import com.liferay.headless.commerce.admin.shipment.client.serdes.v1_0.ShipmentSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -553,10 +554,15 @@ public abstract class BaseShipmentResourceTestCase {
 		Shipment shipment =
 			testDeleteShipmentByExternalReferenceCode_addShipment();
 
-		assertHttpResponseStatusCode(
-			204,
-			shipmentResource.deleteShipmentByExternalReferenceCodeHttpResponse(
-				shipment.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				shipmentResource.
+					deleteShipmentByExternalReferenceCodeHttpResponse(
+						shipment.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -816,8 +822,12 @@ public abstract class BaseShipmentResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		Shipment shipment = testDeleteShipment_addShipment();
 
-		assertHttpResponseStatusCode(
-			204, shipmentResource.deleteShipmentHttpResponse(shipment.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> shipmentResource.deleteShipmentHttpResponse(shipment.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404, shipmentResource.getShipmentHttpResponse(shipment.getId()));

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-test/src/testIntegration/java/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/test/BaseAvailabilityEstimateResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-test/src/testIntegration/java/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/test/BaseAvailabilityEstimateResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.admin.site.setting.client.pagination.Page;
 import com.liferay.headless.commerce.admin.site.setting.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.site.setting.client.resource.v1_0.AvailabilityEstimateResource;
 import com.liferay.headless.commerce.admin.site.setting.client.serdes.v1_0.AvailabilityEstimateSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -198,10 +199,15 @@ public abstract class BaseAvailabilityEstimateResourceTestCase {
 		AvailabilityEstimate availabilityEstimate =
 			testDeleteAvailabilityEstimate_addAvailabilityEstimate();
 
-		assertHttpResponseStatusCode(
-			204,
-			availabilityEstimateResource.deleteAvailabilityEstimateHttpResponse(
-				availabilityEstimate.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				availabilityEstimateResource.
+					deleteAvailabilityEstimateHttpResponse(
+						availabilityEstimate.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-test/src/testIntegration/java/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/test/BaseMeasurementUnitResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-test/src/testIntegration/java/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/test/BaseMeasurementUnitResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.admin.site.setting.client.pagination.Page;
 import com.liferay.headless.commerce.admin.site.setting.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.site.setting.client.resource.v1_0.MeasurementUnitResource;
 import com.liferay.headless.commerce.admin.site.setting.client.serdes.v1_0.MeasurementUnitSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -605,11 +606,15 @@ public abstract class BaseMeasurementUnitResourceTestCase {
 		MeasurementUnit measurementUnit =
 			testDeleteMeasurementUnitByExternalReferenceCode_addMeasurementUnit();
 
-		assertHttpResponseStatusCode(
-			204,
-			measurementUnitResource.
-				deleteMeasurementUnitByExternalReferenceCodeHttpResponse(
-					measurementUnit.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				measurementUnitResource.
+					deleteMeasurementUnitByExternalReferenceCodeHttpResponse(
+						measurementUnit.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -730,10 +735,14 @@ public abstract class BaseMeasurementUnitResourceTestCase {
 		MeasurementUnit measurementUnit =
 			testDeleteMeasurementUnitByKey_addMeasurementUnit();
 
-		assertHttpResponseStatusCode(
-			204,
-			measurementUnitResource.deleteMeasurementUnitByKeyHttpResponse(
-				measurementUnit.getKey()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				measurementUnitResource.deleteMeasurementUnitByKeyHttpResponse(
+					measurementUnit.getKey());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -1117,10 +1126,13 @@ public abstract class BaseMeasurementUnitResourceTestCase {
 		MeasurementUnit measurementUnit =
 			testDeleteMeasurementUnit_addMeasurementUnit();
 
-		assertHttpResponseStatusCode(
-			204,
-			measurementUnitResource.deleteMeasurementUnitHttpResponse(
-				measurementUnit.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> measurementUnitResource.deleteMeasurementUnitHttpResponse(
+				measurementUnit.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-test/src/testIntegration/java/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/test/BaseTaxCategoryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-test/src/testIntegration/java/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/test/BaseTaxCategoryResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.admin.site.setting.client.pagination.Page;
 import com.liferay.headless.commerce.admin.site.setting.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.site.setting.client.resource.v1_0.TaxCategoryResource;
 import com.liferay.headless.commerce.admin.site.setting.client.serdes.v1_0.TaxCategorySerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -360,10 +361,13 @@ public abstract class BaseTaxCategoryResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		TaxCategory taxCategory = testDeleteTaxCategory_addTaxCategory();
 
-		assertHttpResponseStatusCode(
-			204,
-			taxCategoryResource.deleteTaxCategoryHttpResponse(
-				taxCategory.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> taxCategoryResource.deleteTaxCategoryHttpResponse(
+				taxCategory.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-test/src/testIntegration/java/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/test/BaseWarehouseResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-test/src/testIntegration/java/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/test/BaseWarehouseResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.admin.site.setting.client.pagination.Page;
 import com.liferay.headless.commerce.admin.site.setting.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.site.setting.client.resource.v1_0.WarehouseResource;
 import com.liferay.headless.commerce.admin.site.setting.client.serdes.v1_0.WarehouseSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -368,9 +369,13 @@ public abstract class BaseWarehouseResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		Warehouse warehouse = testDeleteWarehouse_addWarehouse();
 
-		assertHttpResponseStatusCode(
-			204,
-			warehouseResource.deleteWarehouseHttpResponse(warehouse.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> warehouseResource.deleteWarehouseHttpResponse(
+				warehouse.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404, warehouseResource.getWarehouseHttpResponse(warehouse.getId()));

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/rest-openapi.yaml
@@ -510,7 +510,7 @@ components:
 info:
     description:
         "Headless Delivery Commerce Cart API. A Java client JAR is available for use with the group ID 'com.liferay',
-        artifact ID 'com.liferay.headless.commerce.delivery.cart.client', and version '4.0.25'."
+        artifact ID 'com.liferay.headless.commerce.delivery.cart.client', and version '4.0.26'."
     license:
         name: Apache 2.0
         url: http://www.apache.org/licenses/LICENSE-2.0.html

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Headless Delivery Commerce Cart API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.delivery.cart.client', and version '4.0.25'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Delivery Commerce Cart API", version = "v1.0")
+	info = @Info(description = "Headless Delivery Commerce Cart API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.delivery.cart.client', and version '4.0.26'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Delivery Commerce Cart API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseCartCommentResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseCartCommentResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.delivery.cart.client.pagination.Page;
 import com.liferay.headless.commerce.delivery.cart.client.pagination.Pagination;
 import com.liferay.headless.commerce.delivery.cart.client.resource.v1_0.CartCommentResource;
 import com.liferay.headless.commerce.delivery.cart.client.serdes.v1_0.CartCommentSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -198,10 +199,13 @@ public abstract class BaseCartCommentResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		CartComment cartComment = testDeleteCartComment_addCartComment();
 
-		assertHttpResponseStatusCode(
-			204,
-			cartCommentResource.deleteCartCommentHttpResponse(
-				cartComment.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> cartCommentResource.deleteCartCommentHttpResponse(
+				cartComment.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseCartItemResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseCartItemResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.delivery.cart.client.pagination.Page;
 import com.liferay.headless.commerce.delivery.cart.client.pagination.Pagination;
 import com.liferay.headless.commerce.delivery.cart.client.resource.v1_0.CartItemResource;
 import com.liferay.headless.commerce.delivery.cart.client.serdes.v1_0.CartItemSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -206,8 +207,12 @@ public abstract class BaseCartItemResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		CartItem cartItem = testDeleteCartItem_addCartItem();
 
-		assertHttpResponseStatusCode(
-			204, cartItemResource.deleteCartItemHttpResponse(cartItem.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> cartItemResource.deleteCartItemHttpResponse(cartItem.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404, cartItemResource.getCartItemHttpResponse(cartItem.getId()));

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseCartResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseCartResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.delivery.cart.client.pagination.Page;
 import com.liferay.headless.commerce.delivery.cart.client.pagination.Pagination;
 import com.liferay.headless.commerce.delivery.cart.client.resource.v1_0.CartResource;
 import com.liferay.headless.commerce.delivery.cart.client.serdes.v1_0.CartSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -224,8 +225,12 @@ public abstract class BaseCartResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		Cart cart = testDeleteCart_addCart();
 
-		assertHttpResponseStatusCode(
-			204, cartResource.deleteCartHttpResponse(cart.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> cartResource.deleteCartHttpResponse(cart.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404, cartResource.getCartHttpResponse(cart.getId()));

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/rest-openapi.yaml
@@ -766,7 +766,7 @@ components:
 info:
     description:
         "Headless Commerce Delivery Catalog API. A Java client JAR is available for use with the group ID 'com.liferay',
-        artifact ID 'com.liferay.headless.commerce.delivery.catalog.client', and version '4.0.33'."
+        artifact ID 'com.liferay.headless.commerce.delivery.catalog.client', and version '4.0.34'."
     license:
         name: Apache 2.0
         url: http://www.apache.org/licenses/LICENSE-2.0.html

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Headless Commerce Delivery Catalog API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.delivery.catalog.client', and version '4.0.33'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Commerce Delivery Catalog API", version = "v1.0")
+	info = @Info(description = "Headless Commerce Delivery Catalog API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.delivery.catalog.client', and version '4.0.34'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Commerce Delivery Catalog API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseWishListItemResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseWishListItemResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.delivery.catalog.client.pagination.Page;
 import com.liferay.headless.commerce.delivery.catalog.client.pagination.Pagination;
 import com.liferay.headless.commerce.delivery.catalog.client.resource.v1_0.WishListItemResource;
 import com.liferay.headless.commerce.delivery.catalog.client.serdes.v1_0.WishListItemSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -202,10 +203,13 @@ public abstract class BaseWishListItemResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		WishListItem wishListItem = testDeleteWishListItem_addWishListItem();
 
-		assertHttpResponseStatusCode(
-			204,
-			wishListItemResource.deleteWishListItemHttpResponse(
-				wishListItem.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> wishListItemResource.deleteWishListItemHttpResponse(
+				wishListItem.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseWishListResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseWishListResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.commerce.delivery.catalog.client.pagination.Page;
 import com.liferay.headless.commerce.delivery.catalog.client.pagination.Pagination;
 import com.liferay.headless.commerce.delivery.catalog.client.resource.v1_0.WishListResource;
 import com.liferay.headless.commerce.delivery.catalog.client.serdes.v1_0.WishListSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -331,8 +332,12 @@ public abstract class BaseWishListResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		WishList wishList = testDeleteWishList_addWishList();
 
-		assertHttpResponseStatusCode(
-			204, wishListResource.deleteWishListHttpResponse(wishList.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> wishListResource.deleteWishListHttpResponse(wishList.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404, wishListResource.getWishListHttpResponse(wishList.getId()));

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/rest-openapi.yaml
@@ -602,7 +602,7 @@ components:
 info:
     description:
         "Headless Delivery Commerce Order API. A Java client JAR is available for use with the group ID 'com.liferay',
-        artifact ID 'com.liferay.headless.commerce.delivery.order.client', and version '1.0.8'."
+        artifact ID 'com.liferay.headless.commerce.delivery.order.client', and version '1.0.9'."
     license:
         name: Apache 2.0
         url: http://www.apache.org/licenses/LICENSE-2.0.html

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Headless Delivery Commerce Order API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.delivery.order.client', and version '1.0.8'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Delivery Commerce Order API", version = "v1.0")
+	info = @Info(description = "Headless Delivery Commerce Order API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.delivery.order.client', and version '1.0.9'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Delivery Commerce Order API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataDefinitionResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataDefinitionResourceTestCase.java
@@ -29,6 +29,7 @@ import com.liferay.data.engine.rest.client.pagination.Pagination;
 import com.liferay.data.engine.rest.client.permission.Permission;
 import com.liferay.data.engine.rest.client.resource.v2_0.DataDefinitionResource;
 import com.liferay.data.engine.rest.client.serdes.v2_0.DataDefinitionSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -540,10 +541,13 @@ public abstract class BaseDataDefinitionResourceTestCase {
 		DataDefinition dataDefinition =
 			testDeleteDataDefinition_addDataDefinition();
 
-		assertHttpResponseStatusCode(
-			204,
-			dataDefinitionResource.deleteDataDefinitionHttpResponse(
-				dataDefinition.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> dataDefinitionResource.deleteDataDefinitionHttpResponse(
+				dataDefinition.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataLayoutResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataLayoutResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.data.engine.rest.client.pagination.Page;
 import com.liferay.data.engine.rest.client.pagination.Pagination;
 import com.liferay.data.engine.rest.client.resource.v2_0.DataLayoutResource;
 import com.liferay.data.engine.rest.client.serdes.v2_0.DataLayoutSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -204,11 +205,14 @@ public abstract class BaseDataLayoutResourceTestCase {
 		DataLayout dataLayout =
 			testDeleteDataDefinitionDataLayout_addDataLayout();
 
-		assertHttpResponseStatusCode(
-			204,
-			dataLayoutResource.deleteDataDefinitionDataLayoutHttpResponse(
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> dataLayoutResource.deleteDataDefinitionDataLayoutHttpResponse(
 				testDeleteDataDefinitionDataLayout_getDataDefinitionId(
-					dataLayout)));
+					dataLayout));
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 	}
 
 	protected Long testDeleteDataDefinitionDataLayout_getDataDefinitionId(
@@ -538,10 +542,13 @@ public abstract class BaseDataLayoutResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		DataLayout dataLayout = testDeleteDataLayout_addDataLayout();
 
-		assertHttpResponseStatusCode(
-			204,
-			dataLayoutResource.deleteDataLayoutHttpResponse(
-				dataLayout.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> dataLayoutResource.deleteDataLayoutHttpResponse(
+				dataLayout.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataListViewResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataListViewResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.data.engine.rest.client.pagination.Page;
 import com.liferay.data.engine.rest.client.pagination.Pagination;
 import com.liferay.data.engine.rest.client.resource.v2_0.DataListViewResource;
 import com.liferay.data.engine.rest.client.serdes.v2_0.DataListViewSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -200,11 +201,16 @@ public abstract class BaseDataListViewResourceTestCase {
 		DataListView dataListView =
 			testDeleteDataDefinitionDataListView_addDataListView();
 
-		assertHttpResponseStatusCode(
-			204,
-			dataListViewResource.deleteDataDefinitionDataListViewHttpResponse(
-				testDeleteDataDefinitionDataListView_getDataDefinitionId(
-					dataListView)));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				dataListViewResource.
+					deleteDataDefinitionDataListViewHttpResponse(
+						testDeleteDataDefinitionDataListView_getDataDefinitionId(
+							dataListView));
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 	}
 
 	protected Long testDeleteDataDefinitionDataListView_getDataDefinitionId(
@@ -544,10 +550,13 @@ public abstract class BaseDataListViewResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		DataListView dataListView = testDeleteDataListView_addDataListView();
 
-		assertHttpResponseStatusCode(
-			204,
-			dataListViewResource.deleteDataListViewHttpResponse(
-				dataListView.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> dataListViewResource.deleteDataListViewHttpResponse(
+				dataListView.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataRecordCollectionResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataRecordCollectionResourceTestCase.java
@@ -29,6 +29,7 @@ import com.liferay.data.engine.rest.client.pagination.Pagination;
 import com.liferay.data.engine.rest.client.permission.Permission;
 import com.liferay.data.engine.rest.client.resource.v2_0.DataRecordCollectionResource;
 import com.liferay.data.engine.rest.client.serdes.v2_0.DataRecordCollectionSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -499,10 +500,15 @@ public abstract class BaseDataRecordCollectionResourceTestCase {
 		DataRecordCollection dataRecordCollection =
 			testDeleteDataRecordCollection_addDataRecordCollection();
 
-		assertHttpResponseStatusCode(
-			204,
-			dataRecordCollectionResource.deleteDataRecordCollectionHttpResponse(
-				dataRecordCollection.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				dataRecordCollectionResource.
+					deleteDataRecordCollectionHttpResponse(
+						dataRecordCollection.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataRecordResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataRecordResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.data.engine.rest.client.pagination.Page;
 import com.liferay.data.engine.rest.client.pagination.Pagination;
 import com.liferay.data.engine.rest.client.resource.v2_0.DataRecordResource;
 import com.liferay.data.engine.rest.client.serdes.v2_0.DataRecordSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -823,10 +824,13 @@ public abstract class BaseDataRecordResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		DataRecord dataRecord = testDeleteDataRecord_addDataRecord();
 
-		assertHttpResponseStatusCode(
-			204,
-			dataRecordResource.deleteDataRecordHttpResponse(
-				dataRecord.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> dataRecordResource.deleteDataRecordHttpResponse(
+				dataRecord.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/DataLayoutResourceTest.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/DataLayoutResourceTest.java
@@ -56,6 +56,7 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -89,6 +90,16 @@ public class DataLayoutResourceTest extends BaseDataLayoutResourceTestCase {
 			testGroup.getGroupId());
 		_irrelevantDataDefinition = DataDefinitionTestUtil.addDataDefinition(
 			irrelevantGroup.getGroupId());
+	}
+
+	@Ignore
+	@Override
+	@Test
+	public void testDeleteDataDefinitionDataLayout() throws Exception {
+
+		// TODO LPS-184020 Ignored until method returns 404 on null deletion
+
+		super.testDeleteDataDefinitionDataLayout();
 	}
 
 	@Override

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/DataListViewResourceTest.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/DataListViewResourceTest.java
@@ -37,6 +37,7 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -70,6 +71,16 @@ public class DataListViewResourceTest extends BaseDataListViewResourceTestCase {
 			testGroup.getGroupId());
 		_irrelevantDataDefinition = DataDefinitionTestUtil.addDataDefinition(
 			irrelevantGroup.getGroupId());
+	}
+
+	@Ignore
+	@Override
+	@Test
+	public void testDeleteDataDefinitionDataListView() throws Exception {
+
+		// TODO LPS-184020 Ignored until method returns 404 on null deletion
+
+		super.testDeleteDataDefinitionDataListView();
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-address/headless-admin-address-test/src/testIntegration/java/com/liferay/headless/admin/address/resource/v1_0/test/BaseCountryResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-address/headless-admin-address-test/src/testIntegration/java/com/liferay/headless/admin/address/resource/v1_0/test/BaseCountryResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.admin.address.client.pagination.Page;
 import com.liferay.headless.admin.address.client.pagination.Pagination;
 import com.liferay.headless.admin.address.client.resource.v1_0.CountryResource;
 import com.liferay.headless.admin.address.client.serdes.v1_0.CountrySerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -723,8 +724,12 @@ public abstract class BaseCountryResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		Country country = testDeleteCountry_addCountry();
 
-		assertHttpResponseStatusCode(
-			204, countryResource.deleteCountryHttpResponse(country.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> countryResource.deleteCountryHttpResponse(country.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404, countryResource.getCountryHttpResponse(country.getId()));

--- a/modules/apps/headless/headless-admin-address/headless-admin-address-test/src/testIntegration/java/com/liferay/headless/admin/address/resource/v1_0/test/BaseRegionResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-address/headless-admin-address-test/src/testIntegration/java/com/liferay/headless/admin/address/resource/v1_0/test/BaseRegionResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.admin.address.client.pagination.Page;
 import com.liferay.headless.admin.address.client.pagination.Pagination;
 import com.liferay.headless.admin.address.client.resource.v1_0.RegionResource;
 import com.liferay.headless.admin.address.client.serdes.v1_0.RegionSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -806,8 +807,12 @@ public abstract class BaseRegionResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		Region region = testDeleteRegion_addRegion();
 
-		assertHttpResponseStatusCode(
-			204, regionResource.deleteRegionHttpResponse(region.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> regionResource.deleteRegionHttpResponse(region.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404, regionResource.getRegionHttpResponse(region.getId()));

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-impl/rest-openapi.yaml
@@ -186,7 +186,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.admin.content.client', and version '2.0.23'."
+        'com.liferay.headless.admin.content.client', and version '2.0.24'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.content.client', and version '2.0.23'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin Content", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.content.client', and version '2.0.24'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin Content", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testIntegration/java/com/liferay/headless/admin/content/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testIntegration/java/com/liferay/headless/admin/content/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.admin.content.client.pagination.Page;
 import com.liferay.headless.admin.content.client.pagination.Pagination;
 import com.liferay.headless.admin.content.client.resource.v1_0.StructuredContentResource;
 import com.liferay.headless.admin.content.client.serdes.v1_0.StructuredContentSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -665,12 +666,16 @@ public abstract class BaseStructuredContentResourceTestCase {
 		StructuredContent structuredContent =
 			testDeleteStructuredContentByVersion_addStructuredContent();
 
-		assertHttpResponseStatusCode(
-			204,
-			structuredContentResource.
-				deleteStructuredContentByVersionHttpResponse(
-					structuredContent.getId(),
-					testDeleteStructuredContentByVersion_getVersion()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				structuredContentResource.
+					deleteStructuredContentByVersionHttpResponse(
+						structuredContent.getId(),
+						testDeleteStructuredContentByVersion_getVersion());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-test/src/testIntegration/java/com/liferay/headless/admin/list/type/resource/v1_0/test/BaseListTypeDefinitionResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-test/src/testIntegration/java/com/liferay/headless/admin/list/type/resource/v1_0/test/BaseListTypeDefinitionResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.admin.list.type.client.pagination.Page;
 import com.liferay.headless.admin.list.type.client.pagination.Pagination;
 import com.liferay.headless.admin.list.type.client.resource.v1_0.ListTypeDefinitionResource;
 import com.liferay.headless.admin.list.type.client.serdes.v1_0.ListTypeDefinitionSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -783,10 +784,14 @@ public abstract class BaseListTypeDefinitionResourceTestCase {
 		ListTypeDefinition listTypeDefinition =
 			testDeleteListTypeDefinition_addListTypeDefinition();
 
-		assertHttpResponseStatusCode(
-			204,
-			listTypeDefinitionResource.deleteListTypeDefinitionHttpResponse(
-				listTypeDefinition.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				listTypeDefinitionResource.deleteListTypeDefinitionHttpResponse(
+					listTypeDefinition.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-test/src/testIntegration/java/com/liferay/headless/admin/list/type/resource/v1_0/test/BaseListTypeEntryResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-test/src/testIntegration/java/com/liferay/headless/admin/list/type/resource/v1_0/test/BaseListTypeEntryResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.admin.list.type.client.pagination.Page;
 import com.liferay.headless.admin.list.type.client.pagination.Pagination;
 import com.liferay.headless.admin.list.type.client.resource.v1_0.ListTypeEntryResource;
 import com.liferay.headless.admin.list.type.client.serdes.v1_0.ListTypeEntrySerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -1083,10 +1084,13 @@ public abstract class BaseListTypeEntryResourceTestCase {
 		ListTypeEntry listTypeEntry =
 			testDeleteListTypeEntry_addListTypeEntry();
 
-		assertHttpResponseStatusCode(
-			204,
-			listTypeEntryResource.deleteListTypeEntryHttpResponse(
-				listTypeEntry.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> listTypeEntryResource.deleteListTypeEntryHttpResponse(
+				listTypeEntry.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseKeywordResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseKeywordResourceTestCase.java
@@ -31,6 +31,7 @@ import com.liferay.headless.admin.taxonomy.client.pagination.Pagination;
 import com.liferay.headless.admin.taxonomy.client.permission.Permission;
 import com.liferay.headless.admin.taxonomy.client.resource.v1_0.KeywordResource;
 import com.liferay.headless.admin.taxonomy.client.serdes.v1_0.KeywordSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -750,8 +751,12 @@ public abstract class BaseKeywordResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		Keyword keyword = testDeleteKeyword_addKeyword();
 
-		assertHttpResponseStatusCode(
-			204, keywordResource.deleteKeywordHttpResponse(keyword.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> keywordResource.deleteKeywordHttpResponse(keyword.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404, keywordResource.getKeywordHttpResponse(keyword.getId()));

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
@@ -29,6 +29,7 @@ import com.liferay.headless.admin.taxonomy.client.pagination.Pagination;
 import com.liferay.headless.admin.taxonomy.client.permission.Permission;
 import com.liferay.headless.admin.taxonomy.client.resource.v1_0.TaxonomyCategoryResource;
 import com.liferay.headless.admin.taxonomy.client.serdes.v1_0.TaxonomyCategorySerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -760,10 +761,13 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		TaxonomyCategory taxonomyCategory =
 			testDeleteTaxonomyCategory_addTaxonomyCategory();
 
-		assertHttpResponseStatusCode(
-			204,
-			taxonomyCategoryResource.deleteTaxonomyCategoryHttpResponse(
-				taxonomyCategory.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> taxonomyCategoryResource.deleteTaxonomyCategoryHttpResponse(
+				taxonomyCategory.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -1489,13 +1493,17 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		TaxonomyCategory taxonomyCategory =
 			testDeleteTaxonomyVocabularyTaxonomyCategoryByExternalReferenceCode_addTaxonomyCategory();
 
-		assertHttpResponseStatusCode(
-			204,
-			taxonomyCategoryResource.
-				deleteTaxonomyVocabularyTaxonomyCategoryByExternalReferenceCodeHttpResponse(
-					testDeleteTaxonomyVocabularyTaxonomyCategoryByExternalReferenceCode_getTaxonomyVocabularyId(
-						taxonomyCategory),
-					taxonomyCategory.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				taxonomyCategoryResource.
+					deleteTaxonomyVocabularyTaxonomyCategoryByExternalReferenceCodeHttpResponse(
+						testDeleteTaxonomyVocabularyTaxonomyCategoryByExternalReferenceCode_getTaxonomyVocabularyId(
+							taxonomyCategory),
+						taxonomyCategory.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
@@ -31,6 +31,7 @@ import com.liferay.headless.admin.taxonomy.client.pagination.Pagination;
 import com.liferay.headless.admin.taxonomy.client.permission.Permission;
 import com.liferay.headless.admin.taxonomy.client.resource.v1_0.TaxonomyVocabularyResource;
 import com.liferay.headless.admin.taxonomy.client.serdes.v1_0.TaxonomyVocabularySerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -670,12 +671,16 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 		TaxonomyVocabulary taxonomyVocabulary =
 			testDeleteAssetLibraryTaxonomyVocabularyByExternalReferenceCode_addTaxonomyVocabulary();
 
-		assertHttpResponseStatusCode(
-			204,
-			taxonomyVocabularyResource.
-				deleteAssetLibraryTaxonomyVocabularyByExternalReferenceCodeHttpResponse(
-					testDeleteAssetLibraryTaxonomyVocabularyByExternalReferenceCode_getAssetLibraryId(),
-					taxonomyVocabulary.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				taxonomyVocabularyResource.
+					deleteAssetLibraryTaxonomyVocabularyByExternalReferenceCodeHttpResponse(
+						testDeleteAssetLibraryTaxonomyVocabularyByExternalReferenceCode_getAssetLibraryId(),
+						taxonomyVocabulary.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -1459,13 +1464,17 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 		TaxonomyVocabulary taxonomyVocabulary =
 			testDeleteSiteTaxonomyVocabularyByExternalReferenceCode_addTaxonomyVocabulary();
 
-		assertHttpResponseStatusCode(
-			204,
-			taxonomyVocabularyResource.
-				deleteSiteTaxonomyVocabularyByExternalReferenceCodeHttpResponse(
-					testDeleteSiteTaxonomyVocabularyByExternalReferenceCode_getSiteId(
-						taxonomyVocabulary),
-					taxonomyVocabulary.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				taxonomyVocabularyResource.
+					deleteSiteTaxonomyVocabularyByExternalReferenceCodeHttpResponse(
+						testDeleteSiteTaxonomyVocabularyByExternalReferenceCode_getSiteId(
+							taxonomyVocabulary),
+						taxonomyVocabulary.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -1769,10 +1778,14 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 		TaxonomyVocabulary taxonomyVocabulary =
 			testDeleteTaxonomyVocabulary_addTaxonomyVocabulary();
 
-		assertHttpResponseStatusCode(
-			204,
-			taxonomyVocabularyResource.deleteTaxonomyVocabularyHttpResponse(
-				taxonomyVocabulary.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				taxonomyVocabularyResource.deleteTaxonomyVocabularyHttpResponse(
+					taxonomyVocabulary.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/AccountRoleResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/AccountRoleResourceTest.java
@@ -54,6 +54,7 @@ import java.util.List;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -139,6 +140,18 @@ public class AccountRoleResourceTest extends BaseAccountRoleResourceTestCase {
 
 		_assertAccountRoleUserAccountAssociation(
 			_account, accountRole, userAccount, false);
+	}
+
+	@Ignore
+	@Override
+	@Test
+	public void testDeleteAccountByExternalReferenceCodeAccountRoleUserAccountByEmailAddress()
+		throws Exception {
+
+		// TODO LPS-184020 Ignored until method returns 404 on null deletion
+
+		super.
+			testDeleteAccountByExternalReferenceCodeAccountRoleUserAccountByEmailAddress();
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseAccountResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseAccountResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.admin.user.client.pagination.Page;
 import com.liferay.headless.admin.user.client.pagination.Pagination;
 import com.liferay.headless.admin.user.client.resource.v1_0.AccountResource;
 import com.liferay.headless.admin.user.client.serdes.v1_0.AccountSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -542,10 +543,15 @@ public abstract class BaseAccountResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		Account account = testDeleteAccountByExternalReferenceCode_addAccount();
 
-		assertHttpResponseStatusCode(
-			204,
-			accountResource.deleteAccountByExternalReferenceCodeHttpResponse(
-				account.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				accountResource.
+					deleteAccountByExternalReferenceCodeHttpResponse(
+						account.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -731,8 +737,12 @@ public abstract class BaseAccountResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		Account account = testDeleteAccount_addAccount();
 
-		assertHttpResponseStatusCode(
-			204, accountResource.deleteAccountHttpResponse(account.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> accountResource.deleteAccountHttpResponse(account.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404, accountResource.getAccountHttpResponse(account.getId()));
@@ -945,10 +955,13 @@ public abstract class BaseAccountResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		Account account = testDeleteOrganizationAccounts_addAccount();
 
-		assertHttpResponseStatusCode(
-			204,
-			accountResource.deleteOrganizationAccountsHttpResponse(
-				testDeleteOrganizationAccounts_getOrganizationId(), null));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> accountResource.deleteOrganizationAccountsHttpResponse(
+				testDeleteOrganizationAccounts_getOrganizationId(), null);
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 	}
 
 	protected Long testDeleteOrganizationAccounts_getOrganizationId()
@@ -1355,12 +1368,16 @@ public abstract class BaseAccountResourceTestCase {
 		Account account =
 			testDeleteOrganizationAccountsByExternalReferenceCode_addAccount();
 
-		assertHttpResponseStatusCode(
-			204,
-			accountResource.
-				deleteOrganizationAccountsByExternalReferenceCodeHttpResponse(
-					testDeleteOrganizationAccountsByExternalReferenceCode_getOrganizationId(),
-					null));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				accountResource.
+					deleteOrganizationAccountsByExternalReferenceCodeHttpResponse(
+						testDeleteOrganizationAccountsByExternalReferenceCode_getOrganizationId(),
+						null);
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 	}
 
 	protected Long

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseAccountRoleResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseAccountRoleResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.admin.user.client.pagination.Page;
 import com.liferay.headless.admin.user.client.pagination.Pagination;
 import com.liferay.headless.admin.user.client.resource.v1_0.AccountRoleResource;
 import com.liferay.headless.admin.user.client.serdes.v1_0.AccountRoleSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -206,13 +207,17 @@ public abstract class BaseAccountRoleResourceTestCase {
 		AccountRole accountRole =
 			testDeleteAccountByExternalReferenceCodeAccountRoleUserAccountByExternalReferenceCode_addAccountRole();
 
-		assertHttpResponseStatusCode(
-			204,
-			accountRoleResource.
-				deleteAccountByExternalReferenceCodeAccountRoleUserAccountByExternalReferenceCodeHttpResponse(
-					testDeleteAccountByExternalReferenceCodeAccountRoleUserAccountByExternalReferenceCode_getAccountExternalReferenceCode(),
-					accountRole.getId(),
-					testDeleteAccountByExternalReferenceCodeAccountRoleUserAccountByExternalReferenceCode_getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				accountRoleResource.
+					deleteAccountByExternalReferenceCodeAccountRoleUserAccountByExternalReferenceCodeHttpResponse(
+						testDeleteAccountByExternalReferenceCodeAccountRoleUserAccountByExternalReferenceCode_getAccountExternalReferenceCode(),
+						accountRole.getId(),
+						testDeleteAccountByExternalReferenceCodeAccountRoleUserAccountByExternalReferenceCode_getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 	}
 
 	protected String
@@ -831,13 +836,17 @@ public abstract class BaseAccountRoleResourceTestCase {
 		AccountRole accountRole =
 			testDeleteAccountByExternalReferenceCodeAccountRoleUserAccountByEmailAddress_addAccountRole();
 
-		assertHttpResponseStatusCode(
-			204,
-			accountRoleResource.
-				deleteAccountByExternalReferenceCodeAccountRoleUserAccountByEmailAddressHttpResponse(
-					testDeleteAccountByExternalReferenceCodeAccountRoleUserAccountByEmailAddress_getExternalReferenceCode(),
-					accountRole.getId(),
-					testDeleteAccountByExternalReferenceCodeAccountRoleUserAccountByEmailAddress_getEmailAddress()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				accountRoleResource.
+					deleteAccountByExternalReferenceCodeAccountRoleUserAccountByEmailAddressHttpResponse(
+						testDeleteAccountByExternalReferenceCodeAccountRoleUserAccountByEmailAddress_getExternalReferenceCode(),
+						accountRole.getId(),
+						testDeleteAccountByExternalReferenceCodeAccountRoleUserAccountByEmailAddress_getEmailAddress());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 	}
 
 	protected String
@@ -1417,14 +1426,18 @@ public abstract class BaseAccountRoleResourceTestCase {
 		AccountRole accountRole =
 			testDeleteAccountAccountRoleUserAccountAssociation_addAccountRole();
 
-		assertHttpResponseStatusCode(
-			204,
-			accountRoleResource.
-				deleteAccountAccountRoleUserAccountAssociationHttpResponse(
-					testDeleteAccountAccountRoleUserAccountAssociation_getAccountId(
-						accountRole),
-					accountRole.getId(),
-					testDeleteAccountAccountRoleUserAccountAssociation_getUserAccountId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				accountRoleResource.
+					deleteAccountAccountRoleUserAccountAssociationHttpResponse(
+						testDeleteAccountAccountRoleUserAccountAssociation_getAccountId(
+							accountRole),
+						accountRole.getId(),
+						testDeleteAccountAccountRoleUserAccountAssociation_getUserAccountId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 	}
 
 	protected Long

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseOrganizationResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseOrganizationResourceTestCase.java
@@ -29,6 +29,7 @@ import com.liferay.headless.admin.user.client.pagination.Page;
 import com.liferay.headless.admin.user.client.pagination.Pagination;
 import com.liferay.headless.admin.user.client.resource.v1_0.OrganizationResource;
 import com.liferay.headless.admin.user.client.serdes.v1_0.OrganizationSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -629,13 +630,17 @@ public abstract class BaseOrganizationResourceTestCase {
 		Organization organization =
 			testDeleteAccountByExternalReferenceCodeOrganization_addOrganization();
 
-		assertHttpResponseStatusCode(
-			204,
-			organizationResource.
-				deleteAccountByExternalReferenceCodeOrganizationHttpResponse(
-					testDeleteAccountByExternalReferenceCodeOrganization_getExternalReferenceCode(
-						organization),
-					organization.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				organizationResource.
+					deleteAccountByExternalReferenceCodeOrganizationHttpResponse(
+						testDeleteAccountByExternalReferenceCodeOrganization_getExternalReferenceCode(
+							organization),
+						organization.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 	}
 
 	protected String
@@ -1069,11 +1074,14 @@ public abstract class BaseOrganizationResourceTestCase {
 		Organization organization =
 			testDeleteAccountOrganization_addOrganization();
 
-		assertHttpResponseStatusCode(
-			204,
-			organizationResource.deleteAccountOrganizationHttpResponse(
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> organizationResource.deleteAccountOrganizationHttpResponse(
 				testDeleteAccountOrganization_getAccountId(),
-				organization.getId()));
+				organization.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 	}
 
 	protected Long testDeleteAccountOrganization_getAccountId()
@@ -1495,11 +1503,15 @@ public abstract class BaseOrganizationResourceTestCase {
 		Organization organization =
 			testDeleteOrganizationByExternalReferenceCode_addOrganization();
 
-		assertHttpResponseStatusCode(
-			204,
-			organizationResource.
-				deleteOrganizationByExternalReferenceCodeHttpResponse(
-					organization.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				organizationResource.
+					deleteOrganizationByExternalReferenceCodeHttpResponse(
+						organization.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -1704,10 +1716,13 @@ public abstract class BaseOrganizationResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		Organization organization = testDeleteOrganization_addOrganization();
 
-		assertHttpResponseStatusCode(
-			204,
-			organizationResource.deleteOrganizationHttpResponse(
-				organization.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> organizationResource.deleteOrganizationHttpResponse(
+				organization.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -2290,10 +2305,15 @@ public abstract class BaseOrganizationResourceTestCase {
 		Organization organization =
 			testDeleteUserAccountsByEmailAddress_addOrganization();
 
-		assertHttpResponseStatusCode(
-			204,
-			organizationResource.deleteUserAccountsByEmailAddressHttpResponse(
-				organization.getId(), null));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				organizationResource.
+					deleteUserAccountsByEmailAddressHttpResponse(
+						organization.getId(), null);
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 	}
 
 	protected Organization
@@ -2315,11 +2335,16 @@ public abstract class BaseOrganizationResourceTestCase {
 		Organization organization =
 			testDeleteUserAccountByEmailAddress_addOrganization();
 
-		assertHttpResponseStatusCode(
-			204,
-			organizationResource.deleteUserAccountByEmailAddressHttpResponse(
-				organization.getId(),
-				testDeleteUserAccountByEmailAddress_getEmailAddress()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				organizationResource.
+					deleteUserAccountByEmailAddressHttpResponse(
+						organization.getId(),
+						testDeleteUserAccountByEmailAddress_getEmailAddress());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 	}
 
 	protected String testDeleteUserAccountByEmailAddress_getEmailAddress()

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseRoleResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseRoleResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.admin.user.client.pagination.Page;
 import com.liferay.headless.admin.user.client.pagination.Pagination;
 import com.liferay.headless.admin.user.client.resource.v1_0.RoleResource;
 import com.liferay.headless.admin.user.client.serdes.v1_0.RoleSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -377,11 +378,14 @@ public abstract class BaseRoleResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		Role role = testDeleteRoleUserAccountAssociation_addRole();
 
-		assertHttpResponseStatusCode(
-			204,
-			roleResource.deleteRoleUserAccountAssociationHttpResponse(
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> roleResource.deleteRoleUserAccountAssociationHttpResponse(
 				role.getId(),
-				testDeleteRoleUserAccountAssociation_getUserAccountId()));
+				testDeleteRoleUserAccountAssociation_getUserAccountId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 	}
 
 	protected Long testDeleteRoleUserAccountAssociation_getUserAccountId()
@@ -427,13 +431,17 @@ public abstract class BaseRoleResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		Role role = testDeleteOrganizationRoleUserAccountAssociation_addRole();
 
-		assertHttpResponseStatusCode(
-			204,
-			roleResource.
-				deleteOrganizationRoleUserAccountAssociationHttpResponse(
-					role.getId(),
-					testDeleteOrganizationRoleUserAccountAssociation_getUserAccountId(),
-					testDeleteOrganizationRoleUserAccountAssociation_getOrganizationId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				roleResource.
+					deleteOrganizationRoleUserAccountAssociationHttpResponse(
+						role.getId(),
+						testDeleteOrganizationRoleUserAccountAssociation_getUserAccountId(),
+						testDeleteOrganizationRoleUserAccountAssociation_getOrganizationId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 	}
 
 	protected Long
@@ -489,12 +497,15 @@ public abstract class BaseRoleResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		Role role = testDeleteSiteRoleUserAccountAssociation_addRole();
 
-		assertHttpResponseStatusCode(
-			204,
-			roleResource.deleteSiteRoleUserAccountAssociationHttpResponse(
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> roleResource.deleteSiteRoleUserAccountAssociationHttpResponse(
 				role.getId(),
 				testDeleteSiteRoleUserAccountAssociation_getUserAccountId(),
-				testDeleteSiteRoleUserAccountAssociation_getSiteId()));
+				testDeleteSiteRoleUserAccountAssociation_getSiteId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 	}
 
 	protected Long testDeleteSiteRoleUserAccountAssociation_getUserAccountId()

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSubscriptionResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSubscriptionResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.admin.user.client.pagination.Page;
 import com.liferay.headless.admin.user.client.pagination.Pagination;
 import com.liferay.headless.admin.user.client.resource.v1_0.SubscriptionResource;
 import com.liferay.headless.admin.user.client.serdes.v1_0.SubscriptionSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -298,10 +299,15 @@ public abstract class BaseSubscriptionResourceTestCase {
 		Subscription subscription =
 			testDeleteMyUserAccountSubscription_addSubscription();
 
-		assertHttpResponseStatusCode(
-			204,
-			subscriptionResource.deleteMyUserAccountSubscriptionHttpResponse(
-				subscription.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				subscriptionResource.
+					deleteMyUserAccountSubscriptionHttpResponse(
+						subscription.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseUserAccountResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseUserAccountResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.admin.user.client.pagination.Page;
 import com.liferay.headless.admin.user.client.pagination.Pagination;
 import com.liferay.headless.admin.user.client.resource.v1_0.UserAccountResource;
 import com.liferay.headless.admin.user.client.serdes.v1_0.UserAccountSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -232,12 +233,16 @@ public abstract class BaseUserAccountResourceTestCase {
 		UserAccount userAccount =
 			testDeleteAccountByExternalReferenceCodeUserAccountByExternalReferenceCode_addUserAccount();
 
-		assertHttpResponseStatusCode(
-			204,
-			userAccountResource.
-				deleteAccountByExternalReferenceCodeUserAccountByExternalReferenceCodeHttpResponse(
-					testDeleteAccountByExternalReferenceCodeUserAccountByExternalReferenceCode_getAccountExternalReferenceCode(),
-					userAccount.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				userAccountResource.
+					deleteAccountByExternalReferenceCodeUserAccountByExternalReferenceCodeHttpResponse(
+						testDeleteAccountByExternalReferenceCodeUserAccountByExternalReferenceCode_getAccountExternalReferenceCode(),
+						userAccount.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 	}
 
 	protected String
@@ -728,13 +733,17 @@ public abstract class BaseUserAccountResourceTestCase {
 		UserAccount userAccount =
 			testDeleteAccountUserAccountsByExternalReferenceCodeByEmailAddress_addUserAccount();
 
-		assertHttpResponseStatusCode(
-			204,
-			userAccountResource.
-				deleteAccountUserAccountsByExternalReferenceCodeByEmailAddressHttpResponse(
-					testDeleteAccountUserAccountsByExternalReferenceCodeByEmailAddress_getExternalReferenceCode(
-						userAccount),
-					null));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				userAccountResource.
+					deleteAccountUserAccountsByExternalReferenceCodeByEmailAddressHttpResponse(
+						testDeleteAccountUserAccountsByExternalReferenceCodeByEmailAddress_getExternalReferenceCode(
+							userAccount),
+						null);
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 	}
 
 	protected String
@@ -790,13 +799,17 @@ public abstract class BaseUserAccountResourceTestCase {
 		UserAccount userAccount =
 			testDeleteAccountUserAccountByExternalReferenceCodeByEmailAddress_addUserAccount();
 
-		assertHttpResponseStatusCode(
-			204,
-			userAccountResource.
-				deleteAccountUserAccountByExternalReferenceCodeByEmailAddressHttpResponse(
-					testDeleteAccountUserAccountByExternalReferenceCodeByEmailAddress_getExternalReferenceCode(
-						userAccount),
-					userAccount.getEmailAddress()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				userAccountResource.
+					deleteAccountUserAccountByExternalReferenceCodeByEmailAddressHttpResponse(
+						testDeleteAccountUserAccountByExternalReferenceCodeByEmailAddress_getExternalReferenceCode(
+							userAccount),
+						userAccount.getEmailAddress());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 	}
 
 	protected String
@@ -1252,12 +1265,16 @@ public abstract class BaseUserAccountResourceTestCase {
 		UserAccount userAccount =
 			testDeleteAccountUserAccountsByEmailAddress_addUserAccount();
 
-		assertHttpResponseStatusCode(
-			204,
-			userAccountResource.
-				deleteAccountUserAccountsByEmailAddressHttpResponse(
-					testDeleteAccountUserAccountsByEmailAddress_getAccountId(),
-					null));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				userAccountResource.
+					deleteAccountUserAccountsByEmailAddressHttpResponse(
+						testDeleteAccountUserAccountsByEmailAddress_getAccountId(),
+						null);
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 	}
 
 	protected Long testDeleteAccountUserAccountsByEmailAddress_getAccountId()
@@ -1286,12 +1303,16 @@ public abstract class BaseUserAccountResourceTestCase {
 		UserAccount userAccount =
 			testDeleteAccountUserAccountByEmailAddress_addUserAccount();
 
-		assertHttpResponseStatusCode(
-			204,
-			userAccountResource.
-				deleteAccountUserAccountByEmailAddressHttpResponse(
-					testDeleteAccountUserAccountByEmailAddress_getAccountId(),
-					userAccount.getEmailAddress()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				userAccountResource.
+					deleteAccountUserAccountByEmailAddressHttpResponse(
+						testDeleteAccountUserAccountByEmailAddress_getAccountId(),
+						userAccount.getEmailAddress());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 	}
 
 	protected Long testDeleteAccountUserAccountByEmailAddress_getAccountId()
@@ -2483,11 +2504,15 @@ public abstract class BaseUserAccountResourceTestCase {
 		UserAccount userAccount =
 			testDeleteUserAccountByExternalReferenceCode_addUserAccount();
 
-		assertHttpResponseStatusCode(
-			204,
-			userAccountResource.
-				deleteUserAccountByExternalReferenceCodeHttpResponse(
-					userAccount.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				userAccountResource.
+					deleteUserAccountByExternalReferenceCodeHttpResponse(
+						userAccount.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -2655,10 +2680,13 @@ public abstract class BaseUserAccountResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		UserAccount userAccount = testDeleteUserAccount_addUserAccount();
 
-		assertHttpResponseStatusCode(
-			204,
-			userAccountResource.deleteUserAccountHttpResponse(
-				userAccount.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> userAccountResource.deleteUserAccountHttpResponse(
+				userAccount.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseUserGroupResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseUserGroupResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.admin.user.client.pagination.Page;
 import com.liferay.headless.admin.user.client.pagination.Pagination;
 import com.liferay.headless.admin.user.client.resource.v1_0.UserGroupResource;
 import com.liferay.headless.admin.user.client.serdes.v1_0.UserGroupSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -638,11 +639,15 @@ public abstract class BaseUserGroupResourceTestCase {
 		UserGroup userGroup =
 			testDeleteUserGroupByExternalReferenceCode_addUserGroup();
 
-		assertHttpResponseStatusCode(
-			204,
-			userGroupResource.
-				deleteUserGroupByExternalReferenceCodeHttpResponse(
-					userGroup.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				userGroupResource.
+					deleteUserGroupByExternalReferenceCodeHttpResponse(
+						userGroup.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -836,9 +841,13 @@ public abstract class BaseUserGroupResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		UserGroup userGroup = testDeleteUserGroup_addUserGroup();
 
-		assertHttpResponseStatusCode(
-			204,
-			userGroupResource.deleteUserGroupHttpResponse(userGroup.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> userGroupResource.deleteUserGroupHttpResponse(
+				userGroup.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404, userGroupResource.getUserGroupHttpResponse(userGroup.getId()));
@@ -1007,10 +1016,13 @@ public abstract class BaseUserGroupResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		UserGroup userGroup = testDeleteUserGroupUsers_addUserGroup();
 
-		assertHttpResponseStatusCode(
-			204,
-			userGroupResource.deleteUserGroupUsersHttpResponse(
-				userGroup.getId(), null));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> userGroupResource.deleteUserGroupUsersHttpResponse(
+				userGroup.getId(), null);
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 	}
 
 	protected UserGroup testDeleteUserGroupUsers_addUserGroup()

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/RoleResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/RoleResourceTest.java
@@ -41,6 +41,7 @@ import java.util.List;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -63,6 +64,37 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 		super.setUp();
 
 		_user = UserTestUtil.addGroupAdminUser(testGroup);
+	}
+
+	@Ignore
+	@Override
+	@Test
+	public void testDeleteOrganizationRoleUserAccountAssociation()
+		throws Exception {
+
+		// TODO LPS-184020 Ignored until method returns 404 on null deletion
+
+		super.testDeleteOrganizationRoleUserAccountAssociation();
+	}
+
+	@Ignore
+	@Override
+	@Test
+	public void testDeleteRoleUserAccountAssociation() throws Exception {
+
+		// TODO LPS-184020 Ignored until method returns 404 on null deletion
+
+		super.testDeleteRoleUserAccountAssociation();
+	}
+
+	@Ignore
+	@Override
+	@Test
+	public void testDeleteSiteRoleUserAccountAssociation() throws Exception {
+
+		// TODO LPS-184020 Ignored until method returns 404 on null deletion
+
+		super.testDeleteSiteRoleUserAccountAssociation();
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/WorkflowInstanceResourceImpl.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/WorkflowInstanceResourceImpl.java
@@ -58,8 +58,8 @@ public class WorkflowInstanceResourceImpl
 	public void deleteWorkflowInstance(Long workflowInstanceId)
 		throws Exception {
 
-		WorkflowInstance workflowInstance =
-			getWorkflowInstance(workflowInstanceId);
+		WorkflowInstance workflowInstance = getWorkflowInstance(
+			workflowInstanceId);
 
 		_workflowInstanceManager.deleteWorkflowInstance(
 			contextCompany.getCompanyId(), workflowInstance.getId());

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/WorkflowInstanceResourceImpl.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/WorkflowInstanceResourceImpl.java
@@ -58,8 +58,11 @@ public class WorkflowInstanceResourceImpl
 	public void deleteWorkflowInstance(Long workflowInstanceId)
 		throws Exception {
 
+		WorkflowInstance workflowInstance =
+			getWorkflowInstance(workflowInstanceId);
+
 		_workflowInstanceManager.deleteWorkflowInstance(
-			contextCompany.getCompanyId(), workflowInstanceId);
+			contextCompany.getCompanyId(), workflowInstance.getId());
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowDefinitionResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowDefinitionResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.admin.workflow.client.pagination.Page;
 import com.liferay.headless.admin.workflow.client.pagination.Pagination;
 import com.liferay.headless.admin.workflow.client.resource.v1_0.WorkflowDefinitionResource;
 import com.liferay.headless.admin.workflow.client.serdes.v1_0.WorkflowDefinitionSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -657,10 +658,14 @@ public abstract class BaseWorkflowDefinitionResourceTestCase {
 		WorkflowDefinition workflowDefinition =
 			testDeleteWorkflowDefinitionUndeploy_addWorkflowDefinition();
 
-		assertHttpResponseStatusCode(
-			204,
-			workflowDefinitionResource.
-				deleteWorkflowDefinitionUndeployHttpResponse(null, null));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				workflowDefinitionResource.
+					deleteWorkflowDefinitionUndeployHttpResponse(null, null);
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 	}
 
 	protected WorkflowDefinition
@@ -699,10 +704,14 @@ public abstract class BaseWorkflowDefinitionResourceTestCase {
 		WorkflowDefinition workflowDefinition =
 			testDeleteWorkflowDefinition_addWorkflowDefinition();
 
-		assertHttpResponseStatusCode(
-			204,
-			workflowDefinitionResource.deleteWorkflowDefinitionHttpResponse(
-				workflowDefinition.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				workflowDefinitionResource.deleteWorkflowDefinitionHttpResponse(
+					workflowDefinition.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowInstanceResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowInstanceResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.admin.workflow.client.pagination.Page;
 import com.liferay.headless.admin.workflow.client.pagination.Pagination;
 import com.liferay.headless.admin.workflow.client.resource.v1_0.WorkflowInstanceResource;
 import com.liferay.headless.admin.workflow.client.serdes.v1_0.WorkflowInstanceSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -383,10 +384,13 @@ public abstract class BaseWorkflowInstanceResourceTestCase {
 		WorkflowInstance workflowInstance =
 			testDeleteWorkflowInstance_addWorkflowInstance();
 
-		assertHttpResponseStatusCode(
-			204,
-			workflowInstanceResource.deleteWorkflowInstanceHttpResponse(
-				workflowInstance.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> workflowInstanceResource.deleteWorkflowInstanceHttpResponse(
+				workflowInstance.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -5574,7 +5574,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.delivery.client', and version '4.0.58'."
+        'com.liferay.headless.delivery.client', and version '4.0.59'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/KnowledgeBaseAttachmentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/KnowledgeBaseAttachmentResourceImpl.java
@@ -53,8 +53,11 @@ public class KnowledgeBaseAttachmentResourceImpl
 	public void deleteKnowledgeBaseAttachment(Long knowledgeBaseAttachmentId)
 		throws Exception {
 
+		KnowledgeBaseAttachment knowledgeBaseAttachment =
+			getKnowledgeBaseAttachment(knowledgeBaseAttachmentId);
+
 		_portletFileRepository.deletePortletFileEntry(
-			knowledgeBaseAttachmentId);
+			knowledgeBaseAttachment.getId());
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardAttachmentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardAttachmentResourceImpl.java
@@ -57,7 +57,10 @@ public class MessageBoardAttachmentResourceImpl
 	public void deleteMessageBoardAttachment(Long messageBoardAttachmentId)
 		throws Exception {
 
-		_portletFileRepository.deletePortletFileEntry(messageBoardAttachmentId);
+		MessageBoardAttachment messageBoardAttachment =
+			getMessageBoardAttachment(messageBoardAttachmentId);
+
+		_portletFileRepository.deletePortletFileEntry(messageBoardAttachment.getId());
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardAttachmentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardAttachmentResourceImpl.java
@@ -60,7 +60,8 @@ public class MessageBoardAttachmentResourceImpl
 		MessageBoardAttachment messageBoardAttachment =
 			getMessageBoardAttachment(messageBoardAttachmentId);
 
-		_portletFileRepository.deletePortletFileEntry(messageBoardAttachment.getId());
+		_portletFileRepository.deletePortletFileEntry(
+			messageBoardAttachment.getId());
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.delivery.client', and version '4.0.58'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Delivery", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.delivery.client', and version '4.0.59'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Delivery", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/WikiPageAttachmentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/WikiPageAttachmentResourceImpl.java
@@ -73,7 +73,10 @@ public class WikiPageAttachmentResourceImpl
 	public void deleteWikiPageAttachment(Long wikiPageAttachmentId)
 		throws Exception {
 
-		_portletFileRepository.deletePortletFileEntry(wikiPageAttachmentId);
+		WikiPageAttachment wikiPageAttachment =
+			getWikiPageAttachment(wikiPageAttachmentId);
+
+		_portletFileRepository.deletePortletFileEntry(wikiPageAttachment.getId());
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/WikiPageAttachmentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/WikiPageAttachmentResourceImpl.java
@@ -73,10 +73,11 @@ public class WikiPageAttachmentResourceImpl
 	public void deleteWikiPageAttachment(Long wikiPageAttachmentId)
 		throws Exception {
 
-		WikiPageAttachment wikiPageAttachment =
-			getWikiPageAttachment(wikiPageAttachmentId);
+		WikiPageAttachment wikiPageAttachment = getWikiPageAttachment(
+			wikiPageAttachmentId);
 
-		_portletFileRepository.deletePortletFileEntry(wikiPageAttachment.getId());
+		_portletFileRepository.deletePortletFileEntry(
+			wikiPageAttachment.getId());
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingImageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingImageResourceTestCase.java
@@ -29,6 +29,7 @@ import com.liferay.headless.delivery.client.pagination.Page;
 import com.liferay.headless.delivery.client.pagination.Pagination;
 import com.liferay.headless.delivery.client.resource.v1_0.BlogPostingImageResource;
 import com.liferay.headless.delivery.client.serdes.v1_0.BlogPostingImageSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -214,10 +215,13 @@ public abstract class BaseBlogPostingImageResourceTestCase {
 		BlogPostingImage blogPostingImage =
 			testDeleteBlogPostingImage_addBlogPostingImage();
 
-		assertHttpResponseStatusCode(
-			204,
-			blogPostingImageResource.deleteBlogPostingImageHttpResponse(
-				blogPostingImage.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> blogPostingImageResource.deleteBlogPostingImageHttpResponse(
+				blogPostingImage.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingResourceTestCase.java
@@ -31,6 +31,7 @@ import com.liferay.headless.delivery.client.pagination.Pagination;
 import com.liferay.headless.delivery.client.permission.Permission;
 import com.liferay.headless.delivery.client.resource.v1_0.BlogPostingResource;
 import com.liferay.headless.delivery.client.serdes.v1_0.BlogPostingSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -218,10 +219,13 @@ public abstract class BaseBlogPostingResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		BlogPosting blogPosting = testDeleteBlogPosting_addBlogPosting();
 
-		assertHttpResponseStatusCode(
-			204,
-			blogPostingResource.deleteBlogPostingHttpResponse(
-				blogPosting.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> blogPostingResource.deleteBlogPostingHttpResponse(
+				blogPosting.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -399,10 +403,13 @@ public abstract class BaseBlogPostingResourceTestCase {
 		BlogPosting blogPosting =
 			testDeleteBlogPostingMyRating_addBlogPosting();
 
-		assertHttpResponseStatusCode(
-			204,
-			blogPostingResource.deleteBlogPostingMyRatingHttpResponse(
-				blogPosting.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> blogPostingResource.deleteBlogPostingMyRatingHttpResponse(
+				blogPosting.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -928,13 +935,17 @@ public abstract class BaseBlogPostingResourceTestCase {
 		BlogPosting blogPosting =
 			testDeleteSiteBlogPostingByExternalReferenceCode_addBlogPosting();
 
-		assertHttpResponseStatusCode(
-			204,
-			blogPostingResource.
-				deleteSiteBlogPostingByExternalReferenceCodeHttpResponse(
-					testDeleteSiteBlogPostingByExternalReferenceCode_getSiteId(
-						blogPosting),
-					blogPosting.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				blogPostingResource.
+					deleteSiteBlogPostingByExternalReferenceCodeHttpResponse(
+						testDeleteSiteBlogPostingByExternalReferenceCode_getSiteId(
+							blogPosting),
+						blogPosting.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseCommentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseCommentResourceTestCase.java
@@ -29,6 +29,7 @@ import com.liferay.headless.delivery.client.pagination.Page;
 import com.liferay.headless.delivery.client.pagination.Pagination;
 import com.liferay.headless.delivery.client.resource.v1_0.CommentResource;
 import com.liferay.headless.delivery.client.serdes.v1_0.CommentSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -582,8 +583,12 @@ public abstract class BaseCommentResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		Comment comment = testDeleteComment_addComment();
 
-		assertHttpResponseStatusCode(
-			204, commentResource.deleteCommentHttpResponse(comment.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> commentResource.deleteCommentHttpResponse(comment.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404, commentResource.getCommentHttpResponse(comment.getId()));
@@ -1441,13 +1446,17 @@ public abstract class BaseCommentResourceTestCase {
 		Comment comment =
 			testDeleteSiteBlogPostingByExternalReferenceCodeBlogPostingExternalReferenceCodeCommentByExternalReferenceCode_addComment();
 
-		assertHttpResponseStatusCode(
-			204,
-			commentResource.
-				deleteSiteBlogPostingByExternalReferenceCodeBlogPostingExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
-					testDeleteSiteBlogPostingByExternalReferenceCodeBlogPostingExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
-					testDeleteSiteBlogPostingByExternalReferenceCodeBlogPostingExternalReferenceCodeCommentByExternalReferenceCode_getBlogPostingExternalReferenceCode(),
-					comment.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				commentResource.
+					deleteSiteBlogPostingByExternalReferenceCodeBlogPostingExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
+						testDeleteSiteBlogPostingByExternalReferenceCodeBlogPostingExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
+						testDeleteSiteBlogPostingByExternalReferenceCodeBlogPostingExternalReferenceCodeCommentByExternalReferenceCode_getBlogPostingExternalReferenceCode(),
+						comment.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -1725,13 +1734,17 @@ public abstract class BaseCommentResourceTestCase {
 		Comment comment =
 			testDeleteSiteCommentByExternalReferenceCodeParentCommentExternalReferenceCodeCommentByExternalReferenceCode_addComment();
 
-		assertHttpResponseStatusCode(
-			204,
-			commentResource.
-				deleteSiteCommentByExternalReferenceCodeParentCommentExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
-					testDeleteSiteCommentByExternalReferenceCodeParentCommentExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
-					testDeleteSiteCommentByExternalReferenceCodeParentCommentExternalReferenceCodeCommentByExternalReferenceCode_getParentCommentExternalReferenceCode(),
-					comment.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				commentResource.
+					deleteSiteCommentByExternalReferenceCodeParentCommentExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
+						testDeleteSiteCommentByExternalReferenceCodeParentCommentExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
+						testDeleteSiteCommentByExternalReferenceCodeParentCommentExternalReferenceCodeCommentByExternalReferenceCode_getParentCommentExternalReferenceCode(),
+						comment.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -2009,13 +2022,17 @@ public abstract class BaseCommentResourceTestCase {
 		Comment comment =
 			testDeleteSiteDocumentByExternalReferenceCodeDocumentExternalReferenceCodeCommentByExternalReferenceCode_addComment();
 
-		assertHttpResponseStatusCode(
-			204,
-			commentResource.
-				deleteSiteDocumentByExternalReferenceCodeDocumentExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
-					testDeleteSiteDocumentByExternalReferenceCodeDocumentExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
-					testDeleteSiteDocumentByExternalReferenceCodeDocumentExternalReferenceCodeCommentByExternalReferenceCode_getDocumentExternalReferenceCode(),
-					comment.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				commentResource.
+					deleteSiteDocumentByExternalReferenceCodeDocumentExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
+						testDeleteSiteDocumentByExternalReferenceCodeDocumentExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
+						testDeleteSiteDocumentByExternalReferenceCodeDocumentExternalReferenceCodeCommentByExternalReferenceCode_getDocumentExternalReferenceCode(),
+						comment.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -2293,13 +2310,17 @@ public abstract class BaseCommentResourceTestCase {
 		Comment comment =
 			testDeleteSiteStructuredContentByExternalReferenceCodeStructuredContentExternalReferenceCodeCommentByExternalReferenceCode_addComment();
 
-		assertHttpResponseStatusCode(
-			204,
-			commentResource.
-				deleteSiteStructuredContentByExternalReferenceCodeStructuredContentExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
-					testDeleteSiteStructuredContentByExternalReferenceCodeStructuredContentExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
-					testDeleteSiteStructuredContentByExternalReferenceCodeStructuredContentExternalReferenceCodeCommentByExternalReferenceCode_getStructuredContentExternalReferenceCode(),
-					comment.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				commentResource.
+					deleteSiteStructuredContentByExternalReferenceCodeStructuredContentExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
+						testDeleteSiteStructuredContentByExternalReferenceCodeStructuredContentExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
+						testDeleteSiteStructuredContentByExternalReferenceCodeStructuredContentExternalReferenceCodeCommentByExternalReferenceCode_getStructuredContentExternalReferenceCode(),
+						comment.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentFolderResourceTestCase.java
@@ -33,6 +33,7 @@ import com.liferay.headless.delivery.client.pagination.Pagination;
 import com.liferay.headless.delivery.client.permission.Permission;
 import com.liferay.headless.delivery.client.resource.v1_0.DocumentFolderResource;
 import com.liferay.headless.delivery.client.serdes.v1_0.DocumentFolderSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -871,10 +872,13 @@ public abstract class BaseDocumentFolderResourceTestCase {
 		DocumentFolder documentFolder =
 			testDeleteDocumentFolder_addDocumentFolder();
 
-		assertHttpResponseStatusCode(
-			204,
-			documentFolderResource.deleteDocumentFolderHttpResponse(
-				documentFolder.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> documentFolderResource.deleteDocumentFolderHttpResponse(
+				documentFolder.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -1067,10 +1071,14 @@ public abstract class BaseDocumentFolderResourceTestCase {
 		DocumentFolder documentFolder =
 			testDeleteDocumentFolderMyRating_addDocumentFolder();
 
-		assertHttpResponseStatusCode(
-			204,
-			documentFolderResource.deleteDocumentFolderMyRatingHttpResponse(
-				documentFolder.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				documentFolderResource.deleteDocumentFolderMyRatingHttpResponse(
+					documentFolder.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -2297,13 +2305,17 @@ public abstract class BaseDocumentFolderResourceTestCase {
 		DocumentFolder documentFolder =
 			testDeleteSiteDocumentsFolderByExternalReferenceCode_addDocumentFolder();
 
-		assertHttpResponseStatusCode(
-			204,
-			documentFolderResource.
-				deleteSiteDocumentsFolderByExternalReferenceCodeHttpResponse(
-					testDeleteSiteDocumentsFolderByExternalReferenceCode_getSiteId(
-						documentFolder),
-					documentFolder.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				documentFolderResource.
+					deleteSiteDocumentsFolderByExternalReferenceCodeHttpResponse(
+						testDeleteSiteDocumentsFolderByExternalReferenceCode_getSiteId(
+							documentFolder),
+						documentFolder.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentResourceTestCase.java
@@ -33,6 +33,7 @@ import com.liferay.headless.delivery.client.pagination.Pagination;
 import com.liferay.headless.delivery.client.permission.Permission;
 import com.liferay.headless.delivery.client.resource.v1_0.DocumentResource;
 import com.liferay.headless.delivery.client.serdes.v1_0.DocumentSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -638,12 +639,16 @@ public abstract class BaseDocumentResourceTestCase {
 		Document document =
 			testDeleteAssetLibraryDocumentByExternalReferenceCode_addDocument();
 
-		assertHttpResponseStatusCode(
-			204,
-			documentResource.
-				deleteAssetLibraryDocumentByExternalReferenceCodeHttpResponse(
-					testDeleteAssetLibraryDocumentByExternalReferenceCode_getAssetLibraryId(),
-					document.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				documentResource.
+					deleteAssetLibraryDocumentByExternalReferenceCodeHttpResponse(
+						testDeleteAssetLibraryDocumentByExternalReferenceCode_getAssetLibraryId(),
+						document.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -1473,8 +1478,12 @@ public abstract class BaseDocumentResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		Document document = testDeleteDocument_addDocument();
 
-		assertHttpResponseStatusCode(
-			204, documentResource.deleteDocumentHttpResponse(document.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> documentResource.deleteDocumentHttpResponse(document.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404, documentResource.getDocumentHttpResponse(document.getId()));
@@ -1648,10 +1657,13 @@ public abstract class BaseDocumentResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		Document document = testDeleteDocumentMyRating_addDocument();
 
-		assertHttpResponseStatusCode(
-			204,
-			documentResource.deleteDocumentMyRatingHttpResponse(
-				document.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> documentResource.deleteDocumentMyRatingHttpResponse(
+				document.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -2151,13 +2163,17 @@ public abstract class BaseDocumentResourceTestCase {
 		Document document =
 			testDeleteSiteDocumentByExternalReferenceCode_addDocument();
 
-		assertHttpResponseStatusCode(
-			204,
-			documentResource.
-				deleteSiteDocumentByExternalReferenceCodeHttpResponse(
-					testDeleteSiteDocumentByExternalReferenceCode_getSiteId(
-						document),
-					document.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				documentResource.
+					deleteSiteDocumentByExternalReferenceCodeHttpResponse(
+						testDeleteSiteDocumentByExternalReferenceCode_getSiteId(
+							document),
+						document.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseArticleResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseArticleResourceTestCase.java
@@ -31,6 +31,7 @@ import com.liferay.headless.delivery.client.pagination.Pagination;
 import com.liferay.headless.delivery.client.permission.Permission;
 import com.liferay.headless.delivery.client.resource.v1_0.KnowledgeBaseArticleResource;
 import com.liferay.headless.delivery.client.serdes.v1_0.KnowledgeBaseArticleSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -223,10 +224,15 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 		KnowledgeBaseArticle knowledgeBaseArticle =
 			testDeleteKnowledgeBaseArticle_addKnowledgeBaseArticle();
 
-		assertHttpResponseStatusCode(
-			204,
-			knowledgeBaseArticleResource.deleteKnowledgeBaseArticleHttpResponse(
-				knowledgeBaseArticle.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				knowledgeBaseArticleResource.
+					deleteKnowledgeBaseArticleHttpResponse(
+						knowledgeBaseArticle.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -437,11 +443,15 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 		KnowledgeBaseArticle knowledgeBaseArticle =
 			testDeleteKnowledgeBaseArticleMyRating_addKnowledgeBaseArticle();
 
-		assertHttpResponseStatusCode(
-			204,
-			knowledgeBaseArticleResource.
-				deleteKnowledgeBaseArticleMyRatingHttpResponse(
-					knowledgeBaseArticle.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				knowledgeBaseArticleResource.
+					deleteKnowledgeBaseArticleMyRatingHttpResponse(
+						knowledgeBaseArticle.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -2004,13 +2014,17 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 		KnowledgeBaseArticle knowledgeBaseArticle =
 			testDeleteSiteKnowledgeBaseArticleByExternalReferenceCode_addKnowledgeBaseArticle();
 
-		assertHttpResponseStatusCode(
-			204,
-			knowledgeBaseArticleResource.
-				deleteSiteKnowledgeBaseArticleByExternalReferenceCodeHttpResponse(
-					testDeleteSiteKnowledgeBaseArticleByExternalReferenceCode_getSiteId(
-						knowledgeBaseArticle),
-					knowledgeBaseArticle.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				knowledgeBaseArticleResource.
+					deleteSiteKnowledgeBaseArticleByExternalReferenceCodeHttpResponse(
+						testDeleteSiteKnowledgeBaseArticleByExternalReferenceCode_getSiteId(
+							knowledgeBaseArticle),
+						knowledgeBaseArticle.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseAttachmentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseAttachmentResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.delivery.client.http.HttpInvoker;
 import com.liferay.headless.delivery.client.pagination.Page;
 import com.liferay.headless.delivery.client.resource.v1_0.KnowledgeBaseAttachmentResource;
 import com.liferay.headless.delivery.client.serdes.v1_0.KnowledgeBaseAttachmentSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -366,11 +367,15 @@ public abstract class BaseKnowledgeBaseAttachmentResourceTestCase {
 		KnowledgeBaseAttachment knowledgeBaseAttachment =
 			testDeleteKnowledgeBaseAttachment_addKnowledgeBaseAttachment();
 
-		assertHttpResponseStatusCode(
-			204,
-			knowledgeBaseAttachmentResource.
-				deleteKnowledgeBaseAttachmentHttpResponse(
-					knowledgeBaseAttachment.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				knowledgeBaseAttachmentResource.
+					deleteKnowledgeBaseAttachmentHttpResponse(
+						knowledgeBaseAttachment.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -518,13 +523,17 @@ public abstract class BaseKnowledgeBaseAttachmentResourceTestCase {
 		KnowledgeBaseAttachment knowledgeBaseAttachment =
 			testDeleteSiteKnowledgeBaseArticleByExternalReferenceCodeKnowledgeBaseArticleExternalReferenceCodeKnowledgeBaseAttachmentByExternalReferenceCode_addKnowledgeBaseAttachment();
 
-		assertHttpResponseStatusCode(
-			204,
-			knowledgeBaseAttachmentResource.
-				deleteSiteKnowledgeBaseArticleByExternalReferenceCodeKnowledgeBaseArticleExternalReferenceCodeKnowledgeBaseAttachmentByExternalReferenceCodeHttpResponse(
-					testDeleteSiteKnowledgeBaseArticleByExternalReferenceCodeKnowledgeBaseArticleExternalReferenceCodeKnowledgeBaseAttachmentByExternalReferenceCode_getSiteId(),
-					testDeleteSiteKnowledgeBaseArticleByExternalReferenceCodeKnowledgeBaseArticleExternalReferenceCodeKnowledgeBaseAttachmentByExternalReferenceCode_getKnowledgeBaseArticleExternalReferenceCode(),
-					knowledgeBaseAttachment.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				knowledgeBaseAttachmentResource.
+					deleteSiteKnowledgeBaseArticleByExternalReferenceCodeKnowledgeBaseArticleExternalReferenceCodeKnowledgeBaseAttachmentByExternalReferenceCodeHttpResponse(
+						testDeleteSiteKnowledgeBaseArticleByExternalReferenceCodeKnowledgeBaseArticleExternalReferenceCodeKnowledgeBaseAttachmentByExternalReferenceCode_getSiteId(),
+						testDeleteSiteKnowledgeBaseArticleByExternalReferenceCodeKnowledgeBaseArticleExternalReferenceCodeKnowledgeBaseAttachmentByExternalReferenceCode_getKnowledgeBaseArticleExternalReferenceCode(),
+						knowledgeBaseAttachment.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseFolderResourceTestCase.java
@@ -30,6 +30,7 @@ import com.liferay.headless.delivery.client.pagination.Pagination;
 import com.liferay.headless.delivery.client.permission.Permission;
 import com.liferay.headless.delivery.client.resource.v1_0.KnowledgeBaseFolderResource;
 import com.liferay.headless.delivery.client.serdes.v1_0.KnowledgeBaseFolderSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -211,10 +212,15 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 		KnowledgeBaseFolder knowledgeBaseFolder =
 			testDeleteKnowledgeBaseFolder_addKnowledgeBaseFolder();
 
-		assertHttpResponseStatusCode(
-			204,
-			knowledgeBaseFolderResource.deleteKnowledgeBaseFolderHttpResponse(
-				knowledgeBaseFolder.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				knowledgeBaseFolderResource.
+					deleteKnowledgeBaseFolderHttpResponse(
+						knowledgeBaseFolder.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -913,13 +919,17 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 		KnowledgeBaseFolder knowledgeBaseFolder =
 			testDeleteSiteKnowledgeBaseFolderByExternalReferenceCode_addKnowledgeBaseFolder();
 
-		assertHttpResponseStatusCode(
-			204,
-			knowledgeBaseFolderResource.
-				deleteSiteKnowledgeBaseFolderByExternalReferenceCodeHttpResponse(
-					testDeleteSiteKnowledgeBaseFolderByExternalReferenceCode_getSiteId(
-						knowledgeBaseFolder),
-					knowledgeBaseFolder.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				knowledgeBaseFolderResource.
+					deleteSiteKnowledgeBaseFolderByExternalReferenceCodeHttpResponse(
+						testDeleteSiteKnowledgeBaseFolderByExternalReferenceCode_getSiteId(
+							knowledgeBaseFolder),
+						knowledgeBaseFolder.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardAttachmentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardAttachmentResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.delivery.client.http.HttpInvoker;
 import com.liferay.headless.delivery.client.pagination.Page;
 import com.liferay.headless.delivery.client.resource.v1_0.MessageBoardAttachmentResource;
 import com.liferay.headless.delivery.client.serdes.v1_0.MessageBoardAttachmentSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -218,11 +219,15 @@ public abstract class BaseMessageBoardAttachmentResourceTestCase {
 		MessageBoardAttachment messageBoardAttachment =
 			testDeleteMessageBoardAttachment_addMessageBoardAttachment();
 
-		assertHttpResponseStatusCode(
-			204,
-			messageBoardAttachmentResource.
-				deleteMessageBoardAttachmentHttpResponse(
-					messageBoardAttachment.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				messageBoardAttachmentResource.
+					deleteMessageBoardAttachmentHttpResponse(
+						messageBoardAttachment.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -664,13 +669,17 @@ public abstract class BaseMessageBoardAttachmentResourceTestCase {
 		MessageBoardAttachment messageBoardAttachment =
 			testDeleteSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode_addMessageBoardAttachment();
 
-		assertHttpResponseStatusCode(
-			204,
-			messageBoardAttachmentResource.
-				deleteSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCodeHttpResponse(
-					testDeleteSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode_getSiteId(),
-					testDeleteSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode_getMessageBoardMessageExternalReferenceCode(),
-					messageBoardAttachment.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				messageBoardAttachmentResource.
+					deleteSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCodeHttpResponse(
+						testDeleteSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode_getSiteId(),
+						testDeleteSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode_getMessageBoardMessageExternalReferenceCode(),
+						messageBoardAttachment.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardMessageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardMessageResourceTestCase.java
@@ -31,6 +31,7 @@ import com.liferay.headless.delivery.client.pagination.Pagination;
 import com.liferay.headless.delivery.client.permission.Permission;
 import com.liferay.headless.delivery.client.resource.v1_0.MessageBoardMessageResource;
 import com.liferay.headless.delivery.client.serdes.v1_0.MessageBoardMessageSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -219,10 +220,15 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 		MessageBoardMessage messageBoardMessage =
 			testDeleteMessageBoardMessage_addMessageBoardMessage();
 
-		assertHttpResponseStatusCode(
-			204,
-			messageBoardMessageResource.deleteMessageBoardMessageHttpResponse(
-				messageBoardMessage.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				messageBoardMessageResource.
+					deleteMessageBoardMessageHttpResponse(
+						messageBoardMessage.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -431,11 +437,15 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 		MessageBoardMessage messageBoardMessage =
 			testDeleteMessageBoardMessageMyRating_addMessageBoardMessage();
 
-		assertHttpResponseStatusCode(
-			204,
-			messageBoardMessageResource.
-				deleteMessageBoardMessageMyRatingHttpResponse(
-					messageBoardMessage.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				messageBoardMessageResource.
+					deleteMessageBoardMessageMyRatingHttpResponse(
+						messageBoardMessage.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -1937,13 +1947,17 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 		MessageBoardMessage messageBoardMessage =
 			testDeleteSiteMessageBoardMessageByExternalReferenceCode_addMessageBoardMessage();
 
-		assertHttpResponseStatusCode(
-			204,
-			messageBoardMessageResource.
-				deleteSiteMessageBoardMessageByExternalReferenceCodeHttpResponse(
-					testDeleteSiteMessageBoardMessageByExternalReferenceCode_getSiteId(
-						messageBoardMessage),
-					messageBoardMessage.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				messageBoardMessageResource.
+					deleteSiteMessageBoardMessageByExternalReferenceCodeHttpResponse(
+						testDeleteSiteMessageBoardMessageByExternalReferenceCode_getSiteId(
+							messageBoardMessage),
+						messageBoardMessage.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardSectionResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardSectionResourceTestCase.java
@@ -30,6 +30,7 @@ import com.liferay.headless.delivery.client.pagination.Pagination;
 import com.liferay.headless.delivery.client.permission.Permission;
 import com.liferay.headless.delivery.client.resource.v1_0.MessageBoardSectionResource;
 import com.liferay.headless.delivery.client.serdes.v1_0.MessageBoardSectionSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -210,10 +211,15 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 		MessageBoardSection messageBoardSection =
 			testDeleteMessageBoardSection_addMessageBoardSection();
 
-		assertHttpResponseStatusCode(
-			204,
-			messageBoardSectionResource.deleteMessageBoardSectionHttpResponse(
-				messageBoardSection.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				messageBoardSectionResource.
+					deleteMessageBoardSectionHttpResponse(
+						messageBoardSection.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardThreadResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardThreadResourceTestCase.java
@@ -31,6 +31,7 @@ import com.liferay.headless.delivery.client.pagination.Pagination;
 import com.liferay.headless.delivery.client.permission.Permission;
 import com.liferay.headless.delivery.client.resource.v1_0.MessageBoardThreadResource;
 import com.liferay.headless.delivery.client.serdes.v1_0.MessageBoardThreadSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -934,10 +935,14 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 		MessageBoardThread messageBoardThread =
 			testDeleteMessageBoardThread_addMessageBoardThread();
 
-		assertHttpResponseStatusCode(
-			204,
-			messageBoardThreadResource.deleteMessageBoardThreadHttpResponse(
-				messageBoardThread.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				messageBoardThreadResource.deleteMessageBoardThreadHttpResponse(
+					messageBoardThread.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -1145,11 +1150,15 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 		MessageBoardThread messageBoardThread =
 			testDeleteMessageBoardThreadMyRating_addMessageBoardThread();
 
-		assertHttpResponseStatusCode(
-			204,
-			messageBoardThreadResource.
-				deleteMessageBoardThreadMyRatingHttpResponse(
-					messageBoardThread.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				messageBoardThreadResource.
+					deleteMessageBoardThreadMyRatingHttpResponse(
+						messageBoardThread.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseNavigationMenuResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseNavigationMenuResourceTestCase.java
@@ -30,6 +30,7 @@ import com.liferay.headless.delivery.client.pagination.Pagination;
 import com.liferay.headless.delivery.client.permission.Permission;
 import com.liferay.headless.delivery.client.resource.v1_0.NavigationMenuResource;
 import com.liferay.headless.delivery.client.serdes.v1_0.NavigationMenuSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -205,10 +206,13 @@ public abstract class BaseNavigationMenuResourceTestCase {
 		NavigationMenu navigationMenu =
 			testDeleteNavigationMenu_addNavigationMenu();
 
-		assertHttpResponseStatusCode(
-			204,
-			navigationMenuResource.deleteNavigationMenuHttpResponse(
-				navigationMenu.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> navigationMenuResource.deleteNavigationMenuHttpResponse(
+				navigationMenu.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentFolderResourceTestCase.java
@@ -32,6 +32,7 @@ import com.liferay.headless.delivery.client.pagination.Pagination;
 import com.liferay.headless.delivery.client.permission.Permission;
 import com.liferay.headless.delivery.client.resource.v1_0.StructuredContentFolderResource;
 import com.liferay.headless.delivery.client.serdes.v1_0.StructuredContentFolderSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -705,12 +706,16 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 		StructuredContentFolder structuredContentFolder =
 			testDeleteAssetLibraryStructuredContentFolderByExternalReferenceCode_addStructuredContentFolder();
 
-		assertHttpResponseStatusCode(
-			204,
-			structuredContentFolderResource.
-				deleteAssetLibraryStructuredContentFolderByExternalReferenceCodeHttpResponse(
-					testDeleteAssetLibraryStructuredContentFolderByExternalReferenceCode_getAssetLibraryId(),
-					structuredContentFolder.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				structuredContentFolderResource.
+					deleteAssetLibraryStructuredContentFolderByExternalReferenceCodeHttpResponse(
+						testDeleteAssetLibraryStructuredContentFolderByExternalReferenceCode_getAssetLibraryId(),
+						structuredContentFolder.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -1522,13 +1527,17 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 		StructuredContentFolder structuredContentFolder =
 			testDeleteSiteStructuredContentFolderByExternalReferenceCode_addStructuredContentFolder();
 
-		assertHttpResponseStatusCode(
-			204,
-			structuredContentFolderResource.
-				deleteSiteStructuredContentFolderByExternalReferenceCodeHttpResponse(
-					testDeleteSiteStructuredContentFolderByExternalReferenceCode_getSiteId(
-						structuredContentFolder),
-					structuredContentFolder.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				structuredContentFolderResource.
+					deleteSiteStructuredContentFolderByExternalReferenceCodeHttpResponse(
+						testDeleteSiteStructuredContentFolderByExternalReferenceCode_getSiteId(
+							structuredContentFolder),
+						structuredContentFolder.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -2376,11 +2385,15 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 		StructuredContentFolder structuredContentFolder =
 			testDeleteStructuredContentFolder_addStructuredContentFolder();
 
-		assertHttpResponseStatusCode(
-			204,
-			structuredContentFolderResource.
-				deleteStructuredContentFolderHttpResponse(
-					structuredContentFolder.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				structuredContentFolderResource.
+					deleteStructuredContentFolderHttpResponse(
+						structuredContentFolder.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
@@ -33,6 +33,7 @@ import com.liferay.headless.delivery.client.pagination.Pagination;
 import com.liferay.headless.delivery.client.permission.Permission;
 import com.liferay.headless.delivery.client.resource.v1_0.StructuredContentResource;
 import com.liferay.headless.delivery.client.serdes.v1_0.StructuredContentSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -672,12 +673,16 @@ public abstract class BaseStructuredContentResourceTestCase {
 		StructuredContent structuredContent =
 			testDeleteAssetLibraryStructuredContentByExternalReferenceCode_addStructuredContent();
 
-		assertHttpResponseStatusCode(
-			204,
-			structuredContentResource.
-				deleteAssetLibraryStructuredContentByExternalReferenceCodeHttpResponse(
-					testDeleteAssetLibraryStructuredContentByExternalReferenceCode_getAssetLibraryId(),
-					structuredContent.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				structuredContentResource.
+					deleteAssetLibraryStructuredContentByExternalReferenceCodeHttpResponse(
+						testDeleteAssetLibraryStructuredContentByExternalReferenceCode_getAssetLibraryId(),
+						structuredContent.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -1869,13 +1874,17 @@ public abstract class BaseStructuredContentResourceTestCase {
 		StructuredContent structuredContent =
 			testDeleteSiteStructuredContentByExternalReferenceCode_addStructuredContent();
 
-		assertHttpResponseStatusCode(
-			204,
-			structuredContentResource.
-				deleteSiteStructuredContentByExternalReferenceCodeHttpResponse(
-					testDeleteSiteStructuredContentByExternalReferenceCode_getSiteId(
-						structuredContent),
-					structuredContent.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				structuredContentResource.
+					deleteSiteStructuredContentByExternalReferenceCodeHttpResponse(
+						testDeleteSiteStructuredContentByExternalReferenceCode_getSiteId(
+							structuredContent),
+						structuredContent.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -2832,10 +2841,13 @@ public abstract class BaseStructuredContentResourceTestCase {
 		StructuredContent structuredContent =
 			testDeleteStructuredContent_addStructuredContent();
 
-		assertHttpResponseStatusCode(
-			204,
-			structuredContentResource.deleteStructuredContentHttpResponse(
-				structuredContent.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> structuredContentResource.deleteStructuredContentHttpResponse(
+				structuredContent.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -3040,11 +3052,15 @@ public abstract class BaseStructuredContentResourceTestCase {
 		StructuredContent structuredContent =
 			testDeleteStructuredContentMyRating_addStructuredContent();
 
-		assertHttpResponseStatusCode(
-			204,
-			structuredContentResource.
-				deleteStructuredContentMyRatingHttpResponse(
-					structuredContent.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				structuredContentResource.
+					deleteStructuredContentMyRatingHttpResponse(
+						structuredContent.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiNodeResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiNodeResourceTestCase.java
@@ -30,6 +30,7 @@ import com.liferay.headless.delivery.client.pagination.Pagination;
 import com.liferay.headless.delivery.client.permission.Permission;
 import com.liferay.headless.delivery.client.resource.v1_0.WikiNodeResource;
 import com.liferay.headless.delivery.client.serdes.v1_0.WikiNodeSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -622,13 +623,17 @@ public abstract class BaseWikiNodeResourceTestCase {
 		WikiNode wikiNode =
 			testDeleteSiteWikiNodeByExternalReferenceCode_addWikiNode();
 
-		assertHttpResponseStatusCode(
-			204,
-			wikiNodeResource.
-				deleteSiteWikiNodeByExternalReferenceCodeHttpResponse(
-					testDeleteSiteWikiNodeByExternalReferenceCode_getSiteId(
-						wikiNode),
-					wikiNode.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				wikiNodeResource.
+					deleteSiteWikiNodeByExternalReferenceCodeHttpResponse(
+						testDeleteSiteWikiNodeByExternalReferenceCode_getSiteId(
+							wikiNode),
+						wikiNode.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -896,8 +901,12 @@ public abstract class BaseWikiNodeResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		WikiNode wikiNode = testDeleteWikiNode_addWikiNode();
 
-		assertHttpResponseStatusCode(
-			204, wikiNodeResource.deleteWikiNodeHttpResponse(wikiNode.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> wikiNodeResource.deleteWikiNodeHttpResponse(wikiNode.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404, wikiNodeResource.getWikiNodeHttpResponse(wikiNode.getId()));

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiPageAttachmentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiPageAttachmentResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.headless.delivery.client.http.HttpInvoker;
 import com.liferay.headless.delivery.client.pagination.Page;
 import com.liferay.headless.delivery.client.resource.v1_0.WikiPageAttachmentResource;
 import com.liferay.headless.delivery.client.serdes.v1_0.WikiPageAttachmentSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -214,13 +215,17 @@ public abstract class BaseWikiPageAttachmentResourceTestCase {
 		WikiPageAttachment wikiPageAttachment =
 			testDeleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_addWikiPageAttachment();
 
-		assertHttpResponseStatusCode(
-			204,
-			wikiPageAttachmentResource.
-				deleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCodeHttpResponse(
-					testDeleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_getSiteId(),
-					testDeleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_getWikiPageExternalReferenceCode(),
-					wikiPageAttachment.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				wikiPageAttachmentResource.
+					deleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCodeHttpResponse(
+						testDeleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_getSiteId(),
+						testDeleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_getWikiPageExternalReferenceCode(),
+						wikiPageAttachment.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -409,10 +414,14 @@ public abstract class BaseWikiPageAttachmentResourceTestCase {
 		WikiPageAttachment wikiPageAttachment =
 			testDeleteWikiPageAttachment_addWikiPageAttachment();
 
-		assertHttpResponseStatusCode(
-			204,
-			wikiPageAttachmentResource.deleteWikiPageAttachmentHttpResponse(
-				wikiPageAttachment.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				wikiPageAttachmentResource.deleteWikiPageAttachmentHttpResponse(
+					wikiPageAttachment.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiPageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiPageResourceTestCase.java
@@ -30,6 +30,7 @@ import com.liferay.headless.delivery.client.pagination.Pagination;
 import com.liferay.headless.delivery.client.permission.Permission;
 import com.liferay.headless.delivery.client.resource.v1_0.WikiPageResource;
 import com.liferay.headless.delivery.client.serdes.v1_0.WikiPageSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -215,13 +216,17 @@ public abstract class BaseWikiPageResourceTestCase {
 		WikiPage wikiPage =
 			testDeleteSiteWikiPageByExternalReferenceCode_addWikiPage();
 
-		assertHttpResponseStatusCode(
-			204,
-			wikiPageResource.
-				deleteSiteWikiPageByExternalReferenceCodeHttpResponse(
-					testDeleteSiteWikiPageByExternalReferenceCode_getSiteId(
-						wikiPage),
-					wikiPage.getExternalReferenceCode()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				wikiPageResource.
+					deleteSiteWikiPageByExternalReferenceCodeHttpResponse(
+						testDeleteSiteWikiPageByExternalReferenceCode_getSiteId(
+							wikiPage),
+						wikiPage.getExternalReferenceCode());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -904,8 +909,12 @@ public abstract class BaseWikiPageResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		WikiPage wikiPage = testDeleteWikiPage_addWikiPage();
 
-		assertHttpResponseStatusCode(
-			204, wikiPageResource.deleteWikiPageHttpResponse(wikiPage.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> wikiPageResource.deleteWikiPageHttpResponse(wikiPage.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404, wikiPageResource.getWikiPageHttpResponse(wikiPage.getId()));

--- a/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormDocumentResourceTestCase.java
+++ b/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormDocumentResourceTestCase.java
@@ -27,6 +27,7 @@ import com.liferay.headless.form.client.http.HttpInvoker;
 import com.liferay.headless.form.client.pagination.Page;
 import com.liferay.headless.form.client.resource.v1_0.FormDocumentResource;
 import com.liferay.headless.form.client.serdes.v1_0.FormDocumentSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -203,10 +204,13 @@ public abstract class BaseFormDocumentResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		FormDocument formDocument = testDeleteFormDocument_addFormDocument();
 
-		assertHttpResponseStatusCode(
-			204,
-			formDocumentResource.deleteFormDocumentHttpResponse(
-				formDocument.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> formDocumentResource.deleteFormDocumentHttpResponse(
+				formDocument.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/notification/notification-rest-impl/rest-openapi.yaml
+++ b/modules/apps/notification/notification-rest-impl/rest-openapi.yaml
@@ -112,7 +112,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.notification.rest.client', and version '1.0.18'."
+        'com.liferay.notification.rest.client', and version '1.0.19'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/notification/notification-rest-impl/src/main/java/com/liferay/notification/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/notification/notification-rest-impl/src/main/java/com/liferay/notification/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.notification.rest.client', and version '1.0.18'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.notification.rest.client', and version '1.0.19'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/notification/notification-rest-test/src/testIntegration/java/com/liferay/notification/rest/resource/v1_0/test/BaseNotificationQueueEntryResourceTestCase.java
+++ b/modules/apps/notification/notification-rest-test/src/testIntegration/java/com/liferay/notification/rest/resource/v1_0/test/BaseNotificationQueueEntryResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.notification.rest.client.pagination.Page;
 import com.liferay.notification.rest.client.pagination.Pagination;
 import com.liferay.notification.rest.client.resource.v1_0.NotificationQueueEntryResource;
 import com.liferay.notification.rest.client.serdes.v1_0.NotificationQueueEntrySerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -636,11 +637,15 @@ public abstract class BaseNotificationQueueEntryResourceTestCase {
 		NotificationQueueEntry notificationQueueEntry =
 			testDeleteNotificationQueueEntry_addNotificationQueueEntry();
 
-		assertHttpResponseStatusCode(
-			204,
-			notificationQueueEntryResource.
-				deleteNotificationQueueEntryHttpResponse(
-					notificationQueueEntry.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				notificationQueueEntryResource.
+					deleteNotificationQueueEntryHttpResponse(
+						notificationQueueEntry.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/notification/notification-rest-test/src/testIntegration/java/com/liferay/notification/rest/resource/v1_0/test/BaseNotificationTemplateResourceTestCase.java
+++ b/modules/apps/notification/notification-rest-test/src/testIntegration/java/com/liferay/notification/rest/resource/v1_0/test/BaseNotificationTemplateResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.notification.rest.client.pagination.Page;
 import com.liferay.notification.rest.client.pagination.Pagination;
 import com.liferay.notification.rest.client.resource.v1_0.NotificationTemplateResource;
 import com.liferay.notification.rest.client.serdes.v1_0.NotificationTemplateSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -806,10 +807,15 @@ public abstract class BaseNotificationTemplateResourceTestCase {
 		NotificationTemplate notificationTemplate =
 			testDeleteNotificationTemplate_addNotificationTemplate();
 
-		assertHttpResponseStatusCode(
-			204,
-			notificationTemplateResource.deleteNotificationTemplateHttpResponse(
-				notificationTemplate.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				notificationTemplateResource.
+					deleteNotificationTemplateHttpResponse(
+						notificationTemplate.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/object/object-admin-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-admin-rest-impl/rest-openapi.yaml
@@ -543,7 +543,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.object.admin.rest.client', and version '1.0.52'."
+        'com.liferay.object.admin.rest.client', and version '1.0.53'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.object.admin.rest.client', and version '1.0.52'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Object", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.object.admin.rest.client', and version '1.0.53'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Object", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectActionResourceTestCase.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectActionResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.object.admin.rest.client.pagination.Page;
 import com.liferay.object.admin.rest.client.pagination.Pagination;
 import com.liferay.object.admin.rest.client.resource.v1_0.ObjectActionResource;
 import com.liferay.object.admin.rest.client.serdes.v1_0.ObjectActionSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -208,10 +209,13 @@ public abstract class BaseObjectActionResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		ObjectAction objectAction = testDeleteObjectAction_addObjectAction();
 
-		assertHttpResponseStatusCode(
-			204,
-			objectActionResource.deleteObjectActionHttpResponse(
-				objectAction.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> objectActionResource.deleteObjectActionHttpResponse(
+				objectAction.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectDefinitionResourceTestCase.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectDefinitionResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.object.admin.rest.client.pagination.Page;
 import com.liferay.object.admin.rest.client.pagination.Pagination;
 import com.liferay.object.admin.rest.client.resource.v1_0.ObjectDefinitionResource;
 import com.liferay.object.admin.rest.client.serdes.v1_0.ObjectDefinitionSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -775,10 +776,13 @@ public abstract class BaseObjectDefinitionResourceTestCase {
 		ObjectDefinition objectDefinition =
 			testDeleteObjectDefinition_addObjectDefinition();
 
-		assertHttpResponseStatusCode(
-			204,
-			objectDefinitionResource.deleteObjectDefinitionHttpResponse(
-				objectDefinition.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> objectDefinitionResource.deleteObjectDefinitionHttpResponse(
+				objectDefinition.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectFieldResourceTestCase.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectFieldResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.object.admin.rest.client.pagination.Page;
 import com.liferay.object.admin.rest.client.pagination.Pagination;
 import com.liferay.object.admin.rest.client.resource.v1_0.ObjectFieldResource;
 import com.liferay.object.admin.rest.client.serdes.v1_0.ObjectFieldSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -1063,10 +1064,13 @@ public abstract class BaseObjectFieldResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		ObjectField objectField = testDeleteObjectField_addObjectField();
 
-		assertHttpResponseStatusCode(
-			204,
-			objectFieldResource.deleteObjectFieldHttpResponse(
-				objectField.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> objectFieldResource.deleteObjectFieldHttpResponse(
+				objectField.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectLayoutResourceTestCase.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectLayoutResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.object.admin.rest.client.pagination.Page;
 import com.liferay.object.admin.rest.client.pagination.Pagination;
 import com.liferay.object.admin.rest.client.resource.v1_0.ObjectLayoutResource;
 import com.liferay.object.admin.rest.client.serdes.v1_0.ObjectLayoutSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -551,10 +552,13 @@ public abstract class BaseObjectLayoutResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		ObjectLayout objectLayout = testDeleteObjectLayout_addObjectLayout();
 
-		assertHttpResponseStatusCode(
-			204,
-			objectLayoutResource.deleteObjectLayoutHttpResponse(
-				objectLayout.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> objectLayoutResource.deleteObjectLayoutHttpResponse(
+				objectLayout.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectRelationshipResourceTestCase.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectRelationshipResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.object.admin.rest.client.pagination.Page;
 import com.liferay.object.admin.rest.client.pagination.Pagination;
 import com.liferay.object.admin.rest.client.resource.v1_0.ObjectRelationshipResource;
 import com.liferay.object.admin.rest.client.serdes.v1_0.ObjectRelationshipSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -807,10 +808,14 @@ public abstract class BaseObjectRelationshipResourceTestCase {
 		ObjectRelationship objectRelationship =
 			testDeleteObjectRelationship_addObjectRelationship();
 
-		assertHttpResponseStatusCode(
-			204,
-			objectRelationshipResource.deleteObjectRelationshipHttpResponse(
-				objectRelationship.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				objectRelationshipResource.deleteObjectRelationshipHttpResponse(
+					objectRelationship.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectValidationRuleResourceTestCase.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectValidationRuleResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.object.admin.rest.client.pagination.Page;
 import com.liferay.object.admin.rest.client.pagination.Pagination;
 import com.liferay.object.admin.rest.client.resource.v1_0.ObjectValidationRuleResource;
 import com.liferay.object.admin.rest.client.serdes.v1_0.ObjectValidationRuleSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -596,10 +597,15 @@ public abstract class BaseObjectValidationRuleResourceTestCase {
 		ObjectValidationRule objectValidationRule =
 			testDeleteObjectValidationRule_addObjectValidationRule();
 
-		assertHttpResponseStatusCode(
-			204,
-			objectValidationRuleResource.deleteObjectValidationRuleHttpResponse(
-				objectValidationRule.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() ->
+				objectValidationRuleResource.
+					deleteObjectValidationRuleHttpResponse(
+						objectValidationRule.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectViewResourceTestCase.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectViewResourceTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.object.admin.rest.client.pagination.Page;
 import com.liferay.object.admin.rest.client.pagination.Pagination;
 import com.liferay.object.admin.rest.client.resource.v1_0.ObjectViewResource;
 import com.liferay.object.admin.rest.client.serdes.v1_0.ObjectViewSerDes;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -540,10 +541,13 @@ public abstract class BaseObjectViewResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		ObjectView objectView = testDeleteObjectView_addObjectView();
 
-		assertHttpResponseStatusCode(
-			204,
-			objectViewResource.deleteObjectViewHttpResponse(
-				objectView.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> objectViewResource.deleteObjectViewHttpResponse(
+				objectView.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/rest-openapi.yaml
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/rest-openapi.yaml
@@ -570,7 +570,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.portal.workflow.metrics.rest.client', and version '3.0.23'."
+        'com.liferay.portal.workflow.metrics.rest.client', and version '3.0.24'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/InstanceResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/InstanceResourceImpl.java
@@ -109,8 +109,10 @@ public class InstanceResourceImpl extends BaseInstanceResourceImpl {
 	public void deleteProcessInstance(Long processId, Long instanceId)
 		throws Exception {
 
+		Instance instance = getProcessInstance(processId, instanceId);
+
 		_instanceWorkflowMetricsIndexer.deleteInstance(
-			contextCompany.getCompanyId(), instanceId);
+			contextCompany.getCompanyId(), instance.getId());
 	}
 
 	@Override

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.portal.workflow.metrics.rest.client', and version '3.0.23'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.portal.workflow.metrics.rest.client', and version '3.0.24'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/SLAResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/SLAResourceImpl.java
@@ -53,7 +53,6 @@ public class SLAResourceImpl extends BaseSLAResourceImpl {
 
 	@Override
 	public void deleteSLA(Long slaId) throws Exception {
-
 		SLA sla = getSLA(slaId);
 
 		_workflowMetricsSLADefinitionLocalService.

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/SLAResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/SLAResourceImpl.java
@@ -53,9 +53,12 @@ public class SLAResourceImpl extends BaseSLAResourceImpl {
 
 	@Override
 	public void deleteSLA(Long slaId) throws Exception {
+
+		SLA sla = getSLA(slaId);
+
 		_workflowMetricsSLADefinitionLocalService.
 			deactivateWorkflowMetricsSLADefinition(
-				slaId, _createServiceContext());
+				sla.getId(), _createServiceContext());
 	}
 
 	@Override

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/TaskResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/TaskResourceImpl.java
@@ -90,6 +90,8 @@ public class TaskResourceImpl extends BaseTaskResourceImpl {
 	public void deleteProcessTask(Long processId, Long taskId)
 		throws Exception {
 
+		Task task = getProcessTask(processId, taskId);
+
 		DeleteTaskRequest.Builder deleteTaskRequestBuilder =
 			new DeleteTaskRequest.Builder();
 
@@ -97,7 +99,7 @@ public class TaskResourceImpl extends BaseTaskResourceImpl {
 			deleteTaskRequestBuilder.companyId(
 				contextCompany.getCompanyId()
 			).taskId(
-				taskId
+				task.getId()
 			).build());
 	}
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseInstanceResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseInstanceResourceTestCase.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -478,11 +479,14 @@ public abstract class BaseInstanceResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		Instance instance = testDeleteProcessInstance_addInstance();
 
-		assertHttpResponseStatusCode(
-			204,
-			instanceResource.deleteProcessInstanceHttpResponse(
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> instanceResource.deleteProcessInstanceHttpResponse(
 				testDeleteProcessInstance_getProcessId(instance),
-				instance.getId()));
+				instance.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseNodeResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseNodeResourceTestCase.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -292,10 +293,13 @@ public abstract class BaseNodeResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		Node node = testDeleteProcessNode_addNode();
 
-		assertHttpResponseStatusCode(
-			204,
-			nodeResource.deleteProcessNodeHttpResponse(
-				testDeleteProcessNode_getProcessId(node), node.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> nodeResource.deleteProcessNodeHttpResponse(
+				testDeleteProcessNode_getProcessId(node), node.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 	}
 
 	protected Long testDeleteProcessNode_getProcessId(Node node)

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseProcessResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseProcessResourceTestCase.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -220,8 +221,12 @@ public abstract class BaseProcessResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		Process process = testDeleteProcess_addProcess();
 
-		assertHttpResponseStatusCode(
-			204, processResource.deleteProcessHttpResponse(process.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> processResource.deleteProcessHttpResponse(process.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404, processResource.getProcessHttpResponse(process.getId()));

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseSLAResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseSLAResourceTestCase.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -330,8 +331,12 @@ public abstract class BaseSLAResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		SLA sla = testDeleteSLA_addSLA();
 
-		assertHttpResponseStatusCode(
-			204, slaResource.deleteSLAHttpResponse(sla.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> slaResource.deleteSLAHttpResponse(sla.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404, slaResource.getSLAHttpResponse(sla.getId()));

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseTaskResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseTaskResourceTestCase.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -296,10 +297,13 @@ public abstract class BaseTaskResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		Task task = testDeleteProcessTask_addTask();
 
-		assertHttpResponseStatusCode(
-			204,
-			taskResource.deleteProcessTaskHttpResponse(
-				testDeleteProcessTask_getProcessId(task), task.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> taskResource.deleteProcessTaskHttpResponse(
+				testDeleteProcessTask_getProcessId(task), task.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/NodeResourceTest.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/NodeResourceTest.java
@@ -31,6 +31,7 @@ import java.util.Map;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -62,6 +63,16 @@ public class NodeResourceTest extends BaseNodeResourceTestCase {
 		}
 
 		_deleteNodes();
+	}
+
+	@Ignore
+	@Override
+	@Test
+	public void testDeleteProcessNode() throws Exception {
+
+		// TODO LPS-184020 Ignored until method returns 404 on null deletion
+
+		super.testDeleteProcessNode();
 	}
 
 	@Override

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/SLAResourceTest.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/SLAResourceTest.java
@@ -32,6 +32,7 @@ import com.liferay.portal.workflow.metrics.rest.client.dto.v1_0.StopNodeKeys;
 import com.liferay.portal.workflow.metrics.rest.client.pagination.Page;
 import com.liferay.portal.workflow.metrics.rest.client.pagination.Pagination;
 import com.liferay.portal.workflow.metrics.rest.resource.v1_0.test.helper.WorkflowMetricsRESTTestHelper;
+import com.liferay.portal.workflow.metrics.service.WorkflowMetricsSLADefinitionLocalService;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -39,13 +40,11 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import com.liferay.portal.workflow.metrics.service.WorkflowMetricsSLADefinitionLocalService;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Rafael Praxedes
@@ -218,7 +217,8 @@ public class SLAResourceTest extends BaseSLAResourceTestCase {
 		for (SLA sla : _slas) {
 			_workflowMetricsSLADefinitionLocalService.
 				deactivateWorkflowMetricsSLADefinition(
-					sla.getId(), new ServiceContext() {
+					sla.getId(),
+					new ServiceContext() {
 						{
 							setCompanyId(testGroup.getCompanyId());
 							setUserId(TestPropsValues.getUserId());

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/SLAResourceTest.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/SLAResourceTest.java
@@ -17,7 +17,9 @@ package com.liferay.portal.workflow.metrics.rest.resource.v1_0.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.DataGuard;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.search.test.util.SearchTestRule;
 import com.liferay.portal.test.rule.Inject;
@@ -37,11 +39,13 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import com.liferay.portal.workflow.metrics.service.WorkflowMetricsSLADefinitionLocalService;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Rafael Praxedes
@@ -212,7 +216,14 @@ public class SLAResourceTest extends BaseSLAResourceTestCase {
 
 	private void _deleteSLAs() throws Exception {
 		for (SLA sla : _slas) {
-			slaResource.deleteSLA(sla.getId());
+			_workflowMetricsSLADefinitionLocalService.
+				deactivateWorkflowMetricsSLADefinition(
+					sla.getId(), new ServiceContext() {
+						{
+							setCompanyId(testGroup.getCompanyId());
+							setUserId(TestPropsValues.getUserId());
+						}
+					});
 		}
 	}
 
@@ -243,5 +254,9 @@ public class SLAResourceTest extends BaseSLAResourceTestCase {
 
 	@Inject
 	private WorkflowMetricsRESTTestHelper _workflowMetricsRESTTestHelper;
+
+	@Inject
+	private WorkflowMetricsSLADefinitionLocalService
+		_workflowMetricsSLADefinitionLocalService;
 
 }

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/rest-openapi.yaml
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/rest-openapi.yaml
@@ -565,7 +565,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.search.experiences.rest.client', and version '3.0.15'."
+        'com.liferay.search.experiences.rest.client', and version '3.0.16'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.search.experiences.rest.client', and version '3.0.15'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.search.experiences.rest.client', and version '3.0.16'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseSXPBlueprintResourceTestCase.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseSXPBlueprintResourceTestCase.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -553,10 +554,13 @@ public abstract class BaseSXPBlueprintResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		SXPBlueprint sxpBlueprint = testDeleteSXPBlueprint_addSXPBlueprint();
 
-		assertHttpResponseStatusCode(
-			204,
-			sxpBlueprintResource.deleteSXPBlueprintHttpResponse(
-				sxpBlueprint.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> sxpBlueprintResource.deleteSXPBlueprintHttpResponse(
+				sxpBlueprint.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseSXPElementResourceTestCase.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseSXPElementResourceTestCase.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -544,10 +545,13 @@ public abstract class BaseSXPElementResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		SXPElement sxpElement = testDeleteSXPElement_addSXPElement();
 
-		assertHttpResponseStatusCode(
-			204,
-			sxpElementResource.deleteSXPElementHttpResponse(
-				sxpElement.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> sxpElementResource.deleteSXPElementHttpResponse(
+				sxpElement.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/dxp/apps/segments/segments-asah-rest-test/src/testIntegration/java/com/liferay/segments/asah/rest/resource/v1_0/test/BaseExperimentResourceTestCase.java
+++ b/modules/dxp/apps/segments/segments-asah-rest-test/src/testIntegration/java/com/liferay/segments/asah/rest/resource/v1_0/test/BaseExperimentResourceTestCase.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -203,10 +204,13 @@ public abstract class BaseExperimentResourceTestCase {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		Experiment experiment = testDeleteExperiment_addExperiment();
 
-		assertHttpResponseStatusCode(
-			204,
-			experimentResource.deleteExperimentHttpResponse(
-				experiment.getId()));
+		UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+			() -> experimentResource.deleteExperimentHttpResponse(
+				experiment.getId());
+
+		assertHttpResponseStatusCode(204, unsafeSupplier.get());
+
+		assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 		assertHttpResponseStatusCode(
 			404,

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
@@ -313,6 +313,51 @@ public abstract class Base${schemaName}ResourceTestCase {
 
 					));
 
+					assertHttpResponseStatusCode(404, ${schemaVarName}Resource.${javaMethodSignature.methodName}HttpResponse(
+
+					<#list javaMethodSignature.javaMethodParameters as javaMethodParameter>
+						<#if !javaMethodParameter?is_first>
+							,
+						</#if>
+
+						<#if freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation)>
+							<#if stringUtil.equals(javaMethodParameter.parameterName, schemaVarName + "Id")>
+								${schemaVarName}.getId()
+							<#elseif properties?keys?seq_contains(javaMethodParameter.parameterName)>
+								<#if freeMarkerTool.isParameterNameSchemaRelated(javaMethodParameter.parameterName, javaMethodSignature.path, schemaName)>
+									${schemaVarName}.get${javaMethodParameter.parameterName?cap_first}()
+								<#else>
+									<#assign
+										addGetterMethod = true
+										defaultImplementationGetterMethod = true
+									/>
+								</#if>
+							<#else>
+								<#assign
+									addGetterMethod = true
+									defaultImplementationGetterMethod = false
+								/>
+							</#if>
+						<#else>
+							null
+						</#if>
+
+						<#if addGetterMethod>
+							<#if defaultImplementationGetterMethod>
+								test${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}(${schemaVarName})
+							<#else>
+								test${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}()
+							</#if>
+
+							<#assign
+								addGetterMethod = false
+								getterJavaMethodParametersMap = getterJavaMethodParametersMap + {javaMethodParameter.parameterName: javaMethodParameter}
+							/>
+						</#if>
+					</#list>
+
+					));
+
 					<#if freeMarkerTool.hasJavaMethodSignature(javaMethodSignatures, "get" + javaMethodSignature.methodName?remove_beginning("delete"))>
 						assertHttpResponseStatusCode(404, ${schemaVarName}Resource.get${javaMethodSignature.methodName?remove_beginning("delete")}HttpResponse(
 

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
@@ -310,7 +310,6 @@ public abstract class Base${schemaName}ResourceTestCase {
 								</#if>
 
 								<#sep>, </#sep>
-
 							</#list>
 					);
 

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
@@ -47,6 +47,7 @@ import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 	import com.liferay.depot.service.DepotEntryLocalServiceUtil;
 </#if>
 
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -268,95 +269,54 @@ public abstract class Base${schemaName}ResourceTestCase {
 					@SuppressWarnings("PMD.UnusedLocalVariable")
 					${schemaName} ${schemaVarName} = test${javaMethodSignature.methodName?cap_first}_add${schemaName}();
 
-					assertHttpResponseStatusCode(204, ${schemaVarName}Resource.${javaMethodSignature.methodName}HttpResponse(
+					UnsafeSupplier<HttpInvoker.HttpResponse, Exception> unsafeSupplier =
+						() ->
+							${schemaVarName}Resource.${javaMethodSignature.methodName}HttpResponse(
 
-					<#list javaMethodSignature.javaMethodParameters as javaMethodParameter>
-						<#if !javaMethodParameter?is_first>
-							,
-						</#if>
-
-						<#if freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation)>
-							<#if stringUtil.equals(javaMethodParameter.parameterName, schemaVarName + "Id")>
-								${schemaVarName}.getId()
-							<#elseif properties?keys?seq_contains(javaMethodParameter.parameterName)>
-								<#if freeMarkerTool.isParameterNameSchemaRelated(javaMethodParameter.parameterName, javaMethodSignature.path, schemaName)>
-									${schemaVarName}.get${javaMethodParameter.parameterName?cap_first}()
+							<#list javaMethodSignature.javaMethodParameters as javaMethodParameter>
+								<#if freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation)>
+									<#if stringUtil.equals(javaMethodParameter.parameterName, schemaVarName + "Id")>
+										${schemaVarName}.getId()
+									<#elseif properties?keys?seq_contains(javaMethodParameter.parameterName)>
+										<#if freeMarkerTool.isParameterNameSchemaRelated(javaMethodParameter.parameterName, javaMethodSignature.path, schemaName)>
+											${schemaVarName}.get${javaMethodParameter.parameterName?cap_first}()
+										<#else>
+											<#assign
+												addGetterMethod = true
+												defaultImplementationGetterMethod = true
+											/>
+										</#if>
+									<#else>
+										<#assign
+											addGetterMethod = true
+											defaultImplementationGetterMethod = false
+										/>
+									</#if>
 								<#else>
+									null
+								</#if>
+
+								<#if addGetterMethod>
+									<#if defaultImplementationGetterMethod>
+										test${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}(${schemaVarName})
+									<#else>
+										test${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}()
+									</#if>
+
 									<#assign
-										addGetterMethod = true
-										defaultImplementationGetterMethod = true
+										addGetterMethod = false
+										getterJavaMethodParametersMap = getterJavaMethodParametersMap + {javaMethodParameter.parameterName: javaMethodParameter}
 									/>
 								</#if>
-							<#else>
-								<#assign
-									addGetterMethod = true
-									defaultImplementationGetterMethod = false
-								/>
-							</#if>
-						<#else>
-							null
-						</#if>
 
-						<#if addGetterMethod>
-							<#if defaultImplementationGetterMethod>
-								test${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}(${schemaVarName})
-							<#else>
-								test${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}()
-							</#if>
+								<#sep>, </#sep>
 
-							<#assign
-								addGetterMethod = false
-								getterJavaMethodParametersMap = getterJavaMethodParametersMap + {javaMethodParameter.parameterName: javaMethodParameter}
-							/>
-						</#if>
-					</#list>
+							</#list>
+					);
 
-					));
+					assertHttpResponseStatusCode(204, unsafeSupplier.get());
 
-					assertHttpResponseStatusCode(404, ${schemaVarName}Resource.${javaMethodSignature.methodName}HttpResponse(
-
-					<#list javaMethodSignature.javaMethodParameters as javaMethodParameter>
-						<#if !javaMethodParameter?is_first>
-							,
-						</#if>
-
-						<#if freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation)>
-							<#if stringUtil.equals(javaMethodParameter.parameterName, schemaVarName + "Id")>
-								${schemaVarName}.getId()
-							<#elseif properties?keys?seq_contains(javaMethodParameter.parameterName)>
-								<#if freeMarkerTool.isParameterNameSchemaRelated(javaMethodParameter.parameterName, javaMethodSignature.path, schemaName)>
-									${schemaVarName}.get${javaMethodParameter.parameterName?cap_first}()
-								<#else>
-									<#assign
-										addGetterMethod = true
-										defaultImplementationGetterMethod = true
-									/>
-								</#if>
-							<#else>
-								<#assign
-									addGetterMethod = true
-									defaultImplementationGetterMethod = false
-								/>
-							</#if>
-						<#else>
-							null
-						</#if>
-
-						<#if addGetterMethod>
-							<#if defaultImplementationGetterMethod>
-								test${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}(${schemaVarName})
-							<#else>
-								test${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}()
-							</#if>
-
-							<#assign
-								addGetterMethod = false
-								getterJavaMethodParametersMap = getterJavaMethodParametersMap + {javaMethodParameter.parameterName: javaMethodParameter}
-							/>
-						</#if>
-					</#list>
-
-					));
+					assertHttpResponseStatusCode(404, unsafeSupplier.get());
 
 					<#if freeMarkerTool.hasJavaMethodSignature(javaMethodSignatures, "get" + javaMethodSignature.methodName?remove_beginning("delete"))>
 						assertHttpResponseStatusCode(404, ${schemaVarName}Resource.get${javaMethodSignature.methodName?remove_beginning("delete")}HttpResponse(

--- a/portal-impl/src/com/liferay/portal/service/impl/UserGroupServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserGroupServiceImpl.java
@@ -154,7 +154,6 @@ public class UserGroupServiceImpl extends UserGroupServiceBaseImpl {
 	 */
 	@Override
 	public void deleteUserGroup(long userGroupId) throws PortalException {
-
 		UserGroup userGroup = userGroupLocalService.getUserGroup(userGroupId);
 
 		UserGroupPermissionUtil.check(

--- a/portal-impl/src/com/liferay/portal/service/impl/UserGroupServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserGroupServiceImpl.java
@@ -154,10 +154,14 @@ public class UserGroupServiceImpl extends UserGroupServiceBaseImpl {
 	 */
 	@Override
 	public void deleteUserGroup(long userGroupId) throws PortalException {
-		UserGroupPermissionUtil.check(
-			getPermissionChecker(), userGroupId, ActionKeys.DELETE);
 
-		userGroupLocalService.deleteUserGroup(userGroupId);
+		UserGroup userGroup = userGroupLocalService.getUserGroup(userGroupId);
+
+		UserGroupPermissionUtil.check(
+			getPermissionChecker(), userGroup.getUserGroupId(),
+			ActionKeys.DELETE);
+
+		userGroupLocalService.deleteUserGroup(userGroup.getUserGroupId());
 	}
 
 	/**


### PR DESCRIPTION
**Forwarded manually from**: [liferay-headless/liferay-portal/1188](https://github.com/liferay-headless/liferay-portal/pull/1188)
**Related Issue**: [LPS-182306](https://issues.liferay.com/browse/LPS-182306)


**Whats new:**
- Added new test conditions inside the delete test-cases to check if the code follows the changed response-code behaviour
- Executed buildREST

**Changes:**
- Modified various entities delete methods to follow the specified patterns

**IMPORTANT:**
The tests located below still remain failing until the methods they test get changed. This tests have de @ ignore tag and a comment with a TODO LPS-184020, which will need to be removed when the methods are fixed.
- testDeleteAccountByExternalReferenceCodeAccountRoleUserAccountByEmailAddress
- testDeleteDataDefinitionDataListView
- testDeleteProcessNode
- testDeleteOrganizationRoleUserAccountAssociation
- testDeleteRoleUserAccountAssociation
- testDeleteSiteRoleUserAccountAssociation
- testDeleteDataDefinitionDataLayout