### PR TITLE
LPS-188162 Fix integration test

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/application/provider/test/APIApplicationProviderTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/application/provider/test/APIApplicationProviderTest.java
@@ -77,7 +77,7 @@ public class APIApplicationProviderTest extends BaseTestCase {
 							).put(
 								"name", "name"
 							).put(
-								"objectFieldERC", RandomTestUtil.randomString()
+								"objectFieldERC", "APPLICATION_STATUS"
 							))
 					).put(
 						"description", "description"


### PR DESCRIPTION
The purpose of this PR is to fix the `APIApplicationProviderTest` integration test, as it needs the `objectFieldERC` field points to an external reference code of an existing field