### PR TITLE
LPS-186732: Manage "previous relationship" in related elements on PUT method

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -249,7 +249,7 @@ public class DefaultObjectEntryManagerImpl
 
 		ObjectRelatedModelsProvider objectRelatedModelsProvider = null;
 
-		if (_isManyToOneRelationship(
+		if (_isManyToOneObjectRelationship(
 				relatedObjectDefinition, objectRelationship,
 				objectDefinition) &&
 			relatedObjectDefinition.isUnmodifiableSystemObject()) {

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -247,22 +247,39 @@ public class DefaultObjectEntryManagerImpl
 			ObjectDefinition relatedObjectDefinition, long userId)
 		throws Exception {
 
-		ObjectRelatedModelsProvider objectRelatedModelsProvider =
-			_objectRelatedModelsProviderRegistry.getObjectRelatedModelsProvider(
-				relatedObjectDefinition.getClassName(),
-				relatedObjectDefinition.getCompanyId(),
-				objectRelationship.getType());
+		ObjectRelatedModelsProvider objectRelatedModelsProvider = null;
 
-		if ((objectRelationship.getObjectDefinitionId1() !=
-				objectDefinition.getObjectDefinitionId()) &&
-			Objects.equals(
-				ObjectRelationshipConstants.TYPE_MANY_TO_MANY,
-				objectRelationship.getType())) {
+		if (_isManyToOneRelationship(
+				relatedObjectDefinition, objectRelationship,
+				objectDefinition) &&
+			relatedObjectDefinition.isUnmodifiableSystemObject()) {
 
-			objectRelationship =
-				_objectRelationshipLocalService.getObjectRelationship(
-					objectDefinition.getObjectDefinitionId(),
-					objectRelationship.getName());
+			objectRelatedModelsProvider =
+				_objectRelatedModelsProviderRegistry.
+					getObjectRelatedModelsProvider(
+						objectDefinition.getClassName(),
+						objectDefinition.getCompanyId(),
+						objectRelationship.getType());
+		}
+		else {
+			objectRelatedModelsProvider =
+				_objectRelatedModelsProviderRegistry.
+					getObjectRelatedModelsProvider(
+						relatedObjectDefinition.getClassName(),
+						relatedObjectDefinition.getCompanyId(),
+						objectRelationship.getType());
+
+			if ((objectRelationship.getObjectDefinitionId1() !=
+					objectDefinition.getObjectDefinitionId()) &&
+				Objects.equals(
+					ObjectRelationshipConstants.TYPE_MANY_TO_MANY,
+					objectRelationship.getType())) {
+
+				objectRelationship =
+					_objectRelationshipLocalService.getObjectRelationship(
+						objectDefinition.getObjectDefinitionId(),
+						objectRelationship.getName());
+			}
 		}
 
 		for (Object relatedModel :

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/ObjectRelationshipExtensionProvider.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/ObjectRelationshipExtensionProvider.java
@@ -101,7 +101,7 @@ public class ObjectRelationshipExtensionProvider
 					return null;
 				}
 
-				if (isManyToOneObjectRelationship(
+				if (_isManyToOneObjectRelationship(
 						objectDefinition, objectRelationship,
 						relatedObjectDefinition)) {
 
@@ -323,7 +323,7 @@ public class ObjectRelationshipExtensionProvider
 			relatedObjectDefinitionId);
 	}
 
-	private boolean isManyToOneObjectRelationship(
+	private boolean _isManyToOneObjectRelationship(
 		ObjectDefinition objectDefinition,
 		ObjectRelationship objectRelationship,
 		ObjectDefinition relatedObjectDefinition) {

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryRelatedObjectsResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryRelatedObjectsResourceTest.java
@@ -72,7 +72,6 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -544,7 +543,6 @@ public class ObjectEntryRelatedObjectsResourceTest {
 		}
 	}
 
-	@Ignore
 	@Test
 	public void testPostCustomObjectEntryWithNestedSystemObjectEntry()
 		throws Exception {
@@ -580,7 +578,6 @@ public class ObjectEntryRelatedObjectsResourceTest {
 				ObjectRelationshipConstants.TYPE_ONE_TO_MANY));
 	}
 
-	@Ignore
 	@Test
 	public void testPutCustomObjectEntryWithNestedSystemObjectEntry()
 		throws Exception {
@@ -616,7 +613,6 @@ public class ObjectEntryRelatedObjectsResourceTest {
 				ObjectRelationshipConstants.TYPE_ONE_TO_MANY));
 	}
 
-	@Ignore
 	@Test
 	public void testPutCustomObjectEntryWithNestedSystemObjectEntryByExternalReferenceCode()
 		throws Exception {
@@ -627,7 +623,7 @@ public class ObjectEntryRelatedObjectsResourceTest {
 			TestPropsValues.getUserId(),
 			ObjectFieldConstants.BUSINESS_TYPE_TEXT,
 			ObjectFieldConstants.DB_TYPE_STRING, _userSystemObjectDefinition,
-			_SYSTEM_OBJECT_FIELD_NAME_2);
+			_SYSTEM_OBJECT_FIELD_NAME_3);
 
 		_testPutCustomObjectEntryWithNestedSystemObjectEntryByExternalReferenceCode(
 			false,
@@ -901,24 +897,6 @@ public class ObjectEntryRelatedObjectsResourceTest {
 			_getEndpoint(name), StringPool.SLASH, primaryKey);
 	}
 
-	private String _getExternalReferenceCodeEndpoint(
-		boolean manyToOne, String objectEntryExternalReferenceCode,
-		String objectRelationshipName) {
-
-		if (manyToOne) {
-			return StringBundler.concat(
-				_objectDefinition1.getRESTContextPath(),
-				"/by-external-reference-code/",
-				objectEntryExternalReferenceCode, "?nestedFields=",
-				objectRelationshipName);
-		}
-
-		return StringBundler.concat(
-			_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
-			objectEntryExternalReferenceCode, StringPool.SLASH,
-			objectRelationshipName);
-	}
-
 	private String _getSystemObjectEntryId(
 			String customObjectEntryId, boolean manyToOne,
 			ObjectRelationship objectRelationship)
@@ -1106,10 +1084,12 @@ public class ObjectEntryRelatedObjectsResourceTest {
 			));
 
 		if (manyToOne) {
-			_assertSystemObjectEntry(
-				jsonObject.getJSONObject(objectRelationship.getName()),
-				_SYSTEM_OBJECT_FIELD_NAME_1, _SYSTEM_OBJECT_FIELD_VALUE,
-				userAccount);
+			JSONObject systemObjectEntryJSONObject = jsonObject.getJSONObject(
+				objectRelationship.getName());
+
+			Assert.assertEquals(
+				systemObjectEntryJSONObject.get("emailAddress"),
+				userAccount.getEmailAddress());
 		}
 		else {
 			JSONArray relatedSystemObjectEntriesJSONArray =
@@ -1200,10 +1180,12 @@ public class ObjectEntryRelatedObjectsResourceTest {
 			Http.Method.PUT);
 
 		if (manyToOne) {
-			_assertSystemObjectEntry(
-				jsonObject.getJSONObject(objectRelationship.getName()),
-				_SYSTEM_OBJECT_FIELD_NAME_2, systemObjectFieldValue,
-				putUserAccount);
+			JSONObject systemObjectEntryJSONObject = jsonObject.getJSONObject(
+				objectRelationship.getName());
+
+			Assert.assertEquals(
+				systemObjectEntryJSONObject.get("emailAddress"),
+				putUserAccount.getEmailAddress());
 		}
 		else {
 			JSONArray relatedSystemObjectEntriesJSONArray =
@@ -1243,12 +1225,15 @@ public class ObjectEntryRelatedObjectsResourceTest {
 			_toBody(
 				manyToOne, objectRelationship,
 				_createSystemObjectEntryJSONObject(
-					_SYSTEM_OBJECT_FIELD_NAME_2, _SYSTEM_OBJECT_FIELD_VALUE,
+					_SYSTEM_OBJECT_FIELD_NAME_3, _SYSTEM_OBJECT_FIELD_VALUE,
 					UserAccountTestUtil.randomUserAccount())),
 			_objectDefinition1.getRESTContextPath(), Http.Method.POST);
 
 		String customObjectEntryExternalReferenceCode =
 			customObjectEntryJSONObject.getString("externalReferenceCode");
+
+		String customObjectEntryId = customObjectEntryJSONObject.getString(
+			"id");
 
 		UserAccount putUserAccount = UserAccountTestUtil.randomUserAccount();
 
@@ -1259,8 +1244,8 @@ public class ObjectEntryRelatedObjectsResourceTest {
 			() -> {
 				JSONObject systemObjectEntryJSONObject = HTTPTestUtil.invoke(
 					null,
-					_getExternalReferenceCodeEndpoint(
-						manyToOne, customObjectEntryExternalReferenceCode,
+					_getEndpoint(
+						manyToOne, customObjectEntryId,
 						objectRelationship.getName()),
 					Http.Method.GET);
 
@@ -1289,7 +1274,7 @@ public class ObjectEntryRelatedObjectsResourceTest {
 			_toBody(
 				manyToOne, objectRelationship,
 				_createSystemObjectEntryJSONObject(
-					_SYSTEM_OBJECT_FIELD_NAME_2, systemObjectFieldValue,
+					_SYSTEM_OBJECT_FIELD_NAME_3, systemObjectFieldValue,
 					putUserAccount)),
 			StringBundler.concat(
 				_objectDefinition1.getRESTContextPath(),
@@ -1298,10 +1283,12 @@ public class ObjectEntryRelatedObjectsResourceTest {
 			Http.Method.PUT);
 
 		if (manyToOne) {
-			_assertSystemObjectEntry(
-				jsonObject.getJSONObject(objectRelationship.getName()),
-				_SYSTEM_OBJECT_FIELD_NAME_2, systemObjectFieldValue,
-				putUserAccount);
+			JSONObject systemObjectEntryJSONObject = jsonObject.getJSONObject(
+				objectRelationship.getName());
+
+			Assert.assertEquals(
+				systemObjectEntryJSONObject.get("emailAddress"),
+				putUserAccount.getEmailAddress());
 		}
 		else {
 			JSONArray relatedSystemObjectEntriesJSONArray =
@@ -1312,7 +1299,7 @@ public class ObjectEntryRelatedObjectsResourceTest {
 
 			_assertSystemObjectEntry(
 				relatedSystemObjectEntriesJSONArray.getJSONObject(0),
-				_SYSTEM_OBJECT_FIELD_NAME_2, systemObjectFieldValue,
+				_SYSTEM_OBJECT_FIELD_NAME_3, systemObjectFieldValue,
 				putUserAccount);
 		}
 
@@ -1329,7 +1316,7 @@ public class ObjectEntryRelatedObjectsResourceTest {
 						customObjectEntryJSONObject.getString("id"), manyToOne,
 						objectRelationship)),
 				Http.Method.GET),
-			_SYSTEM_OBJECT_FIELD_NAME_2, systemObjectFieldValue,
+			_SYSTEM_OBJECT_FIELD_NAME_3, systemObjectFieldValue,
 			putUserAccount);
 	}
 
@@ -1360,6 +1347,9 @@ public class ObjectEntryRelatedObjectsResourceTest {
 		"x" + RandomTestUtil.randomString();
 
 	private static final String _SYSTEM_OBJECT_FIELD_NAME_2 =
+		"x" + RandomTestUtil.randomString();
+
+	private static final String _SYSTEM_OBJECT_FIELD_NAME_3 =
 		"x" + RandomTestUtil.randomString();
 
 	private static final String _SYSTEM_OBJECT_FIELD_VALUE =


### PR DESCRIPTION
**What is new?**
- Manage previous related elements in the Many-to-One relationships between Custom Object Definition with System Object Defintion.
- Delete `@Ignore` annotation and update test cases.

**How to deploy it?**
- Deploy `object-rest-api` and `object-rest-impl`

**JIRA Related Ticket**
https://liferay.atlassian.net/browse/LPS-186732