### PR TITLE
LPS-185851 Making upgrade.database.auto.run property non-final to avoid flaky tests

### DIFF
--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/component/enabler/ComponentEnabler.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/component/enabler/ComponentEnabler.java
@@ -14,8 +14,8 @@
 
 package com.liferay.portal.upgrade.internal.component.enabler;
 
+import com.liferay.portal.tools.DBUpgrader;
 import com.liferay.portal.upgrade.internal.jmx.UpgradeManager;
-import com.liferay.portal.util.PropsValues;
 
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
@@ -29,7 +29,7 @@ public class ComponentEnabler {
 
 	@Activate
 	protected void activate(ComponentContext componentContext) {
-		if (PropsValues.UPGRADE_DATABASE_AUTO_RUN) {
+		if (DBUpgrader.isUpgradeDatabaseAutoRunEnabled()) {
 			componentContext.enableComponent(UpgradeManager.class.getName());
 		}
 	}

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/recorder/UpgradeRecorder.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/recorder/UpgradeRecorder.java
@@ -302,8 +302,29 @@ public class UpgradeRecorder {
 	private static final Log _log = LogFactoryUtil.getLog(
 		UpgradeRecorder.class);
 
-	private final Map<String, Map<String, Integer>> _errorMessages =
+	private static final Map<String, Map<String, Integer>> _errorMessages =
 		new ConcurrentHashMap<>();
+	private static String _result;
+	private static final Map<String, SchemaVersions> _schemaVersionsMap =
+		new ConcurrentHashMap<>();
+	private static String _type;
+	private static final Map<String, ArrayList<String>>
+		_upgradeProcessMessages = new ConcurrentHashMap<>();
+	private static final Map<String, Map<String, Integer>> _warningMessages =
+		new ConcurrentHashMap<>();
+
+	static {
+		if (DBUpgrader.isUpgradeDatabaseAutoRunEnabled() ||
+			DBUpgrader.isUpgradeClient()) {
+
+			_result = "pending";
+			_type = "pending";
+		}
+		else {
+			_result = "not enabled";
+			_type = "not enabled";
+		}
+	}
 
 	@Reference(
 		cardinality = ReferenceCardinality.OPTIONAL,
@@ -311,17 +332,6 @@ public class UpgradeRecorder {
 		policyOption = ReferencePolicyOption.GREEDY
 	)
 	private volatile ReleaseManager _releaseManager;
-
-	private String _result = DBUpgrader.isUpgradeDatabaseAutoRunEnabled() ||
-	DBUpgrader.isUpgradeClient() ? "pending" : "not enabled";
-	private final Map<String, SchemaVersions> _schemaVersionsMap =
-		new ConcurrentHashMap<>();
-	private String _type = DBUpgrader.isUpgradeDatabaseAutoRunEnabled() ||
-	DBUpgrader.isUpgradeClient() ? "pending" : "not enabled";
-	private final Map<String, ArrayList<String>> _upgradeProcessMessages =
-		new ConcurrentHashMap<>();
-	private final Map<String, Map<String, Integer>> _warningMessages =
-		new ConcurrentHashMap<>();
 
 	private class SchemaVersions {
 

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/recorder/UpgradeRecorder.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/recorder/UpgradeRecorder.java
@@ -312,14 +312,12 @@ public class UpgradeRecorder {
 	)
 	private volatile ReleaseManager _releaseManager;
 
-	private String _result =
-		PropsValues.UPGRADE_DATABASE_AUTO_RUN || DBUpgrader.isUpgradeClient() ?
-			"pending" : "not enabled";
+	private String _result = DBUpgrader.isUpgradeDatabaseAutoRunEnabled() ||
+	DBUpgrader.isUpgradeClient() ? "pending" : "not enabled";
 	private final Map<String, SchemaVersions> _schemaVersionsMap =
 		new ConcurrentHashMap<>();
-	private String _type =
-		PropsValues.UPGRADE_DATABASE_AUTO_RUN || DBUpgrader.isUpgradeClient() ?
-			"pending" : "not enabled";
+	private String _type = DBUpgrader.isUpgradeDatabaseAutoRunEnabled() ||
+	DBUpgrader.isUpgradeClient() ? "pending" : "not enabled";
 	private final Map<String, ArrayList<String>> _upgradeProcessMessages =
 		new ConcurrentHashMap<>();
 	private final Map<String, Map<String, Integer>> _warningMessages =

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/registry/UpgradeStepRegistratorTracker.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/registry/UpgradeStepRegistratorTracker.java
@@ -27,11 +27,11 @@ import com.liferay.portal.kernel.upgrade.UpgradeException;
 import com.liferay.portal.kernel.upgrade.UpgradeStep;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.tools.DBUpgrader;
 import com.liferay.portal.upgrade.PortalUpgradeProcess;
 import com.liferay.portal.upgrade.internal.executor.UpgradeExecutor;
 import com.liferay.portal.upgrade.log.UpgradeLogContext;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
-import com.liferay.portal.util.PropsValues;
 
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -176,7 +176,7 @@ public class UpgradeStepRegistratorTracker {
 			List<UpgradeInfo> upgradeInfos =
 				upgradeStepRegistry.getUpgradeInfos(_portalUpgraded);
 
-			if (PropsValues.UPGRADE_DATABASE_AUTO_RUN ||
+			if (DBUpgrader.isUpgradeDatabaseAutoRunEnabled() ||
 				(_releaseLocalService.fetchRelease(bundleSymbolicName) ==
 					null)) {
 

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/AutoUpgradeProcessTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/AutoUpgradeProcessTest.java
@@ -23,13 +23,12 @@ import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
-import com.liferay.portal.util.PropsValues;
+import com.liferay.portal.util.PropsUtil;
 
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -52,15 +51,12 @@ public class AutoUpgradeProcessTest {
 
 	@BeforeClass
 	public static void setUpClass() throws Exception {
-		_originalUpgradeDatabaseAutoRun = ReflectionTestUtil.getFieldValue(
-			PropsValues.class, "UPGRADE_DATABASE_AUTO_RUN");
+		_originalDatabaseAutoRun = PropsUtil.get("upgrade.database.auto.run");
 	}
 
 	@After
 	public void tearDown() throws Exception {
-		ReflectionTestUtil.setFieldValue(
-			PropsValues.class, "UPGRADE_DATABASE_AUTO_RUN",
-			_originalUpgradeDatabaseAutoRun);
+		PropsUtil.set("upgrade.database.auto.run", _originalDatabaseAutoRun);
 
 		_upgradeProcessRun = false;
 
@@ -78,8 +74,7 @@ public class AutoUpgradeProcessTest {
 
 	@Test
 	public void testInitializationWhenAutoUpgradeDisabled() throws Exception {
-		ReflectionTestUtil.setFieldValue(
-			PropsValues.class, "UPGRADE_DATABASE_AUTO_RUN", false);
+		PropsUtil.set("upgrade.database.auto.run", "false");
 
 		Assert.assertEquals(
 			"2.0.0", _registerNewUpgradeProcess().getSchemaVersion());
@@ -98,8 +93,7 @@ public class AutoUpgradeProcessTest {
 			upgradeStepRegistratorTracker, "_portalUpgraded", false);
 
 		try {
-			ReflectionTestUtil.setFieldValue(
-				PropsValues.class, "UPGRADE_DATABASE_AUTO_RUN", false);
+			PropsUtil.set("upgrade.database.auto.run", "false");
 
 			Assert.assertNull(_registerNewUpgradeProcess());
 		}
@@ -116,8 +110,7 @@ public class AutoUpgradeProcessTest {
 
 		_releaseLocalService.addRelease(_SERVLET_CONTEXT_NAME, "1.0.0");
 
-		ReflectionTestUtil.setFieldValue(
-			PropsValues.class, "UPGRADE_DATABASE_AUTO_RUN", false);
+		PropsUtil.set("upgrade.database.auto.run", "false");
 
 		Assert.assertEquals(
 			"1.0.0", _registerNewUpgradeProcess().getSchemaVersion());
@@ -129,8 +122,7 @@ public class AutoUpgradeProcessTest {
 	public void testUpgradeProcessWhenAutoUpgradeEnabled() throws Exception {
 		_releaseLocalService.addRelease(_SERVLET_CONTEXT_NAME, "1.0.0");
 
-		ReflectionTestUtil.setFieldValue(
-			PropsValues.class, "UPGRADE_DATABASE_AUTO_RUN", true);
+		PropsUtil.set("upgrade.database.auto.run", "true");
 
 		Assert.assertEquals(
 			"2.0.0", _registerNewUpgradeProcess().getSchemaVersion());
@@ -153,7 +145,7 @@ public class AutoUpgradeProcessTest {
 	private static final String _SERVLET_CONTEXT_NAME =
 		"com.liferay.portal.upgrade.test";
 
-	private static boolean _originalUpgradeDatabaseAutoRun;
+	private static String _originalDatabaseAutoRun;
 
 	@Inject
 	private static ReleaseLocalService _releaseLocalService;

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/AutoUpgradeProcessTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/AutoUpgradeProcessTest.java
@@ -125,7 +125,6 @@ public class AutoUpgradeProcessTest {
 		Assert.assertFalse(_upgradeProcessRun);
 	}
 
-	@Ignore
 	@Test
 	public void testUpgradeProcessWhenAutoUpgradeEnabled() throws Exception {
 		_releaseLocalService.addRelease(_SERVLET_CONTEXT_NAME, "1.0.0");

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/AutoUpgradeProcessTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/AutoUpgradeProcessTest.java
@@ -51,12 +51,14 @@ public class AutoUpgradeProcessTest {
 
 	@BeforeClass
 	public static void setUpClass() throws Exception {
-		_originalDatabaseAutoRun = PropsUtil.get("upgrade.database.auto.run");
+		_originalUpgradeDatabaseAutoRun = PropsUtil.get(
+			"upgrade.database.auto.run");
 	}
 
 	@After
 	public void tearDown() throws Exception {
-		PropsUtil.set("upgrade.database.auto.run", _originalDatabaseAutoRun);
+		PropsUtil.set(
+			"upgrade.database.auto.run", _originalUpgradeDatabaseAutoRun);
 
 		_upgradeProcessRun = false;
 
@@ -145,7 +147,7 @@ public class AutoUpgradeProcessTest {
 	private static final String _SERVLET_CONTEXT_NAME =
 		"com.liferay.portal.upgrade.test";
 
-	private static String _originalDatabaseAutoRun;
+	private static String _originalUpgradeDatabaseAutoRun;
 
 	@Inject
 	private static ReleaseLocalService _releaseLocalService;

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeManagerTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeManagerTest.java
@@ -55,12 +55,14 @@ public class UpgradeManagerTest {
 
 	@BeforeClass
 	public static void setUpClass() {
-		_originalDatabaseAutoRun = PropsUtil.get("upgrade.database.auto.run");
+		_originalUpgradeDatabaseAutoRun = PropsUtil.get(
+			"upgrade.database.auto.run");
 	}
 
 	@AfterClass
 	public static void tearDownClass() {
-		PropsUtil.set("upgrade.database.auto.run", _originalDatabaseAutoRun);
+		PropsUtil.set(
+			"upgrade.database.auto.run", _originalUpgradeDatabaseAutoRun);
 	}
 
 	@After
@@ -183,7 +185,7 @@ public class UpgradeManagerTest {
 			_upgradeManager, methodName, new Class<?>[0], null);
 	}
 
-	private static String _originalDatabaseAutoRun;
+	private static String _originalUpgradeDatabaseAutoRun;
 	private static Object _upgradeManager;
 
 	@Inject

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeManagerTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeManagerTest.java
@@ -19,7 +19,7 @@ import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
-import com.liferay.portal.util.PropsValues;
+import com.liferay.portal.util.PropsUtil;
 
 import java.lang.management.ManagementFactory;
 
@@ -55,15 +55,12 @@ public class UpgradeManagerTest {
 
 	@BeforeClass
 	public static void setUpClass() {
-		_originalUpgradeDatabaseAutoRun = ReflectionTestUtil.getFieldValue(
-			PropsValues.class, "UPGRADE_DATABASE_AUTO_RUN");
+		_originalDatabaseAutoRun = PropsUtil.get("upgrade.database.auto.run");
 	}
 
 	@AfterClass
 	public static void tearDownClass() {
-		ReflectionTestUtil.setFieldValue(
-			PropsValues.class, "UPGRADE_DATABASE_AUTO_RUN",
-			_originalUpgradeDatabaseAutoRun);
+		PropsUtil.set("upgrade.database.auto.run", _originalDatabaseAutoRun);
 	}
 
 	@After
@@ -153,9 +150,9 @@ public class UpgradeManagerTest {
 
 		promise.getValue();
 
-		ReflectionTestUtil.setFieldValue(
-			PropsValues.class, "UPGRADE_DATABASE_AUTO_RUN",
-			upgradeDatabaseAutoRun);
+		PropsUtil.set(
+			"upgrade.database.auto.run",
+			String.valueOf(upgradeDatabaseAutoRun));
 
 		promise = _serviceComponentRuntime.enableComponent(
 			_serviceComponentRuntime.getComponentDescriptionDTO(
@@ -186,7 +183,7 @@ public class UpgradeManagerTest {
 			_upgradeManager, methodName, new Class<?>[0], null);
 	}
 
-	private static boolean _originalUpgradeDatabaseAutoRun;
+	private static String _originalDatabaseAutoRun;
 	private static Object _upgradeManager;
 
 	@Inject

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeRegistryTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeRegistryTest.java
@@ -94,8 +94,7 @@ public class UpgradeRegistryTest {
 			_releaseLocalService.deleteRelease(release);
 		}
 	}
-
-	@Ignore
+	
 	@Test
 	public void testUpgradeRegistryFollowsShortestPath() {
 		_releaseLocalService.addRelease(

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeRegistryTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeRegistryTest.java
@@ -50,14 +50,16 @@ public class UpgradeRegistryTest {
 
 	@Before
 	public void setUp() throws Exception {
-		_originalDatabaseAutoRun = PropsUtil.get("upgrade.database.auto.run");
+		_originalUpgradeDatabaseAutoRun = PropsUtil.get(
+			"upgrade.database.auto.run");
 
 		PropsUtil.set("upgrade.database.auto.run", "true");
 	}
 
 	@After
 	public void tearDown() throws Exception {
-		PropsUtil.set("upgrade.database.auto.run", _originalDatabaseAutoRun);
+		PropsUtil.set(
+			"upgrade.database.auto.run", _originalUpgradeDatabaseAutoRun);
 
 		if (_serviceRegistration != null) {
 			_serviceRegistration.unregister();
@@ -101,7 +103,7 @@ public class UpgradeRegistryTest {
 		Assert.assertTrue(testUpgradeSteps[3]._upgradeCalled);
 	}
 
-	private static String _originalDatabaseAutoRun;
+	private static String _originalUpgradeDatabaseAutoRun;
 
 	@Inject
 	private static ReleaseLocalService _releaseLocalService;

--- a/modules/apps/static/portal-dependency-manager-component-executor-factory/portal-dependency-manager-component-executor-factory/src/main/java/com/liferay/portal/dependency/manager/component/executor/factory/internal/activator/ComponentExecutorFactoryBundleActivator.java
+++ b/modules/apps/static/portal-dependency-manager-component-executor-factory/portal-dependency-manager-component-executor-factory/src/main/java/com/liferay/portal/dependency/manager/component/executor/factory/internal/activator/ComponentExecutorFactoryBundleActivator.java
@@ -23,7 +23,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
-import com.liferay.portal.util.PropsValues;
+import com.liferay.portal.tools.DBUpgrader;
 
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
@@ -50,7 +50,7 @@ public class ComponentExecutorFactoryBundleActivator
 		if (GetterUtil.getBoolean(
 				PropsUtil.get(PropsKeys.DEPENDENCY_MANAGER_THREAD_POOL_ENABLED),
 				true) &&
-			!PropsValues.UPGRADE_DATABASE_AUTO_RUN) {
+			!DBUpgrader.isUpgradeDatabaseAutoRunEnabled()) {
 
 			ExecutorService executorService =
 				SystemExecutorServiceUtil.getExecutorService();

--- a/modules/test/external-data-source-test-controller-test/src/testIntegration/java/com/liferay/external/data/source/test/controller/test/ExternalDataSourceControllerTest.java
+++ b/modules/test/external-data-source-test-controller-test/src/testIntegration/java/com/liferay/external/data/source/test/controller/test/ExternalDataSourceControllerTest.java
@@ -84,7 +84,7 @@ public class ExternalDataSourceControllerTest {
 
 		_apiBundle.start();
 
-		String originalDatabaseAutoRun = PropsUtil.get(
+		String originalUpgradeDatabaseAutoRun = PropsUtil.get(
 			"upgrade.database.auto.run");
 
 		try {
@@ -93,7 +93,8 @@ public class ExternalDataSourceControllerTest {
 			_serviceBundle.start();
 		}
 		finally {
-			PropsUtil.set("upgrade.database.auto.run", originalDatabaseAutoRun);
+			PropsUtil.set(
+				"upgrade.database.auto.run", originalUpgradeDatabaseAutoRun);
 		}
 	}
 

--- a/modules/test/external-data-source-test-controller-test/src/testIntegration/java/com/liferay/external/data/source/test/controller/test/ExternalDataSourceControllerTest.java
+++ b/modules/test/external-data-source-test-controller-test/src/testIntegration/java/com/liferay/external/data/source/test/controller/test/ExternalDataSourceControllerTest.java
@@ -16,13 +16,11 @@ package com.liferay.external.data.source.test.controller.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.io.unsync.UnsyncStringWriter;
-import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.io.unsync.UnsyncByteArrayInputStream;
 import com.liferay.portal.kernel.io.unsync.UnsyncByteArrayOutputStream;
 import com.liferay.portal.kernel.io.unsync.UnsyncPrintWriter;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
-import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.StreamUtil;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -86,11 +84,16 @@ public class ExternalDataSourceControllerTest {
 
 		_apiBundle.start();
 
-		try (SafeCloseable safeCloseable =
-				PropsValuesTestUtil.swapWithSafeCloseable(
-					"UPGRADE_DATABASE_AUTO_RUN", true)) {
+		String originalDatabaseAutoRun = PropsUtil.get(
+			"upgrade.database.auto.run");
+
+		try {
+			PropsUtil.set("upgrade.database.auto.run", "true");
 
 			_serviceBundle.start();
+		}
+		finally {
+			PropsUtil.set("upgrade.database.auto.run", originalDatabaseAutoRun);
 		}
 	}
 

--- a/portal-impl/bnd.bnd
+++ b/portal-impl/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 82.0.3
+Bundle-Version: 83.0.0
 Export-Package:\
 	com.liferay.portal.bean,\
 	com.liferay.portal.dao.orm.hibernate,\

--- a/portal-impl/src/com/liferay/portal/internal/servlet/MainServlet.java
+++ b/portal-impl/src/com/liferay/portal/internal/servlet/MainServlet.java
@@ -389,7 +389,7 @@ public class MainServlet extends HttpServlet {
 			_log.error(exception);
 		}
 
-		if (PropsValues.UPGRADE_DATABASE_AUTO_RUN) {
+		if (DBUpgrader.isUpgradeDatabaseAutoRunEnabled()) {
 			DBUpgrader.upgradeModules();
 
 			StartupHelperUtil.setUpgrading(false);

--- a/portal-impl/src/com/liferay/portal/spring/context/PortalContextLoaderListener.java
+++ b/portal-impl/src/com/liferay/portal/spring/context/PortalContextLoaderListener.java
@@ -338,7 +338,7 @@ public class PortalContextLoaderListener extends ContextLoaderListener {
 
 		dynamicProxyCreator.clear();
 
-		if (PropsValues.UPGRADE_DATABASE_AUTO_RUN) {
+		if (DBUpgrader.isUpgradeDatabaseAutoRunEnabled()) {
 			StartupHelperUtil.setUpgrading(true);
 
 			try {

--- a/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
+++ b/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
@@ -135,10 +135,6 @@ public class DBUpgrader {
 
 	public static boolean isUpgradeDatabaseAutoRunEnabled() {
 		if (PortalRunMode.isTestMode()) {
-			if (PropsValues.JDBC_DEFAULT_DRIVER_CLASS_NAME.contains("hsql")) {
-				return false;
-			}
-
 			return GetterUtil.getBoolean(
 				PropsUtil.get(PropsKeys.UPGRADE_DATABASE_AUTO_RUN));
 		}

--- a/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
+++ b/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
@@ -35,8 +35,10 @@ import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
 import com.liferay.portal.kernel.module.util.ServiceLatch;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.service.ClassNameLocalServiceUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.PortalRunMode;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.ReleaseInfo;
 import com.liferay.portal.kernel.util.Time;
@@ -129,6 +131,19 @@ public class DBUpgrader {
 
 	public static boolean isUpgradeClient() {
 		return _upgradeClient;
+	}
+
+	public static boolean isUpgradeDatabaseAutoRunEnabled() {
+		if (PortalRunMode.isTestMode()) {
+			if (PropsValues.JDBC_DEFAULT_DRIVER_CLASS_NAME.contains("hsql")) {
+				return false;
+			}
+
+			return GetterUtil.getBoolean(
+				PropsUtil.get(PropsKeys.UPGRADE_DATABASE_AUTO_RUN));
+		}
+
+		return _UPGRADE_DATABASE_AUTO_RUN;
 	}
 
 	public static void main(String[] args) {
@@ -439,6 +454,8 @@ public class DBUpgrader {
 		}
 	}
 
+	private static final boolean _UPGRADE_DATABASE_AUTO_RUN;
+
 	private static final Version _VERSION_7010 = new Version(0, 0, 6);
 
 	private static final Log _log = LogFactoryUtil.getLog(DBUpgrader.class);
@@ -448,5 +465,15 @@ public class DBUpgrader {
 		_appenderServiceReference;
 	private static volatile StopWatch _stopWatch;
 	private static volatile boolean _upgradeClient;
+
+	static {
+		if (PropsValues.JDBC_DEFAULT_DRIVER_CLASS_NAME.contains("hsql")) {
+			_UPGRADE_DATABASE_AUTO_RUN = false;
+		}
+		else {
+			_UPGRADE_DATABASE_AUTO_RUN = GetterUtil.getBoolean(
+				PropsUtil.get(PropsKeys.UPGRADE_DATABASE_AUTO_RUN));
+		}
+	}
 
 }

--- a/portal-impl/src/com/liferay/portal/tools/packageinfo
+++ b/portal-impl/src/com/liferay/portal/tools/packageinfo
@@ -1,1 +1,1 @@
-version 13.1.0
+version 13.2.0

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -2389,8 +2389,6 @@ public class PropsValues {
 	public static final String UNICODE_TEXT_NORMALIZER_FORM = PropsUtil.get(
 		PropsKeys.UNICODE_TEXT_NORMALIZER_FORM);
 
-	public static final boolean UPGRADE_DATABASE_AUTO_RUN;
-
 	public static final boolean UPGRADE_DATABASE_TRANSACTIONS_DISABLED =
 		GetterUtil.getBoolean(
 			PropsUtil.get(PropsKeys.UPGRADE_DATABASE_TRANSACTIONS_DISABLED));
@@ -2629,14 +2627,6 @@ public class PropsValues {
 		for (int i = 0; i < LOGIN_FORM_NAVIGATION_PRE.length; i++) {
 			LOGIN_FORM_NAVIGATION_PRE[i] = TextFormatter.format(
 				LOGIN_FORM_NAVIGATION_PRE[i], TextFormatter.N);
-		}
-
-		if (JDBC_DEFAULT_DRIVER_CLASS_NAME.contains("hsql")) {
-			UPGRADE_DATABASE_AUTO_RUN = false;
-		}
-		else {
-			UPGRADE_DATABASE_AUTO_RUN = GetterUtil.getBoolean(
-				PropsUtil.get(PropsKeys.UPGRADE_DATABASE_AUTO_RUN));
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/util/packageinfo
+++ b/portal-impl/src/com/liferay/portal/util/packageinfo
@@ -1,1 +1,1 @@
-version 50.0.0
+version 51.0.0


### PR DESCRIPTION
- LPS-185851 Re-enable tests disabled temporarily on LPS-187398
- LPS-185851 Making the property upgrade.database.auto.run more testable
- LPS-185851 Baseline
- LPS-185851 Applying new method to classes that used the old value in PropsValues
- LPS-185851 Applying new method to test classes that used the old value in PropsValues
- LPS-185851 Making some variables static as they belong to a component and require static initialization by code
- LPS-185851 We are not executing upgrade tests for hypersonic
- LPS-185851 Naming
