### PR TITLE
Lps 187404 2

### DIFF
--- a/modules/apps/external-reference/external-reference-service/bnd.bnd
+++ b/modules/apps/external-reference/external-reference-service/bnd.bnd
@@ -1,6 +1,4 @@
 Bundle-Name: Liferay External Reference Service
 Bundle-SymbolicName: com.liferay.external.reference.service
 Bundle-Version: 4.0.14
-Liferay-Require-SchemaVersion: 1.0.0
-Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/flags/flags-service/bnd.bnd
+++ b/modules/apps/flags/flags-service/bnd.bnd
@@ -1,6 +1,4 @@
 Bundle-Name: Liferay Flags Service
 Bundle-SymbolicName: com.liferay.flags.service
 Bundle-Version: 6.0.24
-Liferay-Require-SchemaVersion: 2.0.1
-Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/portal-instances/portal-instances-service/bnd.bnd
+++ b/modules/apps/portal-instances/portal-instances-service/bnd.bnd
@@ -1,6 +1,4 @@
 Bundle-Name: Liferay Portal Instances Service
 Bundle-SymbolicName: com.liferay.portal.instances.service
 Bundle-Version: 5.0.28
-Liferay-Require-SchemaVersion: 1.0.0
-Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/portal/portal-aop-impl/src/main/java/com/liferay/portal/aop/internal/AopServiceManager.java
+++ b/modules/apps/portal/portal-aop-impl/src/main/java/com/liferay/portal/aop/internal/AopServiceManager.java
@@ -107,8 +107,9 @@ public class AopServiceManager {
 
 				if (transactionExecutor == null) {
 					throw new IllegalStateException(
-						"Unable to locate transaction executor for bundle " +
-							bundleId);
+						StringBundler.concat(
+							"Unable to locate transaction executor for bundle ",
+							bundleId, ", service ", aopService));
 				}
 
 				aopServiceRegistrar.register(transactionExecutor);

--- a/modules/dxp/apps/osb/osb-testray/osb-testray-service/bnd.bnd
+++ b/modules/dxp/apps/osb/osb-testray/osb-testray-service/bnd.bnd
@@ -1,6 +1,4 @@
 Bundle-Name: Liferay OSB Testray Service
 Bundle-SymbolicName: com.liferay.osb.testray.service
 Bundle-Version: 1.0.0
-Liferay-Require-SchemaVersion: 1.0.0
-Liferay-Service: true
 -dsannotations-options: inherit


### PR DESCRIPTION
@ling-alan-huang can you add a SF check for this?
Basically "Liferay-Require-SchemaVersion" and "Liferay-Service" in bnd.bnd can only be used for modules with service.xml that contains real entities. If the module does not contain service.xml or the service.xml only contains empty entity with no columns, the bnd.bnd should not use those 2 headers.