### PR TITLE
LPS-181918 Support default value

### DIFF
--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBInspectorTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBInspectorTest.java
@@ -61,8 +61,10 @@ public class DBInspectorTest {
 				"key, notNilColumn VARCHAR(75) not null, nilColumn ",
 				"VARCHAR(75) null, typeBlob BLOB, typeBoolean BOOLEAN,",
 				"typeDate DATE null, typeDouble DOUBLE, typeInteger INTEGER, ",
-				"typeLong LONG null, typeSBlob SBLOB, typeString STRING null, ",
-				"typeText TEXT null, typeVarchar VARCHAR(75) null);"));
+				"typeLong LONG null, typeLongDefault LONG default 10 not null,",
+				"typeSBlob SBLOB, typeString STRING null, ",
+				"typeText TEXT null, typeVarchar VARCHAR(75) null, ",
+				"typeVarcharDefault VARCHAR(10) default 'testValue' not null);"));
 	}
 
 	@AfterClass
@@ -189,6 +191,28 @@ public class DBInspectorTest {
 		Assert.assertFalse(
 			_dbInspector.hasColumnType(
 				_TABLE_NAME, "nilColumn", "VARCHAR(75) not null"));
+	}
+
+	@Test
+	public void testHasColumnTypeLongDefaultNotNull() throws Exception {
+		Assert.assertTrue(
+			_dbInspector.hasColumnType(
+				_TABLE_NAME, "typeLongDefault", "LONG default 10 not null"));
+
+		Assert.assertFalse(
+			_dbInspector.hasColumnType(
+				_TABLE_NAME, "typeLongDefault", "LONG default 15 not null"));
+	}
+
+	@Test
+	public void testHasColumnTypeVarcharDefaultNotNull() throws Exception {
+		Assert.assertTrue(
+			_dbInspector.hasColumnType(
+				_TABLE_NAME, "typeVarcharDefault", "VARCHAR(10) default 'testValue' not null"));
+
+		Assert.assertFalse(
+			_dbInspector.hasColumnType(
+				_TABLE_NAME, "typeVarcharDefault", "VARCHAR(10) default 'notTestValue' not null"));
 	}
 
 	@Test

--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBInspectorTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBInspectorTest.java
@@ -62,9 +62,9 @@ public class DBInspectorTest {
 				"VARCHAR(75) null, typeBlob BLOB, typeBoolean BOOLEAN,",
 				"typeDate DATE null, typeDouble DOUBLE, typeInteger INTEGER, ",
 				"typeLong LONG null, typeLongDefault LONG default 10 not null,",
-				"typeSBlob SBLOB, typeString STRING null, ",
-				"typeText TEXT null, typeVarchar VARCHAR(75) null, ",
-				"typeVarcharDefault VARCHAR(10) default 'testValue' not null);"));
+				"typeSBlob SBLOB, typeString STRING null, typeText TEXT null, ",
+				"typeVarchar VARCHAR(75) null, typeVarcharDefault VARCHAR(10) ",
+				"default 'testValue' not null);"));
 	}
 
 	@AfterClass
@@ -136,6 +136,17 @@ public class DBInspectorTest {
 	}
 
 	@Test
