### PR TITLE
LPS-188635 The commit(LPS-147938 fc67bebeab9638bcf4b04372b82df624d5dc…

### DIFF
--- a/modules/apps/portal/portal-tika/src/main/resources/META-INF/module-log4j.xml
+++ b/modules/apps/portal/portal-tika/src/main/resources/META-INF/module-log4j.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+
+<Configuration strict="true">
+	<Loggers>
+		<Logger level="WARN" name="com.liferay.portal.tika.internal.extract.TextExtractorImpl" />
+	</Loggers>
+</Configuration>


### PR DESCRIPTION
…82b9) moved FileImpl's text extraction logic to TextExtractorImpl. But it didn't update related logger level because FileImpl's logger level is WARN. The fix will keep the same logger level with FileImpl.