### PR TITLE
LPS-192051 Use different name so that we can hide the label of the categories selector and the label of a specific vocabulary separately

### DIFF
--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/AssetVocabularyCategoriesSelector.es.js
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/AssetVocabularyCategoriesSelector.es.js
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
@@ -31,7 +31,7 @@ function AssetVocabulariesCategoriesSelector({
 	portletURL,
 	required,
 	selectedItems = [],
-	showLabel = true,
+	showVocabularyLabel = true,
 	singleSelect,
 	sourceItemsVocabularyIds = [],
 	useFallbackInput,
@@ -201,7 +201,7 @@ function AssetVocabulariesCategoriesSelector({
 
 				{label && (
 					<label
-						className={showLabel ? '' : 'sr-only'}
+						className={showVocabularyLabel ? '' : 'sr-only'}
 						htmlFor={inputName + '_MultiSelect'}
 					>
 						{label}

--- a/modules/apps/commerce/commerce-product-content-web/src/main/resources/META-INF/resources/js/CategorySelector.tsx
+++ b/modules/apps/commerce/commerce-product-content-web/src/main/resources/META-INF/resources/js/CategorySelector.tsx
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
@@ -74,7 +74,7 @@ export function CategorySelector({
 				portletURL={categorySelectorURL}
 				required={false}
 				selectedItems={selectedItems}
-				showLabel={false}
+				showVocabularyLabel={false}
 				singleSelect={false}
 				sourceItemsVocabularyIds={sourceItemsVocabularyIds}
 				useFallbackInput={false}

--- a/modules/apps/commerce/commerce-product-content-web/types/src/main/resources/META-INF/resources/js/CategorySelector.d.ts
+++ b/modules/apps/commerce/commerce-product-content-web/types/src/main/resources/META-INF/resources/js/CategorySelector.d.ts
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 


### PR DESCRIPTION
Manual forward since ci:forward:force is not working https://github.com/liferay-echo/liferay-portal/pull/13070#issuecomment-1656142089