### PR TITLE
LPS-188416 Add Pagination support to HeadlessBuilder endpoints

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/application/resource/BaseHeadlessBuilderResourceImpl.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/application/resource/BaseHeadlessBuilderResourceImpl.java
@@ -16,6 +16,7 @@ package com.liferay.headless.builder.internal.application.resource;
 
 import com.liferay.headless.builder.application.APIApplication;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.vulcan.pagination.Pagination;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -33,7 +34,8 @@ public abstract class BaseHeadlessBuilderResourceImpl {
 	@GET
 	@Path("{any: .*}")
 	@Produces({"application/json", "application/xml"})
-	public abstract Response get() throws Exception;
+	public abstract Response get(@Context Pagination pagination)
+		throws Exception;
 
 	@Context
 	protected APIApplication contextAPIApplication;

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/application/resource/HeadlessBuilderResourceImpl.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/application/resource/HeadlessBuilderResourceImpl.java
@@ -45,9 +45,14 @@ public class HeadlessBuilderResourceImpl
 				contextAPIApplication.getEndpoints()) {
 
 			if (Objects.equals(endpoint.getPath(), endpointPath)) {
+				if (endpoint.getResponseSchema() == null) {
+					return Response.noContent(
+					).build();
+				}
+
 				return Response.ok(
-					_objectEntryHelper.getResponseEntityMaps(
-						contextCompany.getCompanyId(), endpoint)
+					_objectEntryHelper.getResponseEntityMapsPage(
+						contextCompany.getCompanyId(), endpoint, pagination)
 				).build();
 			}
 		}

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/application/resource/HeadlessBuilderResourceImpl.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/application/resource/HeadlessBuilderResourceImpl.java
@@ -19,6 +19,7 @@ import com.liferay.headless.builder.internal.helper.ObjectEntryHelper;
 import com.liferay.headless.builder.internal.util.PathUtil;
 import com.liferay.portal.kernel.exception.NoSuchModelException;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.pagination.Pagination;
 
 import java.util.Objects;
 
@@ -35,7 +36,7 @@ public class HeadlessBuilderResourceImpl
 	}
 
 	@Override
