### PR TITLE
LPS-190839 revert updating okio

### DIFF
--- a/lib/versions-complete.xml
+++ b/lib/versions-complete.xml
@@ -2003,7 +2003,7 @@
 			</library>
 			<library>
 				<file-name>com.liferay.oauth2.provider.rest.jar!jose4j.jar</file-name>
-				<version>0.9.3</version>
+				<version>0.9.2</version>
 				<project-name>jose4j</project-name>
 				<project-url>https://bitbucket.org/b_c/jose4j/</project-url>
 				<licenses>
@@ -2218,18 +2218,6 @@
 				<licenses>
 					<license>
 						<license-name>The Apache Software License, Version 2.0</license-name>
-						<license-url>http://www.apache.org/licenses/LICENSE-2.0.txt</license-url>
-					</license>
-				</licenses>
-			</library>
-			<library>
-				<file-name>com.liferay.portal.k8s.agent.impl.jar!kotlin-stdlib.jar</file-name>
-				<version>1.8.0</version>
-				<project-name>Kotlin Stdlib</project-name>
-				<project-url>https://kotlinlang.org/</project-url>
-				<licenses>
-					<license>
-						<license-name>The Apache License, Version 2.0</license-name>
 						<license-url>http://www.apache.org/licenses/LICENSE-2.0.txt</license-url>
 					</license>
 				</licenses>
@@ -2508,13 +2496,12 @@
 				</licenses>
 			</library>
 			<library>
-				<file-name>com.liferay.portal.k8s.agent.impl.jar!okio-jvm.jar</file-name>
-				<version>3.4.0</version>
-				<project-name>com.squareup.okio</project-name>
-				<project-url>https://github.com/square/okio/</project-url>
+				<file-name>com.liferay.portal.k8s.agent.impl.jar!okio.jar</file-name>
+				<version>1.15.0</version>
+				<project-name>Okio</project-name>
 				<licenses>
 					<license>
-						<license-name>The Apache Software License, Version 2.0</license-name>
+						<license-name>Apache 2.0</license-name>
 						<license-url>http://www.apache.org/licenses/LICENSE-2.0.txt</license-url>
 					</license>
 				</licenses>
@@ -4589,13 +4576,12 @@
 				</licenses>
 			</library>
 			<library>
-				<file-name>com.liferay.push.notifications.sender.firebase.jar!okio-jvm.jar</file-name>
-				<version>3.4.0</version>
-				<project-name>com.squareup.okio</project-name>
-				<project-url>https://github.com/square/okio/</project-url>
+				<file-name>com.liferay.push.notifications.sender.firebase.jar!okio.jar</file-name>
+				<version>1.11.0</version>
+				<project-name>Okio</project-name>
 				<licenses>
 					<license>
-						<license-name>The Apache Software License, Version 2.0</license-name>
+						<license-name>Apache 2.0</license-name>
 						<license-url>http://www.apache.org/licenses/LICENSE-2.0.txt</license-url>
 					</license>
 				</licenses>

--- a/lib/versions.html
+++ b/lib/versions.html
@@ -1070,7 +1070,7 @@
 </tr>
 			
 <tr>
-<td nowrap="nowrap">com.liferay.oauth2.provider.rest.jar!jose4j.jar</td><td nowrap="nowrap">0.9.3</td><td nowrap="nowrap"><a href="https://bitbucket.org/b_c/jose4j/">jose4j</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a>
+<td nowrap="nowrap">com.liferay.oauth2.provider.rest.jar!jose4j.jar</td><td nowrap="nowrap">0.9.2</td><td nowrap="nowrap"><a href="https://bitbucket.org/b_c/jose4j/">jose4j</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a>
 <br>
 </td><td></td>
 </tr>
@@ -1179,12 +1179,6 @@
 			
 <tr>
 <td nowrap="nowrap">com.liferay.portal.k8s.agent.impl.jar!jackson-datatype-jsr310.jar</td><td nowrap="nowrap">2.13.2</td><td nowrap="nowrap"><a href="https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jsr310">Jackson datatype: JSR310</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a>
-<br>
-</td><td></td>
-</tr>
-			
-<tr>
-<td nowrap="nowrap">com.liferay.portal.k8s.agent.impl.jar!kotlin-stdlib.jar</td><td nowrap="nowrap">1.8.0</td><td nowrap="nowrap"><a href="https://kotlinlang.org/">Kotlin Stdlib</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache License, Version 2.0</a>
 <br>
 </td><td></td>
 </tr>
@@ -1328,7 +1322,7 @@
 </tr>
 			
 <tr>
