### PR TITLE
LPS-192359 An ugly workaround for the bad design. BundleSiteInitializ…

### DIFF
--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
@@ -120,6 +120,7 @@ import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.LayoutTypePortlet;
+import com.liferay.portal.kernel.model.ModelListener;
 import com.liferay.portal.kernel.model.OrganizationModel;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.Role;
@@ -253,6 +254,7 @@ public class BundleSiteInitializer implements SiteInitializer {
 		KnowledgeBaseFolderResource.Factory knowledgeBaseFolderResourceFactory,
 		LayoutCopyHelper layoutCopyHelper,
 		LayoutLocalService layoutLocalService,
+		ModelListener<Layout> layoutModelListener,
 		LayoutPageTemplateEntryLocalService layoutPageTemplateEntryLocalService,
 		LayoutsImporter layoutsImporter,
 		LayoutPageTemplateStructureLocalService
@@ -332,6 +334,7 @@ public class BundleSiteInitializer implements SiteInitializer {
 			knowledgeBaseFolderResourceFactory;
 		_layoutCopyHelper = layoutCopyHelper;
 		_layoutLocalService = layoutLocalService;
+		_layoutModelListener = layoutModelListener;
 		_layoutPageTemplateEntryLocalService =
 			layoutPageTemplateEntryLocalService;
 		_layoutsImporter = layoutsImporter;
@@ -1009,6 +1012,16 @@ public class BundleSiteInitializer implements SiteInitializer {
 							fetchLayoutPageTemplateStructure(
 								draftLayout.getGroupId(),
 								draftLayout.getPlid());
+
+					if (layoutPageTemplateStructure == null) {
+						_layoutModelListener.onAfterCreate(draftLayout);
+
+						layoutPageTemplateStructure =
+							_layoutPageTemplateStructureLocalService.
+								fetchLayoutPageTemplateStructure(
+									draftLayout.getGroupId(),
+									draftLayout.getPlid());
+					}
 
 					LayoutStructure layoutStructure = null;
 
@@ -5132,6 +5145,7 @@ public class BundleSiteInitializer implements SiteInitializer {
 		_knowledgeBaseFolderResourceFactory;
 	private final LayoutCopyHelper _layoutCopyHelper;
 	private final LayoutLocalService _layoutLocalService;
+	private final ModelListener<Layout> _layoutModelListener;
 	private final LayoutPageTemplateEntryLocalService
 		_layoutPageTemplateEntryLocalService;
 	private final LayoutPageTemplateStructureLocalService

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/SiteInitializerExtender.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/SiteInitializerExtender.java
@@ -51,6 +51,8 @@ import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.ModelListener;
 import com.liferay.portal.kernel.module.configuration.ConfigurationProvider;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
@@ -140,7 +142,8 @@ public class SiteInitializerExtender
 				_journalArticleLocalService, _jsonFactory,
 				_knowledgeBaseArticleResourceFactory,
 				_knowledgeBaseFolderResourceFactory, _layoutCopyHelper,
-				_layoutLocalService, _layoutPageTemplateEntryLocalService,
+				_layoutLocalService, _layoutModelListener,
+				_layoutPageTemplateEntryLocalService,
 				_layoutPageTemplateStructureLocalService,
 				_layoutPageTemplateStructureRelLocalService,
 				_layoutSetLocalService, _layoutsImporter,
@@ -260,7 +263,8 @@ public class SiteInitializerExtender
 				_journalArticleLocalService, _jsonFactory,
 				_knowledgeBaseArticleResourceFactory,
 				_knowledgeBaseFolderResourceFactory, _layoutCopyHelper,
-				_layoutLocalService, _layoutPageTemplateEntryLocalService,
+				_layoutLocalService, _layoutModelListener,
+				_layoutPageTemplateEntryLocalService,
 				_layoutPageTemplateStructureLocalService,
 				_layoutPageTemplateStructureRelLocalService,
 				_layoutSetLocalService, _layoutsImporter,
@@ -385,6 +389,11 @@ public class SiteInitializerExtender
 
 	@Reference
 	private LayoutLocalService _layoutLocalService;
+
+	@Reference(
+		target = "(component.name=com.liferay.layout.page.template.internal.model.listener.LayoutModelListener)"
+	)
+	private ModelListener<Layout> _layoutModelListener;
 
 	@Reference
 	private LayoutPageTemplateEntryLocalService

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/SiteInitializerExtension.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/SiteInitializerExtension.java
@@ -51,6 +51,8 @@ import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.ModelListener;
 import com.liferay.portal.kernel.module.configuration.ConfigurationProvider;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
@@ -119,6 +121,7 @@ public class SiteInitializerExtension {
 		KnowledgeBaseFolderResource.Factory knowledgeBaseFolderResourceFactory,
 		LayoutCopyHelper layoutCopyHelper,
 		LayoutLocalService layoutLocalService,
+		ModelListener<Layout> layoutModelListener,
 		LayoutPageTemplateEntryLocalService layoutPageTemplateEntryLocalService,
 		LayoutPageTemplateStructureLocalService
 			layoutPageTemplateStructureLocalService,
@@ -186,8 +189,9 @@ public class SiteInitializerExtension {
 			fragmentsImporter, groupLocalService, journalArticleLocalService,
 			jsonFactory, knowledgeBaseArticleResourceFactory,
 			knowledgeBaseFolderResourceFactory, layoutCopyHelper,
-			layoutLocalService, layoutPageTemplateEntryLocalService,
-			layoutsImporter, layoutPageTemplateStructureLocalService,
+			layoutLocalService, layoutModelListener,
+			layoutPageTemplateEntryLocalService, layoutsImporter,
+			layoutPageTemplateStructureLocalService,
 			layoutPageTemplateStructureRelLocalService, layoutSetLocalService,
 			layoutUtilityPageEntryLocalService, listTypeDefinitionResource,
 			listTypeDefinitionResourceFactory, listTypeEntryLocalService,

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/SiteInitializerFactoryImpl.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/SiteInitializerFactoryImpl.java
@@ -51,6 +51,8 @@ import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.ModelListener;
 import com.liferay.portal.kernel.module.configuration.ConfigurationProvider;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
@@ -128,8 +130,9 @@ public class SiteInitializerFactoryImpl implements SiteInitializerFactory {
 			_fragmentsImporter, _groupLocalService, _journalArticleLocalService,
 			_jsonFactory, _knowledgeBaseArticleResourceFactory,
 			_knowledgeBaseFolderResourceFactory, _layoutCopyHelper,
-			_layoutLocalService, _layoutPageTemplateEntryLocalService,
-			_layoutsImporter, _layoutPageTemplateStructureLocalService,
+			_layoutLocalService, _layoutModelListener,
+			_layoutPageTemplateEntryLocalService, _layoutsImporter,
+			_layoutPageTemplateStructureLocalService,
 			_layoutPageTemplateStructureRelLocalService, _layoutSetLocalService,
 			_layoutUtilityPageEntryLocalService, _listTypeDefinitionResource,
 			_listTypeDefinitionResourceFactory, _listTypeEntryLocalService,
@@ -257,6 +260,11 @@ public class SiteInitializerFactoryImpl implements SiteInitializerFactory {
 
 	@Reference
 	private LayoutLocalService _layoutLocalService;
+
+	@Reference(
+		target = "(component.name=com.liferay.layout.page.template.internal.model.listener.LayoutModelListener)"
+	)
+	private ModelListener<Layout> _layoutModelListener;
 
 	@Reference
 	private LayoutPageTemplateEntryLocalService


### PR DESCRIPTION
…er._addLayoutContent() is assuming the LayoutPageTemplateStructure is ready to use. But the LayoutPageTemplateStructure is created by previous Layout creation triggered by com.liferay.layout.page.template.internal.model.listener.LayoutModelListener.onAfterCreate(). During startup time with an empty db, BundleSiteInitializer may run before the LayoutModelListener is registered. Then the layout will be created without creating its LayoutPageTemplateStructure, causing BundleSiteInitializer._addLayoutContent() throws a NPE. By design, stuff created by ModelListener must be considered "optional", since other code simply has no knowledge about whether certain ModelListener exists or not. Any assumption about a ModelListener has previous invoked for an entity is fundamentally wrong.