### PR TITLE
LPS-186288  Display draft configuration in Design section

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutLookAndFeelDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutLookAndFeelDisplayContext.java
@@ -155,14 +155,16 @@ public class LayoutLookAndFeelDisplayContext {
 					return StringPool.BLANK;
 				}
 
-				Layout selLayout = _layoutsAdminDisplayContext.getSelLayout();
+				Layout configLayout =
+					_layoutsAdminDisplayContext.getConfigLayout();
 
 				Layout masterLayout = LayoutLocalServiceUtil.getLayout(
-					selLayout.getMasterLayoutPlid());
+					configLayout.getMasterLayoutPlid());
 
 				String editLayoutURL = HttpComponentsUtil.addParameter(
 					HttpComponentsUtil.addParameter(
-						PortalUtil.getLayoutFullURL(selLayout, _themeDisplay),
+						PortalUtil.getLayoutFullURL(
+							configLayout, _themeDisplay),
 						"p_l_mode", Constants.EDIT),
 					"p_l_back_url",
 					ParamUtil.getString(_httpServletRequest, "redirect"));
@@ -182,10 +184,10 @@ public class LayoutLookAndFeelDisplayContext {
 			"masterLayoutPlid",
 			() -> {
 				if (hasMasterLayout()) {
-					Layout selLayout =
-						_layoutsAdminDisplayContext.getSelLayout();
+					Layout configLayout =
+						_layoutsAdminDisplayContext.getConfigLayout();
 
-					return String.valueOf(selLayout.getMasterLayoutPlid());
+					return String.valueOf(configLayout.getMasterLayoutPlid());
 				}
 
 				return StringPool.BLANK;
@@ -201,13 +203,13 @@ public class LayoutLookAndFeelDisplayContext {
 		String masterLayoutName = LanguageUtil.get(
 			_httpServletRequest, "blank");
 
-		Layout selLayout = _layoutsAdminDisplayContext.getSelLayout();
+		Layout configLayout = _layoutsAdminDisplayContext.getConfigLayout();
 
-		if (selLayout.getMasterLayoutPlid() > 0) {
+		if (configLayout.getMasterLayoutPlid() > 0) {
 			LayoutPageTemplateEntry layoutPageTemplateEntry =
 				LayoutPageTemplateEntryLocalServiceUtil.
 					fetchLayoutPageTemplateEntryByPlid(
-						selLayout.getMasterLayoutPlid());
+						configLayout.getMasterLayoutPlid());
 
 			if (layoutPageTemplateEntry != null) {
 				masterLayoutName = layoutPageTemplateEntry.getName();
@@ -249,9 +251,10 @@ public class LayoutLookAndFeelDisplayContext {
 		).put(
 			"styleBookEntryId",
 			() -> {
-				Layout selLayout = _layoutsAdminDisplayContext.getSelLayout();
+				Layout configLayout =
+					_layoutsAdminDisplayContext.getConfigLayout();
 
-				return String.valueOf(selLayout.getStyleBookEntryId());
+				return String.valueOf(configLayout.getStyleBookEntryId());
 			}
 		).put(
 			"styleBookEntryName", getStyleBookEntryName()
@@ -259,12 +262,12 @@ public class LayoutLookAndFeelDisplayContext {
 	}
 
 	public String getStyleBookEntryName() {
-		Layout selLayout = _layoutsAdminDisplayContext.getSelLayout();
+		Layout configLayout = _layoutsAdminDisplayContext.getConfigLayout();
 
 		StyleBookEntry defaultStyleBookEntry =
-			DefaultStyleBookEntryUtil.getDefaultStyleBookEntry(selLayout);
+			DefaultStyleBookEntryUtil.getDefaultStyleBookEntry(configLayout);
 
-		if (selLayout.getStyleBookEntryId() > 0) {
+		if (configLayout.getStyleBookEntryId() > 0) {
 			return defaultStyleBookEntry.getName();
 		}
 
@@ -273,7 +276,7 @@ public class LayoutLookAndFeelDisplayContext {
 		}
 
 		if (hasEditableMasterLayout() &&
-			(selLayout.getMasterLayoutPlid() > 0)) {
+			(configLayout.getMasterLayoutPlid() > 0)) {
 
 			return LanguageUtil.get(_httpServletRequest, "styles-from-master");
 		}
@@ -372,13 +375,13 @@ public class LayoutLookAndFeelDisplayContext {
 
 		boolean hasMasterLayout = false;
 
-		Layout selLayout = _layoutsAdminDisplayContext.getSelLayout();
+		Layout configLayout = _layoutsAdminDisplayContext.getConfigLayout();
 
-		if (selLayout.getMasterLayoutPlid() > 0) {
+		if (configLayout.getMasterLayoutPlid() > 0) {
 			LayoutPageTemplateEntry layoutPageTemplateEntry =
 				LayoutPageTemplateEntryLocalServiceUtil.
 					fetchLayoutPageTemplateEntryByPlid(
-						selLayout.getMasterLayoutPlid());
+						configLayout.getMasterLayoutPlid());
 
 			if (layoutPageTemplateEntry != null) {
 				hasMasterLayout = true;
@@ -456,14 +459,16 @@ public class LayoutLookAndFeelDisplayContext {
 							_getLayoutRootNodeName(), false)));
 			}
 
-			Layout layout = _layoutsAdminDisplayContext.getSelLayout();
+			Layout configLayout = _layoutsAdminDisplayContext.getConfigLayout();
 
-			if ((layout != null) && (layout.getMasterLayoutPlid() > 0)) {
+			if ((configLayout != null) &&
+				(configLayout.getMasterLayoutPlid() > 0)) {
+
 				clientExtensionEntryRels =
 					ClientExtensionEntryRelLocalServiceUtil.
 						getClientExtensionEntryRels(
 							PortalUtil.getClassNameId(Layout.class),
-							layout.getMasterLayoutPlid(), type);
+							configLayout.getMasterLayoutPlid(), type);
 
 				for (ClientExtensionEntryRel clientExtensionEntryRel :
 						clientExtensionEntryRels) {

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContext.java
@@ -35,6 +35,7 @@ import com.liferay.item.selector.criteria.FileEntryItemSelectorReturnType;
 import com.liferay.item.selector.criteria.UUIDItemSelectorReturnType;
 import com.liferay.item.selector.criteria.file.criterion.FileItemSelectorCriterion;
 import com.liferay.layout.admin.constants.LayoutAdminPortletKeys;
+import com.liferay.layout.admin.constants.LayoutScreenNavigationEntryConstants;
 import com.liferay.layout.admin.web.internal.helper.LayoutActionsHelper;
 import com.liferay.layout.admin.web.internal.util.FaviconUtil;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
@@ -321,6 +322,28 @@ public class LayoutsAdminDisplayContext {
 		return _itemSelector.getItemSelectorURL(
 			RequestBackedPortletURLFactoryUtil.create(httpServletRequest),
 			selectEventName, cetItemSelectorCriterion);
+	}
+
+	public Layout getConfigLayout() {
+		Layout selLayout = getSelLayout();
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPS-153951")) {
+			return selLayout;
+		}
+
+		if (_isDraftLayoutConfiguration()) {
+			if (selLayout.isDraftLayout()) {
+				return getSelLayout();
+			}
+
+			Layout draftLayout = selLayout.fetchDraftLayout();
+
+			if (draftLayout != null) {
+				return draftLayout;
+			}
+		}
+
+		return selLayout;
 	}
 
 	public Long getConfigLayoutPlid() {
@@ -2282,6 +2305,13 @@ public class LayoutsAdminDisplayContext {
 		};
 
 		return _types;
+	}
+
+	private boolean _isDraftLayoutConfiguration() {
+		return StringUtil.equalsIgnoreCase(
+			ParamUtil.getString(
+				_liferayPortletRequest, "screenNavigationEntryKey"),
+			LayoutScreenNavigationEntryConstants.ENTRY_KEY_DESIGN);
 	}
 
 	private boolean _matchesHostname(

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContext.java
@@ -323,6 +323,30 @@ public class LayoutsAdminDisplayContext {
 			selectEventName, cetItemSelectorCriterion);
 	}
 
+	public Long getConfigLayoutPlid() {
+		if (!FeatureFlagManagerUtil.isEnabled("LPS-153951")) {
+			return getSelPlid();
+		}
+
+		Layout selLayout = getSelLayout();
+
+		if (selLayout == null) {
+			return getSelPlid();
+		}
+
+		if (selLayout.isDraftLayout()) {
+			return selLayout.getPlid();
+		}
+
+		Layout draftLayout = selLayout.fetchDraftLayout();
+
+		if (draftLayout == null) {
+			return selLayout.getPlid();
+		}
+
+		return draftLayout.getPlid();
+	}
+
 	public String getConfigurationTitle(Layout layout, Locale locale) {
 		LayoutPageTemplateEntry layoutPageTemplateEntry =
 			LayoutPageTemplateEntryLocalServiceUtil.

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContext.java
@@ -573,10 +573,10 @@ public class LayoutsAdminDisplayContext {
 		).put(
 			"faviconFileEntryId",
 			() -> {
-				Layout selLayout = getSelLayout();
+				Layout configLayout = getConfigLayout();
 
-				if (selLayout != null) {
-					return selLayout.getFaviconFileEntryId();
+				if (configLayout != null) {
+					return configLayout.getFaviconFileEntryId();
 				}
 
 				LayoutSet selLayoutSet = getSelLayoutSet();
@@ -598,9 +598,9 @@ public class LayoutsAdminDisplayContext {
 	}
 
 	public String getFaviconTitle() {
-		if (getSelLayout() != null) {
+		if (getConfigLayout() != null) {
 			return FaviconUtil.getFaviconTitle(
-				_cetManager, getSelLayout(), themeDisplay.getLocale());
+				_cetManager, getConfigLayout(), themeDisplay.getLocale());
 		}
 
 		return FaviconUtil.getFaviconTitle(
@@ -610,8 +610,9 @@ public class LayoutsAdminDisplayContext {
 	public String getFaviconURL() {
 		String faviconURL = StringPool.BLANK;
 
-		if (getSelLayout() != null) {
-			faviconURL = FaviconUtil.getFaviconURL(_cetManager, getSelLayout());
+		if (getConfigLayout() != null) {
+			faviconURL = FaviconUtil.getFaviconURL(
+				_cetManager, getConfigLayout());
 		}
 
 		if (Validator.isNotNull(faviconURL)) {
@@ -1392,11 +1393,11 @@ public class LayoutsAdminDisplayContext {
 		String className = LayoutSet.class.getName();
 		long classPK = setLayoutSet.getLayoutSetId();
 
-		Layout selLayout = getSelLayout();
+		Layout configLayout = getConfigLayout();
 
-		if (selLayout != null) {
+		if (configLayout != null) {
 			className = Layout.class.getName();
-			classPK = selLayout.getPlid();
+			classPK = configLayout.getPlid();
 		}
 
 		ClientExtensionEntryRel clientExtensionEntryRel =
@@ -1447,14 +1448,14 @@ public class LayoutsAdminDisplayContext {
 	}
 
 	public String getThemeFaviconCETExternalReferenceCode() {
-		Layout selLayout = getSelLayout();
+		Layout configLayout = getConfigLayout();
 
-		if (selLayout != null) {
+		if (configLayout != null) {
 			ClientExtensionEntryRel clientExtensionEntryRel =
 				ClientExtensionEntryRelLocalServiceUtil.
 					fetchClientExtensionEntryRel(
 						PortalUtil.getClassNameId(Layout.class),
-						selLayout.getPlid(),
+						configLayout.getPlid(),
 						ClientExtensionEntryConstants.TYPE_THEME_FAVICON);
 
 			if (clientExtensionEntryRel != null) {
@@ -1663,10 +1664,10 @@ public class LayoutsAdminDisplayContext {
 	}
 
 	public boolean isClearFaviconButtonEnabled() {
-		Layout selLayout = getSelLayout();
+		Layout configLayout = getConfigLayout();
 
-		if (selLayout != null) {
-			if (selLayout.getFaviconFileEntryId() > 0) {
+		if (configLayout != null) {
+			if (configLayout.getFaviconFileEntryId() > 0) {
 				return true;
 			}
 
@@ -1674,7 +1675,7 @@ public class LayoutsAdminDisplayContext {
 				ClientExtensionEntryRelLocalServiceUtil.
 					fetchClientExtensionEntryRel(
 						PortalUtil.getClassNameId(Layout.class),
-						selLayout.getPlid(),
+						configLayout.getPlid(),
 						ClientExtensionEntryConstants.TYPE_THEME_FAVICON);
 
 			if (clientExtensionEntryRel != null) {
@@ -2047,21 +2048,21 @@ public class LayoutsAdminDisplayContext {
 	}
 
 	private String _getDefaultFaviconTitle() {
-		Layout selLayout = getSelLayout();
+		Layout configLayout = getConfigLayout();
 
-		if (selLayout != null) {
+		if (configLayout != null) {
 			if (hasEditableMasterLayout() &&
-				(selLayout.getMasterLayoutPlid() > 0)) {
+				(configLayout.getMasterLayoutPlid() > 0)) {
 
 				Layout masterLayout = LayoutLocalServiceUtil.fetchLayout(
-					selLayout.getMasterLayoutPlid());
+					configLayout.getMasterLayoutPlid());
 
 				if (masterLayout != null) {
 					ClientExtensionEntryRel clientExtensionEntryRel =
 						ClientExtensionEntryRelLocalServiceUtil.
 							fetchClientExtensionEntryRel(
 								PortalUtil.getClassNameId(Layout.class),
-								selLayout.getPlid(),
+								configLayout.getPlid(),
 								ClientExtensionEntryConstants.
 									TYPE_THEME_FAVICON);
 

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/EditLayoutMVCActionCommand.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/EditLayoutMVCActionCommand.java
@@ -247,10 +247,10 @@ public class EditLayoutMVCActionCommand extends BaseMVCActionCommand {
 			}
 			else {
 				layoutTypeSettingsUnicodeProperties.putAll(
-					formTypeSettingsUnicodeProperties);
+					layout.getTypeSettingsProperties());
 
 				layoutTypeSettingsUnicodeProperties.putAll(
-					layout.getTypeSettingsProperties());
+					formTypeSettingsUnicodeProperties);
 			}
 
 			layout = _layoutService.updateLayout(

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/advanced.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/advanced.jsp
@@ -17,9 +17,9 @@
 <%@ include file="/init.jsp" %>
 
 <%
-Layout selLayout = layoutsAdminDisplayContext.getSelLayout();
+Layout configLayout = layoutsAdminDisplayContext.getConfigLayout();
 
-UnicodeProperties layoutTypeSettingsUnicodeProperties = selLayout.getTypeSettingsProperties();
+UnicodeProperties layoutTypeSettingsUnicodeProperties = configLayout.getTypeSettingsProperties();
 %>
 
 <liferay-ui:error-marker
@@ -27,7 +27,7 @@ UnicodeProperties layoutTypeSettingsUnicodeProperties = selLayout.getTypeSetting
 	value="advanced"
 />
 
-<aui:model-context bean="<%= selLayout %>" model="<%= Layout.class %>" />
+<aui:model-context bean="<%= configLayout %>" model="<%= Layout.class %>" />
 
 <liferay-ui:error exception="<%= ImageTypeException.class %>" message="please-enter-a-file-with-a-valid-file-type" />
 
@@ -36,11 +36,11 @@ Group group = layoutsAdminDisplayContext.getGroup();
 %>
 
 <c:if test="<%= !group.isLayoutPrototype() %>">
-	<div class="alert alert-warning layout-prototype-info-message <%= selLayout.isLayoutPrototypeLinkActive() ? StringPool.BLANK : "hide" %>">
+	<div class="alert alert-warning layout-prototype-info-message <%= configLayout.isLayoutPrototypeLinkActive() ? StringPool.BLANK : "hide" %>">
 		<liferay-ui:message arguments='<%= new String[] {LanguageUtil.get(request, "inherit-changes"), "General"} %>' key="some-page-settings-are-unavailable-because-x-is-enabled" translateArguments="<%= false %>" />
 	</div>
 
-	<aui:input cssClass="propagatable-field" disabled="<%= selLayout.isLayoutPrototypeLinkActive() %>" helpMessage="query-string-help" label="query-string" name="TypeSettingsProperties--query-string--" size="30" type="text" value='<%= GetterUtil.getString(layoutTypeSettingsUnicodeProperties.getProperty("query-string")) %>' />
+	<aui:input cssClass="propagatable-field" disabled="<%= configLayout.isLayoutPrototypeLinkActive() %>" helpMessage="query-string-help" label="query-string" name="TypeSettingsProperties--query-string--" size="30" type="text" value='<%= GetterUtil.getString(layoutTypeSettingsUnicodeProperties.getProperty("query-string")) %>' />
 </c:if>
 
 <%
@@ -53,11 +53,11 @@ String targetType = GetterUtil.getString(layoutTypeSettingsUnicodeProperties.get
 		<aui:option label="new-tab" selected='<%= Objects.equals(targetType, "useNewTab") %>' value="useNewTab" />
 	</aui:select>
 
-	<aui:input cssClass="propagatable-field" disabled="<%= selLayout.isLayoutPrototypeLinkActive() %>" id="target" label="target" name="TypeSettingsProperties--target--" size="15" type="text" value='<%= GetterUtil.getString(layoutTypeSettingsUnicodeProperties.getProperty("target")) %>' wrapperCssClass='<%= Objects.equals(targetType, "useNewTab") ? "hide" : "w-50" %>' />
+	<aui:input cssClass="propagatable-field" disabled="<%= configLayout.isLayoutPrototypeLinkActive() %>" id="target" label="target" name="TypeSettingsProperties--target--" size="15" type="text" value='<%= GetterUtil.getString(layoutTypeSettingsUnicodeProperties.getProperty("target")) %>' wrapperCssClass='<%= Objects.equals(targetType, "useNewTab") ? "hide" : "w-50" %>' />
 </div>
 
 <liferay-frontend:logo-selector
-	currentLogoURL='<%= (selLayout.getIconImageId() == 0) ? themeDisplay.getPathThemeImages() + "/spacer.png" : themeDisplay.getPathImage() + "/logo?img_id=" + selLayout.getIconImageId() + "&t=" + WebServerServletTokenUtil.getToken(selLayout.getIconImageId()) %>'
+	currentLogoURL='<%= (configLayout.getIconImageId() == 0) ? themeDisplay.getPathThemeImages() + "/spacer.png" : themeDisplay.getPathImage() + "/logo?img_id=" + configLayout.getIconImageId() + "&t=" + WebServerServletTokenUtil.getToken(configLayout.getIconImageId()) %>'
 	defaultLogoURL='<%= themeDisplay.getPathThemeImages() + "/spacer.png" %>'
 	description='<%= LanguageUtil.get(request, "this-icon-will-be-shown-in-the-navigation-menu") %>'
 	label='<%= LanguageUtil.get(request, "icon") %>'

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/basic_settings.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/basic_settings.jsp
@@ -21,7 +21,7 @@
 	value="basic-settings"
 />
 
-<aui:model-context bean="<%= layoutsAdminDisplayContext.getSelLayout() %>" model="<%= Layout.class %>" />
+<aui:model-context bean="<%= layoutsAdminDisplayContext.getConfigLayout() %>" model="<%= Layout.class %>" />
 
 <%
 LayoutLookAndFeelDisplayContext layoutLookAndFeelDisplayContext = new LayoutLookAndFeelDisplayContext(request, layoutsAdminDisplayContext, liferayPortletResponse);

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/css.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/css.jsp
@@ -17,7 +17,7 @@
 <%@ include file="/init.jsp" %>
 
 <%
-Layout selLayout = layoutsAdminDisplayContext.getSelLayout();
+Layout configLayout = layoutsAdminDisplayContext.getConfigLayout();
 
 LayoutLookAndFeelDisplayContext layoutLookAndFeelDisplayContext = new LayoutLookAndFeelDisplayContext(request, layoutsAdminDisplayContext, liferayPortletResponse);
 %>
@@ -40,7 +40,7 @@ LayoutLookAndFeelDisplayContext layoutLookAndFeelDisplayContext = new LayoutLook
 >
 	<react:component
 		module="js/layout/look_and_feel/GlobalCSSCETsConfiguration"
-		props="<%= layoutLookAndFeelDisplayContext.getGlobalCSSCETsConfigurationProps(Layout.class.getName(), selLayout.getPlid()) %>"
+		props="<%= layoutLookAndFeelDisplayContext.getGlobalCSSCETsConfigurationProps(Layout.class.getName(), configLayout.getPlid()) %>"
 	/>
 </liferay-frontend:fieldset>
 
@@ -52,7 +52,7 @@ LayoutLookAndFeelDisplayContext layoutLookAndFeelDisplayContext = new LayoutLook
 	>
 		<react:component
 			module="js/layout/look_and_feel/ThemeSpritemapCETsConfiguration"
-			props="<%= layoutLookAndFeelDisplayContext.getThemeSpritemapCETConfigurationProps(Layout.class.getName(), selLayout.getPlid()) %>"
+			props="<%= layoutLookAndFeelDisplayContext.getThemeSpritemapCETConfigurationProps(Layout.class.getName(), configLayout.getPlid()) %>"
 		/>
 	</liferay-frontend:fieldset>
 </c:if>
@@ -63,13 +63,13 @@ LayoutLookAndFeelDisplayContext layoutLookAndFeelDisplayContext = new LayoutLook
 	label="custom-css"
 >
 	<clay:alert
-		cssClass='<%= selLayout.isInheritLookAndFeel() ? StringPool.BLANK : "d-none" %>'
+		cssClass='<%= configLayout.isInheritLookAndFeel() ? StringPool.BLANK : "d-none" %>'
 		displayType="info"
 		id='<%= liferayPortletResponse.getNamespace() + "regularCssAlert" %>'
 		message='<%= LanguageUtil.get(request, "custom-css-is-disabled-when-using-the-inherited-theme") %>'
 	/>
 
-	<aui:input disabled="<%= selLayout.isInheritLookAndFeel() || layoutsAdminDisplayContext.isReadOnly() %>" label="css" name="regularCss" type="textarea" value="<%= selLayout.getCssText() %>" wrapperCssClass="c-mb-0" />
+	<aui:input disabled="<%= configLayout.isInheritLookAndFeel() || layoutsAdminDisplayContext.isReadOnly() %>" label="css" name="regularCss" type="textarea" value="<%= configLayout.getCssText() %>" wrapperCssClass="c-mb-0" />
 
 	<p class="text-secondary">
 		<liferay-ui:message key="this-css-is-loaded-after-the-theme" />

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/customization.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/customization.jsp
@@ -21,7 +21,7 @@
 	value="customization"
 />
 
-<aui:model-context bean="<%= layoutsAdminDisplayContext.getSelLayout() %>" model="<%= Layout.class %>" />
+<aui:model-context bean="<%= layoutsAdminDisplayContext.getConfigLayout() %>" model="<%= Layout.class %>" />
 
 <%
 LayoutLookAndFeelDisplayContext layoutLookAndFeelDisplayContext = new LayoutLookAndFeelDisplayContext(request, layoutsAdminDisplayContext, liferayPortletResponse);

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/customization_settings.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/customization_settings.jsp
@@ -23,10 +23,10 @@ boolean prototypeGroup = false;
 String templateContent = null;
 String templateId = null;
 
-Layout selLayout = layoutsAdminDisplayContext.getSelLayout();
+Layout configLayout = layoutsAdminDisplayContext.getConfigLayout();
 
-if (selLayout != null) {
-	LayoutTypePortlet selLayoutTypePortlet = (LayoutTypePortlet)selLayout.getLayoutType();
+if (configLayout != null) {
+	LayoutTypePortlet selLayoutTypePortlet = (LayoutTypePortlet)configLayout.getLayoutType();
 
 	String layoutTemplateId = selLayoutTypePortlet.getLayoutTemplateId();
 
@@ -34,13 +34,13 @@ if (selLayout != null) {
 		layoutTemplateId = PropsValues.DEFAULT_LAYOUT_TEMPLATE_ID;
 	}
 
-	group = selLayout.getGroup();
+	group = configLayout.getGroup();
 
 	if (group.isLayoutPrototype() || group.isLayoutSetPrototype()) {
 		prototypeGroup = true;
 	}
 
-	Theme selLayoutTheme = selLayout.getTheme();
+	Theme selLayoutTheme = configLayout.getTheme();
 
 	if (!prototypeGroup) {
 		LayoutTemplate layoutTemplate = LayoutTemplateLocalServiceUtil.getLayoutTemplate(layoutTemplateId, false, selLayoutTheme.getThemeId());
@@ -61,7 +61,7 @@ if (selLayout != null) {
 	value="customization-settings"
 />
 
-<aui:model-context bean="<%= selLayout %>" model="<%= Layout.class %>" />
+<aui:model-context bean="<%= configLayout %>" model="<%= Layout.class %>" />
 
 <c:choose>
 	<c:when test="<%= prototypeGroup %>">
@@ -70,7 +70,7 @@ if (selLayout != null) {
 		</div>
 	</c:when>
 	<c:otherwise>
-		<aui:input aria-describedby='<%= liferayPortletResponse.getNamespace() + "customizableDescription" %>' label="customizable" labelCssClass="font-weight-normal" name='<%= "TypeSettingsProperties--" + LayoutConstants.CUSTOMIZABLE_LAYOUT + "--" %>' type="checkbox" value="<%= selLayout.isCustomizable() %>" wrapperCssClass="c-mb-2" />
+		<aui:input aria-describedby='<%= liferayPortletResponse.getNamespace() + "customizableDescription" %>' label="customizable" labelCssClass="font-weight-normal" name='<%= "TypeSettingsProperties--" + LayoutConstants.CUSTOMIZABLE_LAYOUT + "--" %>' type="checkbox" value="<%= configLayout.isCustomizable() %>" wrapperCssClass="c-mb-2" />
 
 		<p class="text-3 text-secondary" id="<portlet:namespace />customizableDescription">
 			<liferay-ui:message key="customizable-help" />

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/javascript.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/javascript.jsp
@@ -17,12 +17,12 @@
 <%@ include file="/init.jsp" %>
 
 <%
-Layout selLayout = layoutsAdminDisplayContext.getSelLayout();
+Layout configLayout = layoutsAdminDisplayContext.getConfigLayout();
 
 UnicodeProperties layoutTypeSettingsUnicodeProperties = null;
 
-if (selLayout != null) {
-	layoutTypeSettingsUnicodeProperties = selLayout.getTypeSettingsProperties();
+if (configLayout != null) {
+	layoutTypeSettingsUnicodeProperties = configLayout.getTypeSettingsProperties();
 }
 %>
 
@@ -31,7 +31,7 @@ if (selLayout != null) {
 	value="javascript"
 />
 
-<aui:model-context bean="<%= selLayout %>" model="<%= Layout.class %>" />
+<aui:model-context bean="<%= configLayout %>" model="<%= Layout.class %>" />
 
 <%
 LayoutLookAndFeelDisplayContext layoutLookAndFeelDisplayContext = new LayoutLookAndFeelDisplayContext(request, layoutsAdminDisplayContext, liferayPortletResponse);
@@ -44,7 +44,7 @@ LayoutLookAndFeelDisplayContext layoutLookAndFeelDisplayContext = new LayoutLook
 >
 	<react:component
 		module="js/layout/look_and_feel/GlobalJSCETsConfiguration"
-		props="<%= layoutLookAndFeelDisplayContext.getGlobalJSCETsConfigurationProps(Layout.class.getName(), selLayout.getPlid()) %>"
+		props="<%= layoutLookAndFeelDisplayContext.getGlobalJSCETsConfigurationProps(Layout.class.getName(), configLayout.getPlid()) %>"
 	/>
 </liferay-frontend:fieldset>
 
@@ -53,7 +53,7 @@ LayoutLookAndFeelDisplayContext layoutLookAndFeelDisplayContext = new LayoutLook
 	collapsible="<%= true %>"
 	label="custom-javascript"
 >
-	<aui:input cssClass="propagatable-field" disabled="<%= layoutsAdminDisplayContext.isReadOnly() || selLayout.isLayoutPrototypeLinkActive() %>" label="javascript" name="TypeSettingsProperties--javascript--" placeholder="javascript" type="textarea" value='<%= layoutTypeSettingsUnicodeProperties.getProperty("javascript") %>' wrap="soft" wrapperCssClass="c-mb-0" />
+	<aui:input cssClass="propagatable-field" disabled="<%= layoutsAdminDisplayContext.isReadOnly() || configLayout.isLayoutPrototypeLinkActive() %>" label="javascript" name="TypeSettingsProperties--javascript--" placeholder="javascript" type="textarea" value='<%= layoutTypeSettingsUnicodeProperties.getProperty("javascript") %>' wrap="soft" wrapperCssClass="c-mb-0" />
 
 	<p class="text-secondary">
 		<liferay-ui:message key="this-javascript-code-is-executed-at-the-bottom-of-the-page" />

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/screen/navigation/entries/design.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/screen/navigation/entries/design.jsp
@@ -54,7 +54,7 @@ LayoutRevision layoutRevision = LayoutStagingUtil.getLayoutRevision(selLayout);
 	<aui:input name="groupId" type="hidden" value="<%= layoutsAdminDisplayContext.getGroupId() %>" />
 	<aui:input name="liveGroupId" type="hidden" value="<%= layoutsAdminDisplayContext.getLiveGroupId() %>" />
 	<aui:input name="stagingGroupId" type="hidden" value="<%= layoutsAdminDisplayContext.getStagingGroupId() %>" />
-	<aui:input name="selPlid" type="hidden" value="<%= layoutsAdminDisplayContext.getSelPlid() %>" />
+	<aui:input name="selPlid" type="hidden" value="<%= layoutsAdminDisplayContext.getConfigLayoutPlid() %>" />
 	<aui:input name="type" type="hidden" value="<%= selLayout.getType() %>" />
 	<aui:input name="<%= PortletDataHandlerKeys.SELECTED_LAYOUTS %>" type="hidden" />
 

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/theme.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/theme.jsp
@@ -23,7 +23,7 @@ LayoutSet layoutSet = layoutsAdminDisplayContext.getSelLayoutSet();
 
 Theme rootTheme = layoutSet.getTheme();
 
-Layout selLayout = layoutsAdminDisplayContext.getSelLayout();
+Layout configLayout = layoutsAdminDisplayContext.getConfigLayout();
 
 PortletURL redirectURL = layoutsAdminDisplayContext.getRedirectURL();
 %>
@@ -33,7 +33,7 @@ PortletURL redirectURL = layoutsAdminDisplayContext.getRedirectURL();
 	value="look-and-feel"
 />
 
-<aui:model-context bean="<%= selLayout %>" model="<%= Layout.class %>" />
+<aui:model-context bean="<%= configLayout %>" model="<%= Layout.class %>" />
 
 <liferay-util:buffer
 	var="rootNodeNameLink"
@@ -64,7 +64,7 @@ else {
 
 <div id="<portlet:namespace />themeContainer">
 	<clay:radio
-		checked="<%= selLayout.isInheritLookAndFeel() %>"
+		checked="<%= configLayout.isInheritLookAndFeel() %>"
 		disabled="<%= layoutsAdminDisplayContext.isReadOnly() %>"
 		id='<%= liferayPortletResponse.getNamespace() + "regularInheritLookAndFeel" %>'
 		label="<%= taglibLabel %>"
@@ -73,7 +73,7 @@ else {
 	/>
 
 	<clay:radio
-		checked="<%= !selLayout.isInheritLookAndFeel() %>"
+		checked="<%= !configLayout.isInheritLookAndFeel() %>"
 		disabled="<%= layoutsAdminDisplayContext.isReadOnly() %>"
 		id='<%= liferayPortletResponse.getNamespace() + "regularUniqueLookAndFeel" %>'
 		label='<%= LanguageUtil.get(request, "define-a-custom-theme-for-this-page") %>'
@@ -82,7 +82,7 @@ else {
 	/>
 
 	<c:if test="<%= !group.isLayoutPrototype() %>">
-		<div class="lfr-inherit-theme-options <%= selLayout.isInheritLookAndFeel() ? StringPool.BLANK : "hide" %>" id="<portlet:namespace />inheritThemeOptions">
+		<div class="lfr-inherit-theme-options <%= configLayout.isInheritLookAndFeel() ? StringPool.BLANK : "hide" %>" id="<portlet:namespace />inheritThemeOptions">
 			<liferay-util:include page="/look_and_feel_themes.jsp" servletContext="<%= application %>">
 				<liferay-util:param name="companyId" value="<%= String.valueOf(group.getCompanyId()) %>" />
 				<liferay-util:param name="editable" value="<%= Boolean.FALSE.toString() %>" />
@@ -91,7 +91,7 @@ else {
 		</div>
 	</c:if>
 
-	<div class="lfr-inherit-theme-options <%= !selLayout.isInheritLookAndFeel() ? StringPool.BLANK : "hide" %>" id="<portlet:namespace />themeOptions">
+	<div class="lfr-inherit-theme-options <%= !configLayout.isInheritLookAndFeel() ? StringPool.BLANK : "hide" %>" id="<portlet:namespace />themeOptions">
 		<liferay-util:include page="/look_and_feel_themes.jsp" servletContext="<%= application %>" />
 	</div>
 </div>
@@ -123,7 +123,7 @@ else {
 
 	const sheet = themeContainer.closest('.sheet');
 
-	if (<%= selLayout.getMasterLayoutPlid() > 0 %>) {
+	if (<%= configLayout.getMasterLayoutPlid() > 0 %>) {
 		sheet.classList.add('hide');
 		sheet.setAttribute('aria-hidden', 'true');
 	}

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/look_and_feel_theme_details.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/look_and_feel_theme_details.jsp
@@ -19,7 +19,7 @@
 <%
 String themeId = ParamUtil.getString(request, "themeId");
 
-Layout selLayout = layoutsAdminDisplayContext.getSelLayout();
+Layout configLayout = layoutsAdminDisplayContext.getConfigLayout();
 LayoutSet selLayoutSet = layoutsAdminDisplayContext.getSelLayoutSet();
 
 Theme selTheme = null;
@@ -34,9 +34,9 @@ if (Validator.isNotNull(themeId)) {
 	useDefaultThemeSettings = true;
 }
 else {
-	if (selLayout != null) {
-		selTheme = selLayout.getTheme();
-		selColorScheme = selLayout.getColorScheme();
+	if (configLayout != null) {
+		selTheme = configLayout.getTheme();
+		selColorScheme = configLayout.getColorScheme();
 	}
 	else {
 		selTheme = selLayoutSet.getTheme();
@@ -105,8 +105,8 @@ String styleBookWarningMessage = layoutsAdminDisplayContext.getStyleBookWarningM
 					value = selTheme.getSetting(entry.getKey());
 				}
 				else {
-					if (selLayout != null) {
-						value = selLayout.getThemeSetting(entry.getKey(), "regular");
+					if (configLayout != null) {
+						value = configLayout.getThemeSetting(entry.getKey(), "regular");
 					}
 					else {
 						value = selLayoutSet.getThemeSetting(entry.getKey(), "regular");

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/look_and_feel_themes_info.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/look_and_feel_themes_info.jsp
@@ -22,13 +22,13 @@ String themeId = ParamUtil.getString(request, "themeId");
 
 Theme selTheme = null;
 
-Layout selLayout = layoutsAdminDisplayContext.getSelLayout();
+Layout configLayout = layoutsAdminDisplayContext.getConfigLayout();
 
 if (Validator.isNotNull(themeId) && Validator.isNotNull(companyId)) {
 	selTheme = ThemeLocalServiceUtil.getTheme(companyId, themeId);
 }
-else if (selLayout == null) {
-	selTheme = selLayout.getTheme();
+else if (configLayout == null) {
+	selTheme = configLayout.getTheme();
 }
 
 PluginPackage selPluginPackage = selTheme.getPluginPackage();
@@ -95,7 +95,7 @@ PluginPackage selPluginPackage = selTheme.getPluginPackage();
 </c:if>
 
 <%
-ColorScheme selColorScheme = selLayout.getColorScheme();
+ColorScheme selColorScheme = configLayout.getColorScheme();
 
 List<ColorScheme> colorSchemes = selTheme.getColorSchemes();
 %>


### PR DESCRIPTION
Comming from : https://github.com/brianchandotcom/liferay-portal/pull/136222#issuecomment-1588550239

@brianchandotcom Related to the changes requested in the comment: I changed the methods to getConfigLayout and getConfigLayoutPlid because with this method we are returning the layout where to save the configuration and also now in the jsp's we have a variable layout created in the define objects tags, so , these are the reasons of the name.


Story: https://issues.liferay.com/browse/LPS-175136
Subtask: https://issues.liferay.com/browse/LPS-186288

Description
------
This changes are not at all related with the previous story, but the story related to this changes (https://issues.liferay.com/browse/LPS-175134) is in ready for release status, so, for that reason we are doing this changes here.  However, the two stories are part of the same epic and for that reason it is not a problem to add the changes here.

The explanation of these changes is that the design configurations have been moved from the draft page configurations to the public page configurations, but design configurations should continue apply to the draft page,so, **for that reason we have to show the draft configurations in the public page configurations**, and only to remember, the draft configurations will be copied to the public layout when the user click on the publish button. 
