### PR TITLE
LPS-193861 Focus working incorrectly when hovering over Inline-text in the Content Tab

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page_content/components/PageContent.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page_content/components/PageContent.js
@@ -140,8 +140,9 @@ export default function PageContent({
 					if (editable) {
 						setIsHovered(
 							editable.classPK === classPK ||
-								editable.externalReferenceCode ===
-									externalReferenceCode
+								(editable.externalReferenceCode &&
+									editable.externalReferenceCode ===
+										externalReferenceCode)
 						);
 					}
 				}


### PR DESCRIPTION
Motivation
=======
The motivation behind this PR is to solve this bug about focusing elements of the Page Editor's Content tab.
Proposed Solution
========
What I is to check if the externalReferenceCode of a collection content is undefined because the comparison  between externalReferenceCode was returning a true when shouldn't.

Steps to Verify
========
1. Create a Manual Collection: Site Builder → Collection
2. Go to the Page Editor → use a collection display to add the Collection recently created
3. Add a Heading or something that contains an Inline-text element.
4. Go to Page Content tab and hover over the Inline-text element and check that looks fine.

cc.: @Stephy6 