-<td nowrap="nowrap">com.liferay.portal.k8s.agent.impl.jar!okio-jvm.jar</td><td nowrap="nowrap">3.4.0</td><td nowrap="nowrap"><a href="https://github.com/square/okio/">com.squareup.okio</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a>
+<td nowrap="nowrap">com.liferay.portal.k8s.agent.impl.jar!okio.jar</td><td nowrap="nowrap">1.15.0</td><td nowrap="nowrap">Okio</td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">Apache 2.0</a>
 <br>
 </td><td></td>
 </tr>
@@ -2390,7 +2384,7 @@
 </tr>
 			
 <tr>
-<td nowrap="nowrap">com.liferay.push.notifications.sender.firebase.jar!okio-jvm.jar</td><td nowrap="nowrap">3.4.0</td><td nowrap="nowrap"><a href="https://github.com/square/okio/">com.squareup.okio</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a>
+<td nowrap="nowrap">com.liferay.push.notifications.sender.firebase.jar!okio.jar</td><td nowrap="nowrap">1.11.0</td><td nowrap="nowrap">Okio</td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">Apache 2.0</a>
 <br>
 </td><td></td>
 </tr>

--- a/modules/apps/push-notifications/push-notifications-sender/push-notifications-sender-firebase/bnd.bnd
+++ b/modules/apps/push-notifications/push-notifications-sender/push-notifications-sender-firebase/bnd.bnd
@@ -6,6 +6,4 @@ Import-Package:\
 	\
 	!io.reactivex.*,\
 	\
-	!kotlin.*,\
-	\
 	*

--- a/modules/apps/push-notifications/push-notifications-sender/push-notifications-sender-firebase/build.gradle
+++ b/modules/apps/push-notifications/push-notifications-sender/push-notifications-sender-firebase/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
 	compileInclude group: "com.liferay.mobile", name: "fcm-client", version: "0.3.0"
 	compileInclude group: "com.squareup.okhttp3", name: "okhttp", version: "3.5.0"
-	compileInclude group: "com.squareup.okio", name: "okio", version: "3.4.0"
+	compileInclude group: "com.squareup.okio", name: "okio", version: "1.11.0"
 
 	compileOnly group: "com.google.code.gson", name: "gson", version: "2.9.0"
 	compileOnly group: "com.liferay", name: "biz.aQute.bnd.annotation", version: "4.2.0.LIFERAY-PATCHED-2"

