### PR TITLE
LPS-185104 Get the serviceRegistration when it is available

### DIFF
--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/component/enabler/ComponentEnabler.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/component/enabler/ComponentEnabler.java
@@ -32,9 +32,6 @@ public class ComponentEnabler {
 		if (PropsValues.UPGRADE_DATABASE_AUTO_RUN) {
 			componentContext.enableComponent(UpgradeManager.class.getName());
 		}
-		else {
-			componentContext.disableComponent(UpgradeManager.class.getName());
-		}
 	}
 
 }


### PR DESCRIPTION
- LPS-185104 Get the serviceRegistration when it is available
- LPS-185104 This is not needed because the property can not change on runtime
