### PR TITLE
[TS] LPS-189199 BreadcrumbEntry titles are escaped in view layer

### DIFF
--- a/modules/apps/site-navigation/site-navigation-taglib/src/main/java/com/liferay/site/navigation/taglib/servlet/taglib/util/BreadcrumbUtil.java
+++ b/modules/apps/site-navigation/site-navigation-taglib/src/main/java/com/liferay/site/navigation/taglib/servlet/taglib/util/BreadcrumbUtil.java
@@ -49,7 +49,6 @@ import com.liferay.portal.kernel.servlet.taglib.ui.BreadcrumbEntry;
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -373,7 +372,7 @@ public class BreadcrumbUtil {
 				httpServletRequest, themeDisplay.getLocale());
 
 			if (Validator.isNotNull(infoItemName)) {
-				layoutName = HtmlUtil.escape(infoItemName);
+				layoutName = infoItemName;
 			}
 		}
 
@@ -415,16 +414,14 @@ public class BreadcrumbUtil {
 				infoItemFieldValues.getInfoFieldValue("title");
 
 			if (titleInfoFieldValue != null) {
-				return HtmlUtil.escape(
-					String.valueOf(titleInfoFieldValue.getValue(locale)));
+				return String.valueOf(titleInfoFieldValue.getValue(locale));
 			}
 
 			InfoFieldValue<Object> nameInfoFieldValue =
 				infoItemFieldValues.getInfoFieldValue("name");
 
 			if (nameInfoFieldValue != null) {
-				return HtmlUtil.escape(
-					String.valueOf(nameInfoFieldValue.getValue(locale)));
+				return String.valueOf(nameInfoFieldValue.getValue(locale));
 			}
 		}
 
@@ -432,7 +429,7 @@ public class BreadcrumbUtil {
 			WebKeys.LAYOUT_ASSET_ENTRY);
 
 		if (assetEntry != null) {
-			return HtmlUtil.escape(assetEntry.getTitle(locale));
+			return assetEntry.getTitle(locale);
 		}
 
 		return StringPool.BLANK;


### PR DESCRIPTION
Motivation
=======
[LPS-189199](https://liferay.atlassian.net/browse/LPS-189199)
The content of Breadcrumb widgets on Content Display Pages appear escaped

Proposed Solution
========
The Breadcrumb widget handles escaping the BreadcrumbEntry's titles in the view layer (ftl, jsp). So there is no need to escape the infoItemName in BreadcrumbUtil.java

Steps to Verify
========
1. Go to Design > Page Templates > Display Page Templates
2. Create a new Display Page Template for Basic Web content
3. Add a Breadcrumb widget to the Display Page Template
4. Publish the Display Page Template
5. Using the Display Page Template’s kebab menu, set it as default
6. Go to Content & Data > Web Content
7. Create a Basic Web Content
8. Set the title to “bed & breakfast”
9. Publish the web content
10. Once back on the Web Content Admin view, use “bed & breakfast”'s kebab menu to preview it

**Expected behaviour:** The “bed & breakfast” is displayed
**Actual behaviour:** “bed &amp;&amp; breakfast” is displayed

Cheers,
Balázs

cc.: @balazssk 