### PR TITLE
Revert "LPS-181325 dev pattern"

### DIFF
--- a/workspaces/liferay-learn-workspace/client-extensions/liferay-learn-etc-cron/client-extension.dev.yaml
+++ b/workspaces/liferay-learn-workspace/client-extensions/liferay-learn-etc-cron/client-extension.dev.yaml
@@ -1,3 +1,0 @@
-liferay-learn-etc-cron-oauth-application-headless-server:
-    .serviceAddress: localhost:8080
-    .serviceScheme: http

--- a/workspaces/liferay-learn-workspace/client-extensions/liferay-learn-etc-cron/client-extension.yaml
+++ b/workspaces/liferay-learn-workspace/client-extensions/liferay-learn-etc-cron/client-extension.yaml
@@ -2,6 +2,8 @@ assemble:
     - from: assets
     - fromTask: bootJar
 liferay-learn-etc-cron-oauth-application-headless-server:
+    .serviceAddress: localhost:8080
+    .serviceScheme: http
     name: Liferay Learn Etc Cron Oauth Application Headless Server
     scopes:
         - Liferay.Data.Engine.REST.everything

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-batch/client-extension.dev.yaml
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-batch/client-extension.dev.yaml
@@ -1,3 +1,0 @@
-liferay-sample-batch-oauth-application-headless-server:
-    .serviceAddress: localhost:8080
-    .serviceScheme: http

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-batch/client-extension.yaml
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-batch/client-extension.yaml
@@ -6,6 +6,8 @@ liferay-sample-batch:
     oAuthApplicationHeadlessServer: liferay-sample-batch-oauth-application-headless-server
     type: batch
 liferay-sample-batch-oauth-application-headless-server:
+    .serviceAddress: localhost:8080
+    .serviceScheme: http
     name: Liferay Sample OAuth Application Headless Server
     scopes:
         - Liferay.Headless.Admin.Workflow.everything

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-etc-node/client-extension.dev.yaml
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-etc-node/client-extension.dev.yaml
@@ -1,3 +1,0 @@
-liferay-sample-node-oauth-application-user-agent:
-    .serviceAddress: localhost:3001
-    .serviceScheme: http

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-etc-node/client-extension.yaml
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-etc-node/client-extension.yaml
@@ -3,6 +3,8 @@ assemble:
           - "**/*.js"
           - package.json
 liferay-sample-node-oauth-application-user-agent:
+    .serviceAddress: localhost:3001
+    .serviceScheme: http
     name: Liferay Sample Node OAuth Application User Agent
     scopes:
         - Liferay.Headless.Admin.Workflow.everything

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-etc-spring-boot/client-extension.dev.yaml
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-etc-spring-boot/client-extension.dev.yaml
@@ -1,3 +1,0 @@
-liferay-sample-etc-spring-boot-oauth-application-user-agent:
-    .serviceAddress: localhost:58081
-    .serviceScheme: http

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-etc-spring-boot/client-extension.yaml
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-etc-spring-boot/client-extension.yaml
@@ -6,6 +6,8 @@ liferay-sample-etc-spring-boot-notification-type-1:
     resourcePath: /notification/type/1
     type: notificationType
 liferay-sample-etc-spring-boot-oauth-application-user-agent:
+    .serviceAddress: localhost:58081
+    .serviceScheme: http
     name: Liferay Sample Etc Spring Boot Spring Boot OAuth Application User Agent
     scopes:
         - Liferay.Headless.Admin.Workflow.everything


### PR DESCRIPTION
This reverts commit 47d7010396cca3215223966a01015ed458227851.

By moving everything to .dev.yaml, it forces developers to run `gradle deployDev` to just get things to work.  Before this revert, if you did `gradle deploy` none of these samples work.   the `.dev.` pattern should be for 'optional' or 'customized' dev experience like for frontend dev servers.