### PR TITLE
LPS-189587 Set context to null when an operation has been performed

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/batch/engine/resource/VulcanBatchEngineExportTaskResourceImpl.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/batch/engine/resource/VulcanBatchEngineExportTaskResourceImpl.java
@@ -18,7 +18,6 @@ import com.liferay.headless.batch.engine.resource.v1_0.ExportTaskResource;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.GroupLocalService;
-import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineExportTaskResource;
 
@@ -102,7 +101,7 @@ public class VulcanBatchEngineExportTaskResourceImpl
 	}
 
 	private String _getTaskItemDelegateName() {
-		if (Validator.isBlank(_taskItemDelegateName)) {
+		if (_taskItemDelegateName == null) {
 			return _getQueryParameterValue("taskItemDelegateName");
 		}
 

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/batch/engine/resource/VulcanBatchEngineExportTaskResourceImpl.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/batch/engine/resource/VulcanBatchEngineExportTaskResourceImpl.java
@@ -50,10 +50,15 @@ public class VulcanBatchEngineExportTaskResourceImpl
 		_exportTaskResource.setContextUser(_contextUser);
 		_exportTaskResource.setGroupLocalService(_groupLocalService);
 
-		return _exportTaskResource.postExportTask(
-			name, contentType, callbackURL,
-			_getQueryParameterValue("externalReferenceCode"), fieldNames,
-			_getTaskItemDelegateName());
+		try {
+			return _exportTaskResource.postExportTask(
+				name, contentType, callbackURL,
+				_getQueryParameterValue("externalReferenceCode"), fieldNames,
+				_getTaskItemDelegateName());
+		}
+		finally {
+			_resetContext();
+		}
 	}
 
 	@Override
@@ -106,6 +111,16 @@ public class VulcanBatchEngineExportTaskResourceImpl
 		}
 
 		return _taskItemDelegateName;
+	}
+
+	private void _resetContext() {
+		_contextAcceptLanguage = null;
+		_contextCompany = null;
+		_contextHttpServletRequest = null;
+		_contextUriInfo = null;
+		_contextUser = null;
+		_groupLocalService = null;
+		_taskItemDelegateName = null;
 	}
 
 	private AcceptLanguage _contextAcceptLanguage;

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/batch/engine/resource/VulcanBatchEngineImportTaskResourceImpl.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/batch/engine/resource/VulcanBatchEngineImportTaskResourceImpl.java
@@ -17,7 +17,6 @@ package com.liferay.portal.vulcan.internal.batch.engine.resource;
 import com.liferay.headless.batch.engine.resource.v1_0.ImportTaskResource;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.User;
-import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 
@@ -151,7 +150,7 @@ public class VulcanBatchEngineImportTaskResourceImpl
 	}
 
 	private String _getTaskItemDelegateName() {
-		if (Validator.isBlank(_taskItemDelegateName)) {
+		if (_taskItemDelegateName == null) {
 			return _getQueryParameterValue("taskItemDelegateName");
 		}
 

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/batch/engine/resource/VulcanBatchEngineImportTaskResourceImpl.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/batch/engine/resource/VulcanBatchEngineImportTaskResourceImpl.java
@@ -46,9 +46,14 @@ public class VulcanBatchEngineImportTaskResourceImpl
 
 		_initializeContext();
 
-		return _importTaskResource.deleteImportTask(
-			name, callbackURL, _getExternalReferenceCode(),
-			_getImportStrategy(), _getTaskItemDelegateName(), object);
+		try {
+			return _importTaskResource.deleteImportTask(
+				name, callbackURL, _getExternalReferenceCode(),
+				_getImportStrategy(), _getTaskItemDelegateName(), object);
+		}
+		finally {
+			_resetContext();
+		}
 	}
 
 	@Override
@@ -58,10 +63,15 @@ public class VulcanBatchEngineImportTaskResourceImpl
 
 		_initializeContext();
 
-		return _importTaskResource.postImportTask(
-			name, callbackURL, _getQueryParameterValue("createStrategy"),
-			_getExternalReferenceCode(), fields, _getImportStrategy(),
-			_getTaskItemDelegateName(), _getItemsArray(object));
+		try {
+			return _importTaskResource.postImportTask(
+				name, callbackURL, _getQueryParameterValue("createStrategy"),
+				_getExternalReferenceCode(), fields, _getImportStrategy(),
+				_getTaskItemDelegateName(), _getItemsArray(object));
+		}
+		finally {
+			_resetContext();
+		}
 	}
 
 	@Override
@@ -70,10 +80,15 @@ public class VulcanBatchEngineImportTaskResourceImpl
 
 		_initializeContext();
 
-		return _importTaskResource.putImportTask(
-			name, callbackURL, _getExternalReferenceCode(),
-			_getImportStrategy(), _getTaskItemDelegateName(),
-			_getQueryParameterValue("updateStrategy"), object);
+		try {
+			return _importTaskResource.putImportTask(
+				name, callbackURL, _getExternalReferenceCode(),
+				_getImportStrategy(), _getTaskItemDelegateName(),
+				_getQueryParameterValue("updateStrategy"), object);
+		}
+		finally {
+			_resetContext();
+		}
 	}
 
 	@Override
@@ -164,6 +179,15 @@ public class VulcanBatchEngineImportTaskResourceImpl
 			_contextHttpServletRequest);
 		_importTaskResource.setContextUriInfo(_contextUriInfo);
 		_importTaskResource.setContextUser(_contextUser);
+	}
+
+	private void _resetContext() {
+		_contextAcceptLanguage = null;
+		_contextCompany = null;
+		_contextHttpServletRequest = null;
+		_contextUriInfo = null;
+		_contextUser = null;
+		_taskItemDelegateName = null;
 	}
 
 	private AcceptLanguage _contextAcceptLanguage;


### PR DESCRIPTION
Related issue: https://liferay.atlassian.net/browse/LPS-189587

The purpose of this PR is to reset the context of the `VulcanBatchEngineExportTaskResourceImpl` and `VulcanBatchEngineImportTaskResourceImpl` when an operation has been performed