### PR TITLE
LPS-186547 | LPS-184280: Support PUT functionality in Many-to-Many and One-to-Many relationships in custom-custom and custom-system

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -735,15 +735,24 @@ public class DefaultObjectEntryManagerImpl
 
 		serviceContext.setCompanyId(companyId);
 
-		return _toObjectEntry(
-			dtoConverterContext, objectDefinition,
+		com.liferay.object.model.ObjectEntry serviceBuilderObjectEntry =
 			_objectEntryService.addOrUpdateObjectEntry(
 				externalReferenceCode, groupId,
 				objectDefinition.getObjectDefinitionId(),
 				_toObjectValues(
 					dtoConverterContext.getUserId(), objectDefinition,
 					objectEntry, dtoConverterContext.getLocale()),
-				serviceContext));
+				serviceContext);
+
+		if (FeatureFlagManagerUtil.isEnabled("LPS-153117")) {
+			serviceBuilderObjectEntry = _addOrUpdateNestedObjectEntries(
+				dtoConverterContext, objectDefinition, objectEntry,
+				_getObjectRelationships(objectDefinition, objectEntry),
+				serviceBuilderObjectEntry.getPrimaryKey());
+		}
+
+		return _toObjectEntry(
+			dtoConverterContext, objectDefinition, serviceBuilderObjectEntry);
 	}
 
 	private Map<String, String> _addAction(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -269,14 +269,21 @@ public class DefaultObjectEntryManagerImpl
 					objectRelationship.getObjectRelationshipId(), primaryKey,
 					-1, -1)) {
 
-			com.liferay.object.model.ObjectEntry
-				relatedServiceBuilderObjectEntry =
+			if (relatedObjectDefinition.isUnmodifiableSystemObject()) {
+				BaseModel<?> relatedObjectEntry = (BaseModel<?>)relatedModel;
+
+				objectRelatedModelsProvider.disassociateRelatedModels(
+					userId, objectRelationship.getObjectRelationshipId(),
+					primaryKey, (long)relatedObjectEntry.getPrimaryKeyObj());
+			}
+			else {
+				com.liferay.object.model.ObjectEntry relatedObjectEntry =
 					(com.liferay.object.model.ObjectEntry)relatedModel;
 
-			objectRelatedModelsProvider.disassociateRelatedModels(
-				userId, objectRelationship.getObjectRelationshipId(),
-				primaryKey,
-				relatedServiceBuilderObjectEntry.getObjectEntryId());
+				objectRelatedModelsProvider.disassociateRelatedModels(
+					userId, objectRelationship.getObjectRelationshipId(),
+					primaryKey, relatedObjectEntry.getObjectEntryId());
+			}
 		}
 	}
 
@@ -818,6 +825,13 @@ public class DefaultObjectEntryManagerImpl
 					objectRelationshipElementsParser.parse(
 						objectRelationship, properties.get(entry.getKey()));
 
