### PR TITLE
LPS-194063 Fix broken version string parsing. Caused by ae37276e . to…

### DIFF
--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/registry/UpgradeStepRegistry.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/registry/UpgradeStepRegistry.java
@@ -121,10 +121,8 @@ public class UpgradeStepRegistry implements UpgradeStepRegistrator.Registry {
 		Version finalSchemaVersion = null;
 
 		for (UpgradeInfo upgradeInfo : upgradeInfos) {
-			String toSchemaVersion = upgradeInfo.getToSchemaVersionString();
-
 			Version schemaVersion = Version.parseVersion(
-				toSchemaVersion.substring(0, 5));
+				upgradeInfo.getToSchemaVersionString());
 
 			if (finalSchemaVersion == null) {
 				finalSchemaVersion = schemaVersion;


### PR DESCRIPTION
…SchemaVersion.substring(0, 5) is assuming major, minor and micro versions are always 1 digit "d.d.d", which is not true. This is why AssetVocabularyUpgradeProcess runs on empty database startup, since its version 1.0.17 got chopped into 1.0.1 which is lower than its previous step 1.0.2 which is fooling upgrade framework to continue execution.

CC @achaparro