### PR TITLE
LPS-171108 Removed @ignore from Accessibily#CanAssertAccessible

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/accessibility/Accessibility.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/accessibility/Accessibility.testcase
@@ -22,7 +22,6 @@ definition {
 	}
 
 	@description = "Verify poshi function AssertAccessible passes atleast one portal page based on WCAG 2.0 AA standards"
-	@ignore = "true"
 	@priority = 5
 	test CanAssertAccessible {
 		property portal.acceptance = "true";


### PR DESCRIPTION
[Original Pull ](https://github.com/liferay-peds/liferay-portal/pull/102)

Removed @ignore from Accessibily#CanAssertAccessible since it is [not blocked](https://issues.liferay.com/browse/LPS-185943) anymore.

[Poshi Report](https://drive.google.com/file/d/1mkECIvHr8Vx4i1OBhJeaVS9CQV2A-vsM/view?usp=sharing)

[Jira Ticket](https://issues.liferay.com/browse/LPS-171108)