### PR TITLE
LPS-182452 Fix DB.copyTableStructure() for Hypersonic

### DIFF
--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -395,6 +395,10 @@ public class DBTest {
 			indexNamePrefix = "TMP_";
 		}
 
+		Assert.assertArrayEquals(
+			new String[] {_dbInspector.normalizeName("id")},
+			_db.getPrimaryKeyColumnNames(_connection, _TABLE_NAME_2));
+
 		Assert.assertTrue(
 			_dbInspector.hasIndex(
 				_TABLE_NAME_2, indexNamePrefix + _INDEX_NAME));

--- a/portal-impl/src/com/liferay/portal/dao/db/HypersonicDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/HypersonicDB.java
@@ -79,6 +79,10 @@ public class HypersonicDB extends BaseDB {
 		return _HYPERSONIC;
 	}
 
+	protected boolean isSupportsDuplicatedIndexName() {
+		return _SUPPORTS_DUPLICATED_INDEX_NAME;
+	}
+
 	@Override
 	protected String reword(String data) throws IOException {
 		try (UnsyncBufferedReader unsyncBufferedReader =
@@ -150,5 +154,7 @@ public class HypersonicDB extends BaseDB {
 	private static final int[] _SQL_VARCHAR_SIZES = {
 		SQL_VARCHAR_MAX_SIZE, SQL_VARCHAR_MAX_SIZE
 	};
+
+	private static final boolean _SUPPORTS_DUPLICATED_INDEX_NAME = false;
 
 }

--- a/portal-impl/src/com/liferay/portal/dao/db/HypersonicDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/HypersonicDB.java
@@ -61,8 +61,7 @@ public class HypersonicDB extends BaseDB {
 		String tableName, String newTableName) {
 
 		return StringBundler.concat(
-			"create table ", newTableName, " as (select * from ", tableName,
-			") without data");
+			"create table ", newTableName, " (like ", tableName, ")");
 	}
 
 	@Override


### PR DESCRIPTION
- LPS-182452 Fix SQL syntax
- LPS-182452 Hypersonic does not support duplicate index names
- LPS-182452 Check if primary keys are copied
