### PR TITLE
LPS-192650 HTML seen in search suggestions widget

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/suggestions/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/suggestions/view.jsp
@@ -10,7 +10,8 @@
 <%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
-<%@ page import="com.liferay.portal.kernel.util.WebKeys" %><%@
+<%@ page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
+page import="com.liferay.portal.kernel.util.WebKeys" %><%@
 page import="com.liferay.portal.search.web.internal.suggestions.display.context.SuggestionDisplayContext" %><%@
 page import="com.liferay.portal.search.web.internal.suggestions.display.context.SuggestionsPortletDisplayContext" %>
 
@@ -32,7 +33,7 @@ SuggestionsPortletDisplayContext suggestionsPortletDisplayContext = (Suggestions
 
 				<clay:link
 					href="<%= suggestionDisplayContext.getURL() %>"
-					label="<%= suggestionDisplayContext.getSuggestedKeywordsFormatted() %>"
+					label="<%= HtmlUtil.stripHtml(suggestionDisplayContext.getSuggestedKeywordsFormatted()) %>"
 				/>
 			</li>
 		</ul>
@@ -51,7 +52,7 @@ SuggestionsPortletDisplayContext suggestionsPortletDisplayContext = (Suggestions
 				<li>
 					<clay:link
 						href="<%= suggestionDisplayContext.getURL() %>"
-						label="<%= suggestionDisplayContext.getSuggestedKeywordsFormatted() %>"
+						label="<%= HtmlUtil.stripHtml(suggestionDisplayContext.getSuggestedKeywordsFormatted()) %>"
 					/>
 				</li>
 

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/suggestions/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/suggestions/view.jsp
@@ -7,11 +7,10 @@
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 
-<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
+<%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
-<%@ page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
-page import="com.liferay.portal.kernel.util.WebKeys" %><%@
+<%@ page import="com.liferay.portal.kernel.util.WebKeys" %><%@
 page import="com.liferay.portal.search.web.internal.suggestions.display.context.SuggestionDisplayContext" %><%@
 page import="com.liferay.portal.search.web.internal.suggestions.display.context.SuggestionsPortletDisplayContext" %>
 
@@ -31,10 +30,9 @@ SuggestionsPortletDisplayContext suggestionsPortletDisplayContext = (Suggestions
 				SuggestionDisplayContext suggestionDisplayContext = suggestionsPortletDisplayContext.getSpellCheckSuggestion();
 				%>
 
-				<clay:link
-					href="<%= suggestionDisplayContext.getURL() %>"
-					label="<%= HtmlUtil.stripHtml(suggestionDisplayContext.getSuggestedKeywordsFormatted()) %>"
-				/>
+				<aui:a href="<%= suggestionDisplayContext.getURL() %>">
+					<%= suggestionDisplayContext.getSuggestedKeywordsFormatted() %>
+				</aui:a>
 			</li>
 		</ul>
 	</c:if>
@@ -50,10 +48,9 @@ SuggestionsPortletDisplayContext suggestionsPortletDisplayContext = (Suggestions
 			%>
 
 				<li>
-					<clay:link
-						href="<%= suggestionDisplayContext.getURL() %>"
-						label="<%= HtmlUtil.stripHtml(suggestionDisplayContext.getSuggestedKeywordsFormatted()) %>"
-					/>
+					<aui:a href="<%= suggestionDisplayContext.getURL() %>">
+						<%= suggestionDisplayContext.getSuggestedKeywordsFormatted() %>
+					</aui:a>
 				</li>
 
 			<%

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/suggestions/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/suggestions/view.jsp
@@ -7,8 +7,7 @@
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 
-<%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
-taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
+<%@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
 <%@ page import="com.liferay.portal.kernel.util.WebKeys" %><%@
 page import="com.liferay.portal.search.web.internal.suggestions.display.context.SuggestionDisplayContext" %><%@
@@ -30,9 +29,9 @@ SuggestionsPortletDisplayContext suggestionsPortletDisplayContext = (Suggestions
 				SuggestionDisplayContext suggestionDisplayContext = suggestionsPortletDisplayContext.getSpellCheckSuggestion();
 				%>
 
-				<aui:a href="<%= suggestionDisplayContext.getURL() %>">
+				<a href="<%= suggestionDisplayContext.getURL() %>">
 					<%= suggestionDisplayContext.getSuggestedKeywordsFormatted() %>
-				</aui:a>
+				</a>
 			</li>
 		</ul>
 	</c:if>
@@ -48,9 +47,9 @@ SuggestionsPortletDisplayContext suggestionsPortletDisplayContext = (Suggestions
 			%>
 
 				<li>
-					<aui:a href="<%= suggestionDisplayContext.getURL() %>">
+					<a href="<%= suggestionDisplayContext.getURL() %>">
 						<%= suggestionDisplayContext.getSuggestedKeywordsFormatted() %>
-					</aui:a>
+					</a>
 				</li>
 
 			<%


### PR DESCRIPTION
### **LPS link:** [LPS-192650](https://liferay.atlassian.net/browse/LPS-192650)

from @almirfe:

# Context

After changes made by https://github.com/liferay-search/liferay-portal/pull/911/commits/effab8390638b7767e395ebfc4eee3eaf69d4901 the [view.jsp](https://github.com/liferay/liferay-portal/blob/7.4.3.89-ga89/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/suggestions/view.jsp) file is using "clay:link" instead of "aui:a" as you can see bellow:

## Before changes

```
<aui:a href="<%= suggestionDisplayContext.getURL() %>">
	<%= suggestionDisplayContext.getSuggestedKeywordsFormatted() %>
</aui:a>
```

## After changes

```
<clay:link
	href="<%= suggestionDisplayContext.getURL() %>"
	label="<%= suggestionDisplayContext.getSuggestedKeywordsFormatted() %>"
/>
```

The getSuggestedKeywordsFormatted function of the SuggestionDisplayContext class returns the suggested keywords with HTML formatting. However, the label field of "clay:link" does not need HTML formatting. Because of this, HTML elements are shown in the UI.

# Proposed solution

The [stripHtml](https://github.com/liferay/liferay-portal/blob/e7b4deb6b873d5f964882141e352d0b9601138eb/portal-kernel/src/com/liferay/portal/kernel/util/HtmlUtil.java#L163C1-L165C3) function of the [HtmlUtil](https://github.com/liferay/liferay-portal/blob/7.4.3.89-ga89/portal-kernel/src/com/liferay/portal/kernel/util/HtmlUtil.java) class is used to strip HTML from clay:link label, as you can see bellow:

```
<clay:link
	href="<%= suggestionDisplayContext.getURL() %>"
	label="<%= HtmlUtil.stripHtml(suggestionDisplayContext.getSuggestedKeywordsFormatted()) %>"
/>
```

Tested in: https://github.com/liferay-search/liferay-portal/pull/1022