### PR TITLE
LPS-194011 Cache current schema version

### DIFF
--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/PortalUpgradeProcessTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/PortalUpgradeProcessTest.java
@@ -346,10 +346,8 @@ public class PortalUpgradeProcessTest {
 		}
 	}
 
-	private void _updateSchemaVersion(Version version) {
-		ReflectionTestUtil.invoke(
-			_innerPortalUpgradeProcess, "updateSchemaVersion",
-			new Class<?>[] {Version.class}, version);
+	private void _updateSchemaVersion(Version version) throws SQLException {
+		_innerPortalUpgradeProcess.updateSchemaVersion(version);
 	}
 
 	private static final Version _ORIGINAL_SCHEMA_VERSION = new Version(
@@ -367,6 +365,13 @@ public class PortalUpgradeProcessTest {
 
 		public void close() throws SQLException {
 			connection.close();
+		}
+
+		public void updateSchemaVersion(Version newSchemaVersion)
+			throws SQLException {
+
+			PortalUpgradeProcess.updateSchemaVersion(
+				connection, newSchemaVersion);
 		}
 
 		private InnerPortalUpgradeProcess() throws SQLException {


### PR DESCRIPTION
@achaparro this removed a few duplicated db queries on startup. Please make sure all future portal release schema version read/write goes through PortalUpgradeProcess, so that the cache can be maintained properly. All production code already does this, in the pull I fixed all test code that did not obey it.