### PR TITLE
LPS-190401 Follow up PR - Fix UpgradeSourceProcessorTest test message

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/UpgradeJavaLayoutServicesCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/UpgradeJavaLayoutServicesCheck.java
@@ -36,8 +36,8 @@ public class UpgradeJavaLayoutServicesCheck extends BaseUpgradeCheck {
 				StringBundler.concat(
 					"Unable to format methods addLayout and updateLayout from ",
 					"LayoutService, LayoutLocalService, LayoutServiceUtil and ",
-					"LayoutLocalServiceUtil. Fill the new parameters manually,",
-					"see LPS-188828 and LPS-190401"));
+					"LayoutLocalServiceUtil. Fill the new parameters ",
+					"manually, see LPS-188828 and LPS-190401"));
 
 			return false;
 		}


### PR DESCRIPTION
Tested here: https://github.com/nicolas-sss/liferay-portal/pull/66

Fixing the following error: 
```
com.liferay.source.formatter.processor.UpgradeSourceProcessorTest > testUpgradeJavaLayoutServicesCheck FAILED
     [exec]     org.junit.ComparisonFailure: expected:<...parameters manually,[ ]see LPS-188828 and L...> but was:<...parameters manually,[]see LPS-188828 and L...>
     [exec]         at org.junit.Assert.assertEquals(Assert.java:117)
     [exec]         at org.junit.Assert.assertEquals(Assert.java:146)
     [exec]         at com.liferay.source.formatter.processor.BaseSourceProcessorTestCase._checkExpectedMessages(BaseSourceProcessorTestCase.java:194)
     [exec]         at com.liferay.source.formatter.processor.BaseSourceProcessorTestCase.test(BaseSourceProcessorTestCase.java:142)
     [exec]         at com.liferay.source.formatter.processor.BaseSourceProcessorTestCase.test(BaseSourceProcessorTestCase.java:159)
     [exec]         at com.liferay.source.formatter.processor.UpgradeSourceProcessorTest.testUpgradeJavaLayoutServicesCheck(UpgradeSourceProcessorTest.java:186)
     [exec]         at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
     [exec]         at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
```