### PR TITLE
[TS] LPS-191924 After a page name update, a "Link to Page" field in a web content structure, shows old page name while staging with page versioning is on

### DIFF
--- a/portal-impl/src/com/liferay/portal/model/impl/LayoutRevisionImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/LayoutRevisionImpl.java
@@ -52,7 +52,7 @@ public class LayoutRevisionImpl extends LayoutRevisionBaseImpl {
 
 	@Override
 	public String getBreadcrumb(Locale locale) throws PortalException {
-		List<Layout> layouts = getAncestors();
+		List<Layout> layouts = _getAncestors();
 
 		StringBundler sb = new StringBundler((4 * layouts.size()) + 5);
 
@@ -67,7 +67,7 @@ public class LayoutRevisionImpl extends LayoutRevisionBaseImpl {
 		Collections.reverse(layouts);
 
 		for (Layout layout : layouts) {
-			sb.append(HtmlUtil.escape(layout.getName(locale)));
+			sb.append(HtmlUtil.escape(_getLayoutName(layout, locale)));
 			sb.append(StringPool.SPACE);
 			sb.append(StringPool.GREATER_THAN);
 			sb.append(StringPool.SPACE);
@@ -351,6 +351,24 @@ public class LayoutRevisionImpl extends LayoutRevisionBaseImpl {
 		_typeSettingsUnicodeProperties = typeSettingsUnicodeProperties;
 
 		super.setTypeSettings(_typeSettingsUnicodeProperties.toString());
+	}
+
+	private List<Layout> _getAncestors() throws PortalException {
+		Layout layout = LayoutLocalServiceUtil.getLayout(getPlid());
+
+		return layout.getAncestors();
+	}
+
+	private String _getLayoutName(Layout layout, Locale locale) {
+		LayoutRevision layoutRevision =
+			LayoutRevisionLocalServiceUtil.fetchLatestLayoutRevision(
+				getLayoutSetBranchId(), layout.getPlid());
+
+		if (layoutRevision == null) {
+			return layout.getName(locale);
+		}
+
+		return layoutRevision.getName(locale);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/portal-kernel/bnd.bnd
+++ b/portal-kernel/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 120.0.0
+Bundle-Version: 120.1.0
 Export-Package:\
 	!com.liferay.portal.kernel.internal.*,\
 	!com.liferay.portal.kernel.module.util,\

--- a/portal-kernel/src/com/liferay/portal/kernel/model/LayoutRevision.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/LayoutRevision.java
@@ -46,6 +46,9 @@ public interface LayoutRevision extends LayoutRevisionModel, PersistedModel {
 
 		};
 
+	public String getBreadcrumb(java.util.Locale locale)
+		throws com.liferay.portal.kernel.exception.PortalException;
+
 	public java.util.List<LayoutRevision> getChildren();
 
 	public ColorScheme getColorScheme()
@@ -53,6 +56,8 @@ public interface LayoutRevision extends LayoutRevisionModel, PersistedModel {
 
 	public String getCssText()
 		throws com.liferay.portal.kernel.exception.PortalException;
+
+	public Group getGroup();
 
 	public String getHTMLTitle(java.util.Locale locale);
 

--- a/portal-kernel/src/com/liferay/portal/kernel/model/LayoutRevisionWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/LayoutRevisionWrapper.java
@@ -254,6 +254,13 @@ public class LayoutRevisionWrapper
 	}
 
 	@Override
+	public String getBreadcrumb(java.util.Locale locale)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return model.getBreadcrumb(locale);
+	}
+
+	@Override
 	public java.util.List<LayoutRevision> getChildren() {
 		return model.getChildren();
 	}
@@ -391,6 +398,11 @@ public class LayoutRevisionWrapper
 	@Override
 	public Map<java.util.Locale, String> getDescriptionMap() {
 		return model.getDescriptionMap();
+	}
+
+	@Override
+	public Group getGroup() {
+		return model.getGroup();
 	}
 
 	/**

--- a/portal-kernel/src/com/liferay/portal/kernel/model/LayoutStagingHandler.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/LayoutStagingHandler.java
@@ -283,13 +283,13 @@ public class LayoutStagingHandler implements InvocationHandler, Serializable {
 			Layout.class);
 	private static final Set<String> _layoutRevisionMethodNames = new HashSet<>(
 		Arrays.asList(
-			"getColorScheme", "getColorSchemeId", "getCss", "getCssText",
-			"getDescription", "getDescriptionMap", "getKeywordsMap",
-			"getGroupId", "getHTMLTitle", "getIconImage", "getIconImageId",
-			"getKeywords", "getLayoutSet", "getModifiedDate", "getName",
-			"getNameMap", "getRobots", "getRobotsMap", "getTarget", "getTheme",
-			"getThemeId", "getThemeSetting", "getTitle", "getTitleMap",
-			"getTypeSettings", "getTypeSettingsProperties",
+			"getBreadcrumb", "getColorScheme", "getColorSchemeId", "getCss",
+			"getCssText", "getDescription", "getDescriptionMap",
+			"getKeywordsMap", "getGroupId", "getHTMLTitle", "getIconImage",
+			"getIconImageId", "getKeywords", "getLayoutSet", "getModifiedDate",
+			"getName", "getNameMap", "getRobots", "getRobotsMap", "getTarget",
+			"getTheme", "getThemeId", "getThemeSetting", "getTitle",
+			"getTitleMap", "getTypeSettings", "getTypeSettingsProperties",
 			"getTypeSettingsProperty", "isContentDisplayPage", "isCustomizable",
 			"isEscapedModel", "isIconImage", "isInheritLookAndFeel",
 			"setColorSchemeId", "setCss", "setDescription", "setDescriptionMap",

--- a/portal-kernel/src/com/liferay/portal/kernel/model/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/packageinfo
@@ -1,1 +1,1 @@
-version 30.3.0
+version 30.4.0


### PR DESCRIPTION
Manual forwarding of https://github.com/liferay-staging/liferay-portal/pull/386 as the automatic forward is not working correctly.

The PR was approved by @vendeltoreki and @JoyceWang08211 checked that no regressions were found (see https://github.com/liferay-staging/liferay-portal/pull/386#issuecomment-1667093608 )

-----

https://liferay.atlassian.net/browse/LPS-191924

After a page name update, a "Link to Page" field in a web content structure, shows old page name while staging with page versioning is on, because the `getBreadcrumb` method retrieves the name from the Layout object instead of using the LayoutRevision one.

To solve it:

- 1d9efa34aa39a1b119c78e59c834e6d502af4b06 => I am adding a copy of the `getBreadcrumb` method of LayoutImpl in the LayoutRevision class
- 648c84672b02b008200051c79e5a5e1471727228 => Delegate the getAncestor to the Layout, to avoid repeating that code. Change the getName code to get it from the LayoutRevision of the different Layouts
- a440a9b11d5b6aa36fe66ce0a430b52fa722c201 => Add the `getBreadcrumb` to the _layoutRevisionMethodNames so the method call is redirected to the LayoutRevision object
- 6d758d2daa5b4cc039b2fc7a74cad35fad3b7610 and 46db02179ba7f2667e8bed050edf638392d9577b => Regen and Semver

Let me know if you have any question