### PR TITLE
LPS-193061

### DIFF
--- a/modules/apps/content-dashboard/content-dashboard-test/src/testIntegration/java/com/liferay/content/dashboard/web/internal/portlet/action/test/GetContentDashboardItemInfoMVCResourceCommandTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-test/src/testIntegration/java/com/liferay/content/dashboard/web/internal/portlet/action/test/GetContentDashboardItemInfoMVCResourceCommandTest.java
@@ -39,6 +39,7 @@ import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.servlet.PortletServlet;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderResponse;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletURL;
 import com.liferay.portal.kernel.test.portlet.MockLiferayResourceRequest;
 import com.liferay.portal.kernel.test.portlet.MockLiferayResourceResponse;
@@ -50,6 +51,7 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -358,6 +360,9 @@ public class GetContentDashboardItemInfoMVCResourceCommandTest {
 		ThemeDisplay themeDisplay = ContentDashboardTestUtil.getThemeDisplay(
 			_group);
 
+		mockHttpServletRequest.setAttribute(
+			JavaConstants.JAVAX_PORTLET_RESPONSE,
+			new MockLiferayPortletRenderResponse());
 		mockHttpServletRequest.setAttribute(
 			WebKeys.THEME_DISPLAY, themeDisplay);
 

--- a/modules/apps/content-dashboard/content-dashboard-test/src/testIntegration/java/com/liferay/content/dashboard/web/internal/portlet/action/test/GetContentDashboardItemInfoMVCResourceCommandTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-test/src/testIntegration/java/com/liferay/content/dashboard/web/internal/portlet/action/test/GetContentDashboardItemInfoMVCResourceCommandTest.java
@@ -380,6 +380,9 @@ public class GetContentDashboardItemInfoMVCResourceCommandTest {
 		MockLiferayResourceRequest mockLiferayResourceRequest =
 			new MockLiferayResourceRequest();
 
+		mockHttpServletRequest.setAttribute(
+			JavaConstants.JAVAX_PORTLET_RESPONSE,
+			new MockLiferayPortletRenderResponse());
 		mockLiferayResourceRequest.setAttribute(WebKeys.LOCALE, LocaleUtil.US);
 
 		MockHttpServletRequest mockHttpServletRequest =
@@ -388,9 +391,6 @@ public class GetContentDashboardItemInfoMVCResourceCommandTest {
 		ThemeDisplay themeDisplay = ContentDashboardTestUtil.getThemeDisplay(
 			_group);
 
-		mockHttpServletRequest.setAttribute(
-			JavaConstants.JAVAX_PORTLET_RESPONSE,
-			new MockLiferayPortletRenderResponse());
 		mockHttpServletRequest.setAttribute(
 			WebKeys.THEME_DISPLAY, themeDisplay);
 

--- a/modules/apps/content-dashboard/content-dashboard-test/src/testIntegration/java/com/liferay/content/dashboard/web/internal/portlet/action/test/GetContentDashboardItemInfoMVCResourceCommandTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-test/src/testIntegration/java/com/liferay/content/dashboard/web/internal/portlet/action/test/GetContentDashboardItemInfoMVCResourceCommandTest.java
@@ -380,9 +380,6 @@ public class GetContentDashboardItemInfoMVCResourceCommandTest {
 		MockLiferayResourceRequest mockLiferayResourceRequest =
 			new MockLiferayResourceRequest();
 
-		mockHttpServletRequest.setAttribute(
-			JavaConstants.JAVAX_PORTLET_RESPONSE,
-			new MockLiferayPortletRenderResponse());
 		mockLiferayResourceRequest.setAttribute(WebKeys.LOCALE, LocaleUtil.US);
 
 		MockHttpServletRequest mockHttpServletRequest =
@@ -391,6 +388,9 @@ public class GetContentDashboardItemInfoMVCResourceCommandTest {
 		ThemeDisplay themeDisplay = ContentDashboardTestUtil.getThemeDisplay(
 			_group);
 
+		mockHttpServletRequest.setAttribute(
+			JavaConstants.JAVAX_PORTLET_RESPONSE,
+			new MockLiferayPortletRenderResponse());
 		mockHttpServletRequest.setAttribute(
 			WebKeys.THEME_DISPLAY, themeDisplay);
 

--- a/modules/apps/content-dashboard/content-dashboard-test/src/testIntegration/java/com/liferay/content/dashboard/web/internal/portlet/action/test/GetContentDashboardItemInfoMVCResourceCommandTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-test/src/testIntegration/java/com/liferay/content/dashboard/web/internal/portlet/action/test/GetContentDashboardItemInfoMVCResourceCommandTest.java
@@ -28,6 +28,7 @@ import com.liferay.journal.constants.JournalFolderConstants;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.test.util.JournalTestUtil;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.configuration.test.util.GroupConfigurationTemporarySwapper;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -39,6 +40,7 @@ import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.servlet.PortletServlet;
+import com.liferay.portal.kernel.settings.SettingsFactoryUtil;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderResponse;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletURL;
 import com.liferay.portal.kernel.test.portlet.MockLiferayResourceRequest;
@@ -51,6 +53,7 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -242,23 +245,48 @@ public class GetContentDashboardItemInfoMVCResourceCommandTest {
 
 	@Test
 	public void testServeResourceWithoutSharingButtonAction() throws Exception {
-		JSONObject jsonObject = _serveResource(
-			_createContentDashboardFileItem());
+		try (GroupConfigurationTemporarySwapper
+				groupConfigurationTemporarySwapper =
+					new GroupConfigurationTemporarySwapper(
+						_group.getGroupId(),
+						"com.liferay.sharing.internal.configuration." +
+							"SharingGroupConfiguration",
+						HashMapDictionaryBuilder.<String, Object>put(
+							"enabled", false
+						).build(),
+						SettingsFactoryUtil.getSettingsFactory())) {
 
-		Assert.assertEquals(
-			StringPool.BLANK, jsonObject.getString("fetchSharingButtonURL"));
+			JSONObject jsonObject = _serveResource(
+				_createContentDashboardFileItem());
+
+			Assert.assertEquals(
+				StringPool.BLANK,
+				jsonObject.getString("fetchSharingButtonURL"));
+		}
 	}
 
 	@Test
 	public void testServeResourceWithoutSharingCollaboratorsAction()
 		throws Exception {
 
-		JSONObject jsonObject = _serveResource(
-			_createContentDashboardFileItem());
+		try (GroupConfigurationTemporarySwapper
+				groupConfigurationTemporarySwapper =
+					new GroupConfigurationTemporarySwapper(
+						_group.getGroupId(),
+						"com.liferay.sharing.internal.configuration." +
+							"SharingGroupConfiguration",
+						HashMapDictionaryBuilder.<String, Object>put(
+							"enabled", false
+						).build(),
+						SettingsFactoryUtil.getSettingsFactory())) {
 
-		Assert.assertEquals(
-			StringPool.BLANK,
-			jsonObject.getString("fetchSharingCollaboratorsURL"));
+			JSONObject jsonObject = _serveResource(
+				_createContentDashboardFileItem());
+
+			Assert.assertEquals(
+				StringPool.BLANK,
+				jsonObject.getString("fetchSharingCollaboratorsURL"));
+		}
 	}
 
 	@Test


### PR DESCRIPTION
- LPS-193061 Adds missing attribute
- LPS-193061 Fix tests. Since the attribute was not present, and an error was thrown, the tests passed, even though they shouldn't
- LPS-193061 Sort
- Revert "LPS-193061 Sort"
