### PR TITLE
LPS-188912 Add new ant task format-source-change-copyrights

### DIFF
--- a/modules/util/copyright-formatter/bnd.bnd
+++ b/modules/util/copyright-formatter/bnd.bnd
@@ -1,0 +1,4 @@
+Bundle-Name: Liferay Copyright Formatter
+Bundle-SymbolicName: com.liferay.copyright.formatter
+Bundle-Version: 1.0.1
+Main-Class: com.liferay.copyright.formatter.CopyrightFormatter

--- a/modules/util/copyright-formatter/build.gradle
+++ b/modules/util/copyright-formatter/build.gradle
@@ -1,0 +1,3 @@
+liferay {
+	deployDir = "../../../tools/sdk/dependencies/com.liferay.copyright.formatter/lib"
+}

--- a/modules/util/copyright-formatter/src/main/java/com/liferay/copyright/formatter/CopyrightFormatter.java
+++ b/modules/util/copyright-formatter/src/main/java/com/liferay/copyright/formatter/CopyrightFormatter.java
@@ -1,0 +1,248 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.copyright.formatter;
+
+import com.liferay.copyright.formatter.util.ArgumentsUtil;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.regex.Pattern;
+
+/**
+ * @author Alan Huang
+ */
+public class CopyrightFormatter {
+
+	public static void main(String[] args) throws Exception {
+		CopyrightFormatter copyrightFormatter = new CopyrightFormatter();
+
+		copyrightFormatter.formatCopyright(
+			ArgumentsUtil.getValue(args, "source.base.dir", "./"));
+	}
+
+	public void formatCopyright(String baseDirName) throws Exception {
+		ExecutorService executorService = Executors.newFixedThreadPool(10);
+
+		List<Future<Void>> futures = new CopyOnWriteArrayList<>();
+
+		for (File file : _getFiles(baseDirName)) {
+			Future<Void> future = executorService.submit(
+				new Callable<Void>() {
+
+					@Override
+					public Void call() throws Exception {
+						_formatCopyright(file);
+
+						return null;
+					}
+
+				});
+
+			futures.add(future);
+		}
+
+		for (Future<Void> future : futures) {
+			future.get();
+		}
+
+		executorService.shutdown();
+
+		while (!executorService.isTerminated()) {
+			Thread.sleep(20);
+		}
+	}
+
+	private void _formatCopyright(File file) throws Exception {
+		String content = new String(Files.readAllBytes(file.toPath()), "UTF-8");
+
+		content = _replaceCopyright(file.getAbsolutePath(), content);
+
+		FileOutputStream fileOutputStream = new FileOutputStream(file);
+
+		fileOutputStream.write(content.getBytes());
+	}
+
+	private String _getFileCreationYear(String absolutePath) throws Exception {
+		Runtime runtime = Runtime.getRuntime();
+
+		Process process = null;
+
+		try {
+			String[] cmd = {
+				"sh", "-c",
+				"git log --follow --pretty=format:%as " + absolutePath +
+					" | tail -n1 | cut -c-4"
+			};
+
+			process = runtime.exec(cmd);
+		}
+		catch (IOException ioException) {
+			throw new Exception("Add Git to your PATH system variable first");
+		}
+
+		InputStreamReader inputStreamReader = new InputStreamReader(
+			process.getInputStream());
+
+		BufferedReader inputBufferedReader = new BufferedReader(
+			inputStreamReader);
+
+		return inputBufferedReader.readLine();
+	}
+
+	private List<File> _getFiles(String baseDirName) throws Exception {
+		List<File> files = new ArrayList<>();
+
+		Files.walkFileTree(
+			Paths.get(baseDirName),
+			new SimpleFileVisitor<Path>() {
+
+				@Override
+				public FileVisitResult preVisitDirectory(
+						Path dirPath, BasicFileAttributes basicFileAttributes)
+					throws IOException {
+
+					String dirName = String.valueOf(dirPath.getFileName());
+
+					List<String> skipDirNames = Arrays.asList(_SKIP_DIR_NAMES);
+
+					if (dirName.startsWith(".") ||
+						skipDirNames.contains(dirName)) {
+
+						return FileVisitResult.SKIP_SUBTREE;
+					}
+
+					return FileVisitResult.CONTINUE;
+				}
+
+				@Override
+				public FileVisitResult visitFile(
+						Path file, BasicFileAttributes basicFileAttributes)
+					throws IOException {
+
+					String fileName = String.valueOf(file.getFileName());
+
+					int x = fileName.lastIndexOf('.');
+
+					if (x == -1) {
+						return FileVisitResult.CONTINUE;
+					}
+
+					String fileExtension = fileName.substring(x);
+
+					List<String> fileExtensions = Arrays.asList(
+						_FILE_EXTENSIONS);
+
+					if (fileExtensions.contains(fileExtension)) {
+						files.add(file.toFile());
+					}
+
+					return FileVisitResult.CONTINUE;
+				}
+
+			});
+
+		return files;
+	}
+
+	private String _replaceCopyright(String absolutePath, String content)
+		throws Exception {
+
+		if (_copyright == null) {
+			ClassLoader classLoader = CopyrightFormatter.class.getClassLoader();
+
+			ByteArrayOutputStream byteArrayOutputStream =
+				new ByteArrayOutputStream();
+
+			InputStream inputStream = classLoader.getResourceAsStream(
+				"dependencies/copyright.txt");
+
+			byte[] bytes = new byte[1024];
+
+			while (true) {
+				int read = inputStream.read(bytes, 0, bytes.length);
+
+				if (read == -1) {
+					break;
+				}
+
+				byteArrayOutputStream.write(bytes, 0, read);
+			}
+
+			byteArrayOutputStream.flush();
+
+			_copyright = byteArrayOutputStream.toString();
+		}
+
+		if (_copyright == null) {
+			return content;
+		}
+
+		String year = _getFileCreationYear(absolutePath);
+
+		if (year == null) {
+			return content;
+		}
+
+		int x = content.indexOf("/**\n * Copyright");
+
+		if (x == -1) {
+			return content;
+		}
+
+		int y = content.indexOf("\n */");
+
+		if (y == -1) {
+			return content;
+		}
+
+		return content.substring(0, x) +
+			_copyright.replaceFirst(Pattern.quote("{$year}"), year) +
+				content.substring(y + 4);
+	}
+
+	private static final String[] _FILE_EXTENSIONS = {
+		".java", ".js", ".jsp", ".jspf", ".jsx"
+	};
+
+	private static final String[] _SKIP_DIR_NAMES = {
+		"bin", "build", "classes", "dependencies", "lib", "node_modules",
+		"node_modules_cache", "sql", "test-classes", "test-coverage",
+		"test-results", "tmp"
+	};
+
+	private String _copyright;
+
+}

--- a/modules/util/copyright-formatter/src/main/java/com/liferay/copyright/formatter/CopyrightFormatter.java
+++ b/modules/util/copyright-formatter/src/main/java/com/liferay/copyright/formatter/CopyrightFormatter.java
@@ -216,15 +216,27 @@ public class CopyrightFormatter {
 			return content;
 		}
 
-		int x = content.indexOf("/**\n * Copyright");
+		int x = content.indexOf("/**\n * SPDX-FileCopyrightText:");
+
+		if (x != -1) {
+			return content;
+		}
+
+		x = content.indexOf("/**\n * Copyright");
 
 		if (x == -1) {
 			return content;
 		}
 
-		int y = content.indexOf("\n */");
+		int y = content.indexOf("\n */", x + 1);
 
 		if (y == -1) {
+			return content;
+		}
+
+		String header = content.substring(x, y - 1);
+
+		if (!header.contains("Liferay")) {
 			return content;
 		}
 

--- a/modules/util/copyright-formatter/src/main/java/com/liferay/copyright/formatter/util/ArgumentsUtil.java
+++ b/modules/util/copyright-formatter/src/main/java/com/liferay/copyright/formatter/util/ArgumentsUtil.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.copyright.formatter.util;
+
+import java.util.Objects;
+
+/**
+ * @author Alan Huang
+ */
+public class ArgumentsUtil {
+
+	public static String getValue(
+		String[] args, String key, String defaultValue) {
+
+		for (String arg : args) {
+			int pos = arg.indexOf('=');
+
+			if (pos <= 0) {
+				continue;
+			}
+
+			String curKey = arg.substring(0, pos);
+
+			if (Objects.equals(key, curKey.trim())) {
+				String curValue = arg.substring(pos + 1);
+
+				return curValue.trim();
+			}
+		}
+
+		return defaultValue;
+	}
+
+}

--- a/modules/util/copyright-formatter/src/main/resources/dependencies/copyright.txt
+++ b/modules/util/copyright-formatter/src/main/resources/dependencies/copyright.txt
@@ -1,4 +1,4 @@
 /**
- * SPDX-FileCopyrightText: © {$year} Liferay, Inc. <https://liferay.com>
+ * SPDX-FileCopyrightText: © {$year} Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */

--- a/modules/util/copyright-formatter/src/main/resources/dependencies/copyright.txt
+++ b/modules/util/copyright-formatter/src/main/resources/dependencies/copyright.txt
@@ -1,0 +1,4 @@
+/**
+ * SPDX-FileCopyrightText: © {$year} Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */

--- a/portal-impl/build.xml
+++ b/portal-impl/build.xml
@@ -446,6 +446,44 @@ svn://svn.liferay.com/repos/public/alloy/trunk/sandbox/taglibs.
 		</if>
 	</target>
 
+	<target name="format-copyright">
+		<if>
+			<available file="${project.dir}/modules/util/copyright-formatter" />
+			<then>
+				<gradle-execute dir="${project.dir}/modules/util/copyright-formatter" task="deploy" />
+
+				<path id="copyright.formatter.classpath">
+					<fileset
+						dir="${sdk.dir}/dependencies/com.liferay.copyright.formatter/lib"
+						includes="*.jar"
+					/>
+				</path>
+
+				<if>
+					<not>
+						<isset property="source.base.dir" />
+					</not>
+					<then>
+						<property name="source.base.dir" value="${project.dir}" />
+					</then>
+				</if>
+
+				<java
+					classname="com.liferay.copyright.formatter.CopyrightFormatter"
+					classpathref="copyright.formatter.classpath"
+					fork="true"
+					newenvironment="true"
+				>
+					<jvmarg if:true="${jvm.debug}" value="${jpda.settings}" />
+					<jvmarg value="-Dfile.encoding=UTF-8" />
+					<jvmarg value="-Duser.country=US" />
+					<jvmarg value="-Duser.language=en" />
+					<arg value="source.base.dir=${source.base.dir}" />
+				</java>
+			</then>
+		</if>
+	</target>
+
 	<target name="format-source">
 		<antcall target="format-source-files">
 			<param name="format.source.default.task" value="true" />

--- a/portal-impl/build.xml
+++ b/portal-impl/build.xml
@@ -446,7 +446,23 @@ svn://svn.liferay.com/repos/public/alloy/trunk/sandbox/taglibs.
 		</if>
 	</target>
 
-	<target name="format-copyright">
+	<target name="format-source">
+		<antcall target="format-source-files">
+			<param name="format.source.default.task" value="true" />
+		</antcall>
+	</target>
+
+	<target name="format-source-all">
+		<antcall target="format-source-files" />
+	</target>
+
+	<target name="format-source-bnd">
+		<antcall target="format-source-files">
+			<param name="source.file.extensions" value="bnd,gradle,json" />
+		</antcall>
+	</target>
+
+	<target name="format-source-change-copyrights">
 		<if>
 			<available file="${project.dir}/modules/util/copyright-formatter" />
 			<then>
@@ -482,22 +498,6 @@ svn://svn.liferay.com/repos/public/alloy/trunk/sandbox/taglibs.
 				</java>
 			</then>
 		</if>
-	</target>
-
-	<target name="format-source">
-		<antcall target="format-source-files">
-			<param name="format.source.default.task" value="true" />
-		</antcall>
-	</target>
-
-	<target name="format-source-all">
-		<antcall target="format-source-files" />
-	</target>
-
-	<target name="format-source-bnd">
-		<antcall target="format-source-files">
-			<param name="source.file.extensions" value="bnd,gradle,json" />
-		</antcall>
 	</target>
 
 	<target name="format-source-current-branch">

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -507,6 +507,8 @@
         static,\
         web-experience
 
+    source.check.CopyrightCheck.enabled=false
+
     source.check.GradleDependenciesCheck.allowedCommerceDependenciesModulePathNames=\
         modules/dxp/apps/commerce-avalara,\
         modules/dxp/apps/commerce-demo-pack,\


### PR DESCRIPTION
Hi Brian,

I added a new ant task `ant format-source-change-copyrights` to replace the copyrights.

Optional parameter: `source.base.dir`

I tried to run it for all source code, but it takes a lot of time due to grabbing the file creation year by`git log`.

---------------------
Here is the test result on my end to prove it:

`ant format-source-change-copyrights
`
**With** the logic git log:
Still running...already 10+ hours, I had to stop it.

**Without** the logic git log:
Total time: 8 seconds
56,000+ files changed.



---------


`ant format-source-change-copyrights -Dsource.base.dir=/home/alan/liferay_code/master/liferay-portal/modules/util/source-formatter/`

**With** the logic git log:
Total time: 36 minutes 30 seconds
668 files changed.

**Without** the logic git log:
Total time: 5 seconds
668 files changed.


