### PR TITLE
LPS-191816: Improve the algorithm for endpoint operationId of API Builder

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/util/OpenAPIUtil.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/util/OpenAPIUtil.java
@@ -5,12 +5,125 @@
 
 package com.liferay.headless.builder.internal.util;
 
+import com.liferay.headless.builder.application.APIApplication;
+import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.CamelCaseUtil;
+import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.TextFormatter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
 /**
  * @author Sergio Jiménez del Coso
  */
 public class OpenAPIUtil {
 
-	public static String formatSingular(String s) {
+	public static String getOperationId(APIApplication.Endpoint endpoint) {
+		Http.Method method = endpoint.getMethod();
+
+		return StringUtil.toLowerCase(method.name()) +
+			_toCamelCase(endpoint.getPath()) + "Page";
+	}
+
+	public static String getOperationId(
+		Http.Method httpMethod, APIApplication.Schema schema,
+		String operationId, String path, String returnType) {
+
+		if (schema == null) {
+			return operationId;
+		}
+
+		String schemaName = schema.getName();
+
+		boolean collection = StringUtil.endsWith(operationId, "Page");
+
+		List<String> methodNameSegments = new ArrayList<>();
+
+		methodNameSegments.add(StringUtil.toLowerCase(httpMethod.name()));
+
+		String[] pathSegments = path.split("/");
+		String pluralSchemaName = TextFormatter.formatPlural(schemaName);
+
+		for (int i = 0; i < pathSegments.length; i++) {
+			String pathSegment = pathSegments[i];
+
+			if (pathSegment.isEmpty()) {
+				if (pathSegments.length != 1) {
+					continue;
+				}
+
+				if (collection) {
+					pathSegment = pluralSchemaName;
+				}
+				else {
+					pathSegment = schemaName;
+				}
+			}
+
+			String pathName = CamelCaseUtil.toCamelCase(
+				pathSegment.replaceAll("\\{|-id|}|Id}", ""));
+
+			if (StringUtil.equalsIgnoreCase(pathName, schemaName)) {
+				pathName = schemaName;
+			}
+			else if (StringUtil.equalsIgnoreCase(pathName, pluralSchemaName)) {
+				pathName = pluralSchemaName;
+			}
+			else {
+				pathName = StringUtil.upperCaseFirstLetter(pathName);
+			}
+
+			if ((i == (pathSegments.length - 1)) && collection) {
+				String previousMethodNameSegment = methodNameSegments.get(
+					methodNameSegments.size() - 1);
+
+				if (!pathName.endsWith(pluralSchemaName) &&
+					previousMethodNameSegment.endsWith(schemaName)) {
+
+					String string = StringUtil.replaceLast(
+						previousMethodNameSegment, schemaName,
+						pluralSchemaName);
+
+					methodNameSegments.set(
+						methodNameSegments.size() - 1, string);
+				}
+
+				methodNameSegments.add(pathName + "Page");
+			}
+			else if (Objects.equals(pathName, schemaName)) {
+				methodNameSegments.add(pathName);
+			}
+			else if ((i != (pathSegments.length - 1)) ||
+					 !Objects.equals(returnType, String.class.getName())) {
+
+				String segment = _formatSingular(pathName);
+
+				String s = StringUtil.toLowerCase(segment);
+
+				if (s.endsWith(StringUtil.toLowerCase(schemaName))) {
+					char c = segment.charAt(
+						segment.length() - schemaName.length());
+
+					if (Character.isUpperCase(c)) {
+						String substring = segment.substring(
+							0, segment.length() - schemaName.length());
+
+						segment = substring + schemaName;
+					}
+				}
+
+				methodNameSegments.add(segment);
+			}
+		}
+
+		return StringUtil.merge(methodNameSegments, "");
+	}
+
+	private static String _formatSingular(String s) {
 		if (s.endsWith("ases")) {
 
 			// bases to base
@@ -34,6 +147,14 @@ public class OpenAPIUtil {
 		}
 
 		return s;
+	}
+
+	private static String _toCamelCase(String path) {
+		path = path.replaceAll("/\\{.*\\}", StringPool.BLANK);
+
+		return CamelCaseUtil.toCamelCase(
+			path.replaceAll(StringPool.MINUS, StringPool.SLASH),
+			CharPool.SLASH);
 	}
 
 }

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/util/OpenAPIUtil.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/util/OpenAPIUtil.java
@@ -1,0 +1,39 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.builder.internal.util;
+
+/**
+ * @author Sergio Jiménez del Coso
+ */
+public class OpenAPIUtil {
+
+	public static String formatSingular(String s) {
+		if (s.endsWith("ases")) {
+
+			// bases to base
+
+			s = s.substring(0, s.length() - 1);
+		}
+		else if (s.endsWith("auses")) {
+
+			// clauses to clause
+
+			s = s.substring(0, s.length() - 1);
+		}
+		else if (s.endsWith("ses") || s.endsWith("xes")) {
+			s = s.substring(0, s.length() - 2);
+		}
+		else if (s.endsWith("ies")) {
+			s = s.substring(0, s.length() - 3) + "y";
+		}
+		else if (s.endsWith("s")) {
+			s = s.substring(0, s.length() - 1);
+		}
+
+		return s;
+	}
+
+}

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/vulcan/openapi/contributor/APIApplicationOpenApiContributor.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/vulcan/openapi/contributor/APIApplicationOpenApiContributor.java
@@ -275,9 +275,9 @@ public class APIApplicationOpenApiContributor implements OpenAPIContributor {
 	private String _toCamelCase(String path) {
 		path = path.replaceAll("/\\{.*\\}", StringPool.BLANK);
 
-		path = path.replaceAll(StringPool.MINUS, StringPool.SLASH);
-
-		return CamelCaseUtil.toCamelCase(path, CharPool.SLASH);
+		return CamelCaseUtil.toCamelCase(
+			path.replaceAll(StringPool.MINUS, StringPool.SLASH),
+			CharPool.SLASH);
 	}
 
 	private PathItem _toOpenAPIPathItem(APIApplication.Endpoint endpoint) {

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/vulcan/openapi/contributor/APIApplicationOpenApiContributor.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/vulcan/openapi/contributor/APIApplicationOpenApiContributor.java
@@ -11,15 +11,11 @@ import com.liferay.headless.builder.constants.HeadlessBuilderConstants;
 import com.liferay.headless.builder.internal.util.OpenAPIUtil;
 import com.liferay.object.rest.dto.v1_0.FileEntry;
 import com.liferay.object.rest.dto.v1_0.ListEntry;
-import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
-import com.liferay.portal.kernel.util.CamelCaseUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.ListUtil;
-import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.kernel.util.TextFormatter;
 import com.liferay.portal.vulcan.openapi.OpenAPIContext;
 import com.liferay.portal.vulcan.openapi.contributor.OpenAPIContributor;
 import com.liferay.portal.vulcan.pagination.Page;
@@ -47,9 +43,7 @@ import io.swagger.v3.oas.models.parameters.Parameter;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.responses.ApiResponses;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.TreeMap;
@@ -171,117 +165,8 @@ public class APIApplicationOpenApiContributor implements OpenAPIContributor {
 		return StringPool.SLASH + path;
 	}
 
-	private String _getOperationId(APIApplication.Endpoint endpoint) {
-		Http.Method method = endpoint.getMethod();
-
-		return StringUtil.toLowerCase(method.name()) +
-			_toCamelCase(endpoint.getPath()) + "Page";
-	}
-
-	private String _getOperationId(
-		Http.Method httpMethod, APIApplication.Schema schema,
-		String operationId, String path, String returnType) {
-
-		if (schema == null) {
-			return operationId;
-		}
-
-		String schemaName = schema.getName();
-
-		boolean collection = StringUtil.endsWith(operationId, "Page");
-
-		List<String> methodNameSegments = new ArrayList<>();
-
-		methodNameSegments.add(StringUtil.toLowerCase(httpMethod.name()));
-
-		String[] pathSegments = path.split("/");
-		String pluralSchemaName = TextFormatter.formatPlural(schemaName);
-
-		for (int i = 0; i < pathSegments.length; i++) {
-			String pathSegment = pathSegments[i];
-
-			if (pathSegment.isEmpty()) {
-				if (pathSegments.length != 1) {
-					continue;
-				}
-
-				if (collection) {
-					pathSegment = pluralSchemaName;
-				}
-				else {
-					pathSegment = schemaName;
-				}
-			}
-
-			String pathName = CamelCaseUtil.toCamelCase(
-				pathSegment.replaceAll("\\{|-id|}|Id}", ""));
-
-			if (StringUtil.equalsIgnoreCase(pathName, schemaName)) {
-				pathName = schemaName;
-			}
-			else if (StringUtil.equalsIgnoreCase(pathName, pluralSchemaName)) {
-				pathName = pluralSchemaName;
-			}
-			else {
-				pathName = StringUtil.upperCaseFirstLetter(pathName);
-			}
-
-			if ((i == (pathSegments.length - 1)) && collection) {
-				String previousMethodNameSegment = methodNameSegments.get(
-					methodNameSegments.size() - 1);
-
-				if (!pathName.endsWith(pluralSchemaName) &&
-					previousMethodNameSegment.endsWith(schemaName)) {
-
-					String string = StringUtil.replaceLast(
-						previousMethodNameSegment, schemaName,
-						pluralSchemaName);
-
-					methodNameSegments.set(
-						methodNameSegments.size() - 1, string);
-				}
-
-				methodNameSegments.add(pathName + "Page");
-			}
-			else if (Objects.equals(pathName, schemaName)) {
-				methodNameSegments.add(pathName);
-			}
-			else if ((i != (pathSegments.length - 1)) ||
-					 !Objects.equals(returnType, String.class.getName())) {
-
-				String segment = OpenAPIUtil.formatSingular(pathName);
-
-				String s = StringUtil.toLowerCase(segment);
-
-				if (s.endsWith(StringUtil.toLowerCase(schemaName))) {
-					char c = segment.charAt(
-						segment.length() - schemaName.length());
-
-					if (Character.isUpperCase(c)) {
-						String substring = segment.substring(
-							0, segment.length() - schemaName.length());
-
-						segment = substring + schemaName;
-					}
-				}
-
-				methodNameSegments.add(segment);
-			}
-		}
-
-		return StringUtil.merge(methodNameSegments, "");
-	}
-
-	private String _toCamelCase(String path) {
-		path = path.replaceAll("/\\{.*\\}", StringPool.BLANK);
-
-		return CamelCaseUtil.toCamelCase(
-			path.replaceAll(StringPool.MINUS, StringPool.SLASH),
-			CharPool.SLASH);
-	}
-
 	private PathItem _toOpenAPIPathItem(APIApplication.Endpoint endpoint) {
-		String operationId = _getOperationId(endpoint);
+		String operationId = OpenAPIUtil.getOperationId(endpoint);
 
 		Operation operation = new Operation() {
 			{
@@ -290,7 +175,7 @@ public class APIApplicationOpenApiContributor implements OpenAPIContributor {
 		};
 
 		operation.setOperationId(
-			_getOperationId(
+			OpenAPIUtil.getOperationId(
 				endpoint.getMethod(), endpoint.getResponseSchema(),
 				operation.getOperationId(), endpoint.getPath(), "Page"));
 

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/vulcan/openapi/contributor/APIApplicationOpenApiContributor.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/vulcan/openapi/contributor/APIApplicationOpenApiContributor.java
@@ -166,20 +166,20 @@ public class APIApplicationOpenApiContributor implements OpenAPIContributor {
 	}
 
 	private PathItem _toOpenAPIPathItem(APIApplication.Endpoint endpoint) {
-		String operationId = OpenAPIUtil.getOperationId(endpoint);
-
-		Operation operation = new Operation() {
-			{
-				setOperationId(operationId);
-			}
-		};
-
-		operation.setOperationId(
-			OpenAPIUtil.getOperationId(
-				endpoint.getMethod(), endpoint.getResponseSchema(),
-				operation.getOperationId(), endpoint.getPath(), "Page"));
+		String schemaName = null;
 
 		APIApplication.Schema responseSchema = endpoint.getResponseSchema();
+
+		if (responseSchema != null) {
+			schemaName = responseSchema.getName();
+		}
+
+		String operationId = OpenAPIUtil.getOperationId(
+			endpoint.getMethod(), endpoint.getPath(), schemaName);
+
+		Operation operation = new Operation();
+
+		operation.setOperationId(operationId);
 
 		if (responseSchema != null) {
 			if (Objects.equals(endpoint.getMethod(), Http.Method.GET) &&

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/test/java/com/liferay/headless/builder/internal/util/OpenAPIUtilTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/test/java/com/liferay/headless/builder/internal/util/OpenAPIUtilTest.java
@@ -3,10 +3,9 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-package com.liferay.headless.builder.internal.vulcan.openapi.contributor;
+package com.liferay.headless.builder.internal.util;
 
 import com.liferay.headless.builder.application.APIApplication;
-import com.liferay.headless.builder.internal.util.OpenAPIUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
@@ -21,7 +20,7 @@ import org.junit.Test;
 /**
  * @author Sergio Jiménez del Coso
  */
-public class APIApplicationOpenApiContributorTest {
+public class OpenAPIUtilTest {
 
 	@ClassRule
 	@Rule

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/test/java/com/liferay/headless/builder/internal/util/OpenAPIUtilTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/test/java/com/liferay/headless/builder/internal/util/OpenAPIUtilTest.java
@@ -5,12 +5,8 @@
 
 package com.liferay.headless.builder.internal.util;
 
-import com.liferay.headless.builder.application.APIApplication;
-import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
-
-import java.util.List;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -28,107 +24,30 @@ public class OpenAPIUtilTest {
 		LiferayUnitTestRule.INSTANCE;
 
 	@Test
-	public void testGetDifferentOperationId() {
-		String expectedOperationId = "endpointPath";
-
-		String newOperationId = OpenAPIUtil.getOperationId(
-			_createHttpMethod("GET"), _createAPISchema(), expectedOperationId,
-			"/path-name", "Page");
-
-		Assert.assertNotNull(newOperationId);
-		Assert.assertNotEquals(expectedOperationId, newOperationId);
-	}
-
-	@Test
 	public void testGetOperationId() {
-		String expectedOperationId = "getPathNamePage";
-
-		String newOperationId = OpenAPIUtil.getOperationId(
-			_createHttpMethod("GET"), _createAPISchema(), expectedOperationId,
-			"/path-name", "Page");
-
-		Assert.assertNotNull(newOperationId);
-		Assert.assertEquals(expectedOperationId, newOperationId);
-	}
-
-	@Test(expected = NullPointerException.class)
-	public void testGetOperationIdNullHttpMethod() {
-		OpenAPIUtil.getOperationId(
-			null, _createAPISchema(), "getPathNamePage", "/path-name", "Page");
-	}
-
-	@Test
-	public void testGetOperationIdNullOperationId() {
-		Assert.assertNotNull(
+		Assert.assertEquals(
+			"getPathNamePage",
+			OpenAPIUtil.getOperationId(Http.Method.GET, "/path-name", null));
+		Assert.assertEquals(
+			"getPathNamePage",
 			OpenAPIUtil.getOperationId(
-				_createHttpMethod("GET"), _createAPISchema(), null,
-				"/path-name", "Page"));
-	}
-
-	@Test(expected = NullPointerException.class)
-	public void testGetOperationIdNullPath() {
-		OpenAPIUtil.getOperationId(
-			_createHttpMethod("GET"), _createAPISchema(), "getPathNamePage",
-			null, "Page");
-	}
-
-	@Test
-	public void testGetOperationIdNullResponseSchema() {
-		String expectedOperationId = "getPathNamePage";
-
-		String newOperationId = OpenAPIUtil.getOperationId(
-			_createHttpMethod("GET"), null, expectedOperationId, "/path-name",
-			"Page");
-
-		Assert.assertNotNull(newOperationId);
-		Assert.assertEquals(expectedOperationId, newOperationId);
-	}
-
-	@Test
-	public void testGetOperationIdNullReturnType() {
-		String expectedOperationId = "getPathNamePage";
-
-		String newOperationId = OpenAPIUtil.getOperationId(
-			_createHttpMethod("GET"), _createAPISchema(), expectedOperationId,
-			"/path-name", null);
-
-		Assert.assertNotNull(newOperationId);
-		Assert.assertEquals(expectedOperationId, newOperationId);
-	}
-
-	private APIApplication.Schema _createAPISchema() {
-		return new APIApplication.Schema() {
-
-			@Override
-			public String getDescription() {
-				return RandomTestUtil.randomString();
-			}
-
-			@Override
-			public String getExternalReferenceCode() {
-				return RandomTestUtil.randomString();
-			}
-
-			@Override
-			public String getMainObjectDefinitionExternalReferenceCode() {
-				return RandomTestUtil.randomString();
-			}
-
-			@Override
-			public String getName() {
-				return RandomTestUtil.randomString();
-			}
-
-			@Override
-			public List<APIApplication.Property> getProperties() {
-				return null;
-			}
-
-		};
-	}
-
-	private Http.Method _createHttpMethod(String method) {
-		return Http.Method.valueOf(method);
+				Http.Method.GET, "/path-name", "Schema"));
+		Assert.assertEquals(
+			"getSegmentASegmentBPage",
+			OpenAPIUtil.getOperationId(
+				Http.Method.GET, "/segment-a/segment-b", "Schema"));
+		Assert.assertEquals(
+			"getCamelSchemasPage",
+			OpenAPIUtil.getOperationId(
+				Http.Method.GET, "/camelschemas", "CamelSchema"));
+		Assert.assertEquals(
+			"getWhateverPage",
+			OpenAPIUtil.getOperationId(
+				Http.Method.GET, "/whatever", "CamelSchema"));
+		Assert.assertEquals(
+			"getSchemasWhateverPage",
+			OpenAPIUtil.getOperationId(
+				Http.Method.GET, "/schema/whatever", "Schema"));
 	}
 
 }

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/test/java/com/liferay/headless/builder/internal/vulcan/openapi/contributor/APIApplicationOpenApiContributorTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/test/java/com/liferay/headless/builder/internal/vulcan/openapi/contributor/APIApplicationOpenApiContributorTest.java
@@ -1,0 +1,135 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.builder.internal.vulcan.openapi.contributor;
+
+import com.liferay.headless.builder.application.APIApplication;
+import com.liferay.headless.builder.internal.util.OpenAPIUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Sergio Jiménez del Coso
+ */
+public class APIApplicationOpenApiContributorTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testGetDifferentOperationId() {
+		String expectedOperationId = "endpointPath";
+
+		String newOperationId = OpenAPIUtil.getOperationId(
+			_createHttpMethod("GET"), _createAPISchema(), expectedOperationId,
+			"/path-name", "Page");
+
+		Assert.assertNotNull(newOperationId);
+		Assert.assertNotEquals(expectedOperationId, newOperationId);
+	}
+
+	@Test
+	public void testGetOperationId() {
+		String expectedOperationId = "getPathNamePage";
+
+		String newOperationId = OpenAPIUtil.getOperationId(
+			_createHttpMethod("GET"), _createAPISchema(), expectedOperationId,
+			"/path-name", "Page");
+
+		Assert.assertNotNull(newOperationId);
+		Assert.assertEquals(expectedOperationId, newOperationId);
+	}
+
+	@Test(expected = NullPointerException.class)
+	public void testGetOperationIdNullHttpMethod() {
+		OpenAPIUtil.getOperationId(
+			null, _createAPISchema(), "getPathNamePage", "/path-name", "Page");
+	}
+
+	@Test
+	public void testGetOperationIdNullOperationId() {
+		Assert.assertNotNull(
+			OpenAPIUtil.getOperationId(
+				_createHttpMethod("GET"), _createAPISchema(), null,
+				"/path-name", "Page"));
+	}
+
+	@Test(expected = NullPointerException.class)
+	public void testGetOperationIdNullPath() {
+		OpenAPIUtil.getOperationId(
+			_createHttpMethod("GET"), _createAPISchema(), "getPathNamePage",
+			null, "Page");
+	}
+
+	@Test
+	public void testGetOperationIdNullResponseSchema() {
+		String expectedOperationId = "getPathNamePage";
+
+		String newOperationId = OpenAPIUtil.getOperationId(
+			_createHttpMethod("GET"), null, expectedOperationId, "/path-name",
+			"Page");
+
+		Assert.assertNotNull(newOperationId);
+		Assert.assertEquals(expectedOperationId, newOperationId);
+	}
+
+	@Test
+	public void testGetOperationIdNullReturnType() {
+		String expectedOperationId = "getPathNamePage";
+
+		String newOperationId = OpenAPIUtil.getOperationId(
+			_createHttpMethod("GET"), _createAPISchema(), expectedOperationId,
+			"/path-name", null);
+
+		Assert.assertNotNull(newOperationId);
+		Assert.assertEquals(expectedOperationId, newOperationId);
+	}
+
+	private APIApplication.Schema _createAPISchema() {
+		return new APIApplication.Schema() {
+
+			@Override
+			public String getDescription() {
+				return RandomTestUtil.randomString();
+			}
+
+			@Override
+			public String getExternalReferenceCode() {
+				return RandomTestUtil.randomString();
+			}
+
+			@Override
+			public String getMainObjectDefinitionExternalReferenceCode() {
+				return RandomTestUtil.randomString();
+			}
+
+			@Override
+			public String getName() {
+				return RandomTestUtil.randomString();
+			}
+
+			@Override
+			public List<APIApplication.Property> getProperties() {
+				return null;
+			}
+
+		};
+	}
+
+	private Http.Method _createHttpMethod(String method) {
+		return Http.Method.valueOf(method);
+	}
+
+}


### PR DESCRIPTION
**What is new?**
- Try to reproduce the `getOperationId` algorithm of generated by the `RESTBuilder` for Collection endpoints.
- Create an OpenAPIUtil to formar singular words in order to create the endpoint's `operationIds`.

**JIRA Related Ticket**
https://liferay.atlassian.net/browse/LPS-191816