### PR TITLE
COMMERCE-11516 Adding onAfterRemove listener for AccountEntry to unlink CommerceCatalogs and CommerceChannels after account deletion

### DIFF
--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CommerceCatalogLocalService.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CommerceCatalogLocalService.java
@@ -317,6 +317,10 @@ public interface CommerceCatalogLocalService
 	public List<CommerceCatalog> getCommerceCatalogs(
 		long companyId, boolean system);
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<CommerceCatalog> getCommerceCatalogsByAccountEntryId(
+		long accountEntryId);
+
 	/**
 	 * Returns the number of commerce catalogs.
 	 *

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CommerceCatalogLocalServiceUtil.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CommerceCatalogLocalServiceUtil.java
@@ -364,6 +364,12 @@ public class CommerceCatalogLocalServiceUtil {
 		return getService().getCommerceCatalogs(companyId, system);
 	}
 
+	public static List<CommerceCatalog> getCommerceCatalogsByAccountEntryId(
+		long accountEntryId) {
+
+		return getService().getCommerceCatalogsByAccountEntryId(accountEntryId);
+	}
+
 	/**
 	 * Returns the number of commerce catalogs.
 	 *

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CommerceCatalogLocalServiceWrapper.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CommerceCatalogLocalServiceWrapper.java
@@ -410,6 +410,14 @@ public class CommerceCatalogLocalServiceWrapper
 			companyId, system);
 	}
 
+	@Override
+	public java.util.List<CommerceCatalog> getCommerceCatalogsByAccountEntryId(
+		long accountEntryId) {
+
+		return _commerceCatalogLocalService.getCommerceCatalogsByAccountEntryId(
+			accountEntryId);
+	}
+
 	/**
 	 * Returns the number of commerce catalogs.
 	 *

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CommerceChannelLocalService.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CommerceChannelLocalService.java
@@ -336,6 +336,10 @@ public interface CommerceChannelLocalService
 			long companyId, String keywords, int start, int end)
 		throws PortalException;
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<CommerceChannel> getCommerceChannelsByAccountEntryId(
+		long accountEntryId);
+
 	/**
 	 * Returns the number of commerce channels.
 	 *

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CommerceChannelLocalServiceUtil.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CommerceChannelLocalServiceUtil.java
@@ -399,6 +399,12 @@ public class CommerceChannelLocalServiceUtil {
 			companyId, keywords, start, end);
 	}
 
+	public static List<CommerceChannel> getCommerceChannelsByAccountEntryId(
+		long accountEntryId) {
+
+		return getService().getCommerceChannelsByAccountEntryId(accountEntryId);
+	}
+
 	/**
 	 * Returns the number of commerce channels.
 	 *

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CommerceChannelLocalServiceWrapper.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CommerceChannelLocalServiceWrapper.java
@@ -447,6 +447,14 @@ public class CommerceChannelLocalServiceWrapper
 			companyId, keywords, start, end);
 	}
 
+	@Override
+	public java.util.List<CommerceChannel> getCommerceChannelsByAccountEntryId(
+		long accountEntryId) {
+
+		return _commerceChannelLocalService.getCommerceChannelsByAccountEntryId(
+			accountEntryId);
+	}
+
 	/**
 	 * Returns the number of commerce channels.
 	 *

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/persistence/CommerceCatalogPersistence.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/persistence/CommerceCatalogPersistence.java
@@ -683,6 +683,215 @@ public interface CommerceCatalogPersistence
 	public int filterCountByCompanyId(long companyId);
 
 	/**
+	 * Returns all the commerce catalogs where accountEntryId = &#63;.
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @return the matching commerce catalogs
+	 */
+	public java.util.List<CommerceCatalog> findByAccountEntryId(
+		long accountEntryId);
+
+	/**
+	 * Returns a range of all the commerce catalogs where accountEntryId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>CommerceCatalogModelImpl</code>.
+	 * </p>
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @param start the lower bound of the range of commerce catalogs
+	 * @param end the upper bound of the range of commerce catalogs (not inclusive)
+	 * @return the range of matching commerce catalogs
+	 */
+	public java.util.List<CommerceCatalog> findByAccountEntryId(
+		long accountEntryId, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the commerce catalogs where accountEntryId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>CommerceCatalogModelImpl</code>.
+	 * </p>
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @param start the lower bound of the range of commerce catalogs
+	 * @param end the upper bound of the range of commerce catalogs (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching commerce catalogs
+	 */
+	public java.util.List<CommerceCatalog> findByAccountEntryId(
+		long accountEntryId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<CommerceCatalog>
+			orderByComparator);
+
+	/**
+	 * Returns an ordered range of all the commerce catalogs where accountEntryId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>CommerceCatalogModelImpl</code>.
+	 * </p>
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @param start the lower bound of the range of commerce catalogs
+	 * @param end the upper bound of the range of commerce catalogs (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching commerce catalogs
+	 */
+	public java.util.List<CommerceCatalog> findByAccountEntryId(
+		long accountEntryId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<CommerceCatalog>
+			orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Returns the first commerce catalog in the ordered set where accountEntryId = &#63;.
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching commerce catalog
+	 * @throws NoSuchCatalogException if a matching commerce catalog could not be found
+	 */
+	public CommerceCatalog findByAccountEntryId_First(
+			long accountEntryId,
+			com.liferay.portal.kernel.util.OrderByComparator<CommerceCatalog>
+				orderByComparator)
+		throws NoSuchCatalogException;
+
+	/**
+	 * Returns the first commerce catalog in the ordered set where accountEntryId = &#63;.
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching commerce catalog, or <code>null</code> if a matching commerce catalog could not be found
+	 */
+	public CommerceCatalog fetchByAccountEntryId_First(
+		long accountEntryId,
+		com.liferay.portal.kernel.util.OrderByComparator<CommerceCatalog>
+			orderByComparator);
+
+	/**
+	 * Returns the last commerce catalog in the ordered set where accountEntryId = &#63;.
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching commerce catalog
+	 * @throws NoSuchCatalogException if a matching commerce catalog could not be found
+	 */
+	public CommerceCatalog findByAccountEntryId_Last(
+			long accountEntryId,
+			com.liferay.portal.kernel.util.OrderByComparator<CommerceCatalog>
+				orderByComparator)
+		throws NoSuchCatalogException;
+
+	/**
+	 * Returns the last commerce catalog in the ordered set where accountEntryId = &#63;.
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching commerce catalog, or <code>null</code> if a matching commerce catalog could not be found
+	 */
+	public CommerceCatalog fetchByAccountEntryId_Last(
+		long accountEntryId,
+		com.liferay.portal.kernel.util.OrderByComparator<CommerceCatalog>
+			orderByComparator);
+
+	/**
+	 * Returns the commerce catalogs before and after the current commerce catalog in the ordered set where accountEntryId = &#63;.
+	 *
+	 * @param commerceCatalogId the primary key of the current commerce catalog
+	 * @param accountEntryId the account entry ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next commerce catalog
+	 * @throws NoSuchCatalogException if a commerce catalog with the primary key could not be found
+	 */
+	public CommerceCatalog[] findByAccountEntryId_PrevAndNext(
+			long commerceCatalogId, long accountEntryId,
+			com.liferay.portal.kernel.util.OrderByComparator<CommerceCatalog>
+				orderByComparator)
+		throws NoSuchCatalogException;
+
+	/**
+	 * Returns all the commerce catalogs that the user has permission to view where accountEntryId = &#63;.
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @return the matching commerce catalogs that the user has permission to view
+	 */
+	public java.util.List<CommerceCatalog> filterFindByAccountEntryId(
+		long accountEntryId);
+
+	/**
+	 * Returns a range of all the commerce catalogs that the user has permission to view where accountEntryId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>CommerceCatalogModelImpl</code>.
+	 * </p>
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @param start the lower bound of the range of commerce catalogs
+	 * @param end the upper bound of the range of commerce catalogs (not inclusive)
+	 * @return the range of matching commerce catalogs that the user has permission to view
+	 */
+	public java.util.List<CommerceCatalog> filterFindByAccountEntryId(
+		long accountEntryId, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the commerce catalogs that the user has permissions to view where accountEntryId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>CommerceCatalogModelImpl</code>.
+	 * </p>
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @param start the lower bound of the range of commerce catalogs
+	 * @param end the upper bound of the range of commerce catalogs (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching commerce catalogs that the user has permission to view
+	 */
+	public java.util.List<CommerceCatalog> filterFindByAccountEntryId(
+		long accountEntryId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<CommerceCatalog>
+			orderByComparator);
+
+	/**
+	 * Returns the commerce catalogs before and after the current commerce catalog in the ordered set of commerce catalogs that the user has permission to view where accountEntryId = &#63;.
+	 *
+	 * @param commerceCatalogId the primary key of the current commerce catalog
+	 * @param accountEntryId the account entry ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next commerce catalog
+	 * @throws NoSuchCatalogException if a commerce catalog with the primary key could not be found
+	 */
+	public CommerceCatalog[] filterFindByAccountEntryId_PrevAndNext(
+			long commerceCatalogId, long accountEntryId,
+			com.liferay.portal.kernel.util.OrderByComparator<CommerceCatalog>
+				orderByComparator)
+		throws NoSuchCatalogException;
+
+	/**
+	 * Removes all the commerce catalogs where accountEntryId = &#63; from the database.
+	 *
+	 * @param accountEntryId the account entry ID
+	 */
+	public void removeByAccountEntryId(long accountEntryId);
+
+	/**
+	 * Returns the number of commerce catalogs where accountEntryId = &#63;.
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @return the number of matching commerce catalogs
+	 */
+	public int countByAccountEntryId(long accountEntryId);
+
+	/**
+	 * Returns the number of commerce catalogs that the user has permission to view where accountEntryId = &#63;.
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @return the number of matching commerce catalogs that the user has permission to view
+	 */
+	public int filterCountByAccountEntryId(long accountEntryId);
+
+	/**
 	 * Returns all the commerce catalogs where companyId = &#63; and system = &#63;.
 	 *
 	 * @param companyId the company ID

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/persistence/CommerceCatalogUtil.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/persistence/CommerceCatalogUtil.java
@@ -879,6 +879,262 @@ public class CommerceCatalogUtil {
 	}
 
 	/**
+	 * Returns all the commerce catalogs where accountEntryId = &#63;.
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @return the matching commerce catalogs
+	 */
+	public static List<CommerceCatalog> findByAccountEntryId(
+		long accountEntryId) {
+
+		return getPersistence().findByAccountEntryId(accountEntryId);
+	}
+
+	/**
+	 * Returns a range of all the commerce catalogs where accountEntryId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>CommerceCatalogModelImpl</code>.
+	 * </p>
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @param start the lower bound of the range of commerce catalogs
+	 * @param end the upper bound of the range of commerce catalogs (not inclusive)
+	 * @return the range of matching commerce catalogs
+	 */
+	public static List<CommerceCatalog> findByAccountEntryId(
+		long accountEntryId, int start, int end) {
+
+		return getPersistence().findByAccountEntryId(
+			accountEntryId, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the commerce catalogs where accountEntryId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>CommerceCatalogModelImpl</code>.
+	 * </p>
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @param start the lower bound of the range of commerce catalogs
+	 * @param end the upper bound of the range of commerce catalogs (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching commerce catalogs
+	 */
+	public static List<CommerceCatalog> findByAccountEntryId(
+		long accountEntryId, int start, int end,
+		OrderByComparator<CommerceCatalog> orderByComparator) {
+
+		return getPersistence().findByAccountEntryId(
+			accountEntryId, start, end, orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the commerce catalogs where accountEntryId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>CommerceCatalogModelImpl</code>.
+	 * </p>
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @param start the lower bound of the range of commerce catalogs
+	 * @param end the upper bound of the range of commerce catalogs (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching commerce catalogs
+	 */
+	public static List<CommerceCatalog> findByAccountEntryId(
+		long accountEntryId, int start, int end,
+		OrderByComparator<CommerceCatalog> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByAccountEntryId(
+			accountEntryId, start, end, orderByComparator, useFinderCache);
+	}
+
+	/**
+	 * Returns the first commerce catalog in the ordered set where accountEntryId = &#63;.
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching commerce catalog
+	 * @throws NoSuchCatalogException if a matching commerce catalog could not be found
+	 */
+	public static CommerceCatalog findByAccountEntryId_First(
+			long accountEntryId,
+			OrderByComparator<CommerceCatalog> orderByComparator)
+		throws com.liferay.commerce.product.exception.NoSuchCatalogException {
+
+		return getPersistence().findByAccountEntryId_First(
+			accountEntryId, orderByComparator);
+	}
+
+	/**
+	 * Returns the first commerce catalog in the ordered set where accountEntryId = &#63;.
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching commerce catalog, or <code>null</code> if a matching commerce catalog could not be found
+	 */
+	public static CommerceCatalog fetchByAccountEntryId_First(
+		long accountEntryId,
+		OrderByComparator<CommerceCatalog> orderByComparator) {
+
+		return getPersistence().fetchByAccountEntryId_First(
+			accountEntryId, orderByComparator);
+	}
+
+	/**
+	 * Returns the last commerce catalog in the ordered set where accountEntryId = &#63;.
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching commerce catalog
+	 * @throws NoSuchCatalogException if a matching commerce catalog could not be found
+	 */
+	public static CommerceCatalog findByAccountEntryId_Last(
+			long accountEntryId,
+			OrderByComparator<CommerceCatalog> orderByComparator)
+		throws com.liferay.commerce.product.exception.NoSuchCatalogException {
+
+		return getPersistence().findByAccountEntryId_Last(
+			accountEntryId, orderByComparator);
+	}
+
+	/**
+	 * Returns the last commerce catalog in the ordered set where accountEntryId = &#63;.
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching commerce catalog, or <code>null</code> if a matching commerce catalog could not be found
+	 */
+	public static CommerceCatalog fetchByAccountEntryId_Last(
+		long accountEntryId,
+		OrderByComparator<CommerceCatalog> orderByComparator) {
+
+		return getPersistence().fetchByAccountEntryId_Last(
+			accountEntryId, orderByComparator);
+	}
+
+	/**
+	 * Returns the commerce catalogs before and after the current commerce catalog in the ordered set where accountEntryId = &#63;.
+	 *
+	 * @param commerceCatalogId the primary key of the current commerce catalog
+	 * @param accountEntryId the account entry ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next commerce catalog
+	 * @throws NoSuchCatalogException if a commerce catalog with the primary key could not be found
+	 */
+	public static CommerceCatalog[] findByAccountEntryId_PrevAndNext(
+			long commerceCatalogId, long accountEntryId,
+			OrderByComparator<CommerceCatalog> orderByComparator)
+		throws com.liferay.commerce.product.exception.NoSuchCatalogException {
+
+		return getPersistence().findByAccountEntryId_PrevAndNext(
+			commerceCatalogId, accountEntryId, orderByComparator);
+	}
+
+	/**
+	 * Returns all the commerce catalogs that the user has permission to view where accountEntryId = &#63;.
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @return the matching commerce catalogs that the user has permission to view
+	 */
+	public static List<CommerceCatalog> filterFindByAccountEntryId(
+		long accountEntryId) {
+
+		return getPersistence().filterFindByAccountEntryId(accountEntryId);
+	}
+
+	/**
+	 * Returns a range of all the commerce catalogs that the user has permission to view where accountEntryId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>CommerceCatalogModelImpl</code>.
+	 * </p>
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @param start the lower bound of the range of commerce catalogs
+	 * @param end the upper bound of the range of commerce catalogs (not inclusive)
+	 * @return the range of matching commerce catalogs that the user has permission to view
+	 */
+	public static List<CommerceCatalog> filterFindByAccountEntryId(
+		long accountEntryId, int start, int end) {
+
+		return getPersistence().filterFindByAccountEntryId(
+			accountEntryId, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the commerce catalogs that the user has permissions to view where accountEntryId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>CommerceCatalogModelImpl</code>.
+	 * </p>
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @param start the lower bound of the range of commerce catalogs
+	 * @param end the upper bound of the range of commerce catalogs (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching commerce catalogs that the user has permission to view
+	 */
+	public static List<CommerceCatalog> filterFindByAccountEntryId(
+		long accountEntryId, int start, int end,
+		OrderByComparator<CommerceCatalog> orderByComparator) {
+
+		return getPersistence().filterFindByAccountEntryId(
+			accountEntryId, start, end, orderByComparator);
+	}
+
+	/**
+	 * Returns the commerce catalogs before and after the current commerce catalog in the ordered set of commerce catalogs that the user has permission to view where accountEntryId = &#63;.
+	 *
+	 * @param commerceCatalogId the primary key of the current commerce catalog
+	 * @param accountEntryId the account entry ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next commerce catalog
+	 * @throws NoSuchCatalogException if a commerce catalog with the primary key could not be found
+	 */
+	public static CommerceCatalog[] filterFindByAccountEntryId_PrevAndNext(
+			long commerceCatalogId, long accountEntryId,
+			OrderByComparator<CommerceCatalog> orderByComparator)
+		throws com.liferay.commerce.product.exception.NoSuchCatalogException {
+
+		return getPersistence().filterFindByAccountEntryId_PrevAndNext(
+			commerceCatalogId, accountEntryId, orderByComparator);
+	}
+
+	/**
+	 * Removes all the commerce catalogs where accountEntryId = &#63; from the database.
+	 *
+	 * @param accountEntryId the account entry ID
+	 */
+	public static void removeByAccountEntryId(long accountEntryId) {
+		getPersistence().removeByAccountEntryId(accountEntryId);
+	}
+
+	/**
+	 * Returns the number of commerce catalogs where accountEntryId = &#63;.
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @return the number of matching commerce catalogs
+	 */
+	public static int countByAccountEntryId(long accountEntryId) {
+		return getPersistence().countByAccountEntryId(accountEntryId);
+	}
+
+	/**
+	 * Returns the number of commerce catalogs that the user has permission to view where accountEntryId = &#63;.
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @return the number of matching commerce catalogs that the user has permission to view
+	 */
+	public static int filterCountByAccountEntryId(long accountEntryId) {
+		return getPersistence().filterCountByAccountEntryId(accountEntryId);
+	}
+
+	/**
 	 * Returns all the commerce catalogs where companyId = &#63; and system = &#63;.
 	 *
 	 * @param companyId the company ID

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/persistence/CommerceChannelPersistence.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/persistence/CommerceChannelPersistence.java
@@ -683,6 +683,215 @@ public interface CommerceChannelPersistence
 	public int filterCountByCompanyId(long companyId);
 
 	/**
+	 * Returns all the commerce channels where accountEntryId = &#63;.
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @return the matching commerce channels
+	 */
+	public java.util.List<CommerceChannel> findByAccountEntryId(
+		long accountEntryId);
+
+	/**
+	 * Returns a range of all the commerce channels where accountEntryId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>CommerceChannelModelImpl</code>.
+	 * </p>
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @param start the lower bound of the range of commerce channels
+	 * @param end the upper bound of the range of commerce channels (not inclusive)
+	 * @return the range of matching commerce channels
+	 */
+	public java.util.List<CommerceChannel> findByAccountEntryId(
+		long accountEntryId, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the commerce channels where accountEntryId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>CommerceChannelModelImpl</code>.
+	 * </p>
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @param start the lower bound of the range of commerce channels
+	 * @param end the upper bound of the range of commerce channels (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching commerce channels
+	 */
+	public java.util.List<CommerceChannel> findByAccountEntryId(
+		long accountEntryId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<CommerceChannel>
+			orderByComparator);
+
+	/**
+	 * Returns an ordered range of all the commerce channels where accountEntryId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>CommerceChannelModelImpl</code>.
+	 * </p>
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @param start the lower bound of the range of commerce channels
+	 * @param end the upper bound of the range of commerce channels (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching commerce channels
+	 */
+	public java.util.List<CommerceChannel> findByAccountEntryId(
+		long accountEntryId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<CommerceChannel>
+			orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Returns the first commerce channel in the ordered set where accountEntryId = &#63;.
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching commerce channel
+	 * @throws NoSuchChannelException if a matching commerce channel could not be found
+	 */
+	public CommerceChannel findByAccountEntryId_First(
+			long accountEntryId,
+			com.liferay.portal.kernel.util.OrderByComparator<CommerceChannel>
+				orderByComparator)
+		throws NoSuchChannelException;
+
+	/**
+	 * Returns the first commerce channel in the ordered set where accountEntryId = &#63;.
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching commerce channel, or <code>null</code> if a matching commerce channel could not be found
+	 */
+	public CommerceChannel fetchByAccountEntryId_First(
+		long accountEntryId,
+		com.liferay.portal.kernel.util.OrderByComparator<CommerceChannel>
+			orderByComparator);
+
+	/**
+	 * Returns the last commerce channel in the ordered set where accountEntryId = &#63;.
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching commerce channel
+	 * @throws NoSuchChannelException if a matching commerce channel could not be found
+	 */
+	public CommerceChannel findByAccountEntryId_Last(
+			long accountEntryId,
+			com.liferay.portal.kernel.util.OrderByComparator<CommerceChannel>
+				orderByComparator)
+		throws NoSuchChannelException;
+
+	/**
+	 * Returns the last commerce channel in the ordered set where accountEntryId = &#63;.
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching commerce channel, or <code>null</code> if a matching commerce channel could not be found
+	 */
+	public CommerceChannel fetchByAccountEntryId_Last(
+		long accountEntryId,
+		com.liferay.portal.kernel.util.OrderByComparator<CommerceChannel>
+			orderByComparator);
+
+	/**
+	 * Returns the commerce channels before and after the current commerce channel in the ordered set where accountEntryId = &#63;.
+	 *
+	 * @param commerceChannelId the primary key of the current commerce channel
+	 * @param accountEntryId the account entry ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next commerce channel
+	 * @throws NoSuchChannelException if a commerce channel with the primary key could not be found
+	 */
+	public CommerceChannel[] findByAccountEntryId_PrevAndNext(
+			long commerceChannelId, long accountEntryId,
+			com.liferay.portal.kernel.util.OrderByComparator<CommerceChannel>
+				orderByComparator)
+		throws NoSuchChannelException;
+
+	/**
+	 * Returns all the commerce channels that the user has permission to view where accountEntryId = &#63;.
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @return the matching commerce channels that the user has permission to view
+	 */
+	public java.util.List<CommerceChannel> filterFindByAccountEntryId(
+		long accountEntryId);
+
+	/**
+	 * Returns a range of all the commerce channels that the user has permission to view where accountEntryId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>CommerceChannelModelImpl</code>.
+	 * </p>
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @param start the lower bound of the range of commerce channels
+	 * @param end the upper bound of the range of commerce channels (not inclusive)
+	 * @return the range of matching commerce channels that the user has permission to view
+	 */
+	public java.util.List<CommerceChannel> filterFindByAccountEntryId(
+		long accountEntryId, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the commerce channels that the user has permissions to view where accountEntryId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>CommerceChannelModelImpl</code>.
+	 * </p>
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @param start the lower bound of the range of commerce channels
+	 * @param end the upper bound of the range of commerce channels (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching commerce channels that the user has permission to view
+	 */
+	public java.util.List<CommerceChannel> filterFindByAccountEntryId(
+		long accountEntryId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<CommerceChannel>
+			orderByComparator);
+
+	/**
+	 * Returns the commerce channels before and after the current commerce channel in the ordered set of commerce channels that the user has permission to view where accountEntryId = &#63;.
+	 *
+	 * @param commerceChannelId the primary key of the current commerce channel
+	 * @param accountEntryId the account entry ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next commerce channel
+	 * @throws NoSuchChannelException if a commerce channel with the primary key could not be found
+	 */
+	public CommerceChannel[] filterFindByAccountEntryId_PrevAndNext(
+			long commerceChannelId, long accountEntryId,
+			com.liferay.portal.kernel.util.OrderByComparator<CommerceChannel>
+				orderByComparator)
+		throws NoSuchChannelException;
+
+	/**
+	 * Removes all the commerce channels where accountEntryId = &#63; from the database.
+	 *
+	 * @param accountEntryId the account entry ID
+	 */
+	public void removeByAccountEntryId(long accountEntryId);
+
+	/**
+	 * Returns the number of commerce channels where accountEntryId = &#63;.
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @return the number of matching commerce channels
+	 */
+	public int countByAccountEntryId(long accountEntryId);
+
+	/**
+	 * Returns the number of commerce channels that the user has permission to view where accountEntryId = &#63;.
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @return the number of matching commerce channels that the user has permission to view
+	 */
+	public int filterCountByAccountEntryId(long accountEntryId);
+
+	/**
 	 * Returns the commerce channel where siteGroupId = &#63; or throws a <code>NoSuchChannelException</code> if it could not be found.
 	 *
 	 * @param siteGroupId the site group ID

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/persistence/CommerceChannelUtil.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/persistence/CommerceChannelUtil.java
@@ -879,6 +879,262 @@ public class CommerceChannelUtil {
 	}
 
 	/**
+	 * Returns all the commerce channels where accountEntryId = &#63;.
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @return the matching commerce channels
+	 */
+	public static List<CommerceChannel> findByAccountEntryId(
+		long accountEntryId) {
+
+		return getPersistence().findByAccountEntryId(accountEntryId);
+	}
+
+	/**
+	 * Returns a range of all the commerce channels where accountEntryId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>CommerceChannelModelImpl</code>.
+	 * </p>
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @param start the lower bound of the range of commerce channels
+	 * @param end the upper bound of the range of commerce channels (not inclusive)
+	 * @return the range of matching commerce channels
+	 */
+	public static List<CommerceChannel> findByAccountEntryId(
+		long accountEntryId, int start, int end) {
+
+		return getPersistence().findByAccountEntryId(
+			accountEntryId, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the commerce channels where accountEntryId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>CommerceChannelModelImpl</code>.
+	 * </p>
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @param start the lower bound of the range of commerce channels
+	 * @param end the upper bound of the range of commerce channels (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching commerce channels
+	 */
+	public static List<CommerceChannel> findByAccountEntryId(
+		long accountEntryId, int start, int end,
+		OrderByComparator<CommerceChannel> orderByComparator) {
+
+		return getPersistence().findByAccountEntryId(
+			accountEntryId, start, end, orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the commerce channels where accountEntryId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>CommerceChannelModelImpl</code>.
+	 * </p>
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @param start the lower bound of the range of commerce channels
+	 * @param end the upper bound of the range of commerce channels (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching commerce channels
+	 */
+	public static List<CommerceChannel> findByAccountEntryId(
+		long accountEntryId, int start, int end,
+		OrderByComparator<CommerceChannel> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByAccountEntryId(
+			accountEntryId, start, end, orderByComparator, useFinderCache);
+	}
+
+	/**
+	 * Returns the first commerce channel in the ordered set where accountEntryId = &#63;.
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching commerce channel
+	 * @throws NoSuchChannelException if a matching commerce channel could not be found
+	 */
+	public static CommerceChannel findByAccountEntryId_First(
+			long accountEntryId,
+			OrderByComparator<CommerceChannel> orderByComparator)
+		throws com.liferay.commerce.product.exception.NoSuchChannelException {
+
+		return getPersistence().findByAccountEntryId_First(
+			accountEntryId, orderByComparator);
+	}
+
+	/**
+	 * Returns the first commerce channel in the ordered set where accountEntryId = &#63;.
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching commerce channel, or <code>null</code> if a matching commerce channel could not be found
+	 */
+	public static CommerceChannel fetchByAccountEntryId_First(
+		long accountEntryId,
+		OrderByComparator<CommerceChannel> orderByComparator) {
+
+		return getPersistence().fetchByAccountEntryId_First(
+			accountEntryId, orderByComparator);
+	}
+
+	/**
+	 * Returns the last commerce channel in the ordered set where accountEntryId = &#63;.
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching commerce channel
+	 * @throws NoSuchChannelException if a matching commerce channel could not be found
+	 */
+	public static CommerceChannel findByAccountEntryId_Last(
+			long accountEntryId,
+			OrderByComparator<CommerceChannel> orderByComparator)
+		throws com.liferay.commerce.product.exception.NoSuchChannelException {
+
+		return getPersistence().findByAccountEntryId_Last(
+			accountEntryId, orderByComparator);
+	}
+
+	/**
+	 * Returns the last commerce channel in the ordered set where accountEntryId = &#63;.
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching commerce channel, or <code>null</code> if a matching commerce channel could not be found
+	 */
+	public static CommerceChannel fetchByAccountEntryId_Last(
+		long accountEntryId,
+		OrderByComparator<CommerceChannel> orderByComparator) {
+
+		return getPersistence().fetchByAccountEntryId_Last(
+			accountEntryId, orderByComparator);
+	}
+
+	/**
+	 * Returns the commerce channels before and after the current commerce channel in the ordered set where accountEntryId = &#63;.
+	 *
+	 * @param commerceChannelId the primary key of the current commerce channel
+	 * @param accountEntryId the account entry ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next commerce channel
+	 * @throws NoSuchChannelException if a commerce channel with the primary key could not be found
+	 */
+	public static CommerceChannel[] findByAccountEntryId_PrevAndNext(
+			long commerceChannelId, long accountEntryId,
+			OrderByComparator<CommerceChannel> orderByComparator)
+		throws com.liferay.commerce.product.exception.NoSuchChannelException {
+
+		return getPersistence().findByAccountEntryId_PrevAndNext(
+			commerceChannelId, accountEntryId, orderByComparator);
+	}
+
+	/**
+	 * Returns all the commerce channels that the user has permission to view where accountEntryId = &#63;.
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @return the matching commerce channels that the user has permission to view
+	 */
+	public static List<CommerceChannel> filterFindByAccountEntryId(
+		long accountEntryId) {
+
+		return getPersistence().filterFindByAccountEntryId(accountEntryId);
+	}
+
+	/**
+	 * Returns a range of all the commerce channels that the user has permission to view where accountEntryId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>CommerceChannelModelImpl</code>.
+	 * </p>
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @param start the lower bound of the range of commerce channels
+	 * @param end the upper bound of the range of commerce channels (not inclusive)
+	 * @return the range of matching commerce channels that the user has permission to view
+	 */
+	public static List<CommerceChannel> filterFindByAccountEntryId(
+		long accountEntryId, int start, int end) {
+
+		return getPersistence().filterFindByAccountEntryId(
+			accountEntryId, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the commerce channels that the user has permissions to view where accountEntryId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>CommerceChannelModelImpl</code>.
+	 * </p>
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @param start the lower bound of the range of commerce channels
+	 * @param end the upper bound of the range of commerce channels (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching commerce channels that the user has permission to view
+	 */
+	public static List<CommerceChannel> filterFindByAccountEntryId(
+		long accountEntryId, int start, int end,
+		OrderByComparator<CommerceChannel> orderByComparator) {
+
+		return getPersistence().filterFindByAccountEntryId(
+			accountEntryId, start, end, orderByComparator);
+	}
+
+	/**
+	 * Returns the commerce channels before and after the current commerce channel in the ordered set of commerce channels that the user has permission to view where accountEntryId = &#63;.
+	 *
+	 * @param commerceChannelId the primary key of the current commerce channel
+	 * @param accountEntryId the account entry ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next commerce channel
+	 * @throws NoSuchChannelException if a commerce channel with the primary key could not be found
+	 */
+	public static CommerceChannel[] filterFindByAccountEntryId_PrevAndNext(
+			long commerceChannelId, long accountEntryId,
+			OrderByComparator<CommerceChannel> orderByComparator)
+		throws com.liferay.commerce.product.exception.NoSuchChannelException {
+
+		return getPersistence().filterFindByAccountEntryId_PrevAndNext(
+			commerceChannelId, accountEntryId, orderByComparator);
+	}
+
+	/**
+	 * Removes all the commerce channels where accountEntryId = &#63; from the database.
+	 *
+	 * @param accountEntryId the account entry ID
+	 */
+	public static void removeByAccountEntryId(long accountEntryId) {
+		getPersistence().removeByAccountEntryId(accountEntryId);
+	}
+
+	/**
+	 * Returns the number of commerce channels where accountEntryId = &#63;.
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @return the number of matching commerce channels
+	 */
+	public static int countByAccountEntryId(long accountEntryId) {
+		return getPersistence().countByAccountEntryId(accountEntryId);
+	}
+
+	/**
+	 * Returns the number of commerce channels that the user has permission to view where accountEntryId = &#63;.
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @return the number of matching commerce channels that the user has permission to view
+	 */
+	public static int filterCountByAccountEntryId(long accountEntryId) {
+		return getPersistence().filterCountByAccountEntryId(accountEntryId);
+	}
+
+	/**
 	 * Returns the commerce channel where siteGroupId = &#63; or throws a <code>NoSuchChannelException</code> if it could not be found.
 	 *
 	 * @param siteGroupId the site group ID

--- a/modules/apps/commerce/commerce-product-api/src/main/resources/com/liferay/commerce/product/service/persistence/packageinfo
+++ b/modules/apps/commerce/commerce-product-api/src/main/resources/com/liferay/commerce/product/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 20.4.0
+version 20.5.0

--- a/modules/apps/commerce/commerce-product-service/service.xml
+++ b/modules/apps/commerce/commerce-product-service/service.xml
@@ -37,6 +37,9 @@
 		<finder name="CompanyId" return-type="Collection">
 			<finder-column name="companyId" />
 		</finder>
+		<finder name="AccountEntryId" return-type="Collection">
+			<finder-column name="accountEntryId" />
+		</finder>
 		<finder name="C_S" return-type="Collection">
 			<finder-column name="companyId" />
 			<finder-column name="system" />
@@ -77,6 +80,9 @@
 
 		<finder name="CompanyId" return-type="Collection">
 			<finder-column name="companyId" />
+		</finder>
+		<finder name="AccountEntryId" return-type="Collection">
+			<finder-column name="accountEntryId" />
 		</finder>
 		<finder name="SiteGroupId" return-type="CommerceChannel">
 			<finder-column name="siteGroupId" />

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/model/listener/AccountEntryModelListener.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/model/listener/AccountEntryModelListener.java
@@ -16,8 +16,12 @@ package com.liferay.commerce.product.internal.model.listener;
 
 import com.liferay.account.model.AccountEntry;
 import com.liferay.commerce.product.constants.CommerceChannelAccountEntryRelConstants;
+import com.liferay.commerce.product.model.CommerceCatalog;
+import com.liferay.commerce.product.model.CommerceChannel;
 import com.liferay.commerce.product.model.CommerceChannelAccountEntryRel;
+import com.liferay.commerce.product.service.CommerceCatalogLocalService;
 import com.liferay.commerce.product.service.CommerceChannelAccountEntryRelLocalService;
+import com.liferay.commerce.product.service.CommerceChannelLocalService;
 import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
@@ -25,6 +29,8 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Address;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.ModelListener;
+
+import java.util.List;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -34,6 +40,29 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(service = ModelListener.class)
 public class AccountEntryModelListener extends BaseModelListener<AccountEntry> {
+
+	@Override
+	public void onAfterRemove(AccountEntry accountEntry) {
+		List<CommerceCatalog> commerceCatalogs =
+			_commerceCatalogLocalService.getCommerceCatalogsByAccountEntryId(
+				accountEntry.getAccountEntryId());
+
+		for (CommerceCatalog commerceCatalog : commerceCatalogs) {
+			commerceCatalog.setAccountEntryId(0);
+
+			_commerceCatalogLocalService.updateCommerceCatalog(commerceCatalog);
+		}
+
+		List<CommerceChannel> commerceChannels =
+			_commerceChannelLocalService.getCommerceChannelsByAccountEntryId(
+				accountEntry.getAccountEntryId());
+
+		for (CommerceChannel commerceChannel : commerceChannels) {
+			commerceChannel.setAccountEntryId(0);
+
+			_commerceChannelLocalService.updateCommerceChannel(commerceChannel);
+		}
+	}
 
 	@Override
 	public void onAfterUpdate(
@@ -171,7 +200,13 @@ public class AccountEntryModelListener extends BaseModelListener<AccountEntry> {
 		AccountEntryModelListener.class);
 
 	@Reference
+	private CommerceCatalogLocalService _commerceCatalogLocalService;
+
+	@Reference
 	private CommerceChannelAccountEntryRelLocalService
 		_commerceChannelAccountEntryRelLocalService;
+
+	@Reference
+	private CommerceChannelLocalService _commerceChannelLocalService;
 
 }

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/model/impl/CommerceCatalogModelImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/model/impl/CommerceCatalogModelImpl.java
@@ -126,32 +126,38 @@ public class CommerceCatalogModelImpl
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long COMPANYID_COLUMN_BITMASK = 1L;
+	public static final long ACCOUNTENTRYID_COLUMN_BITMASK = 1L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long EXTERNALREFERENCECODE_COLUMN_BITMASK = 2L;
+	public static final long COMPANYID_COLUMN_BITMASK = 2L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long SYSTEM_COLUMN_BITMASK = 4L;
+	public static final long EXTERNALREFERENCECODE_COLUMN_BITMASK = 4L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long UUID_COLUMN_BITMASK = 8L;
+	public static final long SYSTEM_COLUMN_BITMASK = 8L;
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
+	 */
+	@Deprecated
+	public static final long UUID_COLUMN_BITMASK = 16L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
 	 *		#getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long CREATEDATE_COLUMN_BITMASK = 16L;
+	public static final long CREATEDATE_COLUMN_BITMASK = 32L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
@@ -601,6 +607,16 @@ public class CommerceCatalogModelImpl
 		}
 
 		_accountEntryId = accountEntryId;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getColumnOriginalValue(String)}
+	 */
+	@Deprecated
+	public long getOriginalAccountEntryId() {
+		return GetterUtil.getLong(
+			this.<Long>getColumnOriginalValue("accountEntryId"));
 	}
 
 	@JSON

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/model/impl/CommerceChannelModelImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/model/impl/CommerceChannelModelImpl.java
@@ -132,32 +132,38 @@ public class CommerceChannelModelImpl
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long COMPANYID_COLUMN_BITMASK = 1L;
+	public static final long ACCOUNTENTRYID_COLUMN_BITMASK = 1L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long EXTERNALREFERENCECODE_COLUMN_BITMASK = 2L;
+	public static final long COMPANYID_COLUMN_BITMASK = 2L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long SITEGROUPID_COLUMN_BITMASK = 4L;
+	public static final long EXTERNALREFERENCECODE_COLUMN_BITMASK = 4L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long UUID_COLUMN_BITMASK = 8L;
+	public static final long SITEGROUPID_COLUMN_BITMASK = 8L;
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
+	 */
+	@Deprecated
+	public static final long UUID_COLUMN_BITMASK = 16L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
 	 *		#getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long CREATEDATE_COLUMN_BITMASK = 16L;
+	public static final long CREATEDATE_COLUMN_BITMASK = 32L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
@@ -624,6 +630,16 @@ public class CommerceChannelModelImpl
 		}
 
 		_accountEntryId = accountEntryId;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getColumnOriginalValue(String)}
+	 */
+	@Deprecated
+	public long getOriginalAccountEntryId() {
+		return GetterUtil.getLong(
+			this.<Long>getColumnOriginalValue("accountEntryId"));
 	}
 
 	@JSON

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CommerceCatalogLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CommerceCatalogLocalServiceImpl.java
@@ -294,6 +294,13 @@ public class CommerceCatalogLocalServiceImpl
 	}
 
 	@Override
+	public List<CommerceCatalog> getCommerceCatalogsByAccountEntryId(
+		long accountEntryId) {
+
+		return commerceCatalogPersistence.findByAccountEntryId(accountEntryId);
+	}
+
+	@Override
 	public List<CommerceCatalog> search(long companyId) throws PortalException {
 		return search(
 			companyId, StringPool.BLANK, QueryUtil.ALL_POS, QueryUtil.ALL_POS,

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CommerceChannelLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CommerceChannelLocalServiceImpl.java
@@ -364,6 +364,13 @@ public class CommerceChannelLocalServiceImpl
 	}
 
 	@Override
+	public List<CommerceChannel> getCommerceChannelsByAccountEntryId(
+		long accountEntryId) {
+
+		return commerceChannelPersistence.findByAccountEntryId(accountEntryId);
+	}
+
+	@Override
 	public int getCommerceChannelsCount(long companyId, String keywords)
 		throws PortalException {
 

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/persistence/impl/CommerceCatalogPersistenceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/persistence/impl/CommerceCatalogPersistenceImpl.java
@@ -3018,6 +3018,912 @@ public class CommerceCatalogPersistenceImpl
 	private static final String _FINDER_COLUMN_COMPANYID_COMPANYID_2 =
 		"commerceCatalog.companyId = ?";
 
+	private FinderPath _finderPathWithPaginationFindByAccountEntryId;
+	private FinderPath _finderPathWithoutPaginationFindByAccountEntryId;
+	private FinderPath _finderPathCountByAccountEntryId;
+
+	/**
+	 * Returns all the commerce catalogs where accountEntryId = &#63;.
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @return the matching commerce catalogs
+	 */
+	@Override
+	public List<CommerceCatalog> findByAccountEntryId(long accountEntryId) {
+		return findByAccountEntryId(
+			accountEntryId, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the commerce catalogs where accountEntryId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>CommerceCatalogModelImpl</code>.
+	 * </p>
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @param start the lower bound of the range of commerce catalogs
+	 * @param end the upper bound of the range of commerce catalogs (not inclusive)
+	 * @return the range of matching commerce catalogs
+	 */
+	@Override
+	public List<CommerceCatalog> findByAccountEntryId(
+		long accountEntryId, int start, int end) {
+
+		return findByAccountEntryId(accountEntryId, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the commerce catalogs where accountEntryId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>CommerceCatalogModelImpl</code>.
+	 * </p>
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @param start the lower bound of the range of commerce catalogs
+	 * @param end the upper bound of the range of commerce catalogs (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching commerce catalogs
+	 */
+	@Override
+	public List<CommerceCatalog> findByAccountEntryId(
+		long accountEntryId, int start, int end,
+		OrderByComparator<CommerceCatalog> orderByComparator) {
+
+		return findByAccountEntryId(
+			accountEntryId, start, end, orderByComparator, true);
+	}
+
+	/**
+	 * Returns an ordered range of all the commerce catalogs where accountEntryId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>CommerceCatalogModelImpl</code>.
+	 * </p>
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @param start the lower bound of the range of commerce catalogs
+	 * @param end the upper bound of the range of commerce catalogs (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching commerce catalogs
+	 */
+	@Override
+	public List<CommerceCatalog> findByAccountEntryId(
+		long accountEntryId, int start, int end,
+		OrderByComparator<CommerceCatalog> orderByComparator,
+		boolean useFinderCache) {
+
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			CommerceCatalog.class);
+
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
+
+		if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
+			(orderByComparator == null)) {
+
+			if (useFinderCache && productionMode) {
+				finderPath = _finderPathWithoutPaginationFindByAccountEntryId;
+				finderArgs = new Object[] {accountEntryId};
+			}
+		}
+		else if (useFinderCache && productionMode) {
+			finderPath = _finderPathWithPaginationFindByAccountEntryId;
+			finderArgs = new Object[] {
+				accountEntryId, start, end, orderByComparator
+			};
+		}
+
+		List<CommerceCatalog> list = null;
+
+		if (useFinderCache && productionMode) {
+			list = (List<CommerceCatalog>)finderCache.getResult(
+				finderPath, finderArgs, this);
+
+			if ((list != null) && !list.isEmpty()) {
+				for (CommerceCatalog commerceCatalog : list) {
+					if (accountEntryId != commerceCatalog.getAccountEntryId()) {
+						list = null;
+
+						break;
+					}
+				}
+			}
+		}
+
+		if (list == null) {
+			StringBundler sb = null;
+
+			if (orderByComparator != null) {
+				sb = new StringBundler(
+					3 + (orderByComparator.getOrderByFields().length * 2));
+			}
+			else {
+				sb = new StringBundler(3);
+			}
+
+			sb.append(_SQL_SELECT_COMMERCECATALOG_WHERE);
+
+			sb.append(_FINDER_COLUMN_ACCOUNTENTRYID_ACCOUNTENTRYID_2);
+
+			if (orderByComparator != null) {
+				appendOrderByComparator(
+					sb, _ORDER_BY_ENTITY_ALIAS, orderByComparator);
+			}
+			else {
+				sb.append(CommerceCatalogModelImpl.ORDER_BY_JPQL);
+			}
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				queryPos.add(accountEntryId);
+
+				list = (List<CommerceCatalog>)QueryUtil.list(
+					query, getDialect(), start, end);
+
+				cacheResult(list);
+
+				if (useFinderCache && productionMode) {
+					finderCache.putResult(finderPath, finderArgs, list);
+				}
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return list;
+	}
+
+	/**
+	 * Returns the first commerce catalog in the ordered set where accountEntryId = &#63;.
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching commerce catalog
+	 * @throws NoSuchCatalogException if a matching commerce catalog could not be found
+	 */
+	@Override
+	public CommerceCatalog findByAccountEntryId_First(
+			long accountEntryId,
+			OrderByComparator<CommerceCatalog> orderByComparator)
+		throws NoSuchCatalogException {
+
+		CommerceCatalog commerceCatalog = fetchByAccountEntryId_First(
+			accountEntryId, orderByComparator);
+
+		if (commerceCatalog != null) {
+			return commerceCatalog;
+		}
+
+		StringBundler sb = new StringBundler(4);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("accountEntryId=");
+		sb.append(accountEntryId);
+
+		sb.append("}");
+
+		throw new NoSuchCatalogException(sb.toString());
+	}
+
+	/**
+	 * Returns the first commerce catalog in the ordered set where accountEntryId = &#63;.
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching commerce catalog, or <code>null</code> if a matching commerce catalog could not be found
+	 */
+	@Override
+	public CommerceCatalog fetchByAccountEntryId_First(
+		long accountEntryId,
+		OrderByComparator<CommerceCatalog> orderByComparator) {
+
+		List<CommerceCatalog> list = findByAccountEntryId(
+			accountEntryId, 0, 1, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the last commerce catalog in the ordered set where accountEntryId = &#63;.
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching commerce catalog
+	 * @throws NoSuchCatalogException if a matching commerce catalog could not be found
+	 */
+	@Override
+	public CommerceCatalog findByAccountEntryId_Last(
+			long accountEntryId,
+			OrderByComparator<CommerceCatalog> orderByComparator)
+		throws NoSuchCatalogException {
+
+		CommerceCatalog commerceCatalog = fetchByAccountEntryId_Last(
+			accountEntryId, orderByComparator);
+
+		if (commerceCatalog != null) {
+			return commerceCatalog;
+		}
+
+		StringBundler sb = new StringBundler(4);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("accountEntryId=");
+		sb.append(accountEntryId);
+
+		sb.append("}");
+
+		throw new NoSuchCatalogException(sb.toString());
+	}
+
+	/**
+	 * Returns the last commerce catalog in the ordered set where accountEntryId = &#63;.
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching commerce catalog, or <code>null</code> if a matching commerce catalog could not be found
+	 */
+	@Override
+	public CommerceCatalog fetchByAccountEntryId_Last(
+		long accountEntryId,
+		OrderByComparator<CommerceCatalog> orderByComparator) {
+
+		int count = countByAccountEntryId(accountEntryId);
+
+		if (count == 0) {
+			return null;
+		}
+
+		List<CommerceCatalog> list = findByAccountEntryId(
+			accountEntryId, count - 1, count, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the commerce catalogs before and after the current commerce catalog in the ordered set where accountEntryId = &#63;.
+	 *
+	 * @param commerceCatalogId the primary key of the current commerce catalog
+	 * @param accountEntryId the account entry ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next commerce catalog
+	 * @throws NoSuchCatalogException if a commerce catalog with the primary key could not be found
+	 */
+	@Override
+	public CommerceCatalog[] findByAccountEntryId_PrevAndNext(
+			long commerceCatalogId, long accountEntryId,
+			OrderByComparator<CommerceCatalog> orderByComparator)
+		throws NoSuchCatalogException {
+
+		CommerceCatalog commerceCatalog = findByPrimaryKey(commerceCatalogId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			CommerceCatalog[] array = new CommerceCatalogImpl[3];
+
+			array[0] = getByAccountEntryId_PrevAndNext(
+				session, commerceCatalog, accountEntryId, orderByComparator,
+				true);
+
+			array[1] = commerceCatalog;
+
+			array[2] = getByAccountEntryId_PrevAndNext(
+				session, commerceCatalog, accountEntryId, orderByComparator,
+				false);
+
+			return array;
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected CommerceCatalog getByAccountEntryId_PrevAndNext(
+		Session session, CommerceCatalog commerceCatalog, long accountEntryId,
+		OrderByComparator<CommerceCatalog> orderByComparator,
+		boolean previous) {
+
+		StringBundler sb = null;
+
+		if (orderByComparator != null) {
+			sb = new StringBundler(
+				4 + (orderByComparator.getOrderByConditionFields().length * 3) +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			sb = new StringBundler(3);
+		}
+
+		sb.append(_SQL_SELECT_COMMERCECATALOG_WHERE);
+
+		sb.append(_FINDER_COLUMN_ACCOUNTENTRYID_ACCOUNTENTRYID_2);
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields =
+				orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				sb.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByConditionFields[i]);
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			sb.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByFields[i]);
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						sb.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC);
+					}
+					else {
+						sb.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			sb.append(CommerceCatalogModelImpl.ORDER_BY_JPQL);
+		}
+
+		String sql = sb.toString();
+
+		Query query = session.createQuery(sql);
+
+		query.setFirstResult(0);
+		query.setMaxResults(2);
+
+		QueryPos queryPos = QueryPos.getInstance(query);
+
+		queryPos.add(accountEntryId);
+
+		if (orderByComparator != null) {
+			for (Object orderByConditionValue :
+					orderByComparator.getOrderByConditionValues(
+						commerceCatalog)) {
+
+				queryPos.add(orderByConditionValue);
+			}
+		}
+
+		List<CommerceCatalog> list = query.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Returns all the commerce catalogs that the user has permission to view where accountEntryId = &#63;.
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @return the matching commerce catalogs that the user has permission to view
+	 */
+	@Override
+	public List<CommerceCatalog> filterFindByAccountEntryId(
+		long accountEntryId) {
+
+		return filterFindByAccountEntryId(
+			accountEntryId, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the commerce catalogs that the user has permission to view where accountEntryId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>CommerceCatalogModelImpl</code>.
+	 * </p>
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @param start the lower bound of the range of commerce catalogs
+	 * @param end the upper bound of the range of commerce catalogs (not inclusive)
+	 * @return the range of matching commerce catalogs that the user has permission to view
+	 */
+	@Override
+	public List<CommerceCatalog> filterFindByAccountEntryId(
+		long accountEntryId, int start, int end) {
+
+		return filterFindByAccountEntryId(accountEntryId, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the commerce catalogs that the user has permissions to view where accountEntryId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>CommerceCatalogModelImpl</code>.
+	 * </p>
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @param start the lower bound of the range of commerce catalogs
+	 * @param end the upper bound of the range of commerce catalogs (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching commerce catalogs that the user has permission to view
+	 */
+	@Override
+	public List<CommerceCatalog> filterFindByAccountEntryId(
+		long accountEntryId, int start, int end,
+		OrderByComparator<CommerceCatalog> orderByComparator) {
+
+		if (!InlineSQLHelperUtil.isEnabled()) {
+			return findByAccountEntryId(
+				accountEntryId, start, end, orderByComparator);
+		}
+
+		StringBundler sb = null;
+
+		if (orderByComparator != null) {
+			sb = new StringBundler(
+				3 + (orderByComparator.getOrderByFields().length * 2));
+		}
+		else {
+			sb = new StringBundler(4);
+		}
+
+		if (getDB().isSupportsInlineDistinct()) {
+			sb.append(_FILTER_SQL_SELECT_COMMERCECATALOG_WHERE);
+		}
+		else {
+			sb.append(
+				_FILTER_SQL_SELECT_COMMERCECATALOG_NO_INLINE_DISTINCT_WHERE_1);
+		}
+
+		sb.append(_FINDER_COLUMN_ACCOUNTENTRYID_ACCOUNTENTRYID_2);
+
+		if (!getDB().isSupportsInlineDistinct()) {
+			sb.append(
+				_FILTER_SQL_SELECT_COMMERCECATALOG_NO_INLINE_DISTINCT_WHERE_2);
+		}
+
+		if (orderByComparator != null) {
+			if (getDB().isSupportsInlineDistinct()) {
+				appendOrderByComparator(
+					sb, _ORDER_BY_ENTITY_ALIAS, orderByComparator, true);
+			}
+			else {
+				appendOrderByComparator(
+					sb, _ORDER_BY_ENTITY_TABLE, orderByComparator, true);
+			}
+		}
+		else {
+			if (getDB().isSupportsInlineDistinct()) {
+				sb.append(CommerceCatalogModelImpl.ORDER_BY_JPQL);
+			}
+			else {
+				sb.append(CommerceCatalogModelImpl.ORDER_BY_SQL);
+			}
+		}
+
+		String sql = InlineSQLHelperUtil.replacePermissionCheck(
+			sb.toString(), CommerceCatalog.class.getName(),
+			_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			SQLQuery sqlQuery = session.createSynchronizedSQLQuery(sql);
+
+			if (getDB().isSupportsInlineDistinct()) {
+				sqlQuery.addEntity(
+					_FILTER_ENTITY_ALIAS, CommerceCatalogImpl.class);
+			}
+			else {
+				sqlQuery.addEntity(
+					_FILTER_ENTITY_TABLE, CommerceCatalogImpl.class);
+			}
+
+			QueryPos queryPos = QueryPos.getInstance(sqlQuery);
+
+			queryPos.add(accountEntryId);
+
+			return (List<CommerceCatalog>)QueryUtil.list(
+				sqlQuery, getDialect(), start, end);
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	/**
+	 * Returns the commerce catalogs before and after the current commerce catalog in the ordered set of commerce catalogs that the user has permission to view where accountEntryId = &#63;.
+	 *
+	 * @param commerceCatalogId the primary key of the current commerce catalog
+	 * @param accountEntryId the account entry ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next commerce catalog
+	 * @throws NoSuchCatalogException if a commerce catalog with the primary key could not be found
+	 */
+	@Override
+	public CommerceCatalog[] filterFindByAccountEntryId_PrevAndNext(
+			long commerceCatalogId, long accountEntryId,
+			OrderByComparator<CommerceCatalog> orderByComparator)
+		throws NoSuchCatalogException {
+
+		if (!InlineSQLHelperUtil.isEnabled()) {
+			return findByAccountEntryId_PrevAndNext(
+				commerceCatalogId, accountEntryId, orderByComparator);
+		}
+
+		CommerceCatalog commerceCatalog = findByPrimaryKey(commerceCatalogId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			CommerceCatalog[] array = new CommerceCatalogImpl[3];
+
+			array[0] = filterGetByAccountEntryId_PrevAndNext(
+				session, commerceCatalog, accountEntryId, orderByComparator,
+				true);
+
+			array[1] = commerceCatalog;
+
+			array[2] = filterGetByAccountEntryId_PrevAndNext(
+				session, commerceCatalog, accountEntryId, orderByComparator,
+				false);
+
+			return array;
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected CommerceCatalog filterGetByAccountEntryId_PrevAndNext(
+		Session session, CommerceCatalog commerceCatalog, long accountEntryId,
+		OrderByComparator<CommerceCatalog> orderByComparator,
+		boolean previous) {
+
+		StringBundler sb = null;
+
+		if (orderByComparator != null) {
+			sb = new StringBundler(
+				5 + (orderByComparator.getOrderByConditionFields().length * 3) +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			sb = new StringBundler(4);
+		}
+
+		if (getDB().isSupportsInlineDistinct()) {
+			sb.append(_FILTER_SQL_SELECT_COMMERCECATALOG_WHERE);
+		}
+		else {
+			sb.append(
+				_FILTER_SQL_SELECT_COMMERCECATALOG_NO_INLINE_DISTINCT_WHERE_1);
+		}
+
+		sb.append(_FINDER_COLUMN_ACCOUNTENTRYID_ACCOUNTENTRYID_2);
+
+		if (!getDB().isSupportsInlineDistinct()) {
+			sb.append(
+				_FILTER_SQL_SELECT_COMMERCECATALOG_NO_INLINE_DISTINCT_WHERE_2);
+		}
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields =
+				orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				sb.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				if (getDB().isSupportsInlineDistinct()) {
+					sb.append(
+						getColumnName(
+							_ORDER_BY_ENTITY_ALIAS, orderByConditionFields[i],
+							true));
+				}
+				else {
+					sb.append(
+						getColumnName(
+							_ORDER_BY_ENTITY_TABLE, orderByConditionFields[i],
+							true));
+				}
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			sb.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				if (getDB().isSupportsInlineDistinct()) {
+					sb.append(
+						getColumnName(
+							_ORDER_BY_ENTITY_ALIAS, orderByFields[i], true));
+				}
+				else {
+					sb.append(
+						getColumnName(
+							_ORDER_BY_ENTITY_TABLE, orderByFields[i], true));
+				}
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						sb.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC);
+					}
+					else {
+						sb.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			if (getDB().isSupportsInlineDistinct()) {
+				sb.append(CommerceCatalogModelImpl.ORDER_BY_JPQL);
+			}
+			else {
+				sb.append(CommerceCatalogModelImpl.ORDER_BY_SQL);
+			}
+		}
+
+		String sql = InlineSQLHelperUtil.replacePermissionCheck(
+			sb.toString(), CommerceCatalog.class.getName(),
+			_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN);
+
+		SQLQuery sqlQuery = session.createSynchronizedSQLQuery(sql);
+
+		sqlQuery.setFirstResult(0);
+		sqlQuery.setMaxResults(2);
+
+		if (getDB().isSupportsInlineDistinct()) {
+			sqlQuery.addEntity(_FILTER_ENTITY_ALIAS, CommerceCatalogImpl.class);
+		}
+		else {
+			sqlQuery.addEntity(_FILTER_ENTITY_TABLE, CommerceCatalogImpl.class);
+		}
+
+		QueryPos queryPos = QueryPos.getInstance(sqlQuery);
+
+		queryPos.add(accountEntryId);
+
+		if (orderByComparator != null) {
+			for (Object orderByConditionValue :
+					orderByComparator.getOrderByConditionValues(
+						commerceCatalog)) {
+
+				queryPos.add(orderByConditionValue);
+			}
+		}
+
+		List<CommerceCatalog> list = sqlQuery.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Removes all the commerce catalogs where accountEntryId = &#63; from the database.
+	 *
+	 * @param accountEntryId the account entry ID
+	 */
+	@Override
+	public void removeByAccountEntryId(long accountEntryId) {
+		for (CommerceCatalog commerceCatalog :
+				findByAccountEntryId(
+					accountEntryId, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+					null)) {
+
+			remove(commerceCatalog);
+		}
+	}
+
+	/**
+	 * Returns the number of commerce catalogs where accountEntryId = &#63;.
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @return the number of matching commerce catalogs
+	 */
+	@Override
+	public int countByAccountEntryId(long accountEntryId) {
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			CommerceCatalog.class);
+
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
+
+		Long count = null;
+
+		if (productionMode) {
+			finderPath = _finderPathCountByAccountEntryId;
+
+			finderArgs = new Object[] {accountEntryId};
+
+			count = (Long)finderCache.getResult(finderPath, finderArgs, this);
+		}
+
+		if (count == null) {
+			StringBundler sb = new StringBundler(2);
+
+			sb.append(_SQL_COUNT_COMMERCECATALOG_WHERE);
+
+			sb.append(_FINDER_COLUMN_ACCOUNTENTRYID_ACCOUNTENTRYID_2);
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				queryPos.add(accountEntryId);
+
+				count = (Long)query.uniqueResult();
+
+				if (productionMode) {
+					finderCache.putResult(finderPath, finderArgs, count);
+				}
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return count.intValue();
+	}
+
+	/**
+	 * Returns the number of commerce catalogs that the user has permission to view where accountEntryId = &#63;.
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @return the number of matching commerce catalogs that the user has permission to view
+	 */
+	@Override
+	public int filterCountByAccountEntryId(long accountEntryId) {
+		if (!InlineSQLHelperUtil.isEnabled()) {
+			return countByAccountEntryId(accountEntryId);
+		}
+
+		StringBundler sb = new StringBundler(2);
+
+		sb.append(_FILTER_SQL_COUNT_COMMERCECATALOG_WHERE);
+
+		sb.append(_FINDER_COLUMN_ACCOUNTENTRYID_ACCOUNTENTRYID_2);
+
+		String sql = InlineSQLHelperUtil.replacePermissionCheck(
+			sb.toString(), CommerceCatalog.class.getName(),
+			_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			SQLQuery sqlQuery = session.createSynchronizedSQLQuery(sql);
+
+			sqlQuery.addScalar(
+				COUNT_COLUMN_NAME, com.liferay.portal.kernel.dao.orm.Type.LONG);
+
+			QueryPos queryPos = QueryPos.getInstance(sqlQuery);
+
+			queryPos.add(accountEntryId);
+
+			Long count = (Long)sqlQuery.uniqueResult();
+
+			return count.intValue();
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	private static final String _FINDER_COLUMN_ACCOUNTENTRYID_ACCOUNTENTRYID_2 =
+		"commerceCatalog.accountEntryId = ?";
+
 	private FinderPath _finderPathWithPaginationFindByC_S;
 	private FinderPath _finderPathWithoutPaginationFindByC_S;
 	private FinderPath _finderPathCountByC_S;
@@ -5159,6 +6065,24 @@ public class CommerceCatalogPersistenceImpl
 			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByCompanyId",
 			new String[] {Long.class.getName()}, new String[] {"companyId"},
 			false);
+
+		_finderPathWithPaginationFindByAccountEntryId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByAccountEntryId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"accountEntryId"}, true);
+
+		_finderPathWithoutPaginationFindByAccountEntryId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByAccountEntryId",
+			new String[] {Long.class.getName()},
+			new String[] {"accountEntryId"}, true);
+
+		_finderPathCountByAccountEntryId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByAccountEntryId",
+			new String[] {Long.class.getName()},
+			new String[] {"accountEntryId"}, false);
 
 		_finderPathWithPaginationFindByC_S = new FinderPath(
 			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_S",

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/persistence/impl/CommerceChannelPersistenceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/persistence/impl/CommerceChannelPersistenceImpl.java
@@ -3019,6 +3019,912 @@ public class CommerceChannelPersistenceImpl
 	private static final String _FINDER_COLUMN_COMPANYID_COMPANYID_2 =
 		"commerceChannel.companyId = ?";
 
+	private FinderPath _finderPathWithPaginationFindByAccountEntryId;
+	private FinderPath _finderPathWithoutPaginationFindByAccountEntryId;
+	private FinderPath _finderPathCountByAccountEntryId;
+
+	/**
+	 * Returns all the commerce channels where accountEntryId = &#63;.
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @return the matching commerce channels
+	 */
+	@Override
+	public List<CommerceChannel> findByAccountEntryId(long accountEntryId) {
+		return findByAccountEntryId(
+			accountEntryId, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the commerce channels where accountEntryId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>CommerceChannelModelImpl</code>.
+	 * </p>
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @param start the lower bound of the range of commerce channels
+	 * @param end the upper bound of the range of commerce channels (not inclusive)
+	 * @return the range of matching commerce channels
+	 */
+	@Override
+	public List<CommerceChannel> findByAccountEntryId(
+		long accountEntryId, int start, int end) {
+
+		return findByAccountEntryId(accountEntryId, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the commerce channels where accountEntryId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>CommerceChannelModelImpl</code>.
+	 * </p>
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @param start the lower bound of the range of commerce channels
+	 * @param end the upper bound of the range of commerce channels (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching commerce channels
+	 */
+	@Override
+	public List<CommerceChannel> findByAccountEntryId(
+		long accountEntryId, int start, int end,
+		OrderByComparator<CommerceChannel> orderByComparator) {
+
+		return findByAccountEntryId(
+			accountEntryId, start, end, orderByComparator, true);
+	}
+
+	/**
+	 * Returns an ordered range of all the commerce channels where accountEntryId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>CommerceChannelModelImpl</code>.
+	 * </p>
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @param start the lower bound of the range of commerce channels
+	 * @param end the upper bound of the range of commerce channels (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching commerce channels
+	 */
+	@Override
+	public List<CommerceChannel> findByAccountEntryId(
+		long accountEntryId, int start, int end,
+		OrderByComparator<CommerceChannel> orderByComparator,
+		boolean useFinderCache) {
+
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			CommerceChannel.class);
+
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
+
+		if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
+			(orderByComparator == null)) {
+
+			if (useFinderCache && productionMode) {
+				finderPath = _finderPathWithoutPaginationFindByAccountEntryId;
+				finderArgs = new Object[] {accountEntryId};
+			}
+		}
+		else if (useFinderCache && productionMode) {
+			finderPath = _finderPathWithPaginationFindByAccountEntryId;
+			finderArgs = new Object[] {
+				accountEntryId, start, end, orderByComparator
+			};
+		}
+
+		List<CommerceChannel> list = null;
+
+		if (useFinderCache && productionMode) {
+			list = (List<CommerceChannel>)finderCache.getResult(
+				finderPath, finderArgs, this);
+
+			if ((list != null) && !list.isEmpty()) {
+				for (CommerceChannel commerceChannel : list) {
+					if (accountEntryId != commerceChannel.getAccountEntryId()) {
+						list = null;
+
+						break;
+					}
+				}
+			}
+		}
+
+		if (list == null) {
+			StringBundler sb = null;
+
+			if (orderByComparator != null) {
+				sb = new StringBundler(
+					3 + (orderByComparator.getOrderByFields().length * 2));
+			}
+			else {
+				sb = new StringBundler(3);
+			}
+
+			sb.append(_SQL_SELECT_COMMERCECHANNEL_WHERE);
+
+			sb.append(_FINDER_COLUMN_ACCOUNTENTRYID_ACCOUNTENTRYID_2);
+
+			if (orderByComparator != null) {
+				appendOrderByComparator(
+					sb, _ORDER_BY_ENTITY_ALIAS, orderByComparator);
+			}
+			else {
+				sb.append(CommerceChannelModelImpl.ORDER_BY_JPQL);
+			}
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				queryPos.add(accountEntryId);
+
+				list = (List<CommerceChannel>)QueryUtil.list(
+					query, getDialect(), start, end);
+
+				cacheResult(list);
+
+				if (useFinderCache && productionMode) {
+					finderCache.putResult(finderPath, finderArgs, list);
+				}
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return list;
+	}
+
+	/**
+	 * Returns the first commerce channel in the ordered set where accountEntryId = &#63;.
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching commerce channel
+	 * @throws NoSuchChannelException if a matching commerce channel could not be found
+	 */
+	@Override
+	public CommerceChannel findByAccountEntryId_First(
+			long accountEntryId,
+			OrderByComparator<CommerceChannel> orderByComparator)
+		throws NoSuchChannelException {
+
+		CommerceChannel commerceChannel = fetchByAccountEntryId_First(
+			accountEntryId, orderByComparator);
+
+		if (commerceChannel != null) {
+			return commerceChannel;
+		}
+
+		StringBundler sb = new StringBundler(4);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("accountEntryId=");
+		sb.append(accountEntryId);
+
+		sb.append("}");
+
+		throw new NoSuchChannelException(sb.toString());
+	}
+
+	/**
+	 * Returns the first commerce channel in the ordered set where accountEntryId = &#63;.
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching commerce channel, or <code>null</code> if a matching commerce channel could not be found
+	 */
+	@Override
+	public CommerceChannel fetchByAccountEntryId_First(
+		long accountEntryId,
+		OrderByComparator<CommerceChannel> orderByComparator) {
+
+		List<CommerceChannel> list = findByAccountEntryId(
+			accountEntryId, 0, 1, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the last commerce channel in the ordered set where accountEntryId = &#63;.
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching commerce channel
+	 * @throws NoSuchChannelException if a matching commerce channel could not be found
+	 */
+	@Override
+	public CommerceChannel findByAccountEntryId_Last(
+			long accountEntryId,
+			OrderByComparator<CommerceChannel> orderByComparator)
+		throws NoSuchChannelException {
+
+		CommerceChannel commerceChannel = fetchByAccountEntryId_Last(
+			accountEntryId, orderByComparator);
+
+		if (commerceChannel != null) {
+			return commerceChannel;
+		}
+
+		StringBundler sb = new StringBundler(4);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("accountEntryId=");
+		sb.append(accountEntryId);
+
+		sb.append("}");
+
+		throw new NoSuchChannelException(sb.toString());
+	}
+
+	/**
+	 * Returns the last commerce channel in the ordered set where accountEntryId = &#63;.
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching commerce channel, or <code>null</code> if a matching commerce channel could not be found
+	 */
+	@Override
+	public CommerceChannel fetchByAccountEntryId_Last(
+		long accountEntryId,
+		OrderByComparator<CommerceChannel> orderByComparator) {
+
+		int count = countByAccountEntryId(accountEntryId);
+
+		if (count == 0) {
+			return null;
+		}
+
+		List<CommerceChannel> list = findByAccountEntryId(
+			accountEntryId, count - 1, count, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the commerce channels before and after the current commerce channel in the ordered set where accountEntryId = &#63;.
+	 *
+	 * @param commerceChannelId the primary key of the current commerce channel
+	 * @param accountEntryId the account entry ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next commerce channel
+	 * @throws NoSuchChannelException if a commerce channel with the primary key could not be found
+	 */
+	@Override
+	public CommerceChannel[] findByAccountEntryId_PrevAndNext(
+			long commerceChannelId, long accountEntryId,
+			OrderByComparator<CommerceChannel> orderByComparator)
+		throws NoSuchChannelException {
+
+		CommerceChannel commerceChannel = findByPrimaryKey(commerceChannelId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			CommerceChannel[] array = new CommerceChannelImpl[3];
+
+			array[0] = getByAccountEntryId_PrevAndNext(
+				session, commerceChannel, accountEntryId, orderByComparator,
+				true);
+
+			array[1] = commerceChannel;
+
+			array[2] = getByAccountEntryId_PrevAndNext(
+				session, commerceChannel, accountEntryId, orderByComparator,
+				false);
+
+			return array;
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected CommerceChannel getByAccountEntryId_PrevAndNext(
+		Session session, CommerceChannel commerceChannel, long accountEntryId,
+		OrderByComparator<CommerceChannel> orderByComparator,
+		boolean previous) {
+
+		StringBundler sb = null;
+
+		if (orderByComparator != null) {
+			sb = new StringBundler(
+				4 + (orderByComparator.getOrderByConditionFields().length * 3) +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			sb = new StringBundler(3);
+		}
+
+		sb.append(_SQL_SELECT_COMMERCECHANNEL_WHERE);
+
+		sb.append(_FINDER_COLUMN_ACCOUNTENTRYID_ACCOUNTENTRYID_2);
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields =
+				orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				sb.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByConditionFields[i]);
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			sb.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByFields[i]);
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						sb.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC);
+					}
+					else {
+						sb.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			sb.append(CommerceChannelModelImpl.ORDER_BY_JPQL);
+		}
+
+		String sql = sb.toString();
+
+		Query query = session.createQuery(sql);
+
+		query.setFirstResult(0);
+		query.setMaxResults(2);
+
+		QueryPos queryPos = QueryPos.getInstance(query);
+
+		queryPos.add(accountEntryId);
+
+		if (orderByComparator != null) {
+			for (Object orderByConditionValue :
+					orderByComparator.getOrderByConditionValues(
+						commerceChannel)) {
+
+				queryPos.add(orderByConditionValue);
+			}
+		}
+
+		List<CommerceChannel> list = query.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Returns all the commerce channels that the user has permission to view where accountEntryId = &#63;.
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @return the matching commerce channels that the user has permission to view
+	 */
+	@Override
+	public List<CommerceChannel> filterFindByAccountEntryId(
+		long accountEntryId) {
+
+		return filterFindByAccountEntryId(
+			accountEntryId, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the commerce channels that the user has permission to view where accountEntryId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>CommerceChannelModelImpl</code>.
+	 * </p>
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @param start the lower bound of the range of commerce channels
+	 * @param end the upper bound of the range of commerce channels (not inclusive)
+	 * @return the range of matching commerce channels that the user has permission to view
+	 */
+	@Override
+	public List<CommerceChannel> filterFindByAccountEntryId(
+		long accountEntryId, int start, int end) {
+
+		return filterFindByAccountEntryId(accountEntryId, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the commerce channels that the user has permissions to view where accountEntryId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>CommerceChannelModelImpl</code>.
+	 * </p>
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @param start the lower bound of the range of commerce channels
+	 * @param end the upper bound of the range of commerce channels (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching commerce channels that the user has permission to view
+	 */
+	@Override
+	public List<CommerceChannel> filterFindByAccountEntryId(
+		long accountEntryId, int start, int end,
+		OrderByComparator<CommerceChannel> orderByComparator) {
+
+		if (!InlineSQLHelperUtil.isEnabled()) {
+			return findByAccountEntryId(
+				accountEntryId, start, end, orderByComparator);
+		}
+
+		StringBundler sb = null;
+
+		if (orderByComparator != null) {
+			sb = new StringBundler(
+				3 + (orderByComparator.getOrderByFields().length * 2));
+		}
+		else {
+			sb = new StringBundler(4);
+		}
+
+		if (getDB().isSupportsInlineDistinct()) {
+			sb.append(_FILTER_SQL_SELECT_COMMERCECHANNEL_WHERE);
+		}
+		else {
+			sb.append(
+				_FILTER_SQL_SELECT_COMMERCECHANNEL_NO_INLINE_DISTINCT_WHERE_1);
+		}
+
+		sb.append(_FINDER_COLUMN_ACCOUNTENTRYID_ACCOUNTENTRYID_2);
+
+		if (!getDB().isSupportsInlineDistinct()) {
+			sb.append(
+				_FILTER_SQL_SELECT_COMMERCECHANNEL_NO_INLINE_DISTINCT_WHERE_2);
+		}
+
+		if (orderByComparator != null) {
+			if (getDB().isSupportsInlineDistinct()) {
+				appendOrderByComparator(
+					sb, _ORDER_BY_ENTITY_ALIAS, orderByComparator, true);
+			}
+			else {
+				appendOrderByComparator(
+					sb, _ORDER_BY_ENTITY_TABLE, orderByComparator, true);
+			}
+		}
+		else {
+			if (getDB().isSupportsInlineDistinct()) {
+				sb.append(CommerceChannelModelImpl.ORDER_BY_JPQL);
+			}
+			else {
+				sb.append(CommerceChannelModelImpl.ORDER_BY_SQL);
+			}
+		}
+
+		String sql = InlineSQLHelperUtil.replacePermissionCheck(
+			sb.toString(), CommerceChannel.class.getName(),
+			_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			SQLQuery sqlQuery = session.createSynchronizedSQLQuery(sql);
+
+			if (getDB().isSupportsInlineDistinct()) {
+				sqlQuery.addEntity(
+					_FILTER_ENTITY_ALIAS, CommerceChannelImpl.class);
+			}
+			else {
+				sqlQuery.addEntity(
+					_FILTER_ENTITY_TABLE, CommerceChannelImpl.class);
+			}
+
+			QueryPos queryPos = QueryPos.getInstance(sqlQuery);
+
+			queryPos.add(accountEntryId);
+
+			return (List<CommerceChannel>)QueryUtil.list(
+				sqlQuery, getDialect(), start, end);
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	/**
+	 * Returns the commerce channels before and after the current commerce channel in the ordered set of commerce channels that the user has permission to view where accountEntryId = &#63;.
+	 *
+	 * @param commerceChannelId the primary key of the current commerce channel
+	 * @param accountEntryId the account entry ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next commerce channel
+	 * @throws NoSuchChannelException if a commerce channel with the primary key could not be found
+	 */
+	@Override
+	public CommerceChannel[] filterFindByAccountEntryId_PrevAndNext(
+			long commerceChannelId, long accountEntryId,
+			OrderByComparator<CommerceChannel> orderByComparator)
+		throws NoSuchChannelException {
+
+		if (!InlineSQLHelperUtil.isEnabled()) {
+			return findByAccountEntryId_PrevAndNext(
+				commerceChannelId, accountEntryId, orderByComparator);
+		}
+
+		CommerceChannel commerceChannel = findByPrimaryKey(commerceChannelId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			CommerceChannel[] array = new CommerceChannelImpl[3];
+
+			array[0] = filterGetByAccountEntryId_PrevAndNext(
+				session, commerceChannel, accountEntryId, orderByComparator,
+				true);
+
+			array[1] = commerceChannel;
+
+			array[2] = filterGetByAccountEntryId_PrevAndNext(
+				session, commerceChannel, accountEntryId, orderByComparator,
+				false);
+
+			return array;
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected CommerceChannel filterGetByAccountEntryId_PrevAndNext(
+		Session session, CommerceChannel commerceChannel, long accountEntryId,
+		OrderByComparator<CommerceChannel> orderByComparator,
+		boolean previous) {
+
+		StringBundler sb = null;
+
+		if (orderByComparator != null) {
+			sb = new StringBundler(
+				5 + (orderByComparator.getOrderByConditionFields().length * 3) +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			sb = new StringBundler(4);
+		}
+
+		if (getDB().isSupportsInlineDistinct()) {
+			sb.append(_FILTER_SQL_SELECT_COMMERCECHANNEL_WHERE);
+		}
+		else {
+			sb.append(
+				_FILTER_SQL_SELECT_COMMERCECHANNEL_NO_INLINE_DISTINCT_WHERE_1);
+		}
+
+		sb.append(_FINDER_COLUMN_ACCOUNTENTRYID_ACCOUNTENTRYID_2);
+
+		if (!getDB().isSupportsInlineDistinct()) {
+			sb.append(
+				_FILTER_SQL_SELECT_COMMERCECHANNEL_NO_INLINE_DISTINCT_WHERE_2);
+		}
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields =
+				orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				sb.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				if (getDB().isSupportsInlineDistinct()) {
+					sb.append(
+						getColumnName(
+							_ORDER_BY_ENTITY_ALIAS, orderByConditionFields[i],
+							true));
+				}
+				else {
+					sb.append(
+						getColumnName(
+							_ORDER_BY_ENTITY_TABLE, orderByConditionFields[i],
+							true));
+				}
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			sb.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				if (getDB().isSupportsInlineDistinct()) {
+					sb.append(
+						getColumnName(
+							_ORDER_BY_ENTITY_ALIAS, orderByFields[i], true));
+				}
+				else {
+					sb.append(
+						getColumnName(
+							_ORDER_BY_ENTITY_TABLE, orderByFields[i], true));
+				}
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						sb.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC);
+					}
+					else {
+						sb.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			if (getDB().isSupportsInlineDistinct()) {
+				sb.append(CommerceChannelModelImpl.ORDER_BY_JPQL);
+			}
+			else {
+				sb.append(CommerceChannelModelImpl.ORDER_BY_SQL);
+			}
+		}
+
+		String sql = InlineSQLHelperUtil.replacePermissionCheck(
+			sb.toString(), CommerceChannel.class.getName(),
+			_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN);
+
+		SQLQuery sqlQuery = session.createSynchronizedSQLQuery(sql);
+
+		sqlQuery.setFirstResult(0);
+		sqlQuery.setMaxResults(2);
+
+		if (getDB().isSupportsInlineDistinct()) {
+			sqlQuery.addEntity(_FILTER_ENTITY_ALIAS, CommerceChannelImpl.class);
+		}
+		else {
+			sqlQuery.addEntity(_FILTER_ENTITY_TABLE, CommerceChannelImpl.class);
+		}
+
+		QueryPos queryPos = QueryPos.getInstance(sqlQuery);
+
+		queryPos.add(accountEntryId);
+
+		if (orderByComparator != null) {
+			for (Object orderByConditionValue :
+					orderByComparator.getOrderByConditionValues(
+						commerceChannel)) {
+
+				queryPos.add(orderByConditionValue);
+			}
+		}
+
+		List<CommerceChannel> list = sqlQuery.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Removes all the commerce channels where accountEntryId = &#63; from the database.
+	 *
+	 * @param accountEntryId the account entry ID
+	 */
+	@Override
+	public void removeByAccountEntryId(long accountEntryId) {
+		for (CommerceChannel commerceChannel :
+				findByAccountEntryId(
+					accountEntryId, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+					null)) {
+
+			remove(commerceChannel);
+		}
+	}
+
+	/**
+	 * Returns the number of commerce channels where accountEntryId = &#63;.
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @return the number of matching commerce channels
+	 */
+	@Override
+	public int countByAccountEntryId(long accountEntryId) {
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			CommerceChannel.class);
+
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
+
+		Long count = null;
+
+		if (productionMode) {
+			finderPath = _finderPathCountByAccountEntryId;
+
+			finderArgs = new Object[] {accountEntryId};
+
+			count = (Long)finderCache.getResult(finderPath, finderArgs, this);
+		}
+
+		if (count == null) {
+			StringBundler sb = new StringBundler(2);
+
+			sb.append(_SQL_COUNT_COMMERCECHANNEL_WHERE);
+
+			sb.append(_FINDER_COLUMN_ACCOUNTENTRYID_ACCOUNTENTRYID_2);
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				queryPos.add(accountEntryId);
+
+				count = (Long)query.uniqueResult();
+
+				if (productionMode) {
+					finderCache.putResult(finderPath, finderArgs, count);
+				}
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return count.intValue();
+	}
+
+	/**
+	 * Returns the number of commerce channels that the user has permission to view where accountEntryId = &#63;.
+	 *
+	 * @param accountEntryId the account entry ID
+	 * @return the number of matching commerce channels that the user has permission to view
+	 */
+	@Override
+	public int filterCountByAccountEntryId(long accountEntryId) {
+		if (!InlineSQLHelperUtil.isEnabled()) {
+			return countByAccountEntryId(accountEntryId);
+		}
+
+		StringBundler sb = new StringBundler(2);
+
+		sb.append(_FILTER_SQL_COUNT_COMMERCECHANNEL_WHERE);
+
+		sb.append(_FINDER_COLUMN_ACCOUNTENTRYID_ACCOUNTENTRYID_2);
+
+		String sql = InlineSQLHelperUtil.replacePermissionCheck(
+			sb.toString(), CommerceChannel.class.getName(),
+			_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			SQLQuery sqlQuery = session.createSynchronizedSQLQuery(sql);
+
+			sqlQuery.addScalar(
+				COUNT_COLUMN_NAME, com.liferay.portal.kernel.dao.orm.Type.LONG);
+
+			QueryPos queryPos = QueryPos.getInstance(sqlQuery);
+
+			queryPos.add(accountEntryId);
+
+			Long count = (Long)sqlQuery.uniqueResult();
+
+			return count.intValue();
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	private static final String _FINDER_COLUMN_ACCOUNTENTRYID_ACCOUNTENTRYID_2 =
+		"commerceChannel.accountEntryId = ?";
+
 	private FinderPath _finderPathFetchBySiteGroupId;
 	private FinderPath _finderPathCountBySiteGroupId;
 
@@ -4445,6 +5351,24 @@ public class CommerceChannelPersistenceImpl
 			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByCompanyId",
 			new String[] {Long.class.getName()}, new String[] {"companyId"},
 			false);
+
+		_finderPathWithPaginationFindByAccountEntryId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByAccountEntryId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"accountEntryId"}, true);
+
+		_finderPathWithoutPaginationFindByAccountEntryId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByAccountEntryId",
+			new String[] {Long.class.getName()},
+			new String[] {"accountEntryId"}, true);
+
+		_finderPathCountByAccountEntryId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByAccountEntryId",
+			new String[] {Long.class.getName()},
+			new String[] {"accountEntryId"}, false);
 
 		_finderPathFetchBySiteGroupId = new FinderPath(
 			FINDER_CLASS_NAME_ENTITY, "fetchBySiteGroupId",

--- a/modules/apps/commerce/commerce-product-service/src/main/resources/META-INF/sql/indexes.sql
+++ b/modules/apps/commerce/commerce-product-service/src/main/resources/META-INF/sql/indexes.sql
@@ -161,12 +161,14 @@ create index IX_4F867FC4 on CProduct (uuid_[$COLUMN_LENGTH:75$], companyId, ctCo
 create index IX_36D0BBE0 on CProduct (uuid_[$COLUMN_LENGTH:75$], ctCollectionId);
 create unique index IX_F70CE3C6 on CProduct (uuid_[$COLUMN_LENGTH:75$], groupId, ctCollectionId);
 
+create index IX_4807BAF6 on CommerceCatalog (accountEntryId, ctCollectionId);
 create index IX_7D2B5F22 on CommerceCatalog (companyId, ctCollectionId);
 create index IX_B053A95A on CommerceCatalog (companyId, system_, ctCollectionId);
 create unique index IX_482EFB0D on CommerceCatalog (externalReferenceCode[$COLUMN_LENGTH:75$], companyId, ctCollectionId);
 create index IX_E567F436 on CommerceCatalog (uuid_[$COLUMN_LENGTH:75$], companyId, ctCollectionId);
 create index IX_570B9AAE on CommerceCatalog (uuid_[$COLUMN_LENGTH:75$], ctCollectionId);
 
+create index IX_4F0C1D60 on CommerceChannel (accountEntryId, ctCollectionId);
 create index IX_6A59A278 on CommerceChannel (companyId, ctCollectionId);
 create unique index IX_782B56F7 on CommerceChannel (externalReferenceCode[$COLUMN_LENGTH:75$], companyId, ctCollectionId);
 create index IX_A12DD9F3 on CommerceChannel (siteGroupId, ctCollectionId);

--- a/modules/apps/commerce/commerce-product-test/src/testFunctional/macros/json/CommerceJSONCatalogsAPI.macro
+++ b/modules/apps/commerce/commerce-product-test/src/testFunctional/macros/json/CommerceJSONCatalogsAPI.macro
@@ -59,6 +59,27 @@ definition {
 		}
 	}
 
+	macro _getCommerceAccountIdByCatalogId {
+		var baseURL = ${baseURL};
+
+		if (!(isSet(baseURL))) {
+			var baseURL = PropsUtil.get("portal.url");
+		}
+
+		var catalogId = CommerceJSONCatalogsAPI._getCommerceCatalogIdByName(catalogName = ${catalogName});
+		var userLoginInfo = JSONUtil2.formatJSONUser();
+
+		var curl = '''
+			${baseURL}/o/headless-commerce-admin-catalog/v1.0/catalog/${catalogId} \
+				-u ${userLoginInfo} \
+				-H 'accept: application/json' \
+		''';
+
+		var accountId = JSONCurlUtil.get(${curl}, "$..['accountId']");
+
+		return ${accountId};
+	}
+
 	macro _getCommerceCatalogIdByName {
 		Variables.assertDefined(parameterList = ${catalogName});
 

--- a/modules/apps/commerce/commerce-product-test/src/testFunctional/macros/json/CommerceJSONChannelsAPI.macro
+++ b/modules/apps/commerce/commerce-product-test/src/testFunctional/macros/json/CommerceJSONChannelsAPI.macro
@@ -5,6 +5,10 @@ definition {
 
 		var baseURL = ${baseURL};
 
+		if (!(isSet(accountId))) {
+			var accountId = 0;
+		}
+
 		if (!(isSet(baseURL))) {
 			var baseURL = PropsUtil.get("portal.url");
 		}
@@ -21,6 +25,7 @@ definition {
 				-H 'accept: application/json' \
 				-H 'Content-Type: application/json' \
 				-d '{
+					"accountId": "${accountId}",
 					"externalReferenceCode": "${externalReferenceCode}",
 					"siteGroupId": 0,
 					"name": "${channelName}",
@@ -63,6 +68,27 @@ definition {
 		else {
 			echo("No Commerce Channels to be deleted");
 		}
+	}
+
+	macro _getCommerceAccountIdByChannelId {
+		var baseURL = ${baseURL};
+
+		if (!(isSet(baseURL))) {
+			var baseURL = PropsUtil.get("portal.url");
+		}
+
+		var channelId = CommerceJSONChannelsAPI._getCommerceChannelIdByName(channelName = ${channelName});
+		var userLoginInfo = JSONUtil2.formatJSONUser();
+
+		var curl = '''
+			${baseURL}/o/headless-commerce-admin-channel/v1.0/channels/${channelId} \
+				-u ${userLoginInfo} \
+				-H 'accept: application/json' \
+		''';
+
+		var accountId = JSONCurlUtil.get(${curl}, "$..['accountId']");
+
+		return ${accountId};
 	}
 
 	macro _getCommerceChannelIdByName {

--- a/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CommerceAccountSupplierRole.testcase
+++ b/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CommerceAccountSupplierRole.testcase
@@ -158,6 +158,72 @@ definition {
 				key_fieldLabel = "Link Channel to a Supplier",
 				locator1 = "Select#GENERIC_SELECT_FIELD",
 				value1 = "Supplier Account 1");
+
+	@description = "This is a test for COMMERCE-11516. When a supplier account is deleted after being linked to a catalog, the account will not be shown as linked to the catalog"
+	@priority = 3
+	test CannotViewDeletedSupplierAccountLinkedToCatalogViaAPI {
+		property portal.acceptance = "false";
+
+		task ("Given a 'Supplier' type of account is created") {
+			CommerceJSONAccountsAPI._addCommerceAccount(
+				accountName = "Supplier Account",
+				accountType = "Supplier",
+				externalReferenceCode = "Supplier Account ERC");
+		}
+
+		task ("And a catalog is created and the supplier account is linked to it") {
+			var accountEntryId = JSONAccountEntryAPI._getAccountEntryId(accountEntryName = "Supplier Account");
+
+			CommerceJSONCatalogsAPI._addCatalog(
+				accountEntryId = ${accountEntryId},
+				catalogName = "Test Catalog");
+		}
+
+		task ("When the supplier account is deleted") {
+			CommerceJSONAccountsAPI._deleteAllCommerceAccounts();
+		}
+
+		task ("Then the supplier account will not be shown as linked to the catalog") {
+			var accountId = CommerceJSONCatalogsAPI._getCommerceAccountIdByCatalogId(catalogName = "Test Catalog");
+
+			TestUtils.assertNotEquals(
+				actual = ${accountId},
+				expected = ${accountEntryId});
+		}
+	}
+
+	@description = "This is a test for COMMERCE-11516. When a supplier account is deleted after being linked to a channel, the account will not be shown as linked to the channel"
+	@priority = 3
+	test CannotViewDeletedSupplierAccountLinkedToChannelViaAPI {
+		property portal.acceptance = "false";
+
+		task ("Given a 'Supplier' type of account is created") {
+			CommerceJSONAccountsAPI._addCommerceAccount(
+				accountName = "Supplier Account",
+				accountType = "Supplier",
+				externalReferenceCode = "Supplier Account ERC");
+		}
+
+		task ("And a channel is created and the supplier account is linked to it") {
+			var accountEntryId = JSONAccountEntryAPI._getAccountEntryId(accountEntryName = "Supplier Account");
+
+			CommerceJSONChannelsAPI._addChannel(
+				accountId = ${accountEntryId},
+				channelName = "Test Channel",
+				channelType = "site",
+				currencyCode = "USD");
+		}
+
+		task ("When the supplier account is deleted") {
+			CommerceJSONAccountsAPI._deleteAllCommerceAccounts();
+		}
+
+		task ("Then the supplier account will not be shown as linked to the channel") {
+			var accountId = CommerceJSONChannelsAPI._getCommerceAccountIdByChannelId(channelName = "Test Channel");
+
+			TestUtils.assertNotEquals(
+				actual = ${accountId},
+				expected = ${accountEntryId});
 		}
 	}
 

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CommerceCatalogPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CommerceCatalogPersistenceTest.java
@@ -253,6 +253,13 @@ public class CommerceCatalogPersistenceTest {
 	}
 
 	@Test
+	public void testCountByAccountEntryId() throws Exception {
+		_persistence.countByAccountEntryId(RandomTestUtil.nextLong());
+
+		_persistence.countByAccountEntryId(0L);
+	}
+
+	@Test
 	public void testCountByC_S() throws Exception {
 		_persistence.countByC_S(
 			RandomTestUtil.nextLong(), RandomTestUtil.randomBoolean());

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CommerceChannelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CommerceChannelPersistenceTest.java
@@ -268,6 +268,13 @@ public class CommerceChannelPersistenceTest {
 	}
 
 	@Test
+	public void testCountByAccountEntryId() throws Exception {
+		_persistence.countByAccountEntryId(RandomTestUtil.nextLong());
+
+		_persistence.countByAccountEntryId(0L);
+	}
+
+	@Test
 	public void testCountBySiteGroupId() throws Exception {
 		_persistence.countBySiteGroupId(RandomTestUtil.nextLong());
 


### PR DESCRIPTION
https://issues.liferay.com/browse/COMMERCE-11516
Base on https://github.com/liferay-commerce/liferay-portal/pull/3905
Resent from https://github.com/brianchandotcom/liferay-portal/pull/136592 (Fix the rebase conflict)

cc @MahmoudAzzam 