### PR TITLE
LPS-179448 Add test to view error message when get asset library structured content by non-exist assetLibraryId

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentResourceTest.java
@@ -222,6 +222,27 @@ public class StructuredContentResourceTest
 					externalReferenceCode, "}"),
 				problem.getTitle());
 		}
+
+		// Non-exist assetLibraryId
+
+		long assetLibraryId = RandomTestUtil.randomLong();
+
+		try {
+			structuredContentResource.
+				getAssetLibraryStructuredContentByExternalReferenceCode(
+					assetLibraryId,
+					postStructuredContent.getExternalReferenceCode());
+
+			Assert.fail();
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			Assert.assertEquals("NOT_FOUND", problem.getStatus());
+			Assert.assertEquals(
+				"Unable to get a valid asset library with ID " + assetLibraryId,
+				problem.getTitle());
+		}
 	}
 
 	@Override


### PR DESCRIPTION
This is only for master.

https://issues.liferay.com/browse/LPS-179448

@jkappler