### PR TITLE
[TS] LPS-190923

### DIFF
--- a/portal-web/docroot/html/portal/extend_session.jsp
+++ b/portal-web/docroot/html/portal/extend_session.jsp
@@ -19,15 +19,21 @@
 <%
 String requestedSessionId = request.getRequestedSessionId();
 
-if (Validator.isNotNull(requestedSessionId) && !StringUtil.equals(requestedSessionId, session.getId())) {
-	response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-
-	if (_log.isWarnEnabled()) {
-		_log.warn("Unable to extend the HTTP session.");
+if (Validator.isNotNull(requestedSessionId)) {
+	if (CompoundSessionIdSplitterUtil.hasSessionDelimiter()) {
+		requestedSessionId = CompoundSessionIdSplitterUtil.parseSessionId(requestedSessionId);
 	}
 
-	if (_log.isDebugEnabled()) {
-		_log.debug("The requested session " + requestedSessionId + " is not the same as session " + session.getId());
+	if (!StringUtil.equals(requestedSessionId, session.getId())) {
+		response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+
+		if (_log.isWarnEnabled()) {
+			_log.warn("Unable to extend the HTTP session.");
+		}
+
+		if (_log.isDebugEnabled()) {
+			_log.debug("The requested session " + requestedSessionId + " is not the same as session " + session.getId());
+		}
 	}
 }
 

--- a/portal-web/docroot/html/portal/init.jsp
+++ b/portal-web/docroot/html/portal/init.jsp
@@ -38,6 +38,7 @@ page import="com.liferay.portal.kernel.license.util.LicenseManagerUtil" %><%@
 page import="com.liferay.portal.kernel.portlet.PortletConfigurationLayoutUtil" %><%@
 page import="com.liferay.portal.kernel.service.LayoutLocalServiceUtil" %><%@
 page import="com.liferay.portal.kernel.servlet.HttpHeaders" %><%@
+page import="com.liferay.portal.kernel.servlet.filters.compoundsessionid.CompoundSessionIdSplitterUtil" %><%@
 page import="com.liferay.portal.kernel.util.ClassUtil" %><%@
 page import="com.liferay.portal.kernel.util.ProgressTracker" %><%@
 page import="com.liferay.portal.setup.SetupWizardUtil" %><%@


### PR DESCRIPTION
Forwarded from: https://github.com/liferay-appsec/liferay-portal/pull/1241

@ericyanLr
@liferay-appsec

Original pull request comment:
Ticket: https://liferay.atlassian.net/browse/LPS-190923

Hi Team,

**Context**
Currently, the comparison: `!StringUtil.equals(requestedSessionId, session.getId())` in `extend_session.jsp`, does not do a proper comparison of the session IDs, when using WebLogic as the application server. 

WebLogic has a unique implementation/usage for the session ID and Liferay also has some additional handling in place to account for this.

**Issue**
Because of Liferay's additional handling:
- The value retrieved from: `session.getId()` has a parsed value ([CompoundSessionIdHttpSession.java#L31-L35](https://github.com/liferay/liferay-portal/blob/7.4.3.85-ga85/portal-kernel/src/com/liferay/portal/kernel/servlet/filters/compoundsessionid/CompoundSessionIdHttpSession.java#L31-L35)). 
- However, the value for `requestedSessionId`, is the entire session ID (not parsed), when retrieved from `request.getRequestedSessionId()`.

For additional details regarding this behavior, here are some additional resources:
- WebLogic - Session ID:  https://issues-archive.liferay.com/browse/LPS-18587
- Relevant classes/files:
    - [CompoundSessionIdHttpSession.java#L31-L35](https://github.com/liferay/liferay-portal/blob/7.4.3.85-ga85/portal-kernel/src/com/liferay/portal/kernel/servlet/filters/compoundsessionid/CompoundSessionIdHttpSession.java#L31-L35)
    - [portal.properties#L2977-L2991](https://github.com/liferay/liferay-portal/blob/7.4.3.85-ga85/portal-impl/src/portal.properties#L2977-L2991)

Please let me know if you have any questions.
Thanks!