### PR TITLE
LRCI-3760 Add support for multiple OAuth2 Applications

### DIFF
--- a/workspaces/liferay-jethr0-workspace/client-extensions/liferay-jethr0-etc-spring-boot/client-extension.yaml
+++ b/workspaces/liferay-jethr0-workspace/client-extensions/liferay-jethr0-etc-spring-boot/client-extension.yaml
@@ -1,5 +1,5 @@
 liferay-jethr0-etc-spring-boot-oauth-application-headless-server:
-    .serverAddress: localhost:58081
+    .serviceAddress: localhost:58081
     .serviceScheme: http
     name: Liferay Jethr0 Etc Spring Boot OAuth Application Headless Server
     scopes:
@@ -19,3 +19,23 @@ liferay-jethr0-etc-spring-boot-oauth-application-headless-server:
         - C_TestSuite.everything
     type: oAuthApplicationHeadlessServer
     userAccountEmailAddress: test@liferay.com
+liferay-jethr0-etc-spring-boot-oauth-application-user-agent:
+    .serviceAddress: localhost:58081
+    .serviceScheme: http
+    name: Liferay Jethr0 Etc Spring Boot OAuth Application User Agent
+    scopes:
+        - C_Build.everything
+        - C_BuildParameter.everything
+        - C_BuildRun.everything
+        - C_Environment.everything
+        - C_GitBranch.everything
+        - C_JenkinsCohort.everything
+        - C_JenkinsNode.everything
+        - C_JenkinsServer.everything
+        - C_Project.everything
+        - C_ProjectComparator.everything
+        - C_ProjectPrioritizer.everything
+        - C_Task.everything
+        - C_TaskRun.everything
+        - C_TestSuite.everything
+    type: oAuthApplicationUserAgent

--- a/workspaces/liferay-jethr0-workspace/client-extensions/liferay-jethr0-etc-spring-boot/client-extension.yaml
+++ b/workspaces/liferay-jethr0-workspace/client-extensions/liferay-jethr0-etc-spring-boot/client-extension.yaml
@@ -23,19 +23,4 @@ liferay-jethr0-etc-spring-boot-oauth-application-user-agent:
     .serviceAddress: localhost:58081
     .serviceScheme: http
     name: Liferay Jethr0 Etc Spring Boot OAuth Application User Agent
-    scopes:
-        - C_Build.everything
-        - C_BuildParameter.everything
-        - C_BuildRun.everything
-        - C_Environment.everything
-        - C_GitBranch.everything
-        - C_JenkinsCohort.everything
-        - C_JenkinsNode.everything
-        - C_JenkinsServer.everything
-        - C_Project.everything
-        - C_ProjectComparator.everything
-        - C_ProjectPrioritizer.everything
-        - C_Task.everything
-        - C_TaskRun.everything
-        - C_TestSuite.everything
     type: oAuthApplicationUserAgent

--- a/workspaces/liferay-jethr0-workspace/client-extensions/liferay-jethr0-etc-spring-boot/src/main/java/com/liferay/jethr0/entity/dalo/BaseEntityDALO.java
+++ b/workspaces/liferay-jethr0-workspace/client-extensions/liferay-jethr0-etc-spring-boot/src/main/java/com/liferay/jethr0/entity/dalo/BaseEntityDALO.java
@@ -5,7 +5,7 @@
 
 package com.liferay.jethr0.entity.dalo;
 
-import com.liferay.client.extension.util.spring.boot.LiferayOAuth2AccessTokenConfiguration;
+import com.liferay.client.extension.util.spring.boot.LiferayOAuth2Util;
 import com.liferay.jethr0.entity.Entity;
 import com.liferay.jethr0.entity.factory.EntityFactory;
 import com.liferay.jethr0.util.BaseRetryable;
@@ -29,6 +29,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 
@@ -144,33 +146,21 @@ public abstract class BaseEntityDALO<T extends Entity>
 
 			@Override
 			public JSONObject execute() {
-				String response;
-
-				try {
-					response = WebClient.create(
-						StringUtil.combine(
-							_liferayPortalURL, _getEntityURLPath())
-					).post(
-					).accept(
-						MediaType.APPLICATION_JSON
-					).contentType(
-						MediaType.APPLICATION_JSON
-					).header(
-						"Authorization",
-						_liferayOAuth2AccessTokenConfiguration.
-							getAuthorization()
-					).body(
-						BodyInserters.fromValue(requestJSONObject.toString())
-					).retrieve(
-					).bodyToMono(
-						String.class
-					).block();
-				}
-				catch (Exception exception) {
-					_liferayOAuth2AccessTokenConfiguration.refresh();
-
-					throw new RuntimeException(exception);
-				}
+				String response = WebClient.create(
+					StringUtil.combine(_liferayPortalURL, _getEntityURLPath())
+				).post(
+				).accept(
+					MediaType.APPLICATION_JSON
+				).contentType(
+					MediaType.APPLICATION_JSON
+				).header(
+					"Authorization", _getOAuth2AccessTokenAuthorization()
+				).body(
+					BodyInserters.fromValue(requestJSONObject.toString())
+				).retrieve(
+				).bodyToMono(
+					String.class
+				).block();
 
 				if (response == null) {
 					throw new RuntimeException("No response");
@@ -209,27 +199,18 @@ public abstract class BaseEntityDALO<T extends Entity>
 
 			@Override
 			public Void execute() {
-				try {
-					WebClient.create(
-						StringUtil.combine(
-							_liferayPortalURL, _getEntityURLPath(objectEntryId))
-					).delete(
-					).accept(
-						MediaType.APPLICATION_JSON
-					).header(
-						"Authorization",
-						_liferayOAuth2AccessTokenConfiguration.
-							getAuthorization()
-					).retrieve(
-					).bodyToMono(
-						Void.class
-					).block();
-				}
-				catch (Exception exception) {
-					_liferayOAuth2AccessTokenConfiguration.refresh();
-
-					throw new RuntimeException(exception);
-				}
+				WebClient.create(
+					StringUtil.combine(
+						_liferayPortalURL, _getEntityURLPath(objectEntryId))
+				).delete(
+				).accept(
+					MediaType.APPLICATION_JSON
+				).header(
+					"Authorization", _getOAuth2AccessTokenAuthorization()
+				).retrieve(
+				).bodyToMono(
+					Void.class
+				).block();
 
 				if (_log.isDebugEnabled()) {
 					_log.debug(
@@ -267,45 +248,34 @@ public abstract class BaseEntityDALO<T extends Entity>
 
 					@Override
 					public Pair<Integer, Set<JSONObject>> execute() {
-						String response;
+						String response = WebClient.create(
+							StringUtil.combine(
+								_liferayPortalURL, _getEntityURLPath())
+						).get(
+						).uri(
+							uriBuilder -> {
+								uriBuilder = uriBuilder.queryParam(
+									"page", String.valueOf(finalCurrentPage));
 
-						try {
-							response = WebClient.create(
-								StringUtil.combine(
-									_liferayPortalURL, _getEntityURLPath())
-							).get(
-							).uri(
-								uriBuilder -> {
-									uriBuilder = uriBuilder.queryParam(
-										"page",
-										String.valueOf(finalCurrentPage));
-
-									if (filter != null) {
-										uriBuilder.queryParam("filter", filter);
-									}
-
-									if (search != null) {
-										uriBuilder.queryParam("search", search);
-									}
-
-									return uriBuilder.build();
+								if (filter != null) {
+									uriBuilder.queryParam("filter", filter);
 								}
-							).accept(
-								MediaType.APPLICATION_JSON
-							).header(
-								"Authorization",
-								_liferayOAuth2AccessTokenConfiguration.
-									getAuthorization()
-							).retrieve(
-							).bodyToMono(
-								String.class
-							).block();
-						}
-						catch (Exception exception) {
-							_liferayOAuth2AccessTokenConfiguration.refresh();
 
-							throw new RuntimeException(exception);
-						}
+								if (search != null) {
+									uriBuilder.queryParam("search", search);
+								}
+
+								return uriBuilder.build();
+							}
+						).accept(
+							MediaType.APPLICATION_JSON
+						).header(
+							"Authorization",
+							_getOAuth2AccessTokenAuthorization()
+						).retrieve(
+						).bodyToMono(
+							String.class
+						).block();
 
 						if (response == null) {
 							throw new RuntimeException("No response");
@@ -407,6 +377,26 @@ public abstract class BaseEntityDALO<T extends Entity>
 		return StringUtil.combine(_getEntityURLPath(), "/", objectEntryId);
 	}
 
+	private String _getOAuth2AccessTokenAuthorization() {
+		OAuth2AccessToken oAuth2AccessToken =
+			LiferayOAuth2Util.getOAuth2AccessToken(
+				_authorizedClientServiceOAuth2AuthorizedClientManager,
+				_LIFERAY_OAUTH_APPLICATION_EXTERNAL_REFERENCE_CODE);
+
+		if (oAuth2AccessToken == null) {
+			return null;
+		}
+
+		OAuth2AccessToken.TokenType tokenType =
+			oAuth2AccessToken.getTokenType();
+
+		if (tokenType == null) {
+			return null;
+		}
+
+		return tokenType.getValue() + " " + oAuth2AccessToken.getTokenValue();
+	}
+
 	private JSONObject _update(JSONObject requestJSONObject) {
 		long requestObjectEntryId = requestJSONObject.getLong("id");
 
@@ -414,34 +404,23 @@ public abstract class BaseEntityDALO<T extends Entity>
 
 			@Override
 			public JSONObject execute() {
-				String response;
-
-				try {
-					response = WebClient.create(
-						StringUtil.combine(
-							_liferayPortalURL,
-							_getEntityURLPath(requestObjectEntryId))
-					).put(
-					).accept(
-						MediaType.APPLICATION_JSON
-					).contentType(
-						MediaType.APPLICATION_JSON
-					).header(
-						"Authorization",
-						_liferayOAuth2AccessTokenConfiguration.
-							getAuthorization()
-					).body(
-						BodyInserters.fromValue(requestJSONObject.toString())
-					).retrieve(
-					).bodyToMono(
-						String.class
-					).block();
-				}
-				catch (Exception exception) {
-					_liferayOAuth2AccessTokenConfiguration.refresh();
-
-					throw new RuntimeException(exception);
-				}
+				String response = WebClient.create(
+					StringUtil.combine(
+						_liferayPortalURL,
+						_getEntityURLPath(requestObjectEntryId))
+				).put(
+				).accept(
+					MediaType.APPLICATION_JSON
+				).contentType(
+					MediaType.APPLICATION_JSON
+				).header(
+					"Authorization", _getOAuth2AccessTokenAuthorization()
+				).body(
+					BodyInserters.fromValue(requestJSONObject.toString())
+				).retrieve(
+				).bodyToMono(
+					String.class
+				).block();
 
 				if (response == null) {
 					throw new RuntimeException("No response");
@@ -483,11 +462,15 @@ public abstract class BaseEntityDALO<T extends Entity>
 		return retryable.executeWithRetries();
 	}
 
+	private static final String
+		_LIFERAY_OAUTH_APPLICATION_EXTERNAL_REFERENCE_CODE =
+			"liferay-jethr0-etc-spring-boot-oauth-application-headless-server";
+
 	private static final Log _log = LogFactory.getLog(BaseEntityDALO.class);
 
 	@Autowired
-	private LiferayOAuth2AccessTokenConfiguration
-		_liferayOAuth2AccessTokenConfiguration;
+	private AuthorizedClientServiceOAuth2AuthorizedClientManager
+		_authorizedClientServiceOAuth2AuthorizedClientManager;
 
 	@Value("${liferay.portal.url}")
 	private String _liferayPortalURL;

--- a/workspaces/liferay-jethr0-workspace/client-extensions/liferay-jethr0-etc-spring-boot/src/main/java/com/liferay/jethr0/entity/dalo/BaseEntityRelationshipDALO.java
+++ b/workspaces/liferay-jethr0-workspace/client-extensions/liferay-jethr0-etc-spring-boot/src/main/java/com/liferay/jethr0/entity/dalo/BaseEntityRelationshipDALO.java
@@ -5,7 +5,7 @@
 
 package com.liferay.jethr0.entity.dalo;
 
-import com.liferay.client.extension.util.spring.boot.LiferayOAuth2AccessTokenConfiguration;
+import com.liferay.client.extension.util.spring.boot.LiferayOAuth2Util;
 import com.liferay.jethr0.entity.Entity;
 import com.liferay.jethr0.entity.factory.EntityFactory;
 import com.liferay.jethr0.util.BaseRetryable;
@@ -28,6 +28,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
 import org.springframework.web.reactive.function.client.WebClient;
 
 /**
@@ -169,30 +171,19 @@ public abstract class BaseEntityRelationshipDALO
 
 			@Override
 			public Void execute() {
-				String response;
-
-				try {
-					response = WebClient.create(
-						objectRelationshipURL
-					).put(
-					).accept(
-						MediaType.APPLICATION_JSON
-					).contentType(
-						MediaType.APPLICATION_JSON
-					).header(
-						"Authorization",
-						_liferayOAuth2AccessTokenConfiguration.
-							getAuthorization()
-					).retrieve(
-					).bodyToMono(
-						String.class
-					).block();
-				}
-				catch (Exception exception) {
-					_liferayOAuth2AccessTokenConfiguration.refresh();
-
-					throw new RuntimeException(exception);
-				}
+				String response = WebClient.create(
+					objectRelationshipURL
+				).put(
+				).accept(
+					MediaType.APPLICATION_JSON
+				).contentType(
+					MediaType.APPLICATION_JSON
+				).header(
+					"Authorization", _getOAuth2AccessTokenAuthorization()
+				).retrieve(
+				).bodyToMono(
+					String.class
+				).block();
 
 				if (response == null) {
 					throw new RuntimeException("No response");
@@ -235,26 +226,17 @@ public abstract class BaseEntityRelationshipDALO
 
 			@Override
 			public Void execute() {
-				try {
-					WebClient.create(
-						objectRelationshipURL
-					).delete(
-					).accept(
-						MediaType.APPLICATION_JSON
-					).header(
-						"Authorization",
-						_liferayOAuth2AccessTokenConfiguration.
-							getAuthorization()
-					).retrieve(
-					).bodyToMono(
-						String.class
-					).block();
-				}
-				catch (Exception exception) {
-					_liferayOAuth2AccessTokenConfiguration.refresh();
-
-					throw new RuntimeException(exception);
-				}
+				WebClient.create(
+					objectRelationshipURL
+				).delete(
+				).accept(
+					MediaType.APPLICATION_JSON
+				).header(
+					"Authorization", _getOAuth2AccessTokenAuthorization()
+				).retrieve(
+				).bodyToMono(
+					String.class
+				).block();
 
 				if (_log.isDebugEnabled()) {
 					_log.debug(
@@ -299,32 +281,22 @@ public abstract class BaseEntityRelationshipDALO
 
 					@Override
 					public Pair<Integer, Set<JSONObject>> execute() {
-						String response;
-
-						try {
-							response = WebClient.create(
-								objectRelationshipURL
-							).get(
-							).uri(
-								uriBuilder -> uriBuilder.queryParam(
-									"page", String.valueOf(finalCurrentPage)
-								).build()
-							).accept(
-								MediaType.APPLICATION_JSON
-							).header(
-								"Authorization",
-								_liferayOAuth2AccessTokenConfiguration.
-									getAuthorization()
-							).retrieve(
-							).bodyToMono(
-								String.class
-							).block();
-						}
-						catch (Exception exception) {
-							_liferayOAuth2AccessTokenConfiguration.refresh();
-
-							throw new RuntimeException(exception);
-						}
+						String response = WebClient.create(
+							objectRelationshipURL
+						).get(
+						).uri(
+							uriBuilder -> uriBuilder.queryParam(
+								"page", String.valueOf(finalCurrentPage)
+							).build()
+						).accept(
+							MediaType.APPLICATION_JSON
+						).header(
+							"Authorization",
+							_getOAuth2AccessTokenAuthorization()
+						).retrieve(
+						).bodyToMono(
+							String.class
+						).block();
 
 						if (response == null) {
 							throw new RuntimeException("No response");
@@ -395,6 +367,26 @@ public abstract class BaseEntityRelationshipDALO
 			StringUtil.toLowerCase(childEntityFactory.getEntityPluralLabel()));
 	}
 
+	private String _getOAuth2AccessTokenAuthorization() {
+		OAuth2AccessToken oAuth2AccessToken =
+			LiferayOAuth2Util.getOAuth2AccessToken(
+				_authorizedClientServiceOAuth2AuthorizedClientManager,
+				_LIFERAY_OAUTH_APPLICATION_EXTERNAL_REFERENCE_CODE);
+
+		if (oAuth2AccessToken == null) {
+			return null;
+		}
+
+		OAuth2AccessToken.TokenType tokenType =
+			oAuth2AccessToken.getTokenType();
+
+		if (tokenType == null) {
+			return null;
+		}
+
+		return tokenType.getValue() + " " + oAuth2AccessToken.getTokenValue();
+	}
+
 	private String _getParentURLPath() {
 		EntityFactory<T> parentEntityFactory = getParentEntityFactory();
 
@@ -403,12 +395,16 @@ public abstract class BaseEntityRelationshipDALO
 			StringUtil.toLowerCase(parentEntityFactory.getEntityPluralLabel()));
 	}
 
+	private static final String
+		_LIFERAY_OAUTH_APPLICATION_EXTERNAL_REFERENCE_CODE =
+			"liferay-jethr0-etc-spring-boot-oauth-application-headless-server";
+
 	private static final Log _log = LogFactory.getLog(
 		BaseEntityRelationshipDALO.class);
 
 	@Autowired
-	private LiferayOAuth2AccessTokenConfiguration
-		_liferayOAuth2AccessTokenConfiguration;
+	private AuthorizedClientServiceOAuth2AuthorizedClientManager
+		_authorizedClientServiceOAuth2AuthorizedClientManager;
 
 	@Value("${liferay.portal.url}")
 	private String _liferayPortalURL;

--- a/workspaces/liferay-jethr0-workspace/client-extensions/liferay-jethr0-etc-spring-boot/src/main/resources/application-default.properties
+++ b/workspaces/liferay-jethr0-workspace/client-extensions/liferay-jethr0-etc-spring-boot/src/main/resources/application-default.properties
@@ -18,7 +18,10 @@ liferay.portal.url=http://localhost:8080
 # OAuth
 #
 
-liferay.oauth.application.external.reference.codes=liferay-jethr0-etc-spring-boot-oauth-application-headless-server
+liferay.oauth.application.external.reference.codes=\
+    liferay-jethr0-etc-spring-boot-oauth-application-headless-server,\
+    liferay-jethr0-etc-spring-boot-oauth-application-user-agent
+
 liferay.oauth.urls.excludes=/ready
 
 #


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-3760

https://github.com/brianchandotcom/liferay-portal/pull/139567#issuecomment-1688588841

After talking to @gamerson I still need both OAuth Applications.  However, I didn't need all of the scopes.

The 2 different OAuth2 Applications serve 2 different purposes.
1. The User Agent is for the Custom Element to the Spring Boot Application. (Front channel)
2. The Headless Server is for the Spring Boot Application to DXP. (Back channel)

Please let us know if you have more questions.