### PR TITLE
LPS-187505 Add missing propsTransformer to enable onClick handlers

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
@@ -372,7 +372,13 @@ Map<String, Object> componentContext = journalDisplayContext.getComponentContext
 							colspan="<%= 2 %>"
 						>
 							<clay:horizontal-card
+								additionalProps='<%=
+									HashMapBuilder.<String, Object>put(
+										"trashEnabled", componentContext.get("trashEnabled")
+									).build()
+								%>'
 								horizontalCard="<%= new JournalFolderHorizontalCard(curFolder, journalDisplayContext.getDisplayStyle(), renderRequest, renderResponse, searchContainer.getRowChecker(), trashHelper) %>"
+								propsTransformer="js/ElementsDefaultPropsTransformer"
 							/>
 						</liferay-ui:search-container-column-text>
 					</c:when>


### PR DESCRIPTION
## Manual forward of https://github.com/liferay-frontend/liferay-portal/pull/3463

Greenlit by QA - https://github.com/liferay-frontend/liferay-portal/pull/3463#issuecomment-1597554257

## Original comment

Source of this task is an [LPP](https://liferay.atlassian.net/browse/LPP-49308).

The problem is that the 2 dropdown options on a Web Content Folder weren't being invoked.

The reason was the lack of a `propsTransformer` defined on the `clay:horizontal-card` usage that represented the Folder.