### PR TITLE
LPS-189504: PUT operation Empty relationship node does not reset items related to the entry.

### DIFF
--- a/modules/apps/object/object-rest-api/bnd.bnd
+++ b/modules/apps/object/object-rest-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Object REST API
 Bundle-SymbolicName: com.liferay.object.rest.api
-Bundle-Version: 17.1.0
+Bundle-Version: 18.0.0
 Export-Package:\
 	com.liferay.object.rest.dto.v1_0,\
 	com.liferay.object.rest.dto.v1_0.util,\

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/manager/v1_0/DefaultObjectEntryManager.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/manager/v1_0/DefaultObjectEntryManager.java
@@ -49,6 +49,7 @@ public interface DefaultObjectEntryManager extends ObjectEntryManager {
 		throws Exception;
 
 	public void disassociateRelatedModels(
+			DTOConverterContext dtoConverterContext,
 			ObjectDefinition objectDefinition,
 			ObjectRelationship objectRelationship, long primaryKey,
 			ObjectDefinition relatedObjectDefinition, long userId)

--- a/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/manager/v1_0/packageinfo
+++ b/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/manager/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 11.2.0
+version 12.0.0

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -880,12 +880,9 @@ public class DefaultObjectEntryManagerImpl
 					objectRelationshipElementsParser.parse(
 						objectRelationship, properties.get(entry.getKey()));
 
-				if (!nestedObjectEntries.isEmpty()) {
-					disassociateRelatedModels(
-						objectDefinition, objectRelationship, primaryKey,
-						relatedObjectDefinition,
-						dtoConverterContext.getUserId());
-				}
+				disassociateRelatedModels(
+					objectDefinition, objectRelationship, primaryKey,
+					relatedObjectDefinition, dtoConverterContext.getUserId());
 
 				for (Map<String, Object> nestedObjectEntry :
 						nestedObjectEntries) {
@@ -908,12 +905,9 @@ public class DefaultObjectEntryManagerImpl
 					objectRelationshipElementsParser.parse(
 						objectRelationship, properties.get(entry.getKey()));
 
-				if (!nestedObjectEntries.isEmpty()) {
-					disassociateRelatedModels(
-						objectDefinition, objectRelationship, primaryKey,
-						relatedObjectDefinition,
-						dtoConverterContext.getUserId());
-				}
+				disassociateRelatedModels(
+					objectDefinition, objectRelationship, primaryKey,
+					relatedObjectDefinition, dtoConverterContext.getUserId());
 
 				for (ObjectEntry nestedObjectEntry : nestedObjectEntries) {
 					if (_isManyToOneObjectRelationship(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/ObjectEntry1toMObjectRelationshipElementsParserImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/ObjectEntry1toMObjectRelationshipElementsParserImpl.java
@@ -66,13 +66,14 @@ public class ObjectEntry1toMObjectRelationshipElementsParserImpl
 	protected ObjectEntry parseOne(Object object) {
 		validateOne(object);
 
-		Map<String, Object> objectMap = (Map<String, Object>)object;
+		Map<String, Object> nestedObjectEntryProperties =
+			(Map<String, Object>)object;
 
-		if (MapUtil.isEmpty(objectMap)) {
+		if (MapUtil.isEmpty(nestedObjectEntryProperties)) {
 			return null;
 		}
 
-		return toObjectEntry(objectMap);
+		return toObjectEntry(nestedObjectEntryProperties);
 	}
 
 }

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/ObjectEntry1toMObjectRelationshipElementsParserImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/ObjectEntry1toMObjectRelationshipElementsParserImpl.java
@@ -18,6 +18,7 @@ import com.liferay.object.constants.ObjectRelationshipConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.rest.dto.v1_0.ObjectEntry;
+import com.liferay.portal.kernel.util.MapUtil;
 
 import java.util.Collections;
 import java.util.List;
@@ -49,7 +50,13 @@ public class ObjectEntry1toMObjectRelationshipElementsParserImpl
 		if (objectRelationship.getObjectDefinitionId1() ==
 				objectDefinition.getObjectDefinitionId()) {
 
-			return Collections.singletonList(parseOne(value));
+			ObjectEntry objectEntry = parseOne(value);
+
+			if (objectEntry == null) {
+				return Collections.emptyList();
+			}
+
+			return Collections.singletonList(objectEntry);
 		}
 
 		return parseMany(value);
@@ -59,7 +66,13 @@ public class ObjectEntry1toMObjectRelationshipElementsParserImpl
 	protected ObjectEntry parseOne(Object object) {
 		validateOne(object);
 
-		return toObjectEntry((Map<String, Object>)object);
+		Map<String, Object> objectMap = (Map<String, Object>)object;
+
+		if (MapUtil.isEmpty(objectMap)) {
+			return null;
+		}
+
+		return toObjectEntry(objectMap);
 	}
 
 }

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/SystemObjectEntry1toMObjectRelationshipElementsParserImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/SystemObjectEntry1toMObjectRelationshipElementsParserImpl.java
@@ -17,6 +17,7 @@ package com.liferay.object.rest.internal.manager.v1_0;
 import com.liferay.object.constants.ObjectRelationshipConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectRelationship;
+import com.liferay.portal.kernel.util.MapUtil;
 
 import java.util.Collections;
 import java.util.List;
@@ -47,7 +48,13 @@ public class SystemObjectEntry1toMObjectRelationshipElementsParserImpl
 		if (objectRelationship.getObjectDefinitionId1() ==
 				objectDefinition.getObjectDefinitionId()) {
 
-			return Collections.singletonList(parseOne(value));
+			Map<String, Object> objectMap = parseOne(value);
+
+			if (objectMap == null) {
+				return Collections.emptyList();
+			}
+
+			return Collections.singletonList(objectMap);
 		}
 
 		return parseMany(value);
@@ -57,7 +64,13 @@ public class SystemObjectEntry1toMObjectRelationshipElementsParserImpl
 	protected Map<String, Object> parseOne(Object object) {
 		validateOne(object);
 
-		return (Map<String, Object>)object;
+		Map<String, Object> objectMap = (Map<String, Object>)object;
+
+		if (MapUtil.isEmpty(objectMap)) {
+			return null;
+		}
+
+		return objectMap;
 	}
 
 }

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/SystemObjectEntry1toMObjectRelationshipElementsParserImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/SystemObjectEntry1toMObjectRelationshipElementsParserImpl.java
@@ -48,13 +48,13 @@ public class SystemObjectEntry1toMObjectRelationshipElementsParserImpl
 		if (objectRelationship.getObjectDefinitionId1() ==
 				objectDefinition.getObjectDefinitionId()) {
 
-			Map<String, Object> objectMap = parseOne(value);
+			Map<String, Object> systemObjectEntry = parseOne(value);
 
-			if (objectMap == null) {
+			if (systemObjectEntry == null) {
 				return Collections.emptyList();
 			}
 
-			return Collections.singletonList(objectMap);
+			return Collections.singletonList(systemObjectEntry);
 		}
 
 		return parseMany(value);
@@ -64,13 +64,14 @@ public class SystemObjectEntry1toMObjectRelationshipElementsParserImpl
 	protected Map<String, Object> parseOne(Object object) {
 		validateOne(object);
 
-		Map<String, Object> objectMap = (Map<String, Object>)object;
+		Map<String, Object> nestedSystemObjectEntryProperties =
+			(Map<String, Object>)object;
 
-		if (MapUtil.isEmpty(objectMap)) {
+		if (MapUtil.isEmpty(nestedSystemObjectEntryProperties)) {
 			return null;
 		}
 
-		return objectMap;
+		return nestedSystemObjectEntryProperties;
 	}
 
 }

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/ObjectRelationshipExtensionProvider.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/ObjectRelationshipExtensionProvider.java
@@ -238,6 +238,8 @@ public class ObjectRelationshipExtensionProvider
 						objectDefinition.getStorageType()));
 
 			defaultObjectEntryManager.disassociateRelatedModels(
+				_getDefaultDTOConverterContext(
+					objectDefinition, getPrimaryKey(entity), null),
 				objectDefinition, objectRelationship, getPrimaryKey(entity),
 				relatedObjectDefinition, userId);
 

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/ObjectRelationshipExtensionProvider.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/ObjectRelationshipExtensionProvider.java
@@ -99,6 +99,8 @@ public class ObjectRelationshipExtensionProvider
 					return null;
 				}
 
+				long primaryKey = getPrimaryKey(entity);
+
 				if (_isManyToOneObjectRelationship(
 						objectDefinition, objectRelationship,
 						relatedObjectDefinition)) {
@@ -111,8 +113,8 @@ public class ObjectRelationshipExtensionProvider
 					return defaultObjectEntryManager.
 						fetchRelatedManyToOneObjectEntry(
 							_getDefaultDTOConverterContext(
-								objectDefinition, getPrimaryKey(entity), null),
-							objectDefinition, getPrimaryKey(entity),
+								objectDefinition, primaryKey, null),
+							objectDefinition, primaryKey,
 							objectRelationship.getName());
 				}
 
