### PR TITLE
LPS-188488 Prevent NPE in case FDS Entry object definition is not yet created

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/display/context/FDSViewItemSelectorDisplayContext.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/display/context/FDSViewItemSelectorDisplayContext.java
@@ -39,7 +39,11 @@ public class FDSViewItemSelectorDisplayContext {
 			ObjectDefinitionLocalServiceUtil.fetchObjectDefinition(
 				_themeDisplay.getCompanyId(), "C_FDSView");
 
-		return objectDefinition.getClassName();
+		if (objectDefinition != null) {
+			return objectDefinition.getClassName();
+		}
+
+		return ObjectDefinition.class.getName();
 	}
 
 	public long getClassNameId() {


### PR DESCRIPTION
In this PR we're avoiding an NPE in the FDSItemSelectorDisplayContext when the referred object definition does not exist. Long-term fix is to create these as system objects so there are no chances for the situation to happen anymore. In the meantime we provide a fallback behavior.

cc @ealonso @markocikos