### PR TITLE
LPS-191923 zh_HK has invalid characters when used as a date mask

### DIFF
--- a/portal-web/docroot/html/taglib/ui/input_date/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_date/page.jsp
@@ -72,6 +72,11 @@ if (!BrowserSnifferUtil.isMobile(request)) {
 
 	mask = simpleDateFormatPattern;
 
+	// Replace single quotes to prevent the string from breaking when passing
+	// into the A.DatePicker mask. This is used for the zh_HK locale which
+	// returns the format yyyy'年'MM'月'dd'日'.
+
+	mask = mask.replaceAll("'", "");
 	mask = mask.replaceAll("yyyy", "%Y");
 	mask = mask.replaceAll("MM", "%m");
 	mask = mask.replaceAll("dd", "%d");


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-191923

Manually forwarding from https://github.com/liferay-frontend/liferay-portal/pull/3599.

Validated with QA there weren't any related failures. https://github.com/liferay-frontend/liferay-portal/pull/3599#issuecomment-1688711019