### PR TITLE
LPS-192508 Move HSQL shutdown to right before destroying datasource. …

### DIFF
--- a/portal-impl/src/com/liferay/portal/events/GlobalShutdownAction.java
+++ b/portal-impl/src/com/liferay/portal/events/GlobalShutdownAction.java
@@ -6,10 +6,6 @@
 package com.liferay.portal.events;
 
 import com.liferay.petra.lang.CentralizedThreadLocal;
-import com.liferay.portal.kernel.dao.db.DB;
-import com.liferay.portal.kernel.dao.db.DBManagerUtil;
-import com.liferay.portal.kernel.dao.db.DBType;
-import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.deploy.auto.AutoDeployDir;
 import com.liferay.portal.kernel.deploy.auto.AutoDeployUtil;
 import com.liferay.portal.kernel.deploy.hot.HotDeployUtil;
@@ -23,9 +19,6 @@ import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.struts.AuthPublicPathRegistry;
 import com.liferay.portal.util.PropsUtil;
 import com.liferay.portal.util.PropsValues;
-
-import java.sql.Connection;
-import java.sql.Statement;
 
 /**
  * @author Brian Wing Shun Chan
@@ -98,21 +91,6 @@ public class GlobalShutdownAction extends SimpleAction {
 	}
 
 	protected void shutdownLevel4() {
-
-		// Hypersonic
-
-		DB db = DBManagerUtil.getDB();
-
-		if (db.getDBType() == DBType.HYPERSONIC) {
-			try (Connection connection = DataAccess.getConnection();
-				Statement statement = connection.createStatement()) {
-
-				statement.executeUpdate("SHUTDOWN");
-			}
-			catch (Exception exception) {
-				_log.error(exception);
-			}
-		}
 	}
 
 	protected void shutdownLevel5() {

--- a/portal-impl/src/com/liferay/portal/spring/context/PortalContextLoaderListener.java
+++ b/portal-impl/src/com/liferay/portal/spring/context/PortalContextLoaderListener.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.concurrent.SystemExecutorServiceUtil;
 import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.db.DBType;
+import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.deploy.hot.HotDeployUtil;
 import com.liferay.portal.kernel.exception.LoggedExceptionInInitializerError;
 import com.liferay.portal.kernel.log.Log;
@@ -66,9 +67,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import java.sql.Statement;
 
 import java.util.Enumeration;
 import java.util.List;
@@ -138,6 +141,21 @@ public class PortalContextLoaderListener extends ContextLoaderListener {
 		}
 		catch (Exception exception) {
 			_log.error(exception);
+		}
+
+		// Hypersonic
+
+		DB db = DBManagerUtil.getDB();
+
+		if (db.getDBType() == DBType.HYPERSONIC) {
+			try (Connection connection = DataAccess.getConnection();
+				Statement statement = connection.createStatement()) {
+
+				statement.executeUpdate("SHUTDOWN");
+			}
+			catch (Exception exception) {
+				_log.error(exception);
+			}
 		}
 
 		closeDataSource("liferayDataSource");


### PR DESCRIPTION
…Service deactivation during shutdown might still need to access db, for example, com.liferay.fragment.renderer.react.internal.model.listener.FragmentEntryLinkModelListener.deactivate(). We need to keep the database alive until we don't need datasource anymore.