### PR TITLE
LPS-186786 API Builder integration test improvements

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/application/provider/test/APIApplicationProviderTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/application/provider/test/APIApplicationProviderTest.java
@@ -28,7 +28,6 @@ import com.liferay.portal.test.rule.Inject;
 
 import java.util.List;
 
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -37,15 +36,6 @@ import org.junit.Test;
  */
 @FeatureFlags({"LPS-184413", "LPS-167253", "LPS-153117"})
 public class APIApplicationProviderTest extends BaseTestCase {
-
-	@After
-	public void tearDown() throws Exception {
-		HTTPTestUtil.invoke(
-			null,
-			"headless-builder/applications/by-external-reference-code/" +
-				_API_APPLICATION_ERC,
-			Http.Method.DELETE);
-	}
 
 	@Test
 	public void test() throws Exception {

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/publisher/test/APIApplicationPublisherTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/publisher/test/APIApplicationPublisherTest.java
@@ -33,7 +33,6 @@ import java.util.concurrent.TimeUnit;
 
 import javax.ws.rs.core.Application;
 
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -48,20 +47,6 @@ import org.osgi.util.tracker.ServiceTracker;
  */
 @FeatureFlags({"LPS-186757", "LPS-184413", "LPS-167253", "LPS-153117"})
 public class APIApplicationPublisherTest extends BaseTestCase {
-
-	@After
-	public void tearDown() throws Exception {
-		HTTPTestUtil.invoke(
-			null,
-			"headless-builder/applications/by-external-reference-code/" +
-				_API_APPLICATION_ERC_1,
-			Http.Method.DELETE);
-		HTTPTestUtil.invoke(
-			null,
-			"headless-builder/applications/by-external-reference-code/" +
-				_API_APPLICATION_ERC_2,
-			Http.Method.DELETE);
-	}
 
 	@Test
 	public void testPublish() throws Exception {

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/test/BaseTestCase.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/test/BaseTestCase.java
@@ -46,6 +46,9 @@ public abstract class BaseTestCase {
 
 	@Before
 	public void setUp() {
+
+		// TODO Delete the bundle deployment when the FF LPS-184413 is removed
+
 		Bundle testBundle = FrameworkUtil.getBundle(BaseTestCase.class);
 
 		BundleContext bundleContext = testBundle.getBundleContext();


### PR DESCRIPTION
The purposes of this PR are the following ones:

- Include a comment to be found when deleting the API Builder feature flag to remove the code that deploys the `Impl` module, as now it is needed because the API Builder Object Definitions are deployed under feature flag.
- Include the code to remove the API Builder Applications created in the tests. This has been done to avoid duplicating the same code in the different integration tests. This code, once the FF is removed, does not have to be deleted as it is prepared to remove only the Applications that have been created during the tests

cc/ @4lejandrito