### PR TITLE
LPS-182364 MBThread UAD deletion errors - service builder changes 

### DIFF
--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/base_uad_anonymizer.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/base_uad_anonymizer.ftl
@@ -53,8 +53,20 @@ public abstract class Base${entity.name}UADAnonymizer extends DynamicQueryUADAno
 	}
 
 	@Override
-	public void delete(${entity.name} ${entity.variableName}) throws PortalException {
-		${entity.variableName}LocalService.${deleteUADEntityMethodName}(${entity.variableName});
+	public void delete(${entity.name} ${entity.variableName}, long userId) throws PortalException {
+		<#if entity.UADUserIdColumnNames?seq_contains("userId")>
+			<#list entity.UADUserIdColumnNames as uadUserIdColumnName>
+				<#assign uadUserIdEntityColumn = entity.getEntityColumn(uadUserIdColumnName) />
+
+				<#if stringUtil.equals(uadUserIdEntityColumn.name, "userId")>
+					if (${entity.variableName}.get${uadUserIdEntityColumn.methodName}() == userId) {
+						${entity.variableName}LocalService.${deleteUADEntityMethodName}(${entity.variableName});
+					}
+				</#if>
+			</#list>
+		<#else>
+			${entity.variableName}LocalService.${deleteUADEntityMethodName}(${entity.variableName});
+		</#if>
 	}
 
 	@Override


### PR DESCRIPTION
The original PR comment:

> This should be merged and published to pass #4331
> 
> The proble we have right now is that we are also using the annonimizable fields to delete the entities.
> 
> It means that if someone hits an entity (and it is persisted) this entity will be deleted (for example the statusByUserId field)
> 
> This is wrong, only owned elements should be removed on deletion action.

@brianchandotcom resending this pull directly to you since after a few retries we confirmed this pull is not related to any of the failing tests in https://github.com/liferay-lima/liferay-portal/pull/4413.