--- a/modules/apps/static/portal-k8s-agent/portal-k8s-agent-impl/build.gradle
+++ b/modules/apps/static/portal-k8s-agent/portal-k8s-agent-impl/build.gradle
@@ -28,7 +28,6 @@ dependencies {
 	compileInclude group: "io.fabric8", name: "kubernetes-model-scheduling", version: "5.12.2"
 	compileInclude group: "io.fabric8", name: "kubernetes-model-storageclass", version: "5.12.2"
 	compileInclude group: "io.fabric8", name: "zjsonpatch", version: "0.3.0"
-	compileInclude group: "org.jetbrains.kotlin", name: "kotlin-stdlib", version: "1.8.0"
 	compileInclude group: "org.yaml", name: "snakeyaml", version: "2.0"
 
 	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.13.4"

--- a/modules/apps/static/portal-k8s-agent/portal-k8s-agent-impl/build.gradle
+++ b/modules/apps/static/portal-k8s-agent/portal-k8s-agent-impl/build.gradle
@@ -4,7 +4,7 @@ dependencies {
 	compileInclude group: "com.github.mifmif", name: "generex", version: "1.0.2"
 	compileInclude group: "com.squareup.okhttp3", name: "logging-interceptor", version: "3.12.12"
 	compileInclude group: "com.squareup.okhttp3", name: "okhttp", version: "3.12.12"
-	compileInclude group: "com.squareup.okio", name: "okio", version: "3.4.0"
+	compileInclude group: "com.squareup.okio", name: "okio", version: "1.15.0"
 	compileInclude group: "dk.brics.automaton", name: "automaton", version: "1.11-8"
 	compileInclude group: "io.fabric8", name: "kubernetes-client", version: "5.12.2"
 	compileInclude group: "io.fabric8", name: "kubernetes-model-admissionregistration", version: "5.12.2"

--- a/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/bnd.bnd
+++ b/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/bnd.bnd
@@ -23,8 +23,6 @@ Import-Package:\
 	\
 	!junit.framework,\
 	\
-	!kotlin.*,\
-	\
 	!net.sf.saxon.*,\
 	\
 	!org.apache.batik.anim.dom.*,\

--- a/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/build.gradle
+++ b/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/build.gradle
@@ -7,7 +7,7 @@ dependencies {
 	compileInclude group: "com.microsoft.graph", name: "microsoft-graph", version: "1.5.0"
 	compileInclude group: "com.microsoft.graph", name: "microsoft-graph-core", version: "1.0.9"
 	compileInclude group: "com.squareup.okhttp3", name: "okhttp", version: "3.12.1"
-	compileInclude group: "com.squareup.okio", name: "okio", version: "3.4.0"
+	compileInclude group: "com.squareup.okio", name: "okio", version: "1.15.0"
 	compileInclude group: "org.apache.xmlbeans", name: "xmlbeans", version: "3.1.0"
 
 	compileOnly group: "com.google.code.gson", name: "gson", version: "2.9.0"


### PR DESCRIPTION
Hi Brian,

I found there is a blocker in upstream (not reported by others yet) when we try to add a word file with one-drive(Reproduce step is similar to https://liferay.atlassian.net/browse/LPS-191330), it should be caused by https://github.com/liferay-core-infra/liferay-portal/pull/5048
```
Exception in thread "liferay/background_task-5" java.lang.NoClassDefFoundError: kotlin/jvm/internal/Intrinsics 
       at okio.Buffer.write(Buffer.kt) 
       at okhttp3.ResponseBody.create(ResponseBody.java:210) 
       at okhttp3.internal.Util.<clinit>(Util.java:62) 
       at okhttp3.OkHttpClient.<clinit>(OkHttpClient.java:127) 
       at okhttp3.OkHttpClient$Builder.<init>(OkHttpClient.java:475) 
       at com.microsoft.graph.httpcore.HttpClients.custom(HttpClients.java:22) 
       at com.microsoft.graph.httpcore.HttpClients.createDefault(HttpClients.java:37) 
       at com.microsoft.graph.http.CoreHttpProvider.sendRequestInternal(CoreHttpProvider.java:245) 
       at com.microsoft.graph.http.CoreHttpProvider.send(CoreHttpProvider.java:204) 
       at com.microsoft.graph.http.CoreHttpProvider.send(CoreHttpProvider.java:184) 
       at com.microsoft.graph.http.BaseRequest.send(BaseRequest.java:306) 
       at com.microsoft.graph.http.CustomRequest.post(CustomRequest.java:106) 
       at com.liferay.document.library.opener.onedrive.web.internal.background.task.UploadOneDriveDocumentBackgroundTaskExecutor._uploadFile(UploadOneDrive
DocumentBackgroundTaskExecutor.java:227) 
       at com.liferay.document.library.opener.onedrive.web.internal.background.task.UploadOneDriveDocumentBackgroundTaskExecutor.execute(UploadOneDriveDocu
mentBackgroundTaskExecutor.java:97) 
       at com.liferay.portal.background.task.internal.SerialBackgroundTaskExecutor.execute(SerialBackgroundTaskExecutor.java:54) 
       at com.liferay.portal.kernel.backgroundtask.DelegatingBackgroundTaskExecutor.execute(DelegatingBackgroundTaskExecutor.java:32) 
       at com.liferay.portal.background.task.internal.ThreadLocalAwareBackgroundTaskExecutor.execute(ThreadLocalAwareBackgroundTaskExecutor.java:63) 
       at com.liferay.portal.background.task.internal.messaging.BackgroundTaskMessageListener.doReceive(BackgroundTaskMessageListener.java:115) 
       at com.liferay.portal.kernel.messaging.BaseMessageListener.doReceive(BaseMessageListener.java:39) 
       at com.liferay.portal.kernel.messaging.BaseMessageListener.receive(BaseMessageListener.java:25) 
       at com.liferay.portal.kernel.messaging.InvokerMessageListener.receive(InvokerMessageListener.java:65) 
       at com.liferay.portal.messaging.internal.ParallelDestination$1.run(ParallelDestination.java:47) 
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) 
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) 
       at java.lang.Thread.run(Thread.java:750) 
Caused by: java.lang.ClassNotFoundException: kotlin.jvm.internal.Intrinsics cannot be found by com.liferay.document.library.opener.onedrive.web_3.0.45 
       at org.eclipse.osgi.internal.loader.BundleLoader.findClassInternal(BundleLoader.java:518) 
       at org.eclipse.osgi.internal.loader.BundleLoader.findClass(BundleLoader.java:429) 
       at org.eclipse.osgi.internal.loader.BundleLoader.findClass(BundleLoader.java:421) 
       at org.eclipse.osgi.internal.loader.ModuleClassLoader.loadClass(ModuleClassLoader.java:151) 
       at java.lang.ClassLoader.loadClass(ClassLoader.java:351) 
       ... 25 more
```

I am going to revert it for now, and send the PR with updating Okio to core-infra. 
Thanks for checking!