### PR TITLE
LRQA-69483 Exclude upgrade and acceptance tests from upstream-dxp since they already run elsewhere

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -9251,6 +9251,7 @@
         functional-upgrade-tomcat90-mariadb106-jdk8,\
         functional-upgrade-tomcat90-mysql57-jdk8,\
         functional-upgrade-tomcat90-oracle193-jdk8,\
+        functional-upgrade-tomcat90-postgresql121-jdk8,\
         functional-upgrade-tomcat90-postgresql134-jdk8,\
         functional-upgrade-tomcat90-postgresql144-jdk8,\
         functional-upgrade-tomcat90-sqlserver2017-jdk8,\
@@ -9506,29 +9507,9 @@
         functional-tomcat90-hypersonic20-jdk8,\
         functional-tomcat90-mariadb102-jdk8,\
         functional-tomcat90-mysql57-chrome100-jdk8,\
-        functional-tomcat90-mysql57-jdk11_open,\
         functional-tomcat90-oracle193-jdk8,\
         functional-tomcat90-postgresql134-jdk8,\
         functional-tomcat90-postgresql144-jdk8,\
-        functional-upgrade-jboss73-mysql57-jdk8,\
-        functional-upgrade-jboss74-mysql57-jdk8,\
-        functional-upgrade-tomcat90-db2111-jdk8,\
-        functional-upgrade-tomcat90-db2115-jdk8,\
-        functional-upgrade-tomcat90-mariadb102-jdk8,\
-        functional-upgrade-tomcat90-oracle193-jdk8,\
-        functional-upgrade-tomcat90-postgresql121-jdk8,\
-        functional-upgrade-tomcat90-postgresql134-jdk8,\
-        functional-upgrade-tomcat90-postgresql144-jdk8,\
-        functional-upgrade-tomcat90-sqlserver2017-jdk8,\
-        functional-upgrade-weblogic122-mysql57-jdk8,\
-        functional-upgrade-weblogic141-mysql57-jdk8,\
-        functional-upgrade-websphere90-mysql57-jdk8,\
-        functional-upgrade-wildfly180-mariadb104-jdk8,\
-        functional-upgrade-wildfly180-mariadb106-jdk8,\
-        functional-upgrade-wildfly230-mariadb104-jdk8,\
-        functional-upgrade-wildfly230-mariadb106-jdk8,\
-        functional-upgrade-wildfly261-mariadb104-jdk8,\
-        functional-upgrade-wildfly261-mariadb106-jdk8,\
         functional-weblogic122-mysql57-jdk8,\
         functional-weblogic141-mysql57-jdk8,\
         functional-websphere90-mysql57-jdk8,\
@@ -9540,7 +9521,6 @@
         modules-integration-db2115-jdk8,\
         modules-integration-hypersonic20-jdk8,\
         modules-integration-mariadb102-jdk8,\
-        modules-integration-mysql57-jdk11_open,\
         modules-integration-mysql80-jdk8,\
         modules-integration-oracle193-jdk8,\
         modules-integration-postgresql121-jdk8,\
@@ -9619,9 +9599,6 @@
             (portal.upstream == quarantine) OR \
             (portal.upstream == true)\
         )
-
-    test.batch.run.property.query[functional-tomcat90-mysql57-jdk11_open][upstream-dxp]=\
-        (portal.upstream ~ openjdk11)
 
     test.batch.run.property.query[functional-tomcat90-oracle193-jdk8][upstream-dxp]=\
         (\

--- a/test.properties
+++ b/test.properties
@@ -9547,7 +9547,10 @@
             (app.server.types == null) OR \
             (app.server.types ~ tomcat)\
         ) AND \
+        (data.archive.type == null) AND \
         (database.types ~ db2) AND \
+        (portal.acceptance != true) AND \
+        (portal.upgrades == null) AND \
         (\
             (portal.upstream == quarantine) OR \
             (portal.upstream == true)\
@@ -9558,7 +9561,10 @@
             (app.server.types == null) OR \
             (app.server.types ~ tomcat)\
         ) AND \
+        (data.archive.type == null) AND \
         (database.types ~ db2) AND \
+        (portal.acceptance != true) AND \
+        (portal.upgrades == null) AND \
         (\
             (portal.upstream == quarantine) OR \
             (portal.upstream == true)\
@@ -9569,7 +9575,10 @@
             (app.server.types == null) OR \
             (app.server.types ~ tomcat)\
         ) AND \
+        (data.archive.type == null) AND \
         (database.types ~ hypersonic) AND \
+        (portal.acceptance != true) AND \
+        (portal.upgrades == null) AND \
         (\
             (portal.upstream == quarantine) OR \
             (portal.upstream == true)\
@@ -9580,7 +9589,10 @@
             (app.server.types == null) OR \
             (app.server.types ~ tomcat)\
         ) AND \
+        (data.archive.type == null) AND \
         (database.types ~ mariadb) AND \