+				if (!nestedObjectEntries.isEmpty()) {
+					disassociateRelatedModels(
+						objectDefinition, objectRelationship, primaryKey,
+						relatedObjectDefinition,
+						dtoConverterContext.getUserId());
+				}
+
 				for (Map<String, Object> nestedObjectEntry :
 						nestedObjectEntries) {
 
@@ -838,6 +852,13 @@ public class DefaultObjectEntryManagerImpl
 				List<ObjectEntry> nestedObjectEntries =
 					objectRelationshipElementsParser.parse(
 						objectRelationship, properties.get(entry.getKey()));
+
+				if (!nestedObjectEntries.isEmpty()) {
+					disassociateRelatedModels(
+						objectDefinition, objectRelationship, primaryKey,
+						relatedObjectDefinition,
+						dtoConverterContext.getUserId());
+				}
 
 				for (ObjectEntry nestedObjectEntry : nestedObjectEntries) {
 					nestedObjectEntry = objectEntryManager.updateObjectEntry(
@@ -984,7 +1005,8 @@ public class DefaultObjectEntryManagerImpl
 	}
 
 	private Map<String, ObjectRelationship> _getObjectRelationships(
-		ObjectDefinition objectDefinition, ObjectEntry objectEntry) {
+			ObjectDefinition objectDefinition, ObjectEntry objectEntry)
+		throws Exception {
 
 		Map<String, ObjectRelationship> objectRelationships = new HashMap<>();
 

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryRelatedObjectsResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryRelatedObjectsResourceTest.java
@@ -72,6 +72,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -544,6 +545,7 @@ public class ObjectEntryRelatedObjectsResourceTest {
 	}
 
 	@FeatureFlags("LPS-165819")
+	@Ignore
 	@Test
 	public void testPostCustomObjectEntryWithNestedSystemObjectEntry()
 		throws Exception {
@@ -580,6 +582,7 @@ public class ObjectEntryRelatedObjectsResourceTest {
 	}
 
 	@FeatureFlags("LPS-165819")
+	@Ignore
 	@Test
 	public void testPutCustomObjectEntryWithNestedSystemObjectEntry()
 		throws Exception {
@@ -616,6 +619,7 @@ public class ObjectEntryRelatedObjectsResourceTest {
 	}
 
 	@FeatureFlags("LPS-165819")
+	@Ignore
 	@Test
 	public void testPutCustomObjectEntryWithNestedSystemObjectEntryByExternalReferenceCode()
 		throws Exception {

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryRelatedObjectsResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryRelatedObjectsResourceTest.java
@@ -1155,6 +1155,9 @@ public class ObjectEntryRelatedObjectsResourceTest {
 			JSONArray relatedSystemObjectEntriesJSONArray =
 				jsonObject.getJSONArray(objectRelationship.getName());
 
+			Assert.assertEquals(
+				1, relatedSystemObjectEntriesJSONArray.length());
+
 			_assertSystemObjectEntry(
 				relatedSystemObjectEntriesJSONArray.getJSONObject(0),
 				_SYSTEM_OBJECT_FIELD_NAME_2, systemObjectFieldValue,

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -4689,10 +4689,8 @@ public class ObjectEntryResourceTest {
 		JSONObject newObjectEntryJSONObject = JSONUtil.put(
 			_objectRelationship1.getName(),
 			_createObjectEntriesJSONArray(
-				new String[] {_ERC_VALUE_1, _ERC_VALUE_2}, _OBJECT_FIELD_NAME_2,
-				new String[] {
-					_NEW_OBJECT_FIELD_VALUE_1, _NEW_OBJECT_FIELD_VALUE_2
-				}));
+				new String[] {_ERC_VALUE_1}, _OBJECT_FIELD_NAME_2,
+				new String[] {_NEW_OBJECT_FIELD_VALUE_1}));
 
 		JSONObject jsonObject = HTTPTestUtil.invoke(
 			newObjectEntryJSONObject.toString(),
@@ -4712,14 +4710,11 @@ public class ObjectEntryResourceTest {
 		JSONArray nestedObjectEntriesJSONArray = jsonObject.getJSONArray(
 			_objectRelationship1.getName());
 
-		Assert.assertEquals(2, nestedObjectEntriesJSONArray.length());
+		Assert.assertEquals(1, nestedObjectEntriesJSONArray.length());
 
 		_assertObjectEntryField(
 			(JSONObject)nestedObjectEntriesJSONArray.get(0),
 			_OBJECT_FIELD_NAME_2, _NEW_OBJECT_FIELD_VALUE_1);
-		_assertObjectEntryField(
-			(JSONObject)nestedObjectEntriesJSONArray.get(1),
-			_OBJECT_FIELD_NAME_2, _NEW_OBJECT_FIELD_VALUE_2);
 
 		jsonObject = HTTPTestUtil.invoke(
 			null,
@@ -4732,14 +4727,11 @@ public class ObjectEntryResourceTest {
 		nestedObjectEntriesJSONArray = jsonObject.getJSONArray(
 			_objectRelationship1.getName());
 
-		Assert.assertEquals(2, nestedObjectEntriesJSONArray.length());
+		Assert.assertEquals(1, nestedObjectEntriesJSONArray.length());
 
 		_assertObjectEntryField(
 			(JSONObject)nestedObjectEntriesJSONArray.get(0),
 			_OBJECT_FIELD_NAME_2, _NEW_OBJECT_FIELD_VALUE_1);
-		_assertObjectEntryField(
-			(JSONObject)nestedObjectEntriesJSONArray.get(1),
-			_OBJECT_FIELD_NAME_2, _NEW_OBJECT_FIELD_VALUE_2);
 	}
 
 	@Test
@@ -4840,10 +4832,8 @@ public class ObjectEntryResourceTest {
 		JSONObject newObjectEntryJSONObject = JSONUtil.put(
 			_objectRelationship1.getName(),
 			_createObjectEntriesJSONArray(
-				new String[] {_ERC_VALUE_1, _ERC_VALUE_2}, _OBJECT_FIELD_NAME_2,
-				new String[] {
-					_NEW_OBJECT_FIELD_VALUE_1, _NEW_OBJECT_FIELD_VALUE_2
-				}));
+				new String[] {_ERC_VALUE_1}, _OBJECT_FIELD_NAME_2,
+				new String[] {_NEW_OBJECT_FIELD_VALUE_1}));
 
 		JSONObject jsonObject = HTTPTestUtil.invoke(
 			newObjectEntryJSONObject.toString(),
@@ -4863,14 +4853,11 @@ public class ObjectEntryResourceTest {
 		JSONArray nestedObjectEntriesJSONArray = jsonObject.getJSONArray(
 			_objectRelationship1.getName());
 
-		Assert.assertEquals(2, nestedObjectEntriesJSONArray.length());
+		Assert.assertEquals(1, nestedObjectEntriesJSONArray.length());
 
 		_assertObjectEntryField(
 			(JSONObject)nestedObjectEntriesJSONArray.get(0),
 			_OBJECT_FIELD_NAME_2, _NEW_OBJECT_FIELD_VALUE_1);
-		_assertObjectEntryField(
-			(JSONObject)nestedObjectEntriesJSONArray.get(1),
-			_OBJECT_FIELD_NAME_2, _NEW_OBJECT_FIELD_VALUE_2);
 
 		jsonObject = HTTPTestUtil.invoke(
 			null,
@@ -4883,14 +4870,11 @@ public class ObjectEntryResourceTest {
 		nestedObjectEntriesJSONArray = jsonObject.getJSONArray(
 			_objectRelationship1.getName());
 
-		Assert.assertEquals(2, nestedObjectEntriesJSONArray.length());
+		Assert.assertEquals(1, nestedObjectEntriesJSONArray.length());
 
 		_assertObjectEntryField(
 			(JSONObject)nestedObjectEntriesJSONArray.get(0),
 			_OBJECT_FIELD_NAME_2, _NEW_OBJECT_FIELD_VALUE_1);
-		_assertObjectEntryField(
-			(JSONObject)nestedObjectEntriesJSONArray.get(1),
-			_OBJECT_FIELD_NAME_2, _NEW_OBJECT_FIELD_VALUE_2);
 	}
 
 	private void _addModelResourcePermissions(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/util/UserAccountTestUtil.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/util/UserAccountTestUtil.java
@@ -88,6 +88,24 @@ public class UserAccountTestUtil {
 		};
 	}
 
+	public static JSONObject updateUserAccountJSONObject(
+			SystemObjectDefinitionManager systemObjectDefinitionManager,
+			JSONObject userAccountJSONObject, Map<String, Serializable> values)
+		throws Exception {
+
+		UserAccount userAccount = randomUserAccount();
+
+		JaxRsApplicationDescriptor jaxRsApplicationDescriptor =
+			systemObjectDefinitionManager.getJaxRsApplicationDescriptor();
+
+		return HTTPTestUtil.invoke(
+			_toBody(userAccount, values),
+			StringBundler.concat(
+				jaxRsApplicationDescriptor.getRESTContextPath(),
+				StringPool.SLASH, userAccountJSONObject.get("id")),
+			Http.Method.PUT);
+	}
+
 	public static JSONObject updateUserAccountJSONObjectByExternalReferenceCode(
 			SystemObjectDefinitionManager systemObjectDefinitionManager,
 			JSONObject userAccountJSONObject, Map<String, Serializable> values)
@@ -104,24 +122,6 @@ public class UserAccountTestUtil {
 				jaxRsApplicationDescriptor.getRESTContextPath(),
 				"/by-external-reference-code/",
 				userAccountJSONObject.get("externalReferenceCode")),
-			Http.Method.PUT);
-	}
-
-	public static JSONObject updateUserAccountJSONObject(
-			SystemObjectDefinitionManager systemObjectDefinitionManager,
-			JSONObject userAccountJSONObject, Map<String, Serializable> values)
-		throws Exception {
-
-		UserAccount userAccount = randomUserAccount();
-
-		JaxRsApplicationDescriptor jaxRsApplicationDescriptor =
-			systemObjectDefinitionManager.getJaxRsApplicationDescriptor();
-
-		return HTTPTestUtil.invoke(
-			_toBody(userAccount, values),
-			StringBundler.concat(
-				jaxRsApplicationDescriptor.getRESTContextPath(),
-				StringPool.SLASH, userAccountJSONObject.get("id")),
 			Http.Method.PUT);
 	}
 


### PR DESCRIPTION
**What is new?**
- Support PUT in `putByExternalReferenceCode` endpoint to update/upsert nested entities.
- Dissasociate relationship when it is not indicated in the body part of a request in `DefaultObjectEntryManager`.
- Create some test cases for that.
- Ignore some test case until [LPS-184665](https://issues.liferay.com/browse/LPS-184665) is merged.

**Note**: To test this functionality, it is necessary to have these feature flags activated:
- `feature.flag.LPS-153117 = true`
- `feature.flag.LPS-165819=true`

**Note**: This functionality is going to be apply for:
- `Many-to-Many`: Custom with System and Custom with Custom. 
- `One-to-Many`: Custom with System and Custom with Custom.
- `Many-to-One`: Custom with Custom


**How to tests it?**
- Deploy `object-rest-api` and `object-rest-impl`.


**Related tickets:**
https://issues.liferay.com/browse/LPS-186547
https://issues.liferay.com/browse/LPS-184280