### PR TITLE
LPS-176940 Fix UpgradeConfigurationPidUpgradeTest integration tests

### DIFF
--- a/modules/apps/static/portal-configuration/portal-configuration-persistence-test/src/testIntegration/java/com/liferay/portal/configuration/persistence/upgrade/test/UpgradeConfigurationPidUpgradeTest.java
+++ b/modules/apps/static/portal-configuration/portal-configuration-persistence-test/src/testIntegration/java/com/liferay/portal/configuration/persistence/upgrade/test/UpgradeConfigurationPidUpgradeTest.java
@@ -50,7 +50,6 @@ import org.apache.felix.cm.file.ConfigurationHandler;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -58,7 +57,6 @@ import org.junit.runner.RunWith;
 /**
  * @author Sam Ziemer
  */
-@Ignore
 @RunWith(Arquillian.class)
 public class UpgradeConfigurationPidUpgradeTest {
 
@@ -84,7 +82,7 @@ public class UpgradeConfigurationPidUpgradeTest {
 								clazz.getName(),
 								"com.liferay.portal.configuration." +
 									"persistence.internal.upgrade.v1_0_0." +
-										"UpgradeConfigurationPid")) {
+										"ConfigurationUpgradeProcess")) {
 
 							_upgradeConfigurationPidUpgradeProcess =
 								(UpgradeProcess)upgradeStep;


### PR DESCRIPTION
Issue link: https://liferay.atlassian.net/browse/LPS-176940
Original PR: https://github.com/liferay-uniform/liferay-portal/pull/1283

Discussion: 

As far as I see here, the issue is caused by [LPS-176672](https://liferay.atlassian.net/browse/LPS-176672): _Portal cannot be started due to issues with orphaned OAuth2ProviderApplicationHeadlessServerConfigurationFactory configurations_
 , can you provide more context why you have assigned it to our team?

> 						if (Objects.equals(
> 								clazz.getName(),
> 								"com.liferay.portal.configuration." +
> 									"persistence.internal.upgrade.v1_0_0." +
> 										"UpgradeConfigurationPid")) {
> 
> 							_upgradeConfigurationPidUpgradeProcess =
> 								(UpgradeProcess)upgradeStep;
> 						}


This class name com.liferay.portal.configuration.persistence.internal.upgrade.v1_0_0.UpgradeConfigurationPid doesn’t exist!
Turns out it was renamed in this commit [liferay-portal: //github LPS-176672 Rename](https://github.com/liferay/liferay-portal/commit/c96e9d942c583168973ded26bbf8b77da5874912)