### PR TITLE
LPS-185393 Convert the Optional Dynamic Greedy references to static references using Snapshot in module portal-search-elasticsearch7-impl

### DIFF
--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/ElasticsearchSearchEngine.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/ElasticsearchSearchEngine.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.search.elasticsearch7.internal;
 
+import com.liferay.osgi.util.service.Snapshot;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.events.StartupHelperUtil;
@@ -69,9 +70,6 @@ import org.elasticsearch.common.Strings;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferenceCardinality;
-import org.osgi.service.component.annotations.ReferencePolicy;
-import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Michael C. Han
@@ -141,7 +139,7 @@ public class ElasticsearchSearchEngine implements SearchEngine {
 		_waitForYellowStatus();
 
 		CrossClusterReplicationHelper crossClusterReplicationHelper =
-			_crossClusterReplicationHelper;
+			_crossClusterReplicationHelperSnapshot.get();
 
 		if (crossClusterReplicationHelper != null) {
 			crossClusterReplicationHelper.follow(
@@ -164,7 +162,7 @@ public class ElasticsearchSearchEngine implements SearchEngine {
 	@Override
 	public void removeCompany(long companyId) {
 		CrossClusterReplicationHelper crossClusterReplicationHelper =
-			_crossClusterReplicationHelper;
+			_crossClusterReplicationHelperSnapshot.get();
 
 		if (crossClusterReplicationHelper != null) {
 			crossClusterReplicationHelper.unfollow(
@@ -403,13 +401,10 @@ public class ElasticsearchSearchEngine implements SearchEngine {
 	private static final Log _log = LogFactoryUtil.getLog(
 		ElasticsearchSearchEngine.class);
 
-	@Reference(
-		cardinality = ReferenceCardinality.OPTIONAL,
-		policy = ReferencePolicy.DYNAMIC,
-		policyOption = ReferencePolicyOption.GREEDY
-	)
-	private volatile CrossClusterReplicationHelper
-		_crossClusterReplicationHelper;
+	private static final Snapshot<CrossClusterReplicationHelper>
+		_crossClusterReplicationHelperSnapshot = new Snapshot(
+			ElasticsearchSearchEngine.class,
+			CrossClusterReplicationHelper.class, null, true);
 
 	@Reference
 	private volatile ElasticsearchConfigurationWrapper

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/connection/ElasticsearchConnectionManager.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/connection/ElasticsearchConnectionManager.java
@@ -139,9 +139,17 @@ public class ElasticsearchConnectionManager
 	public String getLocalClusterConnectionId() {
 		ClusterNode localClusterNode = _clusterExecutor.getLocalClusterNode();
 
+		CrossClusterReplicationConfigurationHelper
+			currentCrossClusterReplicationConfigurationHelper =
+				crossClusterReplicationConfigurationHelper;
+
 		if (localClusterNode == null) {
+			if (currentCrossClusterReplicationConfigurationHelper == null) {
+				return null;
+			}
+
 			List<String> localClusterConnectionIds =
-				crossClusterReplicationConfigurationHelper.
+				currentCrossClusterReplicationConfigurationHelper.
 					getLocalClusterConnectionIds();
 
 			return localClusterConnectionIds.get(0);
@@ -149,17 +157,19 @@ public class ElasticsearchConnectionManager
 
 		InetAddress portalInetAddress = localClusterNode.getPortalInetAddress();
 
-		if (portalInetAddress == null) {
+		if ((portalInetAddress == null) ||
+			(currentCrossClusterReplicationConfigurationHelper == null)) {
+
 			return null;
 		}
+
+		Map<String, String> localClusterConnectionConfigurations =
+			currentCrossClusterReplicationConfigurationHelper.
+				getLocalClusterConnectionIdsMap();
 
 		String localClusterNodeHostName =
 			portalInetAddress.getHostName() + StringPool.COLON +
 				localClusterNode.getPortalPort();
-
-		Map<String, String> localClusterConnectionConfigurations =
-			crossClusterReplicationConfigurationHelper.
-				getLocalClusterConnectionIdsMap();
 
 		return localClusterConnectionConfigurations.get(
 			localClusterNodeHostName);

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/connection/ElasticsearchConnectionManager.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/connection/ElasticsearchConnectionManager.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.search.elasticsearch7.internal.connection;
 
+import com.liferay.osgi.util.service.Snapshot;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.cluster.ClusterExecutor;
@@ -42,9 +43,6 @@ import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferenceCardinality;
-import org.osgi.service.component.annotations.ReferencePolicy;
-import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Michael C. Han
@@ -141,7 +139,7 @@ public class ElasticsearchConnectionManager
 
 		CrossClusterReplicationConfigurationHelper
 			currentCrossClusterReplicationConfigurationHelper =
-				crossClusterReplicationConfigurationHelper;
+				_crossClusterReplicationConfigurationHelperSnapshot.get();
 
 		if (localClusterNode == null) {
 			if (currentCrossClusterReplicationConfigurationHelper == null) {
@@ -221,7 +219,7 @@ public class ElasticsearchConnectionManager
 	public boolean isCrossClusterReplicationEnabled() {
 		CrossClusterReplicationConfigurationHelper
 			currentCrossClusterReplicationConfigurationHelper =
-				crossClusterReplicationConfigurationHelper;
+				_crossClusterReplicationConfigurationHelperSnapshot.get();
 
 		if (currentCrossClusterReplicationConfigurationHelper == null) {
 			return false;
@@ -366,14 +364,6 @@ public class ElasticsearchConnectionManager
 		return getElasticsearchConnection(remoteClusterConnectionId);
 	}
 
-	@Reference(
-		cardinality = ReferenceCardinality.OPTIONAL,
-		policy = ReferencePolicy.DYNAMIC,
-		policyOption = ReferencePolicyOption.GREEDY
-	)
-	protected volatile CrossClusterReplicationConfigurationHelper
-		crossClusterReplicationConfigurationHelper;
-
 	@Reference
 	protected volatile ElasticsearchConfigurationWrapper
 		elasticsearchConfigurationWrapper;
@@ -433,6 +423,11 @@ public class ElasticsearchConnectionManager
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		ElasticsearchConnectionManager.class);
+
+	private static final Snapshot<CrossClusterReplicationConfigurationHelper>
+		_crossClusterReplicationConfigurationHelperSnapshot = new Snapshot<>(
+			ElasticsearchConnectionManager.class,
+			CrossClusterReplicationConfigurationHelper.class, null, true);
 
 	@Reference
 	private ClusterExecutor _clusterExecutor;

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/index/CompanyIndexFactory.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/index/CompanyIndexFactory.java
@@ -235,8 +235,11 @@ public class CompanyIndexFactory
 
 		IndicesClient indicesClient = restHighLevelClient.indices();
 
-		if (_crossClusterReplicationHelper != null) {
-			_crossClusterReplicationHelper.unfollow(removeIndex);
+		CrossClusterReplicationHelper crossClusterReplicationHelper =
+			_crossClusterReplicationHelper;
+
+		if (crossClusterReplicationHelper != null) {
+			crossClusterReplicationHelper.unfollow(removeIndex);
 		}
 
 		indicesClient.updateAliases(
@@ -244,8 +247,8 @@ public class CompanyIndexFactory
 
 		_companyLocalService.updateIndexNames(companyId, indexNameNext, null);
 
-		if (_crossClusterReplicationHelper != null) {
-			_crossClusterReplicationHelper.follow(indexNameNext);
+		if (crossClusterReplicationHelper != null) {
+			crossClusterReplicationHelper.follow(indexNameNext);
 		}
 	}
 

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/index/CompanyIndexFactory.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/index/CompanyIndexFactory.java
@@ -17,6 +17,7 @@ package com.liferay.portal.search.elasticsearch7.internal.index;
 import com.liferay.osgi.service.tracker.collections.EagerServiceTrackerCustomizer;
 import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerList;
 import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerListFactory;
+import com.liferay.osgi.util.service.Snapshot;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.json.JSONFactory;
@@ -67,9 +68,6 @@ import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferenceCardinality;
-import org.osgi.service.component.annotations.ReferencePolicy;
-import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Michael C. Han
@@ -236,7 +234,7 @@ public class CompanyIndexFactory
 		IndicesClient indicesClient = restHighLevelClient.indices();
 
 		CrossClusterReplicationHelper crossClusterReplicationHelper =
-			_crossClusterReplicationHelper;
+			_crossClusterReplicationHelperSnapshot.get();
 
 		if (crossClusterReplicationHelper != null) {
 			crossClusterReplicationHelper.unfollow(removeIndex);
@@ -652,18 +650,15 @@ public class CompanyIndexFactory
 	private static final Log _log = LogFactoryUtil.getLog(
 		CompanyIndexFactory.class);
 
+	private static final Snapshot<CrossClusterReplicationHelper>
+		_crossClusterReplicationHelperSnapshot = new Snapshot(
+			CompanyIndexFactory.class, CrossClusterReplicationHelper.class,
+			null, true);
+
 	private final Set<Long> _companyIds = new HashSet<>();
 
 	@Reference
 	private CompanyLocalService _companyLocalService;
-
-	@Reference(
-		cardinality = ReferenceCardinality.OPTIONAL,
-		policy = ReferencePolicy.DYNAMIC,
-		policyOption = ReferencePolicyOption.GREEDY
-	)
-	private volatile CrossClusterReplicationHelper
-		_crossClusterReplicationHelper;
 
 	@Reference
 	private volatile ElasticsearchConfigurationWrapper

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/ElasticsearchSearchEngineFixture.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/ElasticsearchSearchEngineFixture.java
@@ -35,7 +35,11 @@ import com.liferay.portal.search.test.util.search.engine.SearchEngineFixture;
 import java.util.Map;
 import java.util.Objects;
 
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
 import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * @author Adam Brandizzi
@@ -73,6 +77,8 @@ public class ElasticsearchSearchEngineFixture implements SearchEngineFixture {
 
 		CompanyIdIndexNameBuilder indexNameBuilder = _createIndexNameBuilder();
 
+		_frameworkUtilMockedStatic = _createFrameworkUtil();
+
 		ElasticsearchConnectionManager elasticsearchConnectionManager =
 			_createElasticsearchConnectionManager(
 				elasticsearchConnectionFixture);
@@ -98,6 +104,12 @@ public class ElasticsearchSearchEngineFixture implements SearchEngineFixture {
 				_companyIndexFactory, "deactivate", new Class<?>[0]);
 
 			_companyIndexFactory = null;
+		}
+
+		if (_frameworkUtilMockedStatic != null) {
+			_frameworkUtilMockedStatic.close();
+
+			_frameworkUtilMockedStatic = null;
 		}
 	}
 
@@ -180,6 +192,21 @@ public class ElasticsearchSearchEngineFixture implements SearchEngineFixture {
 		return elasticsearchSearchEngine;
 	}
 
+	private MockedStatic<FrameworkUtil> _createFrameworkUtil() {
+		MockedStatic<FrameworkUtil> frameworkUtilMockedStatic =
+			Mockito.mockStatic(FrameworkUtil.class);
+
+		BundleContext bundleContext = SystemBundleUtil.getBundleContext();
+
+		frameworkUtilMockedStatic.when(
+			() -> FrameworkUtil.getBundle(Mockito.any())
+		).thenReturn(
+			bundleContext.getBundle()
+		);
+
+		return frameworkUtilMockedStatic;
+	}
+
 	private CompanyIdIndexNameBuilder _createIndexNameBuilder() {
 		return new CompanyIdIndexNameBuilder() {
 			{
@@ -221,6 +248,7 @@ public class ElasticsearchSearchEngineFixture implements SearchEngineFixture {
 	private ElasticsearchEngineAdapterFixture
 		_elasticsearchEngineAdapterFixture;
 	private ElasticsearchSearchEngine _elasticsearchSearchEngine;
+	private MockedStatic<FrameworkUtil> _frameworkUtilMockedStatic;
 	private IndexNameBuilder _indexNameBuilder;
 
 }

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/ElasticsearchSearchEngineMeetsMinimumVersionRequirementTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/ElasticsearchSearchEngineMeetsMinimumVersionRequirementTest.java
@@ -14,13 +14,22 @@
 
 package com.liferay.portal.search.elasticsearch7.internal;
 
+import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.version.Version;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * @author Bryan Engler
@@ -31,6 +40,22 @@ public class ElasticsearchSearchEngineMeetsMinimumVersionRequirementTest {
 	@Rule
 	public static LiferayUnitTestRule liferayUnitTestRule =
 		LiferayUnitTestRule.INSTANCE;
+
+	@BeforeClass
+	public static void setUpClass() {
+		BundleContext bundleContext = SystemBundleUtil.getBundleContext();
+
+		_frameworkUtilMockedStatic.when(
+			() -> FrameworkUtil.getBundle(Mockito.any())
+		).thenReturn(
+			bundleContext.getBundle()
+		);
+	}
+
+	@AfterClass
+	public static void tearDownClass() {
+		_frameworkUtilMockedStatic.close();
+	}
 
 	@Test
 	public void testMeetsRequirement() {
@@ -61,5 +86,8 @@ public class ElasticsearchSearchEngineMeetsMinimumVersionRequirementTest {
 			elasticsearchSearchEngine.meetsMinimumVersionRequirement(
 				Version.parseVersion(minimumVersionString), versionString));
 	}
+
+	private static final MockedStatic<FrameworkUtil>
+		_frameworkUtilMockedStatic = Mockito.mockStatic(FrameworkUtil.class);
 
 }

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/connection/ElasticsearchConnectionLogTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/connection/ElasticsearchConnectionLogTest.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.search.elasticsearch7.internal.connection;
 
+import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.search.elasticsearch7.configuration.RESTClientLoggerLevel;
 import com.liferay.portal.search.elasticsearch7.internal.configuration.ElasticsearchConfigurationWrapper;
 import com.liferay.portal.search.elasticsearch7.internal.configuration.OperationModeResolver;
@@ -22,12 +23,18 @@ import com.liferay.portal.search.elasticsearch7.internal.helper.SearchLogHelperI
 import com.liferay.portal.search.elasticsearch7.internal.helper.SearchLogHelperUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * @author Adam Brandizzi
@@ -38,6 +45,22 @@ public class ElasticsearchConnectionLogTest {
 	@Rule
 	public static final LiferayUnitTestRule liferayUnitTestRule =
 		LiferayUnitTestRule.INSTANCE;
+
+	@BeforeClass
+	public static void setUpClass() {
+		BundleContext bundleContext = SystemBundleUtil.getBundleContext();
+
+		_frameworkUtilMockedStatic.when(
+			() -> FrameworkUtil.getBundle(Mockito.any())
+		).thenReturn(
+			bundleContext.getBundle()
+		);
+	}
+
+	@AfterClass
+	public static void tearDownClass() {
+		_frameworkUtilMockedStatic.close();
+	}
 
 	@Before
 	public void setUp() {
@@ -75,6 +98,9 @@ public class ElasticsearchConnectionLogTest {
 			RESTClientLoggerLevel.DEBUG
 		);
 	}
+
+	private static final MockedStatic<FrameworkUtil>
+		_frameworkUtilMockedStatic = Mockito.mockStatic(FrameworkUtil.class);
 
 	private ElasticsearchConfigurationWrapper
 		_elasticsearchConfigurationWrapper;

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/connection/ElasticsearchConnectionManagerTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/connection/ElasticsearchConnectionManagerTest.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.search.elasticsearch7.internal.connection;
 
+import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.search.elasticsearch7.configuration.RESTClientLoggerLevel;
 import com.liferay.portal.search.elasticsearch7.internal.configuration.ElasticsearchConfigurationWrapper;
@@ -23,13 +24,19 @@ import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import org.elasticsearch.client.RestHighLevelClient;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * @author André de Oliveira
@@ -40,6 +47,22 @@ public class ElasticsearchConnectionManagerTest {
 	@Rule
 	public static final LiferayUnitTestRule liferayUnitTestRule =
 		LiferayUnitTestRule.INSTANCE;
+
+	@BeforeClass
+	public static void setUpClass() {
+		BundleContext bundleContext = SystemBundleUtil.getBundleContext();
+
+		_frameworkUtilMockedStatic.when(
+			() -> FrameworkUtil.getBundle(Mockito.any())
+		).thenReturn(
+			bundleContext.getBundle()
+		);
+	}
+
+	@AfterClass
+	public static void tearDownClass() {
+		_frameworkUtilMockedStatic.close();
+	}
 
 	@Before
 	public void setUp() {
@@ -743,6 +766,9 @@ public class ElasticsearchConnectionManagerTest {
 	private static final String _REMOTE_2_CONNECTION_ID = "remote 2";
 
 	private static final String _REMOTE_3_CONNECTION_ID = "remote 3";
+
+	private static final MockedStatic<FrameworkUtil>
+		_frameworkUtilMockedStatic = Mockito.mockStatic(FrameworkUtil.class);
 
 	private final ElasticsearchConnection
 		_defaultRemoteElasticsearchConnection = Mockito.mock(

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/index/CompanyIdIndexNameBuilderTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/index/CompanyIdIndexNameBuilderTest.java
@@ -34,14 +34,18 @@ import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.client.indices.GetIndexResponse;
 
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * @author André de Oliveira
@@ -51,6 +55,22 @@ public class CompanyIdIndexNameBuilderTest {
 	@ClassRule
 	public static LiferayUnitTestRule liferayUnitTestRule =
 		LiferayUnitTestRule.INSTANCE;
+
+	@BeforeClass
+	public static void setUpClass() {
+		BundleContext bundleContext = SystemBundleUtil.getBundleContext();
+
+		_frameworkUtilMockedStatic.when(
+			() -> FrameworkUtil.getBundle(Mockito.any())
+		).thenReturn(
+			bundleContext.getBundle()
+		);
+	}
+
+	@AfterClass
+	public static void tearDownClass() {
+		_frameworkUtilMockedStatic.close();
+	}
 
 	@Before
 	public void setUp() throws Exception {
@@ -193,6 +213,9 @@ public class CompanyIdIndexNameBuilderTest {
 		Assert.assertArrayEquals(
 			new String[] {expectedIndexName}, getIndexResponse.getIndices());
 	}
+
+	private static final MockedStatic<FrameworkUtil>
+		_frameworkUtilMockedStatic = Mockito.mockStatic(FrameworkUtil.class);
 
 	private CompanyIndexFactory _companyIndexFactory;
 	private ElasticsearchFixture _elasticsearchFixture;

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/index/CompanyIndexFactoryFixture.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/index/CompanyIndexFactoryFixture.java
@@ -29,9 +29,11 @@ import java.util.HashMap;
 
 import org.elasticsearch.client.RestHighLevelClient;
 
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * @author Adam Brandizzi
@@ -44,6 +46,8 @@ public class CompanyIndexFactoryFixture {
 
 		_elasticsearchClientResolver = elasticsearchClientResolver;
 		_indexName = indexName;
+
+		_frameworkUtilMockedStatic = _createFrameworkUtil();
 
 		_elasticsearchConnectionManager = Mockito.mock(
 			ElasticsearchConnectionManager.class);
@@ -115,6 +119,12 @@ public class CompanyIndexFactoryFixture {
 
 			_companyIndexFactory = null;
 		}
+
+		if (_frameworkUtilMockedStatic != null) {
+			_frameworkUtilMockedStatic.close();
+
+			_frameworkUtilMockedStatic = null;
+		}
 	}
 
 	protected ElasticsearchConfigurationWrapper
@@ -136,10 +146,26 @@ public class CompanyIndexFactoryFixture {
 
 	}
 
+	private MockedStatic<FrameworkUtil> _createFrameworkUtil() {
+		MockedStatic<FrameworkUtil> frameworkUtilMockedStatic =
+			Mockito.mockStatic(FrameworkUtil.class);
+
+		BundleContext bundleContext = SystemBundleUtil.getBundleContext();
+
+		frameworkUtilMockedStatic.when(
+			() -> FrameworkUtil.getBundle(Mockito.any())
+		).thenReturn(
+			bundleContext.getBundle()
+		);
+
+		return frameworkUtilMockedStatic;
+	}
+
 	private CompanyIndexFactory _companyIndexFactory;
 	private final ElasticsearchClientResolver _elasticsearchClientResolver;
 	private final ElasticsearchConnectionManager
 		_elasticsearchConnectionManager;
+	private MockedStatic<FrameworkUtil> _frameworkUtilMockedStatic;
 	private final String _indexName;
 
 }

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/index/CompanyIndexFactoryTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/index/CompanyIndexFactoryTest.java
@@ -263,11 +263,11 @@ public class CompanyIndexFactoryTest {
 
 	@Test
 	public void testIndexContributors() throws Exception {
-		CompanyIndexFactoryFixture companyIndexFactoryFixture =
-			new CompanyIndexFactoryFixture(_elasticsearchFixture, "other");
+		ReflectionTestUtil.setFieldValue(
+			_companyIndexFactoryFixture, "_indexName", "other");
 
 		ReflectionTestUtil.setFieldValue(
-			companyIndexFactoryFixture.getCompanyIndexFactory(),
+			_companyIndexFactoryFixture.getCompanyIndexFactory(),
 			"_indexContributorServiceTrackerList",
 			ServiceTrackerListFactory.open(
 				_bundleContext, IndexContributor.class, null,
@@ -300,23 +300,23 @@ public class CompanyIndexFactoryTest {
 
 				@Override
 				public void onAfterCreate(String indexName) {
-					companyIndexFactoryFixture.createIndices();
+					_companyIndexFactoryFixture.createIndices();
 				}
 
 				@Override
 				public void onBeforeRemove(String indexName) {
-					companyIndexFactoryFixture.deleteIndices();
+					_companyIndexFactoryFixture.deleteIndices();
 				}
 
 			});
 
 		createIndices();
 
-		_assertHasIndex(companyIndexFactoryFixture.getIndexName());
+		_assertHasIndex(_companyIndexFactoryFixture.getIndexName());
 
 		deleteIndices();
 
-		_assertNoIndex(companyIndexFactoryFixture.getIndexName());
+		_assertNoIndex(_companyIndexFactoryFixture.getIndexName());
 	}
 
 	@Test


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-185393

Tested in: https://github.com/liferay-search/liferay-portal/pull/946

Original message:

Hi Team, I am doing the task of replacing OSGI Optional Dynamic Greedy references with Snapshot. Considering that the variable might be null, I added some null checks.

Please let me know if you have any concerns with these changes or would like it implemented differently. Thanks in advance!