@@ -120,8 +122,6 @@ public class ObjectRelationshipExtensionProvider
 					DefaultObjectEntryManagerProvider.provide(
 						_objectEntryManagerRegistry.getObjectEntryManager(
 							objectDefinition.getStorageType()));
-
-				long primaryKey = getPrimaryKey(entity);
 
 				Page<ObjectEntry> relatedObjectEntriesPage =
 					defaultObjectEntryManager.
@@ -204,6 +204,8 @@ public class ObjectRelationshipExtensionProvider
 				"No object definition exists with class name " + className);
 		}
 
+		long primaryKey = getPrimaryKey(entity);
+
 		for (Map.Entry<String, Serializable> entry :
 				extendedProperties.entrySet()) {
 
@@ -239,21 +241,21 @@ public class ObjectRelationshipExtensionProvider
 
 			defaultObjectEntryManager.disassociateRelatedModels(
 				_getDefaultDTOConverterContext(
-					objectDefinition, getPrimaryKey(entity), null),
-				objectDefinition, objectRelationship, getPrimaryKey(entity),
+					objectDefinition, primaryKey, null),
+				objectDefinition, objectRelationship, primaryKey,
 				relatedObjectDefinition, userId);
 
 			for (ObjectEntry nestedObjectEntry : nestedObjectEntries) {
 				nestedObjectEntry = objectEntryManager.updateObjectEntry(
 					objectDefinition.getCompanyId(),
 					_getDefaultDTOConverterContext(
-						objectDefinition, getPrimaryKey(entity), null),
+						objectDefinition, primaryKey, null),
 					nestedObjectEntry.getExternalReferenceCode(),
 					relatedObjectDefinition, nestedObjectEntry,
 					relatedObjectDefinition.getScope());
 
 				_relateNestedObjectEntry(
-					objectDefinition, objectRelationship, getPrimaryKey(entity),
+					objectDefinition, objectRelationship, primaryKey,
 					nestedObjectEntry.getId());
 			}
 

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/ObjectRelationshipExtensionProvider.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/ObjectRelationshipExtensionProvider.java
@@ -232,16 +232,14 @@ public class ObjectRelationshipExtensionProvider
 				objectRelationshipElementsParser.parse(
 					objectRelationship, entry.getValue());
 
