### PR TITLE
LPS-193843 Since we still support direct upgrades from 6.2.x and even 6.1.x, these verifiers are not longer deprecated because they are needed for customers upgrading from 6.2 or below

### DIFF
--- a/modules/apps/bookmarks/bookmarks-service/src/main/java/com/liferay/bookmarks/internal/verify/BookmarksServiceVerifyProcess.java
+++ b/modules/apps/bookmarks/bookmarks-service/src/main/java/com/liferay/bookmarks/internal/verify/BookmarksServiceVerifyProcess.java
@@ -33,10 +33,8 @@ import org.osgi.service.component.annotations.Reference;
 /**
  * @author     Raymond Augé
  * @author     Alexander Chow
- * @deprecated As of Mueller (7.2.x), with no direct replacement
  */
 @Component(service = VerifyProcess.class)
-@Deprecated
 public class BookmarksServiceVerifyProcess extends VerifyProcess {
 
 	@Override

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/verify/DLServiceVerifyProcess.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/verify/DLServiceVerifyProcess.java
@@ -70,10 +70,8 @@ import org.osgi.service.component.annotations.Reference;
  * @author     Raymond Augé
  * @author     Douglas Wong
  * @author     Alexander Chow
- * @deprecated As of Mueller (7.2.x), with no direct replacement
  */
 @Component(service = VerifyProcess.class)
-@Deprecated
 public class DLServiceVerifyProcess extends VerifyProcess {
 
 	@Override

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/verify/DDMServiceVerifyProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/verify/DDMServiceVerifyProcess.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-package com.liferay.dynamic.data.mapping.verify;
+package com.liferay.dynamic.data.mapping.internal.verify;
 
 import com.liferay.dynamic.data.mapping.io.DDMFormValuesDeserializer;
 import com.liferay.dynamic.data.mapping.io.DDMFormValuesDeserializerDeserializeRequest;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/verify/DDMServiceVerifyProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/verify/DDMServiceVerifyProcess.java
@@ -30,10 +30,8 @@ import org.osgi.service.component.annotations.Reference;
 /**
  * @author     Marcellus Tavares
  * @author     Rafael Praxedes
- * @deprecated As of Mueller (7.2.x), with no direct replacement
  */
 @Component(service = VerifyProcess.class)
-@Deprecated
 public class DDMServiceVerifyProcess extends VerifyProcess {
 
 	@Override

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/META-INF/module-log4j.xml
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/META-INF/module-log4j.xml
@@ -6,6 +6,6 @@
 		<Logger level="WARN" name="com.liferay.dynamic.data.mapping.internal.storage" />
 		<Logger level="WARN" name="com.liferay.dynamic.data.mapping.internal.upgrade" />
 		<Logger level="WARN" name="com.liferay.dynamic.data.mapping.internal.util" />
-		<Logger level="WARN" name="com.liferay.dynamic.data.mapping.verify.DDMServiceVerifyProcess" />
+		<Logger level="WARN" name="com.liferay.dynamic.data.mapping.internal.verify.DDMServiceVerifyProcess" />
 	</Loggers>
 </Configuration>

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/verify/MessageBoardsServiceVerifyProcess.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/verify/MessageBoardsServiceVerifyProcess.java
@@ -31,10 +31,8 @@ import org.osgi.service.component.annotations.Reference;
 /**
  * @author     Brian Wing Shun Chan
  * @author     Zsolt Berentey
- * @deprecated As of Mueller (7.2.x), with no direct replacement
  */
 @Component(service = VerifyProcess.class)
-@Deprecated
 public class MessageBoardsServiceVerifyProcess extends VerifyProcess {
 
 	@Override

--- a/modules/apps/portal-security/portal-security-service-access-policy-service/src/main/java/com/liferay/portal/security/service/access/policy/internal/verify/SAPServiceVerifyProcess.java
+++ b/modules/apps/portal-security/portal-security-service-access-policy-service/src/main/java/com/liferay/portal/security/service/access/policy/internal/verify/SAPServiceVerifyProcess.java
@@ -18,10 +18,8 @@ import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author     Mika Koivisto
- * @deprecated As of Mueller (7.2.x), with no direct replacement
  */
 @Component(property = "initial.deployment=true", service = VerifyProcess.class)
-@Deprecated
 public class SAPServiceVerifyProcess extends VerifyProcess {
 
 	public void verifyDefaultSAPEntry() {

--- a/portal-impl/src/com/liferay/portal/verify/VerifyGroup.java
+++ b/portal-impl/src/com/liferay/portal/verify/VerifyGroup.java
@@ -44,9 +44,7 @@ import java.util.Set;
 
 /**
  * @author     Brian Wing Shun Chan
- * @deprecated As of Mueller (7.2.x), with no direct replacement
  */
-@Deprecated
 public class VerifyGroup extends VerifyProcess {
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/verify/VerifyResourcePermissions.java
+++ b/portal-impl/src/com/liferay/portal/verify/VerifyResourcePermissions.java
@@ -30,9 +30,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 /**
  * @author     Raymond Augé
  * @author     James Lefeu
- * @deprecated As of Mueller (7.2.x), with no direct replacement
  */
-@Deprecated
 public class VerifyResourcePermissions extends VerifyProcess {
 
 	public static void verify(


### PR DESCRIPTION
cc/ @shuyangzhou