+        (portal.acceptance != true) AND \
+        (portal.upgrades == null) AND \
         (\
             (portal.upstream == quarantine) OR \
             (portal.upstream == true)\
@@ -9591,10 +9603,13 @@
             (app.server.types == null) OR \
             (app.server.types ~ tomcat)\
         ) AND \
+        (data.archive.type == null) AND \
         (\
             (database.types == null) OR \
             (database.types ~ mysql)\
         ) AND \
+        (portal.acceptance != true) AND \
+        (portal.upgrades == null) AND \
         (\
             (portal.upstream == quarantine) OR \
             (portal.upstream == true)\
@@ -9605,7 +9620,10 @@
             (app.server.types == null) OR \
             (app.server.types ~ tomcat)\
         ) AND \
+        (data.archive.type == null) AND \
         (database.types ~ oracle) AND \
+        (portal.acceptance != true) AND \
+        (portal.upgrades == null) AND \
         (\
             (portal.upstream == quarantine) OR \
             (portal.upstream == true)\
@@ -9616,7 +9634,10 @@
             (app.server.types == null) OR \
             (app.server.types ~ tomcat)\
         ) AND \
+        (data.archive.type == null) AND \
         (database.types ~ postgresql) AND \
+        (portal.acceptance != true) AND \
+        (portal.upgrades == null) AND \
         (\
             (portal.upstream == quarantine) OR \
             (portal.upstream == true)\
@@ -9627,7 +9648,10 @@
             (app.server.types == null) OR \
             (app.server.types ~ tomcat)\
         ) AND \
+        (data.archive.type == null) AND \
         (database.types ~ postgresql) AND \
+        (portal.acceptance != true) AND \
+        (portal.upgrades == null) AND \
         (\
             (portal.upstream == quarantine) OR \
             (portal.upstream == true)\
@@ -9635,10 +9659,13 @@
 
     test.batch.run.property.query[functional-weblogic122-mysql57-jdk8][upstream-dxp]=\
         (app.server.types ~ weblogic) AND \
+        (data.archive.type == null) AND \
         (\
             (database.types == null) OR \
             (database.types ~ mysql)\
         ) AND \
+        (portal.acceptance != true) AND \
+        (portal.upgrades == null) AND \
         (\
             (portal.upstream == quarantine) OR \
             (portal.upstream == true)\
@@ -9646,10 +9673,13 @@
 
     test.batch.run.property.query[functional-weblogic141-mysql57-jdk8][upstream-dxp]=\
         (app.server.types ~ weblogic) AND \
+        (data.archive.type == null) AND \
         (\
             (database.types == null) OR \
             (database.types ~ mysql)\
         ) AND \
+        (portal.acceptance != true) AND \
+        (portal.upgrades == null) AND \
         (\
             (portal.upstream == quarantine) OR \
             (portal.upstream == true)\
@@ -9657,11 +9687,14 @@
 
     test.batch.run.property.query[functional-websphere90-mysql57-jdk8][upstream-dxp]=\
         (app.server.types ~ websphere) AND \
+        (data.archive.type == null) AND \
         (\
             (database.types == null) OR \
             (database.types ~ mysql)\
         ) AND \
         (embedded.elasticsearch.only != "true") AND \
+        (portal.acceptance != true) AND \
+        (portal.upgrades == null) AND \
         (\
             (portal.upstream == quarantine) OR \
             (portal.upstream == true)\
@@ -9669,10 +9702,13 @@
 
     test.batch.run.property.query[functional-wildfly180-mysql57-jdk8][upstream-dxp]=\
         (app.server.types ~ wildfly) AND \
+        (data.archive.type == null) AND \
         (\
             (database.types == null) OR \
             (database.types ~ mysql)\
         ) AND \
+        (portal.acceptance != true) AND \
+        (portal.upgrades == null) AND \
         (\
             (portal.upstream == quarantine) OR \
             (portal.upstream == true)\
@@ -9680,10 +9716,13 @@
 
     test.batch.run.property.query[functional-wildfly230-mysql57-jdk8][upstream-dxp]=\
         (app.server.types ~ wildfly) AND \
+        (data.archive.type == null) AND \
         (\
             (database.types == null) OR \
             (database.types ~ mysql)\
         ) AND \
+        (portal.acceptance != true) AND \
+        (portal.upgrades == null) AND \
         (\
             (portal.upstream == quarantine) OR \
             (portal.upstream == true)\
@@ -9691,10 +9730,13 @@
 
     test.batch.run.property.query[functional-wildfly261-mysql57-jdk8][upstream-dxp]=\
         (app.server.types ~ wildfly) AND \
+        (data.archive.type == null) AND \
         (\
             (database.types == null) OR \
             (database.types ~ mysql)\
         ) AND \
+        (portal.acceptance != true) AND \
+        (portal.upgrades == null) AND \
         (\
             (portal.upstream == quarantine) OR \
             (portal.upstream == true)\


### PR DESCRIPTION
@pyoo47 This should significantly reduce load for Development Upstream (upstream-dxp) on master. Removes at least 8024 poshi tests (46%) that we are already running elsewhere.