-			if (!nestedObjectEntries.isEmpty()) {
-				DefaultObjectEntryManager defaultObjectEntryManager =
-					DefaultObjectEntryManagerProvider.provide(
-						_objectEntryManagerRegistry.getObjectEntryManager(
-							objectDefinition.getStorageType()));
+			DefaultObjectEntryManager defaultObjectEntryManager =
+				DefaultObjectEntryManagerProvider.provide(
+					_objectEntryManagerRegistry.getObjectEntryManager(
+						objectDefinition.getStorageType()));
 
-				defaultObjectEntryManager.disassociateRelatedModels(
-					objectDefinition, objectRelationship, getPrimaryKey(entity),
-					relatedObjectDefinition, userId);
-			}
+			defaultObjectEntryManager.disassociateRelatedModels(
+				objectDefinition, objectRelationship, getPrimaryKey(entity),
+				relatedObjectDefinition, userId);
 
 			for (ObjectEntry nestedObjectEntry : nestedObjectEntries) {
 				nestedObjectEntry = objectEntryManager.updateObjectEntry(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -4666,6 +4666,79 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
+	public void testPutCustomObjectEntryUnlinkNestedCustomObjectEntries()
+		throws Exception {
+
+		// Many to many
+
+		_objectRelationship1 = ObjectRelationshipTestUtil.addObjectRelationship(
+			_objectDefinition1, _objectDefinition2, TestPropsValues.getUserId(),
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		_testPutCustomObjectEntryUnlinkNestedCustomObjectEntries(false);
+
+		_objectRelationshipLocalService.deleteObjectRelationship(
+			_objectRelationship1);
+
+		// Many to one
+
+		_objectRelationship1 = ObjectRelationshipTestUtil.addObjectRelationship(
+			_objectDefinition2, _objectDefinition1, TestPropsValues.getUserId(),
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		_testPutCustomObjectEntryUnlinkNestedCustomObjectEntries(true);
+
+		_objectRelationshipLocalService.deleteObjectRelationship(
+			_objectRelationship1);
+
+		// One to many
+
+		_objectRelationship1 = ObjectRelationshipTestUtil.addObjectRelationship(
+			_objectDefinition1, _objectDefinition2, TestPropsValues.getUserId(),
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		_testPutCustomObjectEntryUnlinkNestedCustomObjectEntries(false);
+	}
+
+	@Test
+	public void testPutCustomObjectEntryUnlinkNestedCustomObjectEntriesByExternalReferenceCode()
+		throws Exception {
+
+		// Many to many
+
+		_objectRelationship1 = ObjectRelationshipTestUtil.addObjectRelationship(
+			_objectDefinition1, _objectDefinition2, TestPropsValues.getUserId(),
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		_testPutCustomObjectEntryUnlinkNestedCustomObjectEntriesByExternalReferenceCode(
+			false);
+
+		_objectRelationshipLocalService.deleteObjectRelationship(
+			_objectRelationship1);
+
+		// Many to one
+
+		_objectRelationship1 = ObjectRelationshipTestUtil.addObjectRelationship(
+			_objectDefinition2, _objectDefinition1, TestPropsValues.getUserId(),
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		_testPutCustomObjectEntryUnlinkNestedCustomObjectEntriesByExternalReferenceCode(
+			true);
+
+		_objectRelationshipLocalService.deleteObjectRelationship(
+			_objectRelationship1);
+
+		// One to many
+
+		_objectRelationship1 = ObjectRelationshipTestUtil.addObjectRelationship(
+			_objectDefinition1, _objectDefinition2, TestPropsValues.getUserId(),
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		_testPutCustomObjectEntryUnlinkNestedCustomObjectEntriesByExternalReferenceCode(
+			false);
+	}
+
+	@Test
 	public void testPutCustomObjectEntryWithNestedCustomObjectEntriesByExternalReferenceCode()
 		throws Exception {
 
@@ -5374,6 +5447,144 @@ public class ObjectEntryResourceTest {
 			Http.Method.POST);
 
 		Assert.assertEquals("BAD_REQUEST", jsonObject.get("status"));
+	}
+
+	private void _testPutCustomObjectEntryUnlinkNestedCustomObjectEntries(
+			boolean manyToOne)
+		throws Exception {
+
+		JSONObject objectEntryJSONObject = JSONUtil.put(
+			_objectRelationship1.getName(),
+			() -> {
+				if (manyToOne) {
+					return JSONFactoryUtil.createJSONObject(
+						JSONUtil.put(
+							_OBJECT_FIELD_NAME_2, RandomTestUtil.randomString()
+						).put(
+							"externalReferenceCode", _ERC_VALUE_1
+						).toString());
+				}
+
+				return _createObjectEntriesJSONArray(
+					new String[] {_ERC_VALUE_1, _ERC_VALUE_2},
+					_OBJECT_FIELD_NAME_2,
+					new String[] {
+						RandomTestUtil.randomString(),
+						RandomTestUtil.randomString()
+					});
+			});
+
+		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+			objectEntryJSONObject.toString(),
+			_objectDefinition1.getRESTContextPath(), Http.Method.POST);
+
+		JSONObject newObjectEntryJSONObject = JSONUtil.put(
+			_objectRelationship1.getName(),
+			() -> {
+				if (manyToOne) {
+					return JSONFactoryUtil.createJSONObject();
+				}
+
+				return JSONFactoryUtil.createJSONArray();
+			});
+
+		jsonObject = HTTPTestUtil.invokeToJSONObject(
+			newObjectEntryJSONObject.toString(),
+			StringBundler.concat(
+				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
+				jsonObject.getString("id")),
+			Http.Method.PUT);
+
+		Assert.assertEquals(
+			0,
+			jsonObject.getJSONObject(
+				"status"
+			).get(
+				"code"
+			));
+
+		if (manyToOne) {
+			JSONObject systemObjectEntryJSONObject = jsonObject.getJSONObject(
+				_objectRelationship1.getName());
+
+			Assert.assertNull(systemObjectEntryJSONObject);
+		}
+		else {
+			JSONArray nestedObjectEntriesJSONArray = jsonObject.getJSONArray(
+				_objectRelationship1.getName());
+
+			Assert.assertEquals(0, nestedObjectEntriesJSONArray.length());
+		}
+	}
+
+	private void
+			_testPutCustomObjectEntryUnlinkNestedCustomObjectEntriesByExternalReferenceCode(
+				boolean manyToOne)
+		throws Exception {
+
+		JSONObject objectEntryJSONObject = JSONUtil.put(
+			_objectRelationship1.getName(),
+			() -> {
+				if (manyToOne) {
+					return JSONFactoryUtil.createJSONObject(
+						JSONUtil.put(
+							_OBJECT_FIELD_NAME_2, RandomTestUtil.randomString()
+						).put(
+							"externalReferenceCode", _ERC_VALUE_1
+						).toString());
+				}
+
+				return _createObjectEntriesJSONArray(
+					new String[] {_ERC_VALUE_1, _ERC_VALUE_2},
+					_OBJECT_FIELD_NAME_2,
+					new String[] {
+						RandomTestUtil.randomString(),
+						RandomTestUtil.randomString()
+					});
+			});
+
+		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+			objectEntryJSONObject.toString(),
+			_objectDefinition1.getRESTContextPath(), Http.Method.POST);
+
+		JSONObject newObjectEntryJSONObject = JSONUtil.put(
+			_objectRelationship1.getName(),
+			() -> {
+				if (manyToOne) {
+					return JSONFactoryUtil.createJSONObject();
+				}
+
+				return JSONFactoryUtil.createJSONArray();
+			});
+
+		jsonObject = HTTPTestUtil.invokeToJSONObject(
+			newObjectEntryJSONObject.toString(),
+			StringBundler.concat(
+				_objectDefinition1.getRESTContextPath(),
+				"/by-external-reference-code/",
+				jsonObject.getString("externalReferenceCode")),
+			Http.Method.PUT);
+
+		Assert.assertEquals(
+			0,
+			jsonObject.getJSONObject(
+				"status"
+			).get(
+				"code"
+			));
+
+		if (manyToOne) {
+			JSONObject systemObjectEntryJSONObject = jsonObject.getJSONObject(
+				_objectRelationship1.getName());
+
+			Assert.assertNull(systemObjectEntryJSONObject);
+		}
+		else {
+			JSONArray nestedObjectEntriesJSONArray = jsonObject.getJSONArray(
+				_objectRelationship1.getName());
+
+			Assert.assertEquals(0, nestedObjectEntriesJSONArray.length());
+		}
 	}
 
 	private void

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/SystemObjectRelatedObjectEntriesTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/SystemObjectRelatedObjectEntriesTest.java
@@ -428,6 +428,71 @@ public class SystemObjectRelatedObjectEntriesTest {
 	}
 
 	@Test
+	public void testPutSystemObjectEntryUnlinkNestedCustomObjectEntries()
+		throws Exception {
+
+		// Many to many relationship
+
+		ObjectRelationship objectRelationship =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				_userSystemObjectDefinition, _objectDefinition,
+				_user.getUserId(),
+				ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		_objectRelationships.add(objectRelationship);
+
+		_testPutSystemObjectEntryUnlinkNestedCustomObjectEntries(
+			objectRelationship);
+
+		// One to many relationship
+
+		objectRelationship = ObjectRelationshipTestUtil.addObjectRelationship(
+			_userSystemObjectDefinition, _objectDefinition, _user.getUserId(),
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		_objectRelationships.add(objectRelationship);
+
+		_testPutSystemObjectEntryUnlinkNestedCustomObjectEntries(
+			objectRelationship);
+	}
+
+	@Test
+	public void testPutSystemObjectEntryUnlinkNestedCustomObjectEntriesInManyToOneRelationship()
+		throws Exception {
+
+		ObjectRelationship objectRelationship =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				_objectDefinition, _userSystemObjectDefinition,
+				_user.getUserId(),
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		_objectRelationships.add(objectRelationship);
+
+		JSONObject jsonObject = UserAccountTestUtil.addUserAccountJSONObject(
+			_userSystemObjectDefinitionManager,
+			HashMapBuilder.<String, Serializable>put(
+				objectRelationship.getName(),
+				JSONFactoryUtil.createJSONObject(
+					JSONUtil.put(
+						_OBJECT_FIELD_NAME, RandomTestUtil.randomString()
+					).put(
+						"externalReferenceCode", _ERC_VALUE_1
+					).toString())
+			).build());
+
+		jsonObject = UserAccountTestUtil.updateUserAccountJSONObject(
+			_userSystemObjectDefinitionManager, jsonObject,
+			HashMapBuilder.<String, Serializable>put(
+				objectRelationship.getName(), JSONFactoryUtil.createJSONObject()
+			).build());
+
+		JSONObject systemObjectEntryJSONObject = jsonObject.getJSONObject(
+			objectRelationship.getName());
+
+		Assert.assertNull(systemObjectEntryJSONObject);
+	}
+
+	@Test
 	public void testPutSystemObjectEntryWithNestedCustomObjectEntries()
 		throws Exception {
 
@@ -853,6 +918,35 @@ public class SystemObjectRelatedObjectEntriesTest {
 				(JSONObject)nestedObjectEntriesJSONArray.get(1),
 				_OBJECT_FIELD_NAME, _NEW_OBJECT_FIELD_VALUE_2);
 		}
+	}
+
+	private void _testPutSystemObjectEntryUnlinkNestedCustomObjectEntries(
+			ObjectRelationship objectRelationship)
+		throws Exception {
+
+		JSONObject jsonObject = UserAccountTestUtil.addUserAccountJSONObject(
+			_userSystemObjectDefinitionManager,
+			HashMapBuilder.<String, Serializable>put(
+				objectRelationship.getName(),
+				_createObjectEntriesJSONArray(
+					new String[] {_ERC_VALUE_1, _ERC_VALUE_2},
+					_OBJECT_FIELD_NAME,
+					new String[] {
+						RandomTestUtil.randomString(),
+						RandomTestUtil.randomString()
+					})
+			).build());
+
+		jsonObject = UserAccountTestUtil.updateUserAccountJSONObject(
+			_userSystemObjectDefinitionManager, jsonObject,
+			HashMapBuilder.<String, Serializable>put(
+				objectRelationship.getName(), JSONFactoryUtil.createJSONArray()
+			).build());
+
+		JSONArray nestedObjectEntriesJSONArray = jsonObject.getJSONArray(
+			objectRelationship.getName());
+
+		Assert.assertEquals(0, nestedObjectEntriesJSONArray.length());
 	}
 
 	private void _testPutSystemObjectEntryWithNestedCustomObjectEntries(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/SystemObject1toMObjectRelatedModelsProviderImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/SystemObject1toMObjectRelatedModelsProviderImpl.java
@@ -186,22 +186,17 @@ public class SystemObject1toMObjectRelatedModelsProviderImpl
 			throw new UnsupportedOperationException();
 		}
 
-		ObjectDefinition objectDefinition =
-			_objectDefinitionLocalService.getObjectDefinition(
-				objectRelationship.getObjectDefinitionId1());
-
 		PersistedModelLocalService persistedModelLocalService =
 			_persistedModelLocalServiceRegistry.getPersistedModelLocalService(
 				_systemObjectDefinitionManager.getModelClassName());
 
-		ObjectField objectField = _objectFieldLocalService.getObjectField(
-			objectRelationship.getObjectFieldId2());
-
-		FromStep fromStep = DSLQueryFactoryUtil.selectDistinct(_table);
-
 		DynamicObjectDefinitionTable dynamicObjectDefinitionTable =
 			_getDynamicObjectDefinitionTable(
 				relatedObjectDefinition.getObjectDefinitionId());
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.getObjectDefinition(
+				objectRelationship.getObjectDefinitionId1());
 
 		Column<DynamicObjectDefinitionTable, Long> column =
 			(Column<DynamicObjectDefinitionTable, Long>)
@@ -216,31 +211,33 @@ public class SystemObject1toMObjectRelatedModelsProviderImpl
 					relatedObjectDefinition.getObjectDefinitionId());
 		}
 
+		FromStep fromStep = DSLQueryFactoryUtil.selectDistinct(_table);
+		ObjectField objectField = _objectFieldLocalService.getObjectField(
+			objectRelationship.getObjectFieldId2());
 		Column<DynamicObjectDefinitionTable, Long> primaryKeyColumn =
 			dynamicObjectDefinitionTable.getPrimaryKeyColumn();
 
-		DSLQuery dslQuery = fromStep.from(
-			_table
-		).innerJoinON(
-			dynamicObjectDefinitionTable,
-			_systemObjectDefinitionManager.getPrimaryKeyColumn(
-			).eq(
-				(Expression<Long>)dynamicObjectDefinitionTable.getColumn(
-					objectField.getDBColumnName())
-			)
-		).where(
-			primaryKeyColumn.eq(
-				primaryKey
-			).and(
-				_table.getColumn(
-					"companyId"
+		List<T> relatedModels = persistedModelLocalService.dslQuery(
+			fromStep.from(
+				_table
+			).innerJoinON(
+				dynamicObjectDefinitionTable,
+				_systemObjectDefinitionManager.getPrimaryKeyColumn(
 				).eq(
-					groupId
+					(Expression<Long>)dynamicObjectDefinitionTable.getColumn(
+						objectField.getDBColumnName())
 				)
-			)
-		);
-
-		List<T> relatedModels = persistedModelLocalService.dslQuery(dslQuery);
+			).where(
+				primaryKeyColumn.eq(
+					primaryKey
+				).and(
+					_table.getColumn(
+						"companyId"
+					).eq(
+						groupId
+					)
+				)
+			));
 
 		if (relatedModels.isEmpty()) {
 			return null;

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -565,6 +565,8 @@ public class ObjectEntryLocalServiceImpl
 			throw new UnsupportedOperationException();
 		}
 
+		DynamicObjectDefinitionTable dynamicObjectDefinitionTable = null;
+
 		ObjectDefinition objectDefinition =
 			_objectDefinitionPersistence.findByPrimaryKey(
 				objectRelationship.getObjectDefinitionId1());
@@ -572,8 +574,6 @@ public class ObjectEntryLocalServiceImpl
 		ObjectDefinition relatedObjectDefinition =
 			_objectDefinitionPersistence.findByPrimaryKey(
 				objectRelationship.getObjectDefinitionId2());
-
-		DynamicObjectDefinitionTable dynamicObjectDefinitionTable = null;
 
 		if (relatedObjectDefinition.isUnmodifiableSystemObject()) {
 			dynamicObjectDefinitionTable =

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -598,7 +598,7 @@ public class ObjectEntryLocalServiceImpl
 			}
 		}
 
-		DSLQuery dslQuery = _buildFetchManyToOneObjectEntryDSLQuery(
+		DSLQuery dslQuery = _getFetchManyToOneObjectEntryDSLQuery(
 			dynamicObjectDefinitionTable, groupId, objectRelationship,
 			primaryKey, dynamicObjectDefinitionTable.getPrimaryKeyColumn());
 
@@ -1677,32 +1677,6 @@ public class ObjectEntryLocalServiceImpl
 		}
 	}
 
-	private DSLQuery _buildFetchManyToOneObjectEntryDSLQuery(
-		DynamicObjectDefinitionTable dynamicObjectDefinitionTable, long groupId,
-		ObjectRelationship objectRelationship, long primaryKey,
-		Column<DynamicObjectDefinitionTable, Long> primaryKeyColumn) {
-
-		FromStep fromStep = DSLQueryFactoryUtil.selectDistinct(
-			ObjectEntryTable.INSTANCE);
-		ObjectField objectField = _objectFieldPersistence.fetchByPrimaryKey(
-			objectRelationship.getObjectFieldId2());
-
-		return fromStep.from(
-			dynamicObjectDefinitionTable
-		).innerJoinON(
-			ObjectEntryTable.INSTANCE,
-			ObjectEntryTable.INSTANCE.objectEntryId.eq(
-				(Expression<Long>)dynamicObjectDefinitionTable.getColumn(
-					objectField.getDBColumnName()))
-		).where(
-			primaryKeyColumn.eq(
-				primaryKey
-			).and(
-				ObjectEntryTable.INSTANCE.groupId.eq(groupId)
-			)
-		);
-	}
-
 	private void _deleteFileEntries(
 		Map<String, Serializable> newValues, long objectDefinitionId,
 		Map<String, Serializable> oldValues) {
@@ -2084,6 +2058,32 @@ public class ObjectEntryLocalServiceImpl
 			extensionDynamicObjectDefinitionTable.getPrimaryKeyColumn(
 			).eq(
 				primaryKey
+			)
+		);
+	}
+
+	private DSLQuery _getFetchManyToOneObjectEntryDSLQuery(
+		DynamicObjectDefinitionTable dynamicObjectDefinitionTable, long groupId,
+		ObjectRelationship objectRelationship, long primaryKey,
+		Column<DynamicObjectDefinitionTable, Long> primaryKeyColumn) {
+
+		FromStep fromStep = DSLQueryFactoryUtil.selectDistinct(
+			ObjectEntryTable.INSTANCE);
+		ObjectField objectField = _objectFieldPersistence.fetchByPrimaryKey(
+			objectRelationship.getObjectFieldId2());
+
+		return fromStep.from(
+			dynamicObjectDefinitionTable
+		).innerJoinON(
+			ObjectEntryTable.INSTANCE,
+			ObjectEntryTable.INSTANCE.objectEntryId.eq(
+				(Expression<Long>)dynamicObjectDefinitionTable.getColumn(
+					objectField.getDBColumnName()))
+		).where(
+			primaryKeyColumn.eq(
+				primaryKey
+			).and(
+				ObjectEntryTable.INSTANCE.groupId.eq(groupId)
 			)
 		);
 	}


### PR DESCRIPTION
**What is new?**
- Implement `fetchRelatedModel` for Custom Object Defintions in ObjectEntry1MModelsRelated and `System1MModelsRelated`.
- Update 1-M parsers checking valid data structure when it is going to set null data.
- Update `DefaultObjectEntryManager` and `ObjectRelationshipExtensionProvider` to disassociate related object entries in a Many to One relationship.
- Create `fetchManyToOneSystemObjectEntry` in DefaultObjectEntryManager.
- Create some test cases in different scenarios
- Requested changes: https://github.com/brianchandotcom/liferay-portal/pull/138091#issuecomment-1643182912

**How to test this?**

1.Create University object
2. Create Student object
3. Create many-to-many relationship universitiesStudents with University as parent
4. Create University entry and Student entry and relate them. Save universityId for following steps.
5. Execute putUniversity:

```curl
curl -X 'PUT' \
  'http://localhost:8080/o/c/universities/${existingUniversityEntryId}' \
  -H 'accept: application/json' \
  -u '${username}:${password}'
  -d '{
  "name": "Oxford_updated",
  "universitiesStudents": [
  ]
}'
```
`universitiesStudents` relationship should be emptied. 

**How to deploy it?**
- Deploy `object-api` and `object-service`
- Deploy `object-rest-api` and `object-rest-impl`

**JIRA Related Ticket**
https://liferay.atlassian.net/browse/LPS-189504