### PR TITLE
[Components with more than 1 service] LPS-188507 Refactor components from portal-messaging, portal-search-solr8 and search-experience modules

### DIFF
--- a/modules/apps/portal-search-solr8/portal-search-solr8-impl/src/main/java/com/liferay/portal/search/solr8/internal/query/BaseQueryVisitor.java
+++ b/modules/apps/portal-search-solr8/portal-search-solr8-impl/src/main/java/com/liferay/portal/search/solr8/internal/query/BaseQueryVisitor.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.solr8.internal.query;
+
+import com.liferay.portal.kernel.search.BooleanQuery;
+import com.liferay.portal.kernel.search.TermQuery;
+import com.liferay.portal.kernel.search.TermRangeQuery;
+import com.liferay.portal.kernel.search.WildcardQuery;
+import com.liferay.portal.kernel.search.generic.DisMaxQuery;
+import com.liferay.portal.kernel.search.generic.FuzzyQuery;
+import com.liferay.portal.kernel.search.generic.MatchAllQuery;
+import com.liferay.portal.kernel.search.generic.MatchQuery;
+import com.liferay.portal.kernel.search.generic.MoreLikeThisQuery;
+import com.liferay.portal.kernel.search.generic.MultiMatchQuery;
+import com.liferay.portal.kernel.search.generic.NestedQuery;
+import com.liferay.portal.kernel.search.generic.StringQuery;
+import com.liferay.portal.kernel.search.query.QueryVisitor;
+
+import org.apache.lucene.search.Query;
+
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Joao Victor Alves
+ */
+public abstract class BaseQueryVisitor implements QueryVisitor<Query> {
+
+	@Override
+	public Query visitQuery(BooleanQuery booleanQuery) {
+		return booleanQueryTranslator.translate(booleanQuery, this);
+	}
+
+	@Override
+	public Query visitQuery(DisMaxQuery disMaxQuery) {
+		return disMaxQueryTranslator.translate(disMaxQuery, this);
+	}
+
+	@Override
+	public Query visitQuery(FuzzyQuery fuzzyQuery) {
+		return fuzzyQueryTranslator.translate(fuzzyQuery);
+	}
+
+	@Override
+	public Query visitQuery(MatchAllQuery matchAllQuery) {
+		return matchAllQueryTranslator.translate(matchAllQuery);
+	}
+
+	@Override
+	public Query visitQuery(MatchQuery matchQuery) {
+		return matchQueryTranslator.translate(matchQuery);
+	}
+
+	@Override
+	public Query visitQuery(MoreLikeThisQuery moreLikeThisQuery) {
+		return moreLikeThisQueryTranslator.translate(moreLikeThisQuery);
+	}
+
+	@Override
+	public Query visitQuery(MultiMatchQuery multiMatchQuery) {
+		return multiMatchQueryTranslator.translate(multiMatchQuery);
+	}
+
+	@Override
+	public Query visitQuery(NestedQuery nestedQuery) {
+		return nestedQueryTranslator.translate(nestedQuery, this);
+	}
+
+	@Override
+	public Query visitQuery(StringQuery stringQuery) {
+		return stringQueryTranslator.translate(stringQuery);
+	}
+
+	@Override
+	public Query visitQuery(TermQuery termQuery) {
+		return termQueryTranslator.translate(termQuery);
+	}
+
+	@Override
+	public Query visitQuery(TermRangeQuery termRangeQuery) {
+		return termRangeQueryTranslator.translate(termRangeQuery);
+	}
+
+	@Override
+	public Query visitQuery(WildcardQuery wildcardQuery) {
+		return wildcardQueryTranslator.translate(wildcardQuery);
+	}
+
+	@Reference
+	protected BooleanQueryTranslator booleanQueryTranslator;
+
+	@Reference
+	protected DisMaxQueryTranslator disMaxQueryTranslator;
+
+	@Reference
+	protected FuzzyQueryTranslator fuzzyQueryTranslator;
+
+	@Reference
+	protected MatchAllQueryTranslator matchAllQueryTranslator;
+
+	@Reference
+	protected MatchQueryTranslator matchQueryTranslator;
+
+	@Reference
+	protected MoreLikeThisQueryTranslator moreLikeThisQueryTranslator;
+
+	@Reference
+	protected MultiMatchQueryTranslator multiMatchQueryTranslator;
+
+	@Reference
+	protected NestedQueryTranslator nestedQueryTranslator;
+
+	@Reference
+	protected StringQueryTranslator stringQueryTranslator;
+
+	@Reference
+	protected TermQueryTranslator termQueryTranslator;
+
+	@Reference
+	protected TermRangeQueryTranslator termRangeQueryTranslator;
+
+	@Reference
+	protected WildcardQueryTranslator wildcardQueryTranslator;
+
+}