+	public void testHasColumnTypeLongDefaultNotNull() throws Exception {
+		Assert.assertTrue(
+			_dbInspector.hasColumnType(
+				_TABLE_NAME, "typeLongDefault", "LONG default 10 not null"));
+
+		Assert.assertFalse(
+			_dbInspector.hasColumnType(
+				_TABLE_NAME, "typeLongDefault", "LONG default 15 not null"));
+	}
+
+	@Test
 	public void testHasColumnTypeSBlob() throws Exception {
 		Assert.assertTrue(
 			_dbInspector.hasColumnType(_TABLE_NAME, "typeSBlob", "SBLOB null"));
@@ -159,6 +170,19 @@ public class DBInspectorTest {
 		Assert.assertTrue(
 			_dbInspector.hasColumnType(
 				_TABLE_NAME, "typeVarchar", "VARCHAR(75) null"));
+	}
+
+	@Test
+	public void testHasColumnTypeVarcharDefaultNotNull() throws Exception {
+		Assert.assertTrue(
+			_dbInspector.hasColumnType(
+				_TABLE_NAME, "typeVarcharDefault",
+				"VARCHAR(10) default 'testValue' not null"));
+
+		Assert.assertFalse(
+			_dbInspector.hasColumnType(
+				_TABLE_NAME, "typeVarcharDefault",
+				"VARCHAR(10) default 'notTestValue' not null"));
 	}
 
 	@Test
@@ -191,28 +215,6 @@ public class DBInspectorTest {
 		Assert.assertFalse(
 			_dbInspector.hasColumnType(
 				_TABLE_NAME, "nilColumn", "VARCHAR(75) not null"));
-	}
-
-	@Test
-	public void testHasColumnTypeLongDefaultNotNull() throws Exception {
-		Assert.assertTrue(
-			_dbInspector.hasColumnType(
-				_TABLE_NAME, "typeLongDefault", "LONG default 10 not null"));
-
-		Assert.assertFalse(
-			_dbInspector.hasColumnType(
-				_TABLE_NAME, "typeLongDefault", "LONG default 15 not null"));
-	}
-
-	@Test
-	public void testHasColumnTypeVarcharDefaultNotNull() throws Exception {
-		Assert.assertTrue(
-			_dbInspector.hasColumnType(
-				_TABLE_NAME, "typeVarcharDefault", "VARCHAR(10) default 'testValue' not null"));
-
-		Assert.assertFalse(
-			_dbInspector.hasColumnType(
-				_TABLE_NAME, "typeVarcharDefault", "VARCHAR(10) default 'notTestValue' not null"));
 	}
 
 	@Test

--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -286,7 +286,7 @@ public class DBTest {
 				_TABLE_NAME_1, "testColumn",
 				"VARCHAR(40) default 'test value' not null"));
 	}
-
+	
 	@Test
 	public void testAlterTableDropIndexedColumn() throws Exception {
 		_addIndex(new String[] {"typeVarchar", "typeBoolean"});

--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -286,7 +286,7 @@ public class DBTest {
 				_TABLE_NAME_1, "testColumn",
 				"VARCHAR(40) default 'test value' not null"));
 	}
-	
+
 	@Test
 	public void testAlterTableDropIndexedColumn() throws Exception {
 		_addIndex(new String[] {"typeVarchar", "typeBoolean"});

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/OracleDB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/OracleDB.java
@@ -244,6 +244,7 @@ public class OracleDB extends BaseDB {
 		}
 	}
 
+	@Override
 	protected boolean isSupportsDuplicatedIndexName() {
 		return _SUPPORTS_DUPLICATED_INDEX_NAME;
 	}

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SQLServerDB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SQLServerDB.java
@@ -109,9 +109,8 @@ public class SQLServerDB extends BaseDB {
 	}
 
 	@Override
-	public String getDefaultValue(String databaseStoredDefaultValue) {
-		Matcher matcher = databaseStoredDefaultValuePattern.matcher(
-			databaseStoredDefaultValue);
+	public String getDefaultValue(String columnDef) {
+		Matcher matcher = defaultValuePattern.matcher(columnDef);
 
 		if (matcher.find()) {
 			if (matcher.group(1) == null) {
@@ -121,7 +120,7 @@ public class SQLServerDB extends BaseDB {
 			return matcher.group(1);
 		}
 
-		return databaseStoredDefaultValue;
+		return columnDef;
 	}
 
 	@Override
@@ -311,9 +310,8 @@ public class SQLServerDB extends BaseDB {
 		}
 	}
 
-	protected static final Pattern databaseStoredDefaultValuePattern =
-		Pattern.compile(
-			"^\\('(.*)'\\)|\\(\\((\\d*)\\)\\)", Pattern.CASE_INSENSITIVE);
+	protected static final Pattern defaultValuePattern = Pattern.compile(
+		"^\\('(.*)'\\)|\\(\\((\\d*)\\)\\)", Pattern.CASE_INSENSITIVE);
 
 	private void _dropDefaultConstraint(
 			Connection connection, String tableName, String columnName)

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SQLServerDB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SQLServerDB.java
@@ -114,7 +114,6 @@ public class SQLServerDB extends BaseDB {
 			databaseStoredDefaultValue);
 
 		if (matcher.find()) {
-
 			if (matcher.group(1) == null) {
 				return matcher.group(2);
 			}

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SQLServerDB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SQLServerDB.java
@@ -110,7 +110,7 @@ public class SQLServerDB extends BaseDB {
 
 	@Override
 	public String getDefaultValue(String columnDef) {
-		Matcher matcher = defaultValuePattern.matcher(columnDef);
+		Matcher matcher = _defaultValuePattern.matcher(columnDef);
 
 		if (matcher.find()) {
 			if (matcher.group(1) == null) {
@@ -310,9 +310,6 @@ public class SQLServerDB extends BaseDB {
 		}
 	}
 
-	protected static final Pattern defaultValuePattern = Pattern.compile(
-		"^\\('(.*)'\\)|\\(\\((\\d*)\\)\\)", Pattern.CASE_INSENSITIVE);
-
 	private void _dropDefaultConstraint(
 			Connection connection, String tableName, String columnName)
 		throws Exception {
@@ -370,5 +367,8 @@ public class SQLServerDB extends BaseDB {
 	};
 
 	private static final boolean _SUPPORTS_NEW_UUID_FUNCTION = true;
+
+	private static final Pattern _defaultValuePattern = Pattern.compile(
+		"^\\('(.*)'\\)|\\(\\((\\d*)\\)\\)", Pattern.CASE_INSENSITIVE);
 
 }

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SQLServerDB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SQLServerDB.java
@@ -37,6 +37,8 @@ import java.sql.Types;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * @author Alexander Chow
@@ -104,6 +106,23 @@ public class SQLServerDB extends BaseDB {
 			new String[] {"\\", "''", "\"", "\n", "\r"});
 
 		return template;
+	}
+
+	@Override
+	public String getDefaultValue(String databaseStoredDefaultValue) {
+		Matcher matcher = databaseStoredDefaultValuePattern.matcher(
+			databaseStoredDefaultValue);
+
+		if (matcher.find()) {
+
+			if (matcher.group(1) == null) {
+				return matcher.group(2);
+			}
+
+			return matcher.group(1);
+		}
+
+		return databaseStoredDefaultValue;
 	}
 
 	@Override
@@ -292,6 +311,10 @@ public class SQLServerDB extends BaseDB {
 			return sb.toString();
 		}
 	}
+
+	protected static final Pattern databaseStoredDefaultValuePattern =
+		Pattern.compile(
+			"^\\('(.*)'\\)|\\(\\((\\d*)\\)\\)", Pattern.CASE_INSENSITIVE);
 
 	private void _dropDefaultConstraint(
 			Connection connection, String tableName, String columnName)

--- a/modules/dxp/apps/portal/portal-dao-db/src/test/java/com/liferay/portal/dao/db/DB2DBTest.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/test/java/com/liferay/portal/dao/db/DB2DBTest.java
@@ -36,15 +36,11 @@ public class DB2DBTest extends BaseDBTestCase {
 
 	@Test
 	public void testGetLongDefaultValue() {
-		DB db = getDB();
-
 		Assert.assertEquals("10", db.getDefaultValue("10"));
 	}
 
 	@Test
 	public void testGetVarcharDefaultValue() {
-		DB db = getDB();
-
 		Assert.assertEquals("test", db.getDefaultValue("'test'"));
 	}
 

--- a/modules/dxp/apps/portal/portal-dao-db/src/test/java/com/liferay/portal/dao/db/DB2DBTest.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/test/java/com/liferay/portal/dao/db/DB2DBTest.java
@@ -35,6 +35,20 @@ public class DB2DBTest extends BaseDBTestCase {
 		LiferayUnitTestRule.INSTANCE;
 
 	@Test
+	public void testGetVarcharDefaultValue() {
+		DB db = getDB();
+
+		Assert.assertEquals(db.getDefaultValue("'test'"), "test");
+	}
+
+	@Test
+	public void testGetLongDefaultValue() {
+		DB db = getDB();
+
+		Assert.assertEquals(db.getDefaultValue("10"), "10");
+	}
+
+	@Test
 	public void testRewordAlterColumnType() throws Exception {
 		Assert.assertEquals(
 			"alter table DLFolder alter column userName set data type " +

--- a/modules/dxp/apps/portal/portal-dao-db/src/test/java/com/liferay/portal/dao/db/DB2DBTest.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/test/java/com/liferay/portal/dao/db/DB2DBTest.java
@@ -35,17 +35,17 @@ public class DB2DBTest extends BaseDBTestCase {
 		LiferayUnitTestRule.INSTANCE;
 
 	@Test
-	public void testGetVarcharDefaultValue() {
-		DB db = getDB();
-
-		Assert.assertEquals(db.getDefaultValue("'test'"), "test");
-	}
-
-	@Test
 	public void testGetLongDefaultValue() {
 		DB db = getDB();
 
-		Assert.assertEquals(db.getDefaultValue("10"), "10");
+		Assert.assertEquals("10", db.getDefaultValue("10"));
+	}
+
+	@Test
+	public void testGetVarcharDefaultValue() {
+		DB db = getDB();
+
+		Assert.assertEquals("test", db.getDefaultValue("'test'"));
 	}
 
 	@Test

--- a/modules/dxp/apps/portal/portal-dao-db/src/test/java/com/liferay/portal/dao/db/OracleDBTest.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/test/java/com/liferay/portal/dao/db/OracleDBTest.java
@@ -344,6 +344,20 @@ public class OracleDBTest extends BaseDBTestCase {
 	}
 
 	@Test
+	public void testGetVarcharDefaultValue() {
+		DB db = getDB();
+
+		Assert.assertEquals(db.getDefaultValue("'test'"), "test");
+	}
+
+	@Test
+	public void testGetLongDefaultValue() {
+		DB db = getDB();
+
+		Assert.assertEquals(db.getDefaultValue("10 "), "10");
+	}
+
+	@Test
 	public void testRewordAlterColumnType() throws Exception {
 		Assert.assertEquals(
 			"alter table DLFolder modify userName VARCHAR2(75 CHAR);\n",

--- a/modules/dxp/apps/portal/portal-dao-db/src/test/java/com/liferay/portal/dao/db/OracleDBTest.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/test/java/com/liferay/portal/dao/db/OracleDBTest.java
@@ -344,17 +344,17 @@ public class OracleDBTest extends BaseDBTestCase {
 	}
 
 	@Test
-	public void testGetVarcharDefaultValue() {
-		DB db = getDB();
-
-		Assert.assertEquals(db.getDefaultValue("'test'"), "test");
-	}
-
-	@Test
 	public void testGetLongDefaultValue() {
 		DB db = getDB();
 
-		Assert.assertEquals(db.getDefaultValue("10 "), "10");
+		Assert.assertEquals("10", db.getDefaultValue("10 "));
+	}
+
+	@Test
+	public void testGetVarcharDefaultValue() {
+		DB db = getDB();
+
+		Assert.assertEquals("test", db.getDefaultValue("'test'"));
 	}
 
 	@Test

--- a/modules/dxp/apps/portal/portal-dao-db/src/test/java/com/liferay/portal/dao/db/OracleDBTest.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/test/java/com/liferay/portal/dao/db/OracleDBTest.java
@@ -345,15 +345,11 @@ public class OracleDBTest extends BaseDBTestCase {
 
 	@Test
 	public void testGetLongDefaultValue() {
-		DB db = getDB();
-
 		Assert.assertEquals("10", db.getDefaultValue("10 "));
 	}
 
 	@Test
 	public void testGetVarcharDefaultValue() {
-		DB db = getDB();
-
 		Assert.assertEquals("test", db.getDefaultValue("'test'"));
 	}
 

--- a/modules/dxp/apps/portal/portal-dao-db/src/test/java/com/liferay/portal/dao/db/SQLServerDBTest.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/test/java/com/liferay/portal/dao/db/SQLServerDBTest.java
@@ -35,6 +35,20 @@ public class SQLServerDBTest extends BaseDBTestCase {
 		LiferayUnitTestRule.INSTANCE;
 
 	@Test
+	public void testGetVarcharDefaultValue() {
+		DB db = getDB();
+
+		Assert.assertEquals(db.getDefaultValue("('test')"), "test");
+	}
+
+	@Test
+	public void testGetLongDefaultValue() {
+		DB db = getDB();
+
+		Assert.assertEquals(db.getDefaultValue("((10))"), "10");
+	}
+
+	@Test
 	public void testRewordAlterColumnType() throws Exception {
 		Assert.assertEquals(
 			"alter table DLFolder alter column userName nvarchar(75);\n",

--- a/modules/dxp/apps/portal/portal-dao-db/src/test/java/com/liferay/portal/dao/db/SQLServerDBTest.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/test/java/com/liferay/portal/dao/db/SQLServerDBTest.java
@@ -35,17 +35,17 @@ public class SQLServerDBTest extends BaseDBTestCase {
 		LiferayUnitTestRule.INSTANCE;
 
 	@Test
-	public void testGetVarcharDefaultValue() {
-		DB db = getDB();
-
-		Assert.assertEquals(db.getDefaultValue("('test')"), "test");
-	}
-
-	@Test
 	public void testGetLongDefaultValue() {
 		DB db = getDB();
 
-		Assert.assertEquals(db.getDefaultValue("((10))"), "10");
+		Assert.assertEquals("10", db.getDefaultValue("((10))"));
+	}
+
+	@Test
+	public void testGetVarcharDefaultValue() {
+		DB db = getDB();
+
+		Assert.assertEquals("test", db.getDefaultValue("('test')"));
 	}
 
 	@Test

--- a/modules/dxp/apps/portal/portal-dao-db/src/test/java/com/liferay/portal/dao/db/SQLServerDBTest.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/test/java/com/liferay/portal/dao/db/SQLServerDBTest.java
@@ -36,15 +36,11 @@ public class SQLServerDBTest extends BaseDBTestCase {
 
 	@Test
 	public void testGetLongDefaultValue() {
-		DB db = getDB();
-
 		Assert.assertEquals("10", db.getDefaultValue("((10))"));
 	}
 
 	@Test
 	public void testGetVarcharDefaultValue() {
-		DB db = getDB();
-
 		Assert.assertEquals("test", db.getDefaultValue("('test')"));
 	}
 

--- a/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
@@ -297,6 +297,18 @@ public abstract class BaseDB implements DB {
 	}
 
 	@Override
+	public String getDefaultValue(String databaseStoredDefaultValue) {
+		Matcher matcher = databaseStoredDefaultValuePattern.matcher(
+			databaseStoredDefaultValue);
+
+		if (matcher.find()) {
+			return matcher.group(2);
+		}
+
+		return databaseStoredDefaultValue;
+	}
+
+	@Override
 	public List<Index> getIndexes(Connection connection) throws SQLException {
 		return TransformUtil.transform(
 			getIndexes(connection, null, null, false),
@@ -1054,6 +1066,8 @@ public abstract class BaseDB implements DB {
 
 	protected static final Pattern columnTypePattern = Pattern.compile(
 		"(^\\w+)", Pattern.CASE_INSENSITIVE);
+	protected static final Pattern databaseStoredDefaultValuePattern =
+		Pattern.compile("^('?)(\\d+|.*)\\1(::.*| )?", Pattern.CASE_INSENSITIVE);
 
 	private void _addIndexes(
 			Connection connection, String indexesSQL,

--- a/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
@@ -298,7 +298,7 @@ public abstract class BaseDB implements DB {
 
 	@Override
 	public String getDefaultValue(String columnDef) {
-		Matcher matcher = defaultValuePattern.matcher(columnDef);
+		Matcher matcher = _defaultValuePattern.matcher(columnDef);
 
 		if (matcher.find()) {
 			return matcher.group(2);
@@ -1065,8 +1065,6 @@ public abstract class BaseDB implements DB {
 
 	protected static final Pattern columnTypePattern = Pattern.compile(
 		"(^\\w+)", Pattern.CASE_INSENSITIVE);
-	protected static final Pattern defaultValuePattern = Pattern.compile(
-		"^('?)(\\d+|.*)\\1(::.*| )?", Pattern.CASE_INSENSITIVE);
 
 	private void _addIndexes(
 			Connection connection, String indexesSQL,
@@ -1196,6 +1194,8 @@ public abstract class BaseDB implements DB {
 
 	private static final Pattern _columnLengthPattern = Pattern.compile(
 		"([^,(\\s]+)\\[\\$COLUMN_LENGTH:(\\d+)\\$\\]");
+	private static final Pattern _defaultValuePattern = Pattern.compile(
+		"^('?)(\\d+|.*)\\1(::.*| )?", Pattern.CASE_INSENSITIVE);
 	private static final Pattern _templatePattern;
 
 	static {

--- a/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
@@ -297,15 +297,14 @@ public abstract class BaseDB implements DB {
 	}
 
 	@Override
-	public String getDefaultValue(String databaseStoredDefaultValue) {
-		Matcher matcher = databaseStoredDefaultValuePattern.matcher(
-			databaseStoredDefaultValue);
+	public String getDefaultValue(String columnDef) {
+		Matcher matcher = defaultValuePattern.matcher(columnDef);
 
 		if (matcher.find()) {
 			return matcher.group(2);
 		}
 
-		return databaseStoredDefaultValue;
+		return columnDef;
 	}
 
 	@Override
@@ -1066,8 +1065,8 @@ public abstract class BaseDB implements DB {
 
 	protected static final Pattern columnTypePattern = Pattern.compile(
 		"(^\\w+)", Pattern.CASE_INSENSITIVE);
-	protected static final Pattern databaseStoredDefaultValuePattern =
-		Pattern.compile("^('?)(\\d+|.*)\\1(::.*| )?", Pattern.CASE_INSENSITIVE);
+	protected static final Pattern defaultValuePattern = Pattern.compile(
+		"^('?)(\\d+|.*)\\1(::.*| )?", Pattern.CASE_INSENSITIVE);
 
 	private void _addIndexes(
 			Connection connection, String indexesSQL,

--- a/portal-impl/test/unit/com/liferay/portal/dao/db/MySQLDBTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/dao/db/MySQLDBTest.java
@@ -35,6 +35,19 @@ public class MySQLDBTest extends BaseDBTestCase {
 		LiferayUnitTestRule.INSTANCE;
 
 	@Test
+	public void testGetVarcharDefaultValue() {
+		DB db = getDB();
+
+		Assert.assertEquals(db.getDefaultValue("test"), "test");
+	}
+
+	@Test
+	public void testGetLongDefaultValue() {
+		DB db = getDB();
+
+		Assert.assertEquals(db.getDefaultValue("10"), "10");
+	}
+	@Test
 	public void testRewordAlterColumnType() throws Exception {
 		Assert.assertEquals(
 			"alter table DLFolder modify userName varchar(75);\n",

--- a/portal-impl/test/unit/com/liferay/portal/dao/db/MySQLDBTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/dao/db/MySQLDBTest.java
@@ -36,15 +36,11 @@ public class MySQLDBTest extends BaseDBTestCase {
 
 	@Test
 	public void testGetLongDefaultValue() {
-		DB db = getDB();
-
 		Assert.assertEquals("10", db.getDefaultValue("10"));
 	}
 
 	@Test
 	public void testGetVarcharDefaultValue() {
-		DB db = getDB();
-
 		Assert.assertEquals("test", db.getDefaultValue("test"));
 	}
 

--- a/portal-impl/test/unit/com/liferay/portal/dao/db/MySQLDBTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/dao/db/MySQLDBTest.java
@@ -35,18 +35,19 @@ public class MySQLDBTest extends BaseDBTestCase {
 		LiferayUnitTestRule.INSTANCE;
 
 	@Test
-	public void testGetVarcharDefaultValue() {
-		DB db = getDB();
-
-		Assert.assertEquals(db.getDefaultValue("test"), "test");
-	}
-
-	@Test
 	public void testGetLongDefaultValue() {
 		DB db = getDB();
 
-		Assert.assertEquals(db.getDefaultValue("10"), "10");
+		Assert.assertEquals("10", db.getDefaultValue("10"));
 	}
+
+	@Test
+	public void testGetVarcharDefaultValue() {
+		DB db = getDB();
+
+		Assert.assertEquals("test", db.getDefaultValue("test"));
+	}
+
 	@Test
 	public void testRewordAlterColumnType() throws Exception {
 		Assert.assertEquals(

--- a/portal-impl/test/unit/com/liferay/portal/dao/db/PostgreSQLDBTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/dao/db/PostgreSQLDBTest.java
@@ -35,6 +35,19 @@ public class PostgreSQLDBTest extends BaseDBTestCase {
 		LiferayUnitTestRule.INSTANCE;
 
 	@Test
+	public void testGetVarcharDefaultValue() {
+		DB db = getDB();
+
+		Assert.assertEquals(db.getDefaultValue("'test'::type"), "test");
+	}
+
+	@Test
+	public void testGetLongDefaultValue() {
+		DB db = getDB();
+
+		Assert.assertEquals(db.getDefaultValue("10"), "10");
+	}
+	@Test
 	public void testRewordAlterColumnType() throws Exception {
 		Assert.assertEquals(
 			"alter table DLFolder alter userName type varchar(75) using " +

--- a/portal-impl/test/unit/com/liferay/portal/dao/db/PostgreSQLDBTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/dao/db/PostgreSQLDBTest.java
@@ -36,15 +36,11 @@ public class PostgreSQLDBTest extends BaseDBTestCase {
 
 	@Test
 	public void testGetLongDefaultValue() {
-		DB db = getDB();
-
 		Assert.assertEquals("10", db.getDefaultValue("10"));
 	}
 
 	@Test
 	public void testGetVarcharDefaultValue() {
-		DB db = getDB();
-
 		Assert.assertEquals("test", db.getDefaultValue("'test'::type"));
 	}
 

--- a/portal-impl/test/unit/com/liferay/portal/dao/db/PostgreSQLDBTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/dao/db/PostgreSQLDBTest.java
@@ -35,18 +35,19 @@ public class PostgreSQLDBTest extends BaseDBTestCase {
 		LiferayUnitTestRule.INSTANCE;
 
 	@Test
-	public void testGetVarcharDefaultValue() {
-		DB db = getDB();
-
-		Assert.assertEquals(db.getDefaultValue("'test'::type"), "test");
-	}
-
-	@Test
 	public void testGetLongDefaultValue() {
 		DB db = getDB();
 
-		Assert.assertEquals(db.getDefaultValue("10"), "10");
+		Assert.assertEquals("10", db.getDefaultValue("10"));
 	}
+
+	@Test
+	public void testGetVarcharDefaultValue() {
+		DB db = getDB();
+
+		Assert.assertEquals("test", db.getDefaultValue("'test'::type"));
+	}
+
 	@Test
 	public void testRewordAlterColumnType() throws Exception {
 		Assert.assertEquals(

--- a/portal-kernel/bnd.bnd
+++ b/portal-kernel/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 114.0.1
+Bundle-Version: 114.1.0
 Export-Package:\
 	!com.liferay.portal.kernel.internal.*,\
 	!com.liferay.portal.kernel.module.util,\

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/DB.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/DB.java
@@ -80,7 +80,7 @@ public interface DB {
 
 	public DBType getDBType();
 
-	public String getDefaultValue(String databaseStoredDefaultValue);
+	public String getDefaultValue(String columnDef);
 
 	public List<Index> getIndexes(Connection connection) throws SQLException;
 

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/DB.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/DB.java
@@ -80,6 +80,8 @@ public interface DB {
 
 	public DBType getDBType();
 
+	public String getDefaultValue(String databaseStoredDefaultValue);
+
 	public List<Index> getIndexes(Connection connection) throws SQLException;
 
 	public ResultSet getIndexResultSet(Connection connection, String tableName)

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/DBInspector.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/DBInspector.java
@@ -174,9 +174,7 @@ public class DBInspector {
 				return false;
 			}
 
-			if (!expectedColumnNullable &&
-				(actualColumnNullable == DatabaseMetaData.columnNoNulls)) {
-
+			if (!expectedColumnNullable) {
 				return StringUtil.equals(
 					_getColumnDefaultValue(columnType),
 					_getColumnDefaultValue(

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/DBInspector.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/DBInspector.java
@@ -187,7 +187,7 @@ public class DBInspector {
 					actualColumnDefaultValue = _getStoredColumnDefaultValue(
 						actualColumnDefaultValue, DB::getDefaultValue);
 				}
-				
+
 				return StringUtil.equals(
 					expectedColumnDefaultValue, actualColumnDefaultValue);
 			}
@@ -410,6 +410,7 @@ public class DBInspector {
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(DBInspector.class);
+
 	private static final Pattern _columnDefaultClausePattern = Pattern.compile(
 		".*DEFAULT '?(.*[^'])'? NOT NULL", Pattern.CASE_INSENSITIVE);
 	private static final Pattern _columnSizePattern = Pattern.compile(

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/packageinfo
@@ -1,1 +1,1 @@
-version 12.2.0
+version 12.3.0

--- a/portal-test/bnd.bnd
+++ b/portal-test/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 16.2.2
+Bundle-Version: 16.3.0
 Export-Package:\
 	com.liferay.portal.kernel.dao.db.test,\
 	com.liferay.portal.kernel.test,\

--- a/portal-test/src/com/liferay/portal/kernel/dao/db/test/BaseDBTestCase.java
+++ b/portal-test/src/com/liferay/portal/kernel/dao/db/test/BaseDBTestCase.java
@@ -36,8 +36,8 @@ public abstract class BaseDBTestCase {
 		Assert.assertEquals(
 			StringBundler.concat(
 				"select * from SomeTable where someColumn1 = ",
-				_db.getTemplateFalse(), " and someColumn2 = ",
-				_db.getTemplateTrue(), StringPool.NEW_LINE),
+				db.getTemplateFalse(), " and someColumn2 = ",
+				db.getTemplateTrue(), StringPool.NEW_LINE),
 			buildSQL(_BOOLEAN_LITERAL_QUERY));
 
 		Assert.assertEquals(
@@ -46,12 +46,14 @@ public abstract class BaseDBTestCase {
 	}
 
 	protected String buildSQL(String query) throws IOException, SQLException {
-		return _db.buildSQL(query);
+		return db.buildSQL(query);
 	}
 
 	protected abstract DB getDB();
 
 	protected static final String RENAME_TABLE_QUERY = "alter_table_name a b";
+
+	protected final DB db = getDB();
 
 	private static final String _BOOLEAN_LITERAL_QUERY =
 		"select * from SomeTable where someColumn1 = FALSE and someColumn2 = " +
@@ -60,7 +62,5 @@ public abstract class BaseDBTestCase {
 	private static final String _BOOLEAN_PATTERN_QUERY =
 		"select * from SomeTable where someColumn1 = [$FALSE$] and " +
 			"someColumn2 = [$TRUE$]";
-
-	private final DB _db = getDB();
 
 }

--- a/portal-test/src/com/liferay/portal/kernel/dao/db/test/packageinfo
+++ b/portal-test/src/com/liferay/portal/kernel/dao/db/test/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0


### PR DESCRIPTION
Hi @sofiamendozalr @luisortiz89,

Please check my changes. I simplified the code a bit and after that I think makes sense to use columnDef [here](https://github.com/brianchandotcom/liferay-portal/pull/136541/commits/39e96006d4427224d5101d1d8abc206813dd0fc8#diff-05477ecd6375c26fe1c6967cbe1a06891296f77f6cf8ed5d3b81e2557c277924R112) since it is what the DatabaseMetadata returns but I am not totally confident about what Brian will do.

On the other hand, @sofiamendozalr is there any reason to not add Hypersonic tests? We do not support upgrades with Hypersonic but maybe this API can be used in another context. This is not relevant but I just wanted to know.

Thanks!



