### PR TITLE
LPS-193346: Fix DTO conversion for Objects and Layouts

### DIFF
--- a/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/resource/v1_0/SearchResultResourceImpl.java
+++ b/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/resource/v1_0/SearchResultResourceImpl.java
@@ -307,15 +307,13 @@ public class SearchResultResourceImpl extends BaseSearchResultResourceImpl {
 		return false;
 	}
 
-	private boolean _isEmptyOrContains(
-		List<String> fields, String... fieldNames) {
-
-		if (fields.isEmpty()) {
+	private boolean _isEmptyOrContains(List<String> list, String... strings) {
+		if (list.isEmpty()) {
 			return true;
 		}
 
-		for (String fieldName : fieldNames) {
-			if (fields.contains(fieldName)) {
+		for (String s : strings) {
+			if (list.contains(s)) {
 				return true;
 			}
 		}


### PR DESCRIPTION
Referring to https://github.com/brianchandotcom/liferay-portal/pull/139365#issuecomment-1683144883

 @brianchandotcom instead of making the names more explicit I made them more abstract because it is a generic function. I hope that's ok?

When it comes to what they are (were): 

- `fields` is the parameter for the fields to be included in the headless response. It is a standard parameter in portal headless APIs.
- `fieldNames` was just to check whether a certain field was requested, to prevent computing the response fields for nothing if they were anyways to be filtered out  later in the headless response chain, in the WriterInterceptors.

