### PR TITLE
LPS-192211 "Hide contents in a category" element doesn't show Global categories

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/sxp_element/category_selector_input/index.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/sxp_element/category_selector_input/index.js
@@ -341,9 +341,23 @@ function CategorySelectorInput({
 		})
 			.then((response) => response.json())
 			.then(({items}) => {
+				const itemsWithGlobalSite = items.some(
+					({id}) =>
+						id.toString() ===
+						Liferay.ThemeDisplay.getCompanyGroupId().toString()
+				)
+					? items
+					: [
+							{
+								descriptiveName: Liferay.Language.get('global'),
+								id: Liferay.ThemeDisplay.getCompanyGroupId(),
+							},
+							...items,
+					  ];
+
 				const tree = [];
 
-				items.forEach((site, siteIndex) => {
+				itemsWithGlobalSite.forEach((site, siteIndex) => {
 					fetch(FETCH_URLS.getVocabularies(site.id), {
 						headers: DEFAULT_HEADERS,
 						method: 'GET',

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/sxp_element/category_selector_input/index.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/sxp_element/category_selector_input/index.js
@@ -22,9 +22,9 @@ export const FETCH_URLS = {
 		`/o/headless-admin-taxonomy/v1.0/taxonomy-vocabularies/${id}/taxonomy-categories`,
 	getCategory: (id) =>
 		`/o/headless-admin-taxonomy/v1.0/taxonomy-categories/${id}/`,
+	getSites: () => '/o/headless-admin-user/v1.0/my-user-account/sites',
 	getSubCategories: (id) =>
 		`/o/headless-admin-taxonomy/v1.0/taxonomy-categories/${id}/taxonomy-categories`,
-	getUserAccount: () => '/o/headless-admin-user/v1.0/my-user-account',
 	getVocabularies: (id) =>
 		`/o/headless-admin-taxonomy/v1.0/sites/${id}/taxonomy-vocabularies`,
 };
@@ -335,15 +335,15 @@ function CategorySelectorInput({
 		// be the start of the category tree, in which the children of the
 		// vocabulary get added on as the tree gets expanded (in modal).
 
-		fetch(FETCH_URLS.getUserAccount(), {
+		fetch(FETCH_URLS.getSites(), {
 			headers: DEFAULT_HEADERS,
 			method: 'GET',
 		})
 			.then((response) => response.json())
-			.then((userData) => {
+			.then(({items}) => {
 				const tree = [];
 
-				userData.siteBriefs.forEach((site, siteIndex) => {
+				items.forEach((site, siteIndex) => {
 					fetch(FETCH_URLS.getVocabularies(site.id), {
 						headers: DEFAULT_HEADERS,
 						method: 'GET',

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/sxp_element/category_selector_input/index.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/sxp_element/category_selector_input/index.js
@@ -350,7 +350,9 @@ function CategorySelectorInput({
 					: [
 							{
 								descriptiveName: Liferay.Language.get('global'),
-								id: Liferay.ThemeDisplay.getCompanyGroupId(),
+								id: Number(
+									Liferay.ThemeDisplay.getCompanyGroupId()
+								),
 							},
 							...items,
 					  ];


### PR DESCRIPTION
From @AlmirFe 
Tested on https://github.com/liferay-search/liferay-portal/pull/1032

### **LPS link:** [LPS-192211](https://liferay.atlassian.net/browse/LPS-192211)

# Context

When trying to select a category in a "Hide contents in a category" element, global categories are not displayed. This issue occurs due to changes made in https://github.com/liferay-appsec/liferay-portal/pull/1128/commits/fb2c4689262277c98e0d300362822dc45acbdfa8 via [LPS-185101](https://liferay.atlassian.net/browse/LPS-185101). Basically the getUserAccountsPage API no longer returns all sites, only user-associated sites, as you can see bellow:

## Before changes

```
siteBriefs = TransformUtil.transformToArray(
	_groupLocalService.getGroups(
		user.getCompanyId(),
		GroupConstants.DEFAULT_PARENT_GROUP_ID, true),
	group -> _toSiteBrief(dtoConverterContext, group),
	SiteBrief.class);
```

## After changes

```
siteBriefs = TransformUtil.transformToArray(
	_groupLocalService.getUserSitesGroups(user.getUserId()),
	group -> _toSiteBrief(dtoConverterContext, group),
	SiteBrief.class);
```

# Proposed solution

Following the solution proposal in [LPS-189258](https://liferay.atlassian.net/browse/LPS-189258), the global site is added separately to the list of sites if it's missing, as you can see bellow:

```
...
const itemsWithGlobalSite = items.some(
	({id}) =>
		id.toString() ===
		Liferay.ThemeDisplay.getCompanyGroupId().toString()
)
	? items
	: [
		{
			descriptiveName: Liferay.Language.get('global'),
			id: Number(
				Liferay.ThemeDisplay.getCompanyGroupId()
			),
		},
		...items,
	  ];
...
```