### PR TITLE
LPS-191399 Unable to connect to Gogo Shell after only executing core upgrades with upgrade tool

### DIFF
--- a/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/DBUpgradeClient.java
+++ b/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/DBUpgradeClient.java
@@ -218,7 +218,9 @@ public class DBUpgradeClient {
 			String line = null;
 
 			while ((line = bufferedReader.readLine()) != null) {
-				if (line.contains("UpgradeRecorder") && line.contains("fail")) {
+				if (line.contains("UpgradeRecorder") &&
+					(line.contains("fail") || line.contains("unresolved"))) {
+
 					upgradeFailed = true;
 				}
 

--- a/modules/util/portal-tools-db-upgrade-client/src/testFunctional/tests/DatabaseUpgradeClient.testcase
+++ b/modules/util/portal-tools-db-upgrade-client/src/testFunctional/tests/DatabaseUpgradeClient.testcase
@@ -102,7 +102,6 @@ definition {
 	}
 
 	@description = "LPS-158522: Upgrade client only upgrades core"
-	@ignore = "true"
 	@priority = 2
 	test CheckUpgradeClientUpgradeCoreOnly {
 		property skip.get.testcase.database.properties = "true";


### PR DESCRIPTION
Original ticket: https://liferay.atlassian.net/browse/LPS-191399
Original PR: https://github.com/liferay-uniform/liferay-portal/pull/1311

Issue:
When we submitted the fix for [LPS-186413](https://issues.liferay.com/browse/LPS-186413), we didn't take into account the unresolved state.

Solution:
Add the unresolved state to the condition.

I add the "remove temp ignore" commit under the LPS that created the temp ignore.

cc/ @javalosjr96 