### PR TITLE
LPS-181763 Record default values to support more complex mappings for modified columns

### DIFF
--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -16,6 +16,7 @@ import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
@@ -448,6 +449,11 @@ public class DBTest {
 
 		_db.runSQL(
 			StringBundler.concat(
+				"insert into ", _TABLE_NAME_1,
+				" (id, notNilColumn) values (3, '3')"));
+
+		_db.runSQL(
+			StringBundler.concat(
 				"insert into ", _TABLE_NAME_2,
 				" (id, notNilColumn, typeString) values (1, '1', ",
 				"'testTable2Value1')"));
@@ -460,7 +466,9 @@ public class DBTest {
 
 		_db.copyTableRows(
 			_connection, _TABLE_NAME_1, _TABLE_NAME_2, columnNamesMap,
-			new HashMap<>());
+			HashMapBuilder.put(
+				_dbInspector.normalizeName("typeString"), "'test'"
+			).build());
 
 		try (PreparedStatement preparedStatement = _connection.prepareStatement(
 				"select * from " + _TABLE_NAME_2 + " order by id asc");
@@ -477,6 +485,11 @@ public class DBTest {
 			Assert.assertEquals("2", resultSet.getString("notNilColumn"));
 			Assert.assertEquals(
 				"testTable1Value2", resultSet.getString("typeString"));
+
+			Assert.assertTrue(resultSet.next());
+			Assert.assertEquals(3, resultSet.getLong("id"));
+			Assert.assertEquals("3", resultSet.getString("notNilColumn"));
+			Assert.assertEquals("test", resultSet.getString("typeString"));
 
 			Assert.assertFalse(resultSet.next());
 		}
@@ -508,6 +521,11 @@ public class DBTest {
 
 		_db.runSQL(
 			StringBundler.concat(
+				"insert into ", _TABLE_NAME_1,
+				" (id, notNilColumn) values (3, '3')"));
+
+		_db.runSQL(
+			StringBundler.concat(
 				"insert into ", _TABLE_NAME_2,
 				" (id2, notNilColumn2, typeString2) values (1, '1', ",
 				"'testTable2Value1')"));
@@ -520,7 +538,9 @@ public class DBTest {
 
 		_db.copyTableRows(
 			_connection, _TABLE_NAME_1, _TABLE_NAME_2, columnNamesMap,
-			new HashMap<>());
+			HashMapBuilder.put(
+				_dbInspector.normalizeName("typeString2"), "'test'"
+			).build());
 
 		try (PreparedStatement preparedStatement = _connection.prepareStatement(
 				"select * from " + _TABLE_NAME_2 + " order by id2 asc");
@@ -537,6 +557,11 @@ public class DBTest {
 			Assert.assertEquals("2", resultSet.getString("notNilColumn2"));
 			Assert.assertEquals(
 				"testTable1Value2", resultSet.getString("typeString2"));
+
+			Assert.assertTrue(resultSet.next());
+			Assert.assertEquals(3, resultSet.getLong("id2"));
+			Assert.assertEquals("3", resultSet.getString("notNilColumn2"));
+			Assert.assertEquals("test", resultSet.getString("typeString2"));
 
 			Assert.assertFalse(resultSet.next());
 		}
@@ -658,7 +683,9 @@ public class DBTest {
 
 		try (AutoCloseable autoCloseable = _db.syncTables(
 				_connection, _TABLE_NAME_1, _TABLE_NAME_2, columnNamesMap,
-				new HashMap<>())) {
+				HashMapBuilder.put(
+					_dbInspector.normalizeName("typeString"), "'test'"
+				).build())) {
 
 			_db.runSQL(
 				StringBundler.concat(
@@ -666,23 +693,31 @@ public class DBTest {
 					" (id, notNilColumn, typeString) values (2, '2', ",
 					"'testValueB')"));
 
+			_db.runSQL(
+				StringBundler.concat(
+					"insert into ", _TABLE_NAME_1,
+					" (id, notNilColumn) values (3, '3')"));
+
 			_db.runSQL("delete from " + _TABLE_NAME_1 + " where id = 1");
 
 			_db.runSQL(
 				"update " + _TABLE_NAME_1 +
-					" set typeString = 'testValueC' where id = 2");
+					" set typeString = NULL where id = 2");
 		}
 
 		try (PreparedStatement preparedStatement = _connection.prepareStatement(
-				"select * from " + _TABLE_NAME_2);
+				"select * from " + _TABLE_NAME_2  + " order by id");
 			ResultSet resultSet = preparedStatement.executeQuery()) {
 
 			Assert.assertTrue(resultSet.next());
-
 			Assert.assertEquals(2, resultSet.getLong("id"));
 			Assert.assertEquals("2", resultSet.getString("notNilColumn"));
-			Assert.assertEquals(
-				"testValueC", resultSet.getString("typeString"));
+			Assert.assertEquals("test", resultSet.getString("typeString"));
+
+			Assert.assertTrue(resultSet.next());
+			Assert.assertEquals(3, resultSet.getLong("id"));
+			Assert.assertEquals("3", resultSet.getString("notNilColumn"));
+			Assert.assertEquals("test", resultSet.getString("typeString"));
 
 			Assert.assertFalse(resultSet.next());
 		}
@@ -722,7 +757,9 @@ public class DBTest {
 
 		try (AutoCloseable autoCloseable = _db.syncTables(
 				_connection, _TABLE_NAME_1, _TABLE_NAME_2, columnNamesMap,
-				new HashMap<>())) {
+				HashMapBuilder.put(
+					_dbInspector.normalizeName("typeString2"), "'test'"
+				).build())) {
 
 			_db.runSQL(
 				StringBundler.concat(
@@ -730,22 +767,31 @@ public class DBTest {
 					" (id, notNilColumn, typeString) values (2, '2', ",
 					"'testValueB')"));
 
+			_db.runSQL(
+				StringBundler.concat(
+					"insert into ", _TABLE_NAME_1,
+					" (id, notNilColumn) values (3, '3')"));
+
 			_db.runSQL("delete from " + _TABLE_NAME_1 + " where id = 1");
 
 			_db.runSQL(
 				"update " + _TABLE_NAME_1 +
-					" set typeString = 'testValueC' where id = 2");
+					" set typeString = NULL where id = 2");
 		}
 
 		try (PreparedStatement preparedStatement = _connection.prepareStatement(
-				"select * from " + _TABLE_NAME_2);
+				"select * from " + _TABLE_NAME_2 + " order by id2");
 			ResultSet resultSet = preparedStatement.executeQuery()) {
 
 			Assert.assertTrue(resultSet.next());
 			Assert.assertEquals(2, resultSet.getLong("id2"));
 			Assert.assertEquals("2", resultSet.getString("notNilColumn2"));
-			Assert.assertEquals(
-				"testValueC", resultSet.getString("typeString2"));
+			Assert.assertEquals("test", resultSet.getString("typeString2"));
+
+			Assert.assertTrue(resultSet.next());
+			Assert.assertEquals(3, resultSet.getLong("id2"));
+			Assert.assertEquals("3", resultSet.getString("notNilColumn2"));
+			Assert.assertEquals("test", resultSet.getString("typeString2"));
 
 			Assert.assertFalse(resultSet.next());
 		}

--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -459,7 +459,8 @@ public class DBTest {
 		}
 
 		_db.copyTableRows(
-			_connection, _TABLE_NAME_1, _TABLE_NAME_2, columnNamesMap);
+			_connection, _TABLE_NAME_1, _TABLE_NAME_2, columnNamesMap,
+			new HashMap<>());
 
 		try (PreparedStatement preparedStatement = _connection.prepareStatement(
 				"select * from " + _TABLE_NAME_2 + " order by id asc");
@@ -518,7 +519,8 @@ public class DBTest {
 		}
 
 		_db.copyTableRows(
-			_connection, _TABLE_NAME_1, _TABLE_NAME_2, columnNamesMap);
+			_connection, _TABLE_NAME_1, _TABLE_NAME_2, columnNamesMap,
+			new HashMap<>());
 
 		try (PreparedStatement preparedStatement = _connection.prepareStatement(
 				"select * from " + _TABLE_NAME_2 + " order by id2 asc");
@@ -655,7 +657,8 @@ public class DBTest {
 		}
 
 		try (AutoCloseable autoCloseable = _db.syncTables(
-				_connection, _TABLE_NAME_1, _TABLE_NAME_2, columnNamesMap)) {
+				_connection, _TABLE_NAME_1, _TABLE_NAME_2, columnNamesMap,
+				new HashMap<>())) {
 
 			_db.runSQL(
 				StringBundler.concat(
@@ -718,7 +721,8 @@ public class DBTest {
 		}
 
 		try (AutoCloseable autoCloseable = _db.syncTables(
-				_connection, _TABLE_NAME_1, _TABLE_NAME_2, columnNamesMap)) {
+				_connection, _TABLE_NAME_1, _TABLE_NAME_2, columnNamesMap,
+				new HashMap<>())) {
 
 			_db.runSQL(
 				StringBundler.concat(

--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -706,7 +706,7 @@ public class DBTest {
 		}
 
 		try (PreparedStatement preparedStatement = _connection.prepareStatement(
-				"select * from " + _TABLE_NAME_2  + " order by id");
+				"select * from " + _TABLE_NAME_2 + " order by id");
 			ResultSet resultSet = preparedStatement.executeQuery()) {
 
 			Assert.assertTrue(resultSet.next());

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/live/LiveUpgradeExecutorImpl.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/live/LiveUpgradeExecutorImpl.java
@@ -19,7 +19,6 @@ import com.liferay.portal.upgrade.live.LiveUpgradeSchemaDiff;
 
 import java.sql.Connection;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
@@ -60,13 +59,16 @@ public class LiveUpgradeExecutorImpl implements LiveUpgradeExecutor {
 			Map<String, String> resultColumnNamesMap =
 				liveUpgradeSchemaDiff.getResultColumnNamesMap();
 
+			Map<String, String> resultDefaultValuesMap =
+				liveUpgradeSchemaDiff.getResultDefaultValuesMap();
+
 			try (AutoCloseable autoCloseable = db.syncTables(
 					connection, tableName, tempTableName, resultColumnNamesMap,
-					new HashMap<>())) {
+					resultDefaultValuesMap)) {
 
 				db.copyTableRows(
 					connection, tableName, tempTableName, resultColumnNamesMap,
-					new HashMap<>());
+					resultDefaultValuesMap);
 			}
 
 			db.renameTables(

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/live/LiveUpgradeExecutorImpl.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/live/LiveUpgradeExecutorImpl.java
@@ -19,6 +19,7 @@ import com.liferay.portal.upgrade.live.LiveUpgradeSchemaDiff;
 
 import java.sql.Connection;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
@@ -60,11 +61,12 @@ public class LiveUpgradeExecutorImpl implements LiveUpgradeExecutor {
 				liveUpgradeSchemaDiff.getResultColumnNamesMap();
 
 			try (AutoCloseable autoCloseable = db.syncTables(
-					connection, tableName, tempTableName,
-					resultColumnNamesMap)) {
+					connection, tableName, tempTableName, resultColumnNamesMap,
+					new HashMap<>())) {
 
 				db.copyTableRows(
-					connection, tableName, tempTableName, resultColumnNamesMap);
+					connection, tableName, tempTableName, resultColumnNamesMap,
+					new HashMap<>());
 			}
 
 			db.renameTables(

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/LiveUpgradeExecutorTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/LiveUpgradeExecutorTest.java
@@ -86,7 +86,7 @@ public class LiveUpgradeExecutorTest {
 		_liveUpgradeExecutor.upgrade(
 			_TABLE_NAME,
 			LiveUpgradeProcessFactory.addColumns(
-				"content SBLOB", "version LONG not null default 1"));
+				"content SBLOB", "version LONG default 1 not null"));
 
 		Assert.assertTrue(_dbInspector.hasColumn(_TABLE_NAME, "content"));
 		Assert.assertTrue(_dbInspector.hasColumn(_TABLE_NAME, "version"));

--- a/modules/apps/static/portal/portal-upgrade-api/src/main/resources/com/liferay/portal/upgrade/live/packageinfo
+++ b/modules/apps/static/portal/portal-upgrade-api/src/main/resources/com/liferay/portal/upgrade/live/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/DB2DB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/DB2DB.java
@@ -299,7 +299,8 @@ public class DB2DB extends BaseDB {
 			String targetTableName, String triggerName,
 			String[] sourceColumnNames, String[] targetColumnNames,
 			String[] sourcePrimaryKeyColumnNames,
-			String[] targetPrimaryKeyColumnNames)
+			String[] targetPrimaryKeyColumnNames,
+			Map<String, String> defaultValuesMap)
 		throws Exception {
 
 		StringBundler sb = new StringBundler();
@@ -319,8 +320,20 @@ public class DB2DB extends BaseDB {
 				sb.append(", ");
 			}
 
+			String defaultValue = defaultValuesMap.get(targetColumnNames[i]);
+
+			if (defaultValue != null) {
+				sb.append("COALESCE(");
+			}
+
 			sb.append("new.");
 			sb.append(sourceColumnNames[i]);
+
+			if (defaultValue != null) {
+				sb.append(", ");
+				sb.append(defaultValue);
+				sb.append(")");
+			}
 		}
 
 		sb.append(")");
@@ -334,7 +347,8 @@ public class DB2DB extends BaseDB {
 			String targetTableName, String triggerName,
 			String[] sourceColumnNames, String[] targetColumnNames,
 			String[] sourcePrimaryKeyColumnNames,
-			String[] targetPrimaryKeyColumnNames)
+			String[] targetPrimaryKeyColumnNames,
+			Map<String, String> defaultValuesMap)
 		throws Exception {
 
 		StringBundler sb = new StringBundler();
@@ -353,8 +367,22 @@ public class DB2DB extends BaseDB {
 			}
 
 			sb.append(targetColumnNames[i]);
-			sb.append(" = new.");
+			sb.append(" = ");
+
+			String defaultValue = defaultValuesMap.get(targetColumnNames[i]);
+
+			if (defaultValue != null) {
+				sb.append("COALESCE(");
+			}
+
+			sb.append("new.");
 			sb.append(sourceColumnNames[i]);
+
+			if (defaultValue != null) {
+				sb.append(", ");
+				sb.append(defaultValue);
+				sb.append(")");
+			}
 		}
 
 		sb.append(" where ");

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/OracleDB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/OracleDB.java
@@ -212,6 +212,7 @@ public class OracleDB extends BaseDB {
 		return template;
 	}
 
+	@Override
 	protected void createSyncDeleteTrigger(
 			Connection connection, String sourceTableName,
 			String targetTableName, String triggerName,
@@ -242,12 +243,14 @@ public class OracleDB extends BaseDB {
 		runSQL(connection, sb.toString());
 	}
 
+	@Override
 	protected void createSyncInsertTrigger(
 			Connection connection, String sourceTableName,
 			String targetTableName, String triggerName,
 			String[] sourceColumnNames, String[] targetColumnNames,
 			String[] sourcePrimaryKeyColumnNames,
-			String[] targetPrimaryKeyColumnNames)
+			String[] targetPrimaryKeyColumnNames,
+			Map<String, String> defaultValuesMap)
 		throws Exception {
 
 		StringBundler sb = new StringBundler();
@@ -267,8 +270,20 @@ public class OracleDB extends BaseDB {
 				sb.append(", ");
 			}
 
+			String defaultValue = defaultValuesMap.get(targetColumnNames[i]);
+
+			if (defaultValue != null) {
+				sb.append("COALESCE(");
+			}
+
 			sb.append(":new.");
 			sb.append(sourceColumnNames[i]);
+
+			if (defaultValue != null) {
+				sb.append(", ");
+				sb.append(defaultValue);
+				sb.append(")");
+			}
 		}
 
 		sb.append(")");
@@ -276,12 +291,14 @@ public class OracleDB extends BaseDB {
 		runSQL(connection, sb.toString());
 	}
 
+	@Override
 	protected void createSyncUpdateTrigger(
 			Connection connection, String sourceTableName,
 			String targetTableName, String triggerName,
 			String[] sourceColumnNames, String[] targetColumnNames,
 			String[] sourcePrimaryKeyColumnNames,
-			String[] targetPrimaryKeyColumnNames)
+			String[] targetPrimaryKeyColumnNames,
+			Map<String, String> defaultValuesMap)
 		throws Exception {
 
 		StringBundler sb = new StringBundler();
@@ -300,8 +317,22 @@ public class OracleDB extends BaseDB {
 			}
 
 			sb.append(targetColumnNames[i]);
-			sb.append(" = :new.");
+			sb.append(" = ");
+
+			String defaultValue = defaultValuesMap.get(targetColumnNames[i]);
+
+			if (defaultValue != null) {
+				sb.append("COALESCE(");
+			}
+
+			sb.append(":new.");
 			sb.append(sourceColumnNames[i]);
+
+			if (defaultValue != null) {
+				sb.append(", ");
+				sb.append(defaultValue);
+				sb.append(")");
+			}
 		}
 
 		sb.append(" where ");

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SQLServerDB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SQLServerDB.java
@@ -265,7 +265,8 @@ public class SQLServerDB extends BaseDB {
 			String targetTableName, String triggerName,
 			String[] sourceColumnNames, String[] targetColumnNames,
 			String[] sourcePrimaryKeyColumnNames,
-			String[] targetPrimaryKeyColumnNames)
+			String[] targetPrimaryKeyColumnNames,
+			Map<String, String> defaultValuesMap)
 		throws Exception {
 
 		StringBundler sb = new StringBundler();
@@ -285,9 +286,21 @@ public class SQLServerDB extends BaseDB {
 				sb.append(", ");
 			}
 
+			String defaultValue = defaultValuesMap.get(targetColumnNames[i]);
+
+			if (defaultValue != null) {
+				sb.append("COALESCE(");
+			}
+
 			sb.append(sourceTableName);
 			sb.append(StringPool.PERIOD);
 			sb.append(sourceColumnNames[i]);
+
+			if (defaultValue != null) {
+				sb.append(", ");
+				sb.append(defaultValue);
+				sb.append(")");
+			}
 		}
 
 		sb.append(" from ");
@@ -315,7 +328,8 @@ public class SQLServerDB extends BaseDB {
 			String targetTableName, String triggerName,
 			String[] sourceColumnNames, String[] targetColumnNames,
 			String[] sourcePrimaryKeyColumnNames,
-			String[] targetPrimaryKeyColumnNames)
+			String[] targetPrimaryKeyColumnNames,
+			Map<String, String> defaultValuesMap)
 		throws Exception {
 
 		StringBundler sb = new StringBundler();
@@ -336,8 +350,22 @@ public class SQLServerDB extends BaseDB {
 			sb.append(targetTableName);
 			sb.append(StringPool.PERIOD);
 			sb.append(targetColumnNames[i]);
-			sb.append(" = res.");
+			sb.append(" = ");
+
+			String defaultValue = defaultValuesMap.get(targetColumnNames[i]);
+
+			if (defaultValue != null) {
+				sb.append("COALESCE(");
+			}
+
+			sb.append("res.");
 			sb.append(sourceColumnNames[i]);
+
+			if (defaultValue != null) {
+				sb.append(", ");
+				sb.append(defaultValue);
+				sb.append(")");
+			}
 		}
 
 		sb.append(" from (select ");

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SQLServerDB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SQLServerDB.java
@@ -396,7 +396,20 @@ public class SQLServerDB extends BaseDB {
 			sb.append(sourcePrimaryKeyColumnNames[i]);
 		}
 
-		sb.append(") as res");
+		sb.append(") as res where ");
+
+		for (int i = 0; i < sourcePrimaryKeyColumnNames.length; i++) {
+			if (i > 0) {
+				sb.append(" and ");
+			}
+
+			sb.append("res.");
+			sb.append(sourcePrimaryKeyColumnNames[i]);
+			sb.append(" = ");
+			sb.append(targetTableName);
+			sb.append(StringPool.PERIOD);
+			sb.append(targetPrimaryKeyColumnNames[i]);
+		}
 
 		runSQL(connection, sb.toString());
 	}

--- a/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
@@ -241,7 +241,7 @@ public abstract class BaseDB implements DB {
 			sb.append(" = ");
 			sb.append(targetTableName);
 			sb.append(".");
-			sb.append(primaryKeyColumnName);
+			sb.append(columnNamesMap.get(primaryKeyColumnName));
 
 			if (i < (primaryKeyColumnNames.length - 1)) {
 				sb.append(" and ");
@@ -251,7 +251,7 @@ public abstract class BaseDB implements DB {
 		sb.append(" where ");
 		sb.append(targetTableName);
 		sb.append(".");
-		sb.append(primaryKeyColumnNames[0]);
+		sb.append(columnNamesMap.get(primaryKeyColumnNames[0]));
 		sb.append(" IS NULL");
 
 		runSQL(sb.toString());

--- a/portal-impl/src/com/liferay/portal/dao/db/HypersonicDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/HypersonicDB.java
@@ -100,7 +100,8 @@ public class HypersonicDB extends BaseDB {
 			String targetTableName, String triggerName,
 			String[] sourceColumnNames, String[] targetColumnNames,
 			String[] sourcePrimaryKeyColumnNames,
-			String[] targetPrimaryKeyColumnNames)
+			String[] targetPrimaryKeyColumnNames,
+			Map<String, String> defaultValuesMap)
 		throws Exception {
 
 		StringBundler sb = new StringBundler();
@@ -120,8 +121,20 @@ public class HypersonicDB extends BaseDB {
 				sb.append(", ");
 			}
 
+			String defaultValue = defaultValuesMap.get(targetColumnNames[i]);
+
+			if (defaultValue != null) {
+				sb.append("COALESCE(");
+			}
+
 			sb.append("new.");
 			sb.append(sourceColumnNames[i]);
+
+			if (defaultValue != null) {
+				sb.append(", ");
+				sb.append(defaultValue);
+				sb.append(")");
+			}
 		}
 
 		sb.append(")");
@@ -135,7 +148,8 @@ public class HypersonicDB extends BaseDB {
 			String targetTableName, String triggerName,
 			String[] sourceColumnNames, String[] targetColumnNames,
 			String[] sourcePrimaryKeyColumnNames,
-			String[] targetPrimaryKeyColumnNames)
+			String[] targetPrimaryKeyColumnNames,
+			Map<String, String> defaultValuesMap)
 		throws Exception {
 
 		StringBundler sb = new StringBundler();
@@ -155,8 +169,22 @@ public class HypersonicDB extends BaseDB {
 			}
 
 			sb.append(targetColumnNames[i]);
-			sb.append(" = new.");
+			sb.append(" = ");
+
+			String defaultValue = defaultValuesMap.get(targetColumnNames[i]);
+
+			if (defaultValue != null) {
+				sb.append("COALESCE(");
+			}
+
+			sb.append("new.");
 			sb.append(sourceColumnNames[i]);
+
+			if (defaultValue != null) {
+				sb.append(", ");
+				sb.append(defaultValue);
+				sb.append(")");
+			}
 		}
 
 		sb.append(" where ");

--- a/portal-impl/src/com/liferay/portal/dao/db/PostgreSQLDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/PostgreSQLDB.java
@@ -174,7 +174,8 @@ public class PostgreSQLDB extends BaseDB {
 			String targetTableName, String triggerName,
 			String[] sourceColumnNames, String[] targetColumnNames,
 			String[] sourcePrimaryKeyColumnNames,
-			String[] targetPrimaryKeyColumnNames)
+			String[] targetPrimaryKeyColumnNames,
+			Map<String, String> defaultValuesMap)
 		throws Exception {
 
 		StringBundler sb = new StringBundler();
@@ -190,8 +191,20 @@ public class PostgreSQLDB extends BaseDB {
 				sb.append(", ");
 			}
 
+			String defaultValue = defaultValuesMap.get(targetColumnNames[i]);
+
+			if (defaultValue != null) {
+				sb.append("COALESCE(");
+			}
+
 			sb.append("new.");
 			sb.append(sourceColumnNames[i]);
+
+			if (defaultValue != null) {
+				sb.append(", ");
+				sb.append(defaultValue);
+				sb.append(")");
+			}
 		}
 
 		sb.append(")");
@@ -208,7 +221,8 @@ public class PostgreSQLDB extends BaseDB {
 			String targetTableName, String triggerName,
 			String[] sourceColumnNames, String[] targetColumnNames,
 			String[] sourcePrimaryKeyColumnNames,
-			String[] targetPrimaryKeyColumnNames)
+			String[] targetPrimaryKeyColumnNames,
+			Map<String, String> defaultValuesMap)
 		throws Exception {
 
 		StringBundler sb = new StringBundler();
@@ -223,8 +237,22 @@ public class PostgreSQLDB extends BaseDB {
 			}
 
 			sb.append(targetColumnNames[i]);
-			sb.append(" = new.");
+			sb.append(" = ");
+
+			String defaultValue = defaultValuesMap.get(targetColumnNames[i]);
+
+			if (defaultValue != null) {
+				sb.append("COALESCE(");
+			}
+
+			sb.append("new.");
 			sb.append(sourceColumnNames[i]);
+
+			if (defaultValue != null) {
+				sb.append(", ");
+				sb.append(defaultValue);
+				sb.append(")");
+			}
 		}
 
 		sb.append(" where ");

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/DB.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/DB.java
@@ -60,7 +60,8 @@ public interface DB {
 
 	public void copyTableRows(
 			Connection connection, String sourceTableName,
-			String targetTableName, Map<String, String> columnNamesMap)
+			String targetTableName, Map<String, String> columnNamesMap,
+			Map<String, String> defaultValuesMap)
 		throws Exception;
 
 	public void copyTableStructure(
@@ -178,7 +179,8 @@ public interface DB {
 
 	public AutoCloseable syncTables(
 			Connection connection, String sourceTableName,
-			String targetTableName, Map<String, String> columnNamesMap)
+			String targetTableName, Map<String, String> columnNamesMap,
+			Map<String, String> defaultValuesMap)
 		throws Exception;
 
 	public void updateIndexes(

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/DBInspector.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/DBInspector.java
@@ -246,18 +246,18 @@ public class DBInspector {
 	public boolean hasTable(String tableName, boolean caseSensitive)
 		throws Exception {
 
-		if (caseSensitive) {
-			if (_hasTable(tableName)) {
-				return true;
-			}
-
-			return false;
-		}
-
 		DatabaseMetaData databaseMetaData = _connection.getMetaData();
 
-		if (_hasTable(normalizeName(tableName, databaseMetaData))) {
-			return true;
+		if (!caseSensitive) {
+			tableName = normalizeName(tableName, databaseMetaData);
+		}
+
+		try (ResultSet resultSet = databaseMetaData.getTables(
+				getCatalog(), getSchema(), tableName, new String[] {"TABLE"})) {
+
+			while (resultSet.next()) {
+				return true;
+			}
 		}
 
 		return false;
@@ -392,20 +392,6 @@ public class DBInspector {
 		return databaseMetaData.getColumns(
 			getCatalog(), getSchema(),
 			normalizeName(tableName, databaseMetaData), columnName);
-	}
-
-	private boolean _hasTable(String tableName) throws Exception {
-		DatabaseMetaData metadata = _connection.getMetaData();
-
-		try (ResultSet resultSet = metadata.getTables(
-				getCatalog(), getSchema(), tableName, new String[] {"TABLE"})) {
-
-			while (resultSet.next()) {
-				return true;
-			}
-		}
-
-		return false;
 	}
 
 	private boolean _isColumnNullable(String typeName) {

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/packageinfo
@@ -1,1 +1,1 @@
-version 14.0.0
+version 15.0.0


### PR DESCRIPTION
Manually forwarding as test failures are unrelated :heavy_check_mark: 

Original PR: https://github.com/liferay-uniform/liferay-portal/pull/1342

-----

https://liferay.atlassian.net/browse/LPS-181763

This PR simply allows the Live Upgrade framework to record and keep track of column default values so that we can support upgrade operations like converting a column from NULL to NOT NULL.

cc: @kevhlee 