### PR TITLE
LPS-194573 Make APIValidation more human-readable

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/model/listener/APIEndpointRelevantObjectEntryModelListener.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/model/listener/APIEndpointRelevantObjectEntryModelListener.java
@@ -171,14 +171,14 @@ public class APIEndpointRelevantObjectEntryModelListener
 								"characters";
 					}
 					else {
-						message = "%s must start with the \"/\" character";
+						message = "%s must start with the '/' character";
 						messageKey = "x-must-start-with-the-x-character";
 					}
 
 					String label = objectField.getLabel(user.getLocale());
 
 					throw new ObjectEntryValuesException.InvalidObjectField(
-						Arrays.asList(label, "\"/\""),
+						Arrays.asList(label, "'/'"),
 						String.format(message, label), messageKey);
 				}
 			}

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[APIRest]APIGenerator/GeneratePathStructureForEndpoints.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[APIRest]APIGenerator/GeneratePathStructureForEndpoints.testcase
@@ -176,7 +176,7 @@ definition {
 		}
 
 		task ("Then I can see error message") {
-			Alert.viewErrorMessage(errorMessage = "Path must start with the \"/\" character.");
+			Alert.viewErrorMessage(errorMessage = "Path must start with the '/' character.");
 		}
 
 		task ("And Then the endpoint is not being created") {

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APIEndpointRelevantObjectEntryModelListenerTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APIEndpointRelevantObjectEntryModelListenerTest.java
@@ -200,7 +200,7 @@ public class APIEndpointRelevantObjectEntryModelListenerTest
 			JSONUtil.put(
 				"status", "BAD_REQUEST"
 			).put(
-				"title", "Path must start with the \"/\" character."
+				"title", "Path must start with the '/' character."
 			).toString(),
 			HTTPTestUtil.invokeToJSONObject(
 				JSONUtil.put(


### PR DESCRIPTION
**What's changed?:**
- The validation of the path starting with single forward-slash now uses single quotes, making it more "human-readable".
- The poshi and integration tests are updated to check the newly defined behavior.

See the following Jira ticket: [LPS-194573](https://liferay.atlassian.net/browse/LPS-194573)