### PR TITLE
LPS-187024 Adds AI Creator toolbar to the CKEditor when is enabled

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorConfigContributor.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorConfigContributor.java
@@ -71,11 +71,7 @@ public class CKEditorConfigContributor extends BaseCKEditorConfigContributor {
 			extraPlugins += ",ajaxsave,restore";
 		}
 
-		boolean showAICreatorToolbar = GetterUtil.getBoolean(
-			inputEditorTaglibAttributes.get(
-				CKEditorConstants.ATTRIBUTE_NAMESPACE + ":showAICreator"));
-
-		if (showAICreatorToolbar) {
+		if (_isShowAICreator(inputEditorTaglibAttributes)) {
 			extraPlugins += ",aicreator";
 		}
 
@@ -97,7 +93,7 @@ public class CKEditorConfigContributor extends BaseCKEditorConfigContributor {
 		);
 
 		JSONArray toolbarSimpleJSONArray = _getToolbarSimpleJSONArray(
-			inputEditorTaglibAttributes, showAICreatorToolbar);
+			inputEditorTaglibAttributes);
 
 		jsonObject.put(
 			"toolbar_editInPlace", toolbarSimpleJSONArray
@@ -115,12 +111,10 @@ public class CKEditorConfigContributor extends BaseCKEditorConfigContributor {
 			"toolbar_tablet", toolbarSimpleJSONArray
 		).put(
 			"toolbar_text_advanced",
-			_getToolbarTextAdvancedJSONArray(
-				inputEditorTaglibAttributes, showAICreatorToolbar)
+			_getToolbarTextAdvancedJSONArray(inputEditorTaglibAttributes)
 		).put(
 			"toolbar_text_simple",
-			_getToolbarTextSimpleJSONArray(
-				inputEditorTaglibAttributes, showAICreatorToolbar)
+			_getToolbarTextSimpleJSONArray(inputEditorTaglibAttributes)
 		);
 	}
 
@@ -173,8 +167,7 @@ public class CKEditorConfigContributor extends BaseCKEditorConfigContributor {
 	}
 
 	private JSONArray _getToolbarSimpleJSONArray(
-		Map<String, Object> inputEditorTaglibAttributes,
-		boolean showAICreatorToolbar) {
+		Map<String, Object> inputEditorTaglibAttributes) {
 
 		return JSONUtil.putAll(
 			toJSONArray("['Undo', 'Redo']"),
@@ -200,7 +193,7 @@ public class CKEditorConfigContributor extends BaseCKEditorConfigContributor {
 			}
 		).put(
 			() -> {
-				if (showAICreatorToolbar) {
+				if (_isShowAICreator(inputEditorTaglibAttributes)) {
 					return toJSONArray("['AICreator']");
 				}
 
@@ -210,8 +203,7 @@ public class CKEditorConfigContributor extends BaseCKEditorConfigContributor {
 	}
 
 	private JSONArray _getToolbarTextAdvancedJSONArray(
-		Map<String, Object> inputEditorTaglibAttributes,
-		boolean showAICreatorToolbar) {
+		Map<String, Object> inputEditorTaglibAttributes) {
 
 		return JSONUtil.putAll(
 			toJSONArray("['Undo', 'Redo']"), toJSONArray("['Styles']"),
@@ -232,7 +224,7 @@ public class CKEditorConfigContributor extends BaseCKEditorConfigContributor {
 			}
 		).put(
 			() -> {
-				if (showAICreatorToolbar) {
+				if (_isShowAICreator(inputEditorTaglibAttributes)) {
 					return toJSONArray("['AICreator']");
 				}
 
@@ -242,8 +234,7 @@ public class CKEditorConfigContributor extends BaseCKEditorConfigContributor {
 	}
 
 	private JSONArray _getToolbarTextSimpleJSONArray(
-		Map<String, Object> inputEditorTaglibAttributes,
-		boolean showAICreatorToolbar) {
+		Map<String, Object> inputEditorTaglibAttributes) {
 
 		return JSONUtil.putAll(
 			toJSONArray("['Undo', 'Redo']"),
@@ -260,13 +251,21 @@ public class CKEditorConfigContributor extends BaseCKEditorConfigContributor {
 			}
 		).put(
 			() -> {
-				if (showAICreatorToolbar) {
+				if (_isShowAICreator(inputEditorTaglibAttributes)) {
 					return toJSONArray("['AICreator']");
 				}
 
 				return null;
 			}
 		);
+	}
+
+	private boolean _isShowAICreator(
+		Map<String, Object> inputEditorTaglibAttributes) {
+
+		return GetterUtil.getBoolean(
+			inputEditorTaglibAttributes.get(
+				CKEditorConstants.ATTRIBUTE_NAMESPACE + ":showAICreator"));
 	}
 
 	@Reference

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorConfigContributor.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorConfigContributor.java
@@ -71,6 +71,14 @@ public class CKEditorConfigContributor extends BaseCKEditorConfigContributor {
 			extraPlugins += ",ajaxsave,restore";
 		}
 
+		boolean showAICreatorToolbar = GetterUtil.getBoolean(
+			inputEditorTaglibAttributes.get(
+				CKEditorConstants.ATTRIBUTE_NAMESPACE + ":showAICreator"));
+
+		if (showAICreatorToolbar) {
+			extraPlugins += ",aicreator";
+		}
+
 		jsonObject.put(
 			"extraPlugins", extraPlugins
 		).put(
@@ -89,7 +97,7 @@ public class CKEditorConfigContributor extends BaseCKEditorConfigContributor {
 		);
 
 		JSONArray toolbarSimpleJSONArray = _getToolbarSimpleJSONArray(
-			inputEditorTaglibAttributes);
+			inputEditorTaglibAttributes, showAICreatorToolbar);
 
 		jsonObject.put(
 			"toolbar_editInPlace", toolbarSimpleJSONArray
@@ -107,10 +115,12 @@ public class CKEditorConfigContributor extends BaseCKEditorConfigContributor {
 			"toolbar_tablet", toolbarSimpleJSONArray
 		).put(
 			"toolbar_text_advanced",
-			_getToolbarTextAdvancedJSONArray(inputEditorTaglibAttributes)
+			_getToolbarTextAdvancedJSONArray(
+				inputEditorTaglibAttributes, showAICreatorToolbar)
 		).put(
 			"toolbar_text_simple",
-			_getToolbarTextSimpleJSONArray(inputEditorTaglibAttributes)
+			_getToolbarTextSimpleJSONArray(
+				inputEditorTaglibAttributes, showAICreatorToolbar)
 		);
 	}
 
@@ -163,7 +173,8 @@ public class CKEditorConfigContributor extends BaseCKEditorConfigContributor {
 	}
 
 	private JSONArray _getToolbarSimpleJSONArray(
-		Map<String, Object> inputEditorTaglibAttributes) {
+		Map<String, Object> inputEditorTaglibAttributes,
+		boolean showAICreatorToolbar) {
 
 		return JSONUtil.putAll(
 			toJSONArray("['Undo', 'Redo']"),
@@ -187,11 +198,20 @@ public class CKEditorConfigContributor extends BaseCKEditorConfigContributor {
 
 				return null;
 			}
+		).put(
+			() -> {
+				if (showAICreatorToolbar) {
+					return toJSONArray("['AICreator']");
+				}
+
+				return null;
+			}
 		);
 	}
 
 	private JSONArray _getToolbarTextAdvancedJSONArray(
-		Map<String, Object> inputEditorTaglibAttributes) {
+		Map<String, Object> inputEditorTaglibAttributes,
+		boolean showAICreatorToolbar) {
 
 		return JSONUtil.putAll(
 			toJSONArray("['Undo', 'Redo']"), toJSONArray("['Styles']"),
@@ -210,11 +230,20 @@ public class CKEditorConfigContributor extends BaseCKEditorConfigContributor {
 
 				return null;
 			}
+		).put(
+			() -> {
+				if (showAICreatorToolbar) {
+					return toJSONArray("['AICreator']");
+				}
+
+				return null;
+			}
 		);
 	}
 
 	private JSONArray _getToolbarTextSimpleJSONArray(
-		Map<String, Object> inputEditorTaglibAttributes) {
+		Map<String, Object> inputEditorTaglibAttributes,
+		boolean showAICreatorToolbar) {
 
 		return JSONUtil.putAll(
 			toJSONArray("['Undo', 'Redo']"),
@@ -225,6 +254,14 @@ public class CKEditorConfigContributor extends BaseCKEditorConfigContributor {
 			() -> {
 				if (isShowSource(inputEditorTaglibAttributes)) {
 					return toJSONArray("['Source', 'Expand']");
+				}
+
+				return null;
+			}
+		).put(
+			() -> {
+				if (showAICreatorToolbar) {
+					return toJSONArray("['AICreator']");
 				}
 
 				return null;


### PR DESCRIPTION
I am manually forwarding this pull request from the Frontend Team's repo because automatic forward is falling. See: https://github.com/liferay-frontend/liferay-portal/pull/3424#issuecomment-1589209786

Original PR from Frontend Team's repo: https://github.com/liferay-frontend/liferay-portal/pull/3424

Approved by the reviewed here: https://github.com/liferay-frontend/liferay-portal/pull/3424#pullrequestreview-1474466742

Analyzed failures by QA here: https://github.com/liferay-frontend/liferay-portal/pull/3424#issuecomment-1587297331

Original Pull Request comment: 

> https://issues.liferay.com/browse/LPS-187024
> 
> Hi Team ✋ 
> 
> From the Echo Team, we are working on a story to [Provide a button to trigger AI in the web content editor.](https://issues.liferay.com/browse/LPS-181285) As part of that story, we need to add an attribute that indicates if the toolbar should be added or not. We are passing it to the editor configuration in a pull request that is reviewing by the Forms team, please see: https://github.com/liferay-forms/liferay-portal/pull/2238
> 
> In this pull request, I am adding the AI-Creator toolbar when this setting is true.
> 
> Could you please review it?
> 
> Thanks in advance! ❤️ 
> 