-	public Response get() throws Exception {
+	public Response get(Pagination pagination) throws Exception {
 		String endpointPath = StringUtil.removeSubstring(
 			PathUtil.sanitize(contextHttpServletRequest.getRequestURI()),
 			contextAPIApplication.getBaseURL());

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/helper/ObjectEntryHelper.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/helper/ObjectEntryHelper.java
@@ -76,6 +76,19 @@ public class ObjectEntryHelper {
 			String objectDefinitionExternalReferenceCode)
 		throws Exception {
 
+		Page<ObjectEntry> objectEntriesPage = getObjectEntriesPage(
+			companyId, filterString,
+			Pagination.of(QueryUtil.ALL_POS, QueryUtil.ALL_POS),
+			objectDefinitionExternalReferenceCode);
+
+		return new ArrayList<>(objectEntriesPage.getItems());
+	}
+
+	public Page<ObjectEntry> getObjectEntriesPage(
+			long companyId, String filterString, Pagination pagination,
+			String objectDefinitionExternalReferenceCode)
+		throws Exception {
+
 		ObjectDefinition objectDefinition =
 			_objectDefinitionLocalService.
 				fetchObjectDefinitionByExternalReferenceCode(
@@ -89,12 +102,10 @@ public class ObjectEntryHelper {
 			_permissionCheckerFactory.create(
 				_userLocalService.getUser(objectDefinition.getUserId())));
 
-		Page<ObjectEntry> page = _objectEntryManager.getObjectEntries(
+		return _objectEntryManager.getObjectEntries(
 			companyId, objectDefinition, null, null,
 			_getDefaultDTOConverterContext(objectDefinition), filterString,
-			Pagination.of(QueryUtil.ALL_POS, QueryUtil.ALL_POS), null, null);
-
-		return new ArrayList<>(page.getItems());
+			pagination, null, null);
 	}
 
 	public ObjectEntry getObjectEntry(
@@ -112,8 +123,9 @@ public class ObjectEntryHelper {
 		return objectEntries.get(0);
 	}
 
-	public List<Map<String, Object>> getResponseEntityMaps(
-			long companyId, APIApplication.Endpoint endpoint)
+	public Page<Map<String, Object>> getResponseEntityMapsPage(
+			long companyId, APIApplication.Endpoint endpoint,
+			Pagination pagination)
 		throws Exception {
 
 		List<Map<String, Object>> responseEntityMaps = new ArrayList<>();
@@ -127,11 +139,11 @@ public class ObjectEntryHelper {
 						getMainObjectDefinitionExternalReferenceCode(),
 					companyId);
 
-		List<ObjectEntry> objectEntries = getObjectEntries(
-			companyId, null,
+		Page<ObjectEntry> objectEntriesPage = getObjectEntriesPage(
+			companyId, null, pagination,
 			schemaMainObjectDefinition.getExternalReferenceCode());
 
-		for (ObjectEntry objectEntry : objectEntries) {
+		for (ObjectEntry objectEntry : objectEntriesPage.getItems()) {
 			Map<String, Object> objectEntryProperties =
 				_getObjectEntryProperties(objectEntry);
 
@@ -148,7 +160,8 @@ public class ObjectEntryHelper {
 			responseEntityMaps.add(responseEntityMap);
 		}
 
-		return responseEntityMaps;
+		return Page.of(
+			responseEntityMaps, pagination, objectEntriesPage.getTotalCount());
 	}
 
 	private DTOConverterContext _getDefaultDTOConverterContext(

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/application/resource/test/HeadlessBuilderResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/application/resource/test/HeadlessBuilderResourceTest.java
@@ -33,7 +33,6 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import org.skyscreamer.jsonassert.JSONAssert;
-import org.skyscreamer.jsonassert.JSONCompareMode;
 
 /**
  * @author Luis Miguel Barcos
@@ -98,20 +97,20 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 
 		JSONAssert.assertEquals(
 			JSONUtil.put(
-				JSONUtil.put("name", _OBJECT_FIELD_VALUE)
+				"items", JSONUtil.put(JSONUtil.put("name", _OBJECT_FIELD_VALUE))
 			).toString(),
-			HTTPTestUtil.invokeJSONArray(
+			HTTPTestUtil.invoke(
 				null, endpointPath1, Http.Method.GET
 			).toString(),
-			JSONCompareMode.STRICT);
+			JSONCompareMode.LENIENT);
 		JSONAssert.assertEquals(
 			JSONUtil.put(
-				JSONUtil.put("name", _OBJECT_FIELD_VALUE)
+				"items", JSONUtil.put(JSONUtil.put("name", _OBJECT_FIELD_VALUE))
 			).toString(),
-			HTTPTestUtil.invokeJSONArray(
+			HTTPTestUtil.invoke(
 				null, endpointPath2, Http.Method.GET
 			).toString(),
-			JSONCompareMode.STRICT);
+			JSONCompareMode.LENIENT);
 
 		Assert.assertEquals(
 			404,

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/application/resource/test/HeadlessBuilderResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/application/resource/test/HeadlessBuilderResourceTest.java
@@ -33,6 +33,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
 
 /**
  * @author Luis Miguel Barcos
@@ -93,7 +94,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 			200,
 			HTTPTestUtil.invokeHttpCode(null, endpointPath2, Http.Method.GET));
 
-		_addCustomObjectEntry();
+		_addCustomObjectEntry(_OBJECT_FIELD_VALUE);
 
 		JSONAssert.assertEquals(
 			JSONUtil.put(
@@ -109,6 +110,35 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 			).toString(),
 			HTTPTestUtil.invoke(
 				null, endpointPath2, Http.Method.GET
+			).toString(),
+			JSONCompareMode.LENIENT);
+
+		for (int i = 0; i < 25; i++) {
+			_addCustomObjectEntry(String.valueOf(i));
+		}
+
+		JSONAssert.assertEquals(
+			JSONUtil.put(
+				"items",
+				JSONUtil.putAll(
+					JSONUtil.put("name", "4"), JSONUtil.put("name", "5"),
+					JSONUtil.put("name", "6"), JSONUtil.put("name", "7"),
+					JSONUtil.put("name", "8"))
+			).put(
+				"lastPage", 6
+			).put(
+				"page", 2
+			).put(
+				"pageSize", 5
+			).put(
+				"totalCount", 26
+			).toString(),
+			HTTPTestUtil.invoke(
+				null,
+				String.format(
+					"%s?page=%d&pageSize=%d",
+					_API_BASE_URL_1 + _API_APPLICATION_PATH_1, 2, 5),
+				Http.Method.GET
 			).toString(),
 			JSONCompareMode.LENIENT);
 
@@ -221,7 +251,9 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 			Http.Method.PUT);
 	}
 
-	private void _addCustomObjectEntry() throws Exception {
+	private void _addCustomObjectEntry(String objectFieldValue)
+		throws Exception {
+
 		String restContextPath = _objectDefinitionJSONObject.getString(
 			"restContextPath");
 
@@ -229,7 +261,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 
 		HTTPTestUtil.invoke(
 			JSONUtil.put(
-				_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE
+				_OBJECT_FIELD_NAME, objectFieldValue
 			).toString(),
 			endpoint, Http.Method.POST);
 	}

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/writer/interceptor/PageEntityExtensionWriterInterceptor.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/writer/interceptor/PageEntityExtensionWriterInterceptor.java
@@ -50,7 +50,10 @@ public class PageEntityExtensionWriterInterceptor implements WriterInterceptor {
 	public void aroundWriteTo(WriterInterceptorContext writerInterceptorContext)
 		throws IOException {
 
-		if (Page.class.isAssignableFrom(writerInterceptorContext.getType())) {
+		if (Page.class.isAssignableFrom(writerInterceptorContext.getType()) &&
+			(writerInterceptorContext.getGenericType() instanceof
+				ParameterizedType)) {
+
 			ParameterizedType parameterizedType =
 				(ParameterizedType)writerInterceptorContext.getGenericType();
 


### PR DESCRIPTION
Related ticket [LPS-188416](https://liferay.atlassian.net/browse/LPS-188416)
____
## Dependencies
This PR should be sent once [this PR](https://github.com/liferay-headless/liferay-portal/pull/1336) would be merged

## Purpose of the PR
This PR adds support for Pagination for the Headless Builder REST Application endpoints. 
With this, a user could now do requests with paginated params like in other Liferay collections endpoints.

## How to test it
It is necessary to deploy the following modules:
* headless-builder-api
* headless-builder-impl
* portal-vulcan-impl