--- a/modules/apps/portal-search-solr8/portal-search-solr8-impl/src/main/java/com/liferay/portal/search/solr8/internal/query/SolrLuceneQueryConverter.java
+++ b/modules/apps/portal-search-solr8/portal-search-solr8-impl/src/main/java/com/liferay/portal/search/solr8/internal/query/SolrLuceneQueryConverter.java
@@ -15,30 +15,21 @@
 package com.liferay.portal.search.solr8.internal.query;
 
 import com.liferay.portal.kernel.search.Query;
-import com.liferay.portal.kernel.search.SearchContext;
-import com.liferay.portal.kernel.search.query.QueryTranslator;
 
 import org.osgi.service.component.annotations.Component;
 
 /**
- * @author André de Oliveira
- * @author Miguel Angelo Caldas Gallindo
+ * @author Joao Victor Alves
  */
 @Component(
-	property = "search.engine.impl=Solr", service = QueryTranslator.class
+	property = "search.engine.impl=Solr", service = LuceneQueryConverter.class
 )
-public class SolrQueryTranslator
-	extends BaseQueryVisitor implements QueryTranslator<String> {
+public class SolrLuceneQueryConverter
+	extends BaseQueryVisitor implements LuceneQueryConverter {
 
 	@Override
-	public String translate(Query query, SearchContext searchContext) {
-		org.apache.lucene.search.Query luceneQuery = query.accept(this);
-
-		if (luceneQuery != null) {
-			return luceneQuery.toString();
-		}
-
-		return null;
+	public org.apache.lucene.search.Query convert(Query query) {
+		return query.accept(this);
 	}
 
 }

--- a/modules/apps/portal-search-solr8/portal-search-solr8-impl/src/test/java/com/liferay/portal/search/solr8/internal/SolrIndexingFixture.java
+++ b/modules/apps/portal-search-solr8/portal-search-solr8-impl/src/test/java/com/liferay/portal/search/solr8/internal/SolrIndexingFixture.java
@@ -144,40 +144,40 @@ public class SolrIndexingFixture implements IndexingFixture {
 		SolrQueryTranslator solrQueryTranslator = new SolrQueryTranslator();
 
 		ReflectionTestUtil.setFieldValue(
-			solrQueryTranslator, "_booleanQueryTranslator",
+			solrQueryTranslator, "booleanQueryTranslator",
 			new BooleanQueryTranslatorImpl());
 		ReflectionTestUtil.setFieldValue(
-			solrQueryTranslator, "_disMaxQueryTranslator",
+			solrQueryTranslator, "disMaxQueryTranslator",
 			new DisMaxQueryTranslatorImpl());
 		ReflectionTestUtil.setFieldValue(
-			solrQueryTranslator, "_fuzzyQueryTranslator",
+			solrQueryTranslator, "fuzzyQueryTranslator",
 			new FuzzyQueryTranslatorImpl());
 		ReflectionTestUtil.setFieldValue(
-			solrQueryTranslator, "_matchAllQueryTranslator",
+			solrQueryTranslator, "matchAllQueryTranslator",
 			new MatchAllQueryTranslatorImpl());
 		ReflectionTestUtil.setFieldValue(
-			solrQueryTranslator, "_matchQueryTranslator",
+			solrQueryTranslator, "matchQueryTranslator",
 			new MatchQueryTranslatorImpl());
 		ReflectionTestUtil.setFieldValue(
-			solrQueryTranslator, "_moreLikeThisQueryTranslator",
+			solrQueryTranslator, "moreLikeThisQueryTranslator",
 			new MoreLikeThisQueryTranslatorImpl());
 		ReflectionTestUtil.setFieldValue(
-			solrQueryTranslator, "_multiMatchQueryTranslator",
+			solrQueryTranslator, "multiMatchQueryTranslator",
 			new MultiMatchQueryTranslatorImpl());
 		ReflectionTestUtil.setFieldValue(
-			solrQueryTranslator, "_nestedQueryTranslator",
+			solrQueryTranslator, "nestedQueryTranslator",
 			new NestedQueryTranslatorImpl());
 		ReflectionTestUtil.setFieldValue(
-			solrQueryTranslator, "_stringQueryTranslator",
+			solrQueryTranslator, "stringQueryTranslator",
 			new StringQueryTranslatorImpl());
 		ReflectionTestUtil.setFieldValue(
-			solrQueryTranslator, "_termQueryTranslator",
+			solrQueryTranslator, "termQueryTranslator",
 			new TermQueryTranslatorImpl());
 		ReflectionTestUtil.setFieldValue(
-			solrQueryTranslator, "_termRangeQueryTranslator",
+			solrQueryTranslator, "termRangeQueryTranslator",
 			new TermRangeQueryTranslatorImpl());
 		ReflectionTestUtil.setFieldValue(
-			solrQueryTranslator, "_wildcardQueryTranslator",
+			solrQueryTranslator, "wildcardQueryTranslator",
 			new WildcardQueryTranslatorImpl());
 
 		return solrQueryTranslator;

--- a/modules/apps/portal/portal-messaging/src/main/java/com/liferay/portal/messaging/internal/DefaultMessageBus.java
+++ b/modules/apps/portal/portal-messaging/src/main/java/com/liferay/portal/messaging/internal/DefaultMessageBus.java
@@ -138,15 +138,6 @@ public class DefaultMessageBus implements MessageBus {
 
 	@Activate
 	protected void activate(BundleContext bundleContext) {
-		_serviceRegistration = bundleContext.registerService(
-			ManagedServiceFactory.class,
-			new DefaultMessageBusManagedServiceFactory(),
-			HashMapDictionaryBuilder.put(
-				Constants.SERVICE_PID,
-				"com.liferay.portal.messaging.internal.configuration." +
-					"DestinationWorkerConfiguration"
-			).build());
-
 		_messageListenerServiceTracker = new ServiceTracker<>(
 			bundleContext, MessageListener.class,
 			new ServiceTrackerCustomizer
@@ -201,15 +192,24 @@ public class DefaultMessageBus implements MessageBus {
 
 		_messageListenerServiceTracker.open();
 
+		_serviceRegistration = bundleContext.registerService(
+			ManagedServiceFactory.class,
+			new DefaultMessageBusManagedServiceFactory(),
+			HashMapDictionaryBuilder.put(
+				Constants.SERVICE_PID,
+				"com.liferay.portal.messaging.internal.configuration." +
+					"DestinationWorkerConfiguration"
+			).build());
+
 		_serviceTrackerList = ServiceTrackerListFactory.open(
 			bundleContext, MessageBusInterceptor.class);
 	}
 
 	@Deactivate
 	protected void deactivate() {
-		_serviceRegistration.unregister();
-
 		_serviceTrackerList.close();
+
+		_serviceRegistration.unregister();
 
 		_messageListenerServiceTracker.close();
 
@@ -219,9 +219,9 @@ public class DefaultMessageBus implements MessageBus {
 			destination.destroy();
 		}
 
-		_messageBusEventListeners.clear();
-
 		_destinations.clear();
+
+		_messageBusEventListeners.clear();
 	}
 
 	@Reference(

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/ml/embedding/text/TextEmbeddingRetrieverImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/ml/embedding/text/TextEmbeddingRetrieverImpl.java
@@ -22,7 +22,6 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.search.ml.embedding.EmbeddingProviderInformation;
 import com.liferay.portal.search.ml.embedding.EmbeddingProviderStatus;
 import com.liferay.search.experiences.configuration.SemanticSearchConfiguration;
 import com.liferay.search.experiences.configuration.SemanticSearchConfigurationProvider;
@@ -42,10 +41,7 @@ import org.osgi.service.component.annotations.Reference;
 /**
  * @author Petteri Karttunen
  */
-@Component(
-	enabled = false,
-	service = {EmbeddingProviderInformation.class, TextEmbeddingRetriever.class}
-)
+@Component(enabled = false, service = TextEmbeddingRetriever.class)
 public class TextEmbeddingRetrieverImpl implements TextEmbeddingRetriever {
 
 	@Override


### PR DESCRIPTION
Related pull: https://github.com/brianchandotcom/liferay-portal/pull/137154

In this commit I followed the order that @shuyangzhou created [here](https://github.com/brianchandotcom/liferay-portal/pull/89601/commits/35edeeaaa9f634d554b55a34f9e9a13a3a3b6363), and also a stack pattern (first in, last out) from activate method to deactivate method, so that's why they are not in an alphabetical order. Lastly, the _destinations and _messageBusEventListeners were switched because above them there is a loop that deregisters the _destinations field, so it makes more sense that the _destinations.clear() is called before the _messageBusEventListeners.clear().