### PR TITLE
LPS-190203: Fix message key when creating an EndPoint with validating if the id of the application is valid

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/model/listener/APIEndpointRelevantObjectEntryModelListener.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/model/listener/APIEndpointRelevantObjectEntryModelListener.java
@@ -212,8 +212,7 @@ public class APIEndpointRelevantObjectEntryModelListener
 
 				throw new ObjectEntryValuesException.InvalidObjectField(
 					"An API endpoint must be related to an API schema",
-					"an-api-endpoint-must-be-related-to-an-api-schema",
-					null);
+					"an-api-endpoint-must-be-related-to-an-api-schema", null);
 			}
 
 			long responseAPISchemaId = (long)values.get(
@@ -224,8 +223,7 @@ public class APIEndpointRelevantObjectEntryModelListener
 
 				throw new ObjectEntryValuesException.InvalidObjectField(
 					"An API endpoint must be related to an API schema",
-					"an-api-endpoint-must-be-related-to-an-api-schema",
-					null);
+					"an-api-endpoint-must-be-related-to-an-api-schema", null);
 			}
 		}
 		catch (Exception exception) {

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APIEndpointRelevantObjectEntryModelListenerTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APIEndpointRelevantObjectEntryModelListenerTest.java
@@ -51,7 +51,83 @@ public class APIEndpointRelevantObjectEntryModelListenerTest
 
 		Assert.assertEquals("BAD_REQUEST", jsonObject.get("status"));
 		Assert.assertEquals(
-			"An API endpoint must be related to a valid API application.",
+			"An API endpoint must be related to an API application.",
+			jsonObject.get("title"));
+
+		jsonObject = HTTPTestUtil.invoke(
+			JSONUtil.put(
+				"httpMethod", "get"
+			).put(
+				"name", RandomTestUtil.randomString()
+			).put(
+				"path", RandomTestUtil.randomString()
+			).put(
+				"r_apiApplicationToAPIEndpoints_c_apiApplicationId",
+				RandomTestUtil.randomLong()
+			).put(
+				"scope", "company"
+			).toString(),
+			"headless-builder/endpoints", Http.Method.POST);
+
+		Assert.assertEquals("BAD_REQUEST", jsonObject.get("status"));
+		Assert.assertEquals(
+			"An API endpoint must be related to an API application.",
+			jsonObject.get("title"));
+
+		jsonObject = HTTPTestUtil.invoke(
+			JSONUtil.put(
+				"httpMethod", "get"
+			).put(
+				"name", RandomTestUtil.randomString()
+			).put(
+				"path", RandomTestUtil.randomString()
+			).put(
+				"r_apiApplicationToAPIEndpoints_c_apiApplicationId",
+				TestPropsValues.getUserId()
+			).put(
+				"scope", "company"
+			).toString(),
+			"headless-builder/endpoints", Http.Method.POST);
+
+		Assert.assertEquals("BAD_REQUEST", jsonObject.get("status"));
+		Assert.assertEquals(
+			"An API endpoint must be related to an API application.",
+			jsonObject.get("title"));
+
+		JSONObject apiApplicationJSONObject = HTTPTestUtil.invoke(
+			JSONUtil.put(
+				"applicationStatus", "published"
+			).put(
+				"baseURL", RandomTestUtil.randomString()
+			).put(
+				"title", RandomTestUtil.randomString()
+			).toString(),
+			"headless-builder/applications", Http.Method.POST);
+
+		jsonObject = HTTPTestUtil.invoke(
+			JSONUtil.put(
+				"httpMethod", "get"
+			).put(
+				"name", RandomTestUtil.randomString()
+			).put(
+				"path", RandomTestUtil.randomString()
+			).put(
+				"r_apiApplicationToAPIEndpoints_c_apiApplicationId",
+				apiApplicationJSONObject.getLong("id")
+			).put(
+				"r_requestAPISchemaToAPIEndpoints_c_apiSchemaId",
+				RandomTestUtil.nextLong()
+			).put(
+				"r_responseAPISchemaToAPIEndpoints_c_apiSchemaId",
+				RandomTestUtil.nextLong()
+			).put(
+				"scope", "company"
+			).toString(),
+			"headless-builder/endpoints", Http.Method.POST);
+
+		Assert.assertEquals("BAD_REQUEST", jsonObject.get("status"));
+		Assert.assertEquals(
+			"An API endpoint must be related to an API schema.",
 			jsonObject.get("title"));
 
 		jsonObject = HTTPTestUtil.invoke(
@@ -73,16 +149,6 @@ public class APIEndpointRelevantObjectEntryModelListenerTest
 		Assert.assertEquals(
 			"Path can have a maximum of 255 alphanumeric characters.",
 			jsonObject.get("title"));
-
-		JSONObject apiApplicationJSONObject = HTTPTestUtil.invoke(
-			JSONUtil.put(
-				"applicationStatus", "published"
-			).put(
-				"baseURL", RandomTestUtil.randomString()
-			).put(
-				"title", RandomTestUtil.randomString()
-			).toString(),
-			"headless-builder/applications", Http.Method.POST);
 
 		JSONObject apiSchemaJSONObject = HTTPTestUtil.invoke(
 			JSONUtil.put(
@@ -167,72 +233,6 @@ public class APIEndpointRelevantObjectEntryModelListenerTest
 		Assert.assertEquals("BAD_REQUEST", jsonObject.get("status"));
 		Assert.assertEquals(
 			"There is an API endpoint with the same HTTP method and path.",
-			jsonObject.get("title"));
-
-		jsonObject = HTTPTestUtil.invoke(
-			JSONUtil.put(
-				"httpMethod", "get"
-			).put(
-				"name", RandomTestUtil.randomString()
-			).put(
-				"path", path
-			).put(
-				"r_apiApplicationToAPIEndpoints_c_apiApplicationId",
-				RandomTestUtil.randomLong()
-			).put(
-				"scope", "company"
-			).toString(),
-			"headless-builder/endpoints", Http.Method.POST);
-
-		Assert.assertEquals("BAD_REQUEST", jsonObject.get("status"));
-		Assert.assertEquals(
-			"An API endpoint must be related to a valid API application.",
-			jsonObject.get("title"));
-
-		jsonObject = HTTPTestUtil.invoke(
-			JSONUtil.put(
-				"httpMethod", "get"
-			).put(
-				"name", RandomTestUtil.randomString()
-			).put(
-				"path", path
-			).put(
-				"r_apiApplicationToAPIEndpoints_c_apiApplicationId",
-				TestPropsValues.getUserId()
-			).put(
-				"scope", "company"
-			).toString(),
-			"headless-builder/endpoints", Http.Method.POST);
-
-		Assert.assertEquals("BAD_REQUEST", jsonObject.get("status"));
-		Assert.assertEquals(
-			"An API endpoint must be related to a valid API application.",
-			jsonObject.get("title"));
-
-		jsonObject = HTTPTestUtil.invoke(
-			JSONUtil.put(
-				"httpMethod", "get"
-			).put(
-				"name", RandomTestUtil.randomString()
-			).put(
-				"path", RandomTestUtil.randomString()
-			).put(
-				"r_apiApplicationToAPIEndpoints_c_apiApplicationId",
-				apiApplicationJSONObject.getLong("id")
-			).put(
-				"r_requestAPISchemaToAPIEndpoints_c_apiSchemaId",
-				RandomTestUtil.nextLong()
-			).put(
-				"r_responseAPISchemaToAPIEndpoints_c_apiSchemaId",
-				RandomTestUtil.nextLong()
-			).put(
-				"scope", "company"
-			).toString(),
-			"headless-builder/endpoints", Http.Method.POST);
-
-		Assert.assertEquals("BAD_REQUEST", jsonObject.get("status"));
-		Assert.assertEquals(
-			"An API endpoint must be related to an API schema.",
 			jsonObject.get("title"));
 	}
 

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APIEndpointRelevantObjectEntryModelListenerTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APIEndpointRelevantObjectEntryModelListenerTest.java
@@ -51,7 +51,7 @@ public class APIEndpointRelevantObjectEntryModelListenerTest
 
 		Assert.assertEquals("BAD_REQUEST", jsonObject.get("status"));
 		Assert.assertEquals(
-			"An API endpoint must be related to an API application.",
+			"An API endpoint must be related to a valid API application.",
 			jsonObject.get("title"));
 
 		jsonObject = HTTPTestUtil.invoke(
@@ -186,7 +186,7 @@ public class APIEndpointRelevantObjectEntryModelListenerTest
 
 		Assert.assertEquals("BAD_REQUEST", jsonObject.get("status"));
 		Assert.assertEquals(
-			"An API endpoint must be related to an API application.",
+			"An API endpoint must be related to a valid API application.",
 			jsonObject.get("title"));
 
 		jsonObject = HTTPTestUtil.invoke(
@@ -206,7 +206,7 @@ public class APIEndpointRelevantObjectEntryModelListenerTest
 
 		Assert.assertEquals("BAD_REQUEST", jsonObject.get("status"));
 		Assert.assertEquals(
-			"An API endpoint must be related to an API application.",
+			"An API endpoint must be related to a valid API application.",
 			jsonObject.get("title"));
 
 		jsonObject = HTTPTestUtil.invoke(
@@ -232,7 +232,7 @@ public class APIEndpointRelevantObjectEntryModelListenerTest
 
 		Assert.assertEquals("BAD_REQUEST", jsonObject.get("status"));
 		Assert.assertEquals(
-			"An API endpoint must be related to a valid API schema.",
+			"An API endpoint must be related to an API schema.",
 			jsonObject.get("title"));
 	}
 


### PR DESCRIPTION
**What is new?**
- Change `messageKey` from: **An API endpoint must be related to an API application.** to **An API endpoint must be related to a valid API application.**
- Update test cases
- Sort test cases based on localized messages
- BuildLanguage

**How to deploy it?**
- Deploy `headless-builder-api` and `headless-builder-impl`

**JIRA Ticket Related**
https://liferay.atlassian.net/browse/LPS-190203