### PR TITLE
COMMERCE-11747 Headless BigDecimal array support

### DIFF
--- a/modules/apps/analytics/analytics-settings-rest-client/src/main/java/com/liferay/analytics/settings/rest/client/json/BaseJSONParser.java
+++ b/modules/apps/analytics/analytics-settings-rest-client/src/main/java/com/liferay/analytics/settings/rest/client/json/BaseJSONParser.java
@@ -5,6 +5,8 @@
 
 package com.liferay.analytics.settings.rest.client.json;
 
+import java.math.BigDecimal;
+
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -180,6 +182,16 @@ public abstract class BaseJSONParser<T> {
 
 	protected abstract void setField(
 		T dto, String jsonParserFieldName, Object jsonParserFieldValue);
+
+	protected BigDecimal[] toBigDecimals(Object[] objects) {
+		BigDecimal[] bigdecimals = new BigDecimal[objects.length];
+
+		for (int i = 0; i < bigdecimals.length; i++) {
+			bigdecimals[i] = new BigDecimal(objects[i].toString());
+		}
+
+		return bigdecimals;
+	}
 
 	protected Date toDate(String string) {
 		try {

--- a/modules/apps/batch-planner/batch-planner-rest-client/src/main/java/com/liferay/batch/planner/rest/client/json/BaseJSONParser.java
+++ b/modules/apps/batch-planner/batch-planner-rest-client/src/main/java/com/liferay/batch/planner/rest/client/json/BaseJSONParser.java
@@ -5,6 +5,8 @@
 
 package com.liferay.batch.planner.rest.client.json;
 
+import java.math.BigDecimal;
+
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -180,6 +182,16 @@ public abstract class BaseJSONParser<T> {
 
 	protected abstract void setField(
 		T dto, String jsonParserFieldName, Object jsonParserFieldValue);
+
+	protected BigDecimal[] toBigDecimals(Object[] objects) {
+		BigDecimal[] bigdecimals = new BigDecimal[objects.length];
+
+		for (int i = 0; i < bigdecimals.length; i++) {
+			bigdecimals[i] = new BigDecimal(objects[i].toString());
+		}
+
+		return bigdecimals;
+	}
 
 	protected Date toDate(String string) {
 		try {

--- a/modules/apps/bulk/bulk-rest-client/src/main/java/com/liferay/bulk/rest/client/json/BaseJSONParser.java
+++ b/modules/apps/bulk/bulk-rest-client/src/main/java/com/liferay/bulk/rest/client/json/BaseJSONParser.java
@@ -5,6 +5,8 @@
 
 package com.liferay.bulk.rest.client.json;
 
+import java.math.BigDecimal;
+
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -180,6 +182,16 @@ public abstract class BaseJSONParser<T> {
 
 	protected abstract void setField(
 		T dto, String jsonParserFieldName, Object jsonParserFieldValue);
+
+	protected BigDecimal[] toBigDecimals(Object[] objects) {
+		BigDecimal[] bigdecimals = new BigDecimal[objects.length];
+
+		for (int i = 0; i < bigdecimals.length; i++) {
+			bigdecimals[i] = new BigDecimal(objects[i].toString());
+		}
+
+		return bigdecimals;
+	}
 
 	protected Date toDate(String string) {
 		try {

--- a/modules/apps/change-tracking/change-tracking-rest-client/src/main/java/com/liferay/change/tracking/rest/client/json/BaseJSONParser.java
+++ b/modules/apps/change-tracking/change-tracking-rest-client/src/main/java/com/liferay/change/tracking/rest/client/json/BaseJSONParser.java
@@ -5,6 +5,8 @@
 
 package com.liferay.change.tracking.rest.client.json;
 
+import java.math.BigDecimal;
+
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -180,6 +182,16 @@ public abstract class BaseJSONParser<T> {
 
 	protected abstract void setField(
 		T dto, String jsonParserFieldName, Object jsonParserFieldValue);
+
+	protected BigDecimal[] toBigDecimals(Object[] objects) {
+		BigDecimal[] bigdecimals = new BigDecimal[objects.length];
+
+		for (int i = 0; i < bigdecimals.length; i++) {
+			bigdecimals[i] = new BigDecimal(objects[i].toString());
+		}
+
+		return bigdecimals;
+	}
 
 	protected Date toDate(String string) {
 		try {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-client/src/main/java/com/liferay/headless/commerce/admin/account/client/json/BaseJSONParser.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-client/src/main/java/com/liferay/headless/commerce/admin/account/client/json/BaseJSONParser.java
@@ -5,6 +5,8 @@
 
 package com.liferay.headless.commerce.admin.account.client.json;
 
+import java.math.BigDecimal;
+
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -180,6 +182,16 @@ public abstract class BaseJSONParser<T> {
 
 	protected abstract void setField(
 		T dto, String jsonParserFieldName, Object jsonParserFieldValue);
+
+	protected BigDecimal[] toBigDecimals(Object[] objects) {
+		BigDecimal[] bigdecimals = new BigDecimal[objects.length];
+
+		for (int i = 0; i < bigdecimals.length; i++) {
+			bigdecimals[i] = new BigDecimal(objects[i].toString());
+		}
+
+		return bigdecimals;
+	}
 
 	protected Date toDate(String string) {
 		try {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/json/BaseJSONParser.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/json/BaseJSONParser.java
@@ -5,6 +5,8 @@
 
 package com.liferay.headless.commerce.admin.catalog.client.json;
 
+import java.math.BigDecimal;
+
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -180,6 +182,16 @@ public abstract class BaseJSONParser<T> {
 
 	protected abstract void setField(
 		T dto, String jsonParserFieldName, Object jsonParserFieldValue);
+
+	protected BigDecimal[] toBigDecimals(Object[] objects) {
+		BigDecimal[] bigdecimals = new BigDecimal[objects.length];
+
+		for (int i = 0; i < bigdecimals.length; i++) {
+			bigdecimals[i] = new BigDecimal(objects[i].toString());
+		}
+
+		return bigdecimals;
+	}
 
 	protected Date toDate(String string) {
 		try {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-client/src/main/java/com/liferay/headless/commerce/admin/channel/client/json/BaseJSONParser.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-client/src/main/java/com/liferay/headless/commerce/admin/channel/client/json/BaseJSONParser.java
@@ -5,6 +5,8 @@
 
 package com.liferay.headless.commerce.admin.channel.client.json;
 
+import java.math.BigDecimal;
+
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -180,6 +182,16 @@ public abstract class BaseJSONParser<T> {
 
 	protected abstract void setField(
 		T dto, String jsonParserFieldName, Object jsonParserFieldValue);
+
+	protected BigDecimal[] toBigDecimals(Object[] objects) {
+		BigDecimal[] bigdecimals = new BigDecimal[objects.length];
+
+		for (int i = 0; i < bigdecimals.length; i++) {
+			bigdecimals[i] = new BigDecimal(objects[i].toString());
+		}
+
+		return bigdecimals;
+	}
 
 	protected Date toDate(String string) {
 		try {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-client/src/main/java/com/liferay/headless/commerce/admin/inventory/client/json/BaseJSONParser.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-client/src/main/java/com/liferay/headless/commerce/admin/inventory/client/json/BaseJSONParser.java
@@ -5,6 +5,8 @@
 
 package com.liferay.headless.commerce.admin.inventory.client.json;
 
+import java.math.BigDecimal;
+
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -180,6 +182,16 @@ public abstract class BaseJSONParser<T> {
 
 	protected abstract void setField(
 		T dto, String jsonParserFieldName, Object jsonParserFieldValue);
+
+	protected BigDecimal[] toBigDecimals(Object[] objects) {
+		BigDecimal[] bigdecimals = new BigDecimal[objects.length];
+
+		for (int i = 0; i < bigdecimals.length; i++) {
+			bigdecimals[i] = new BigDecimal(objects[i].toString());
+		}
+
+		return bigdecimals;
+	}
 
 	protected Date toDate(String string) {
 		try {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-client/src/main/java/com/liferay/headless/commerce/admin/order/client/json/BaseJSONParser.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-client/src/main/java/com/liferay/headless/commerce/admin/order/client/json/BaseJSONParser.java
@@ -5,6 +5,8 @@
 
 package com.liferay.headless.commerce.admin.order.client.json;
 
+import java.math.BigDecimal;
+
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -180,6 +182,16 @@ public abstract class BaseJSONParser<T> {
 
 	protected abstract void setField(
 		T dto, String jsonParserFieldName, Object jsonParserFieldValue);
+
+	protected BigDecimal[] toBigDecimals(Object[] objects) {
+		BigDecimal[] bigdecimals = new BigDecimal[objects.length];
+
+		for (int i = 0; i < bigdecimals.length; i++) {
+			bigdecimals[i] = new BigDecimal(objects[i].toString());
+		}
+
+		return bigdecimals;
+	}
 
 	protected Date toDate(String string) {
 		try {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/json/BaseJSONParser.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/json/BaseJSONParser.java
@@ -5,6 +5,8 @@
 
 package com.liferay.headless.commerce.admin.pricing.client.json;
 
+import java.math.BigDecimal;
+
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -180,6 +182,16 @@ public abstract class BaseJSONParser<T> {
 
 	protected abstract void setField(
 		T dto, String jsonParserFieldName, Object jsonParserFieldValue);
+
+	protected BigDecimal[] toBigDecimals(Object[] objects) {
+		BigDecimal[] bigdecimals = new BigDecimal[objects.length];
+
+		for (int i = 0; i < bigdecimals.length; i++) {
+			bigdecimals[i] = new BigDecimal(objects[i].toString());
+		}
+
+		return bigdecimals;
+	}
 
 	protected Date toDate(String string) {
 		try {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-client/src/main/java/com/liferay/headless/commerce/admin/shipment/client/json/BaseJSONParser.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-client/src/main/java/com/liferay/headless/commerce/admin/shipment/client/json/BaseJSONParser.java
@@ -5,6 +5,8 @@
 
 package com.liferay.headless.commerce.admin.shipment.client.json;
 
+import java.math.BigDecimal;
+
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -180,6 +182,16 @@ public abstract class BaseJSONParser<T> {
 
 	protected abstract void setField(
 		T dto, String jsonParserFieldName, Object jsonParserFieldValue);
+
+	protected BigDecimal[] toBigDecimals(Object[] objects) {
+		BigDecimal[] bigdecimals = new BigDecimal[objects.length];
+
+		for (int i = 0; i < bigdecimals.length; i++) {
+			bigdecimals[i] = new BigDecimal(objects[i].toString());
+		}
+
+		return bigdecimals;
+	}
 
 	protected Date toDate(String string) {
 		try {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-client/src/main/java/com/liferay/headless/commerce/admin/site/setting/client/json/BaseJSONParser.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-client/src/main/java/com/liferay/headless/commerce/admin/site/setting/client/json/BaseJSONParser.java
@@ -5,6 +5,8 @@
 
 package com.liferay.headless.commerce.admin.site.setting.client.json;
 
+import java.math.BigDecimal;
+
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -180,6 +182,16 @@ public abstract class BaseJSONParser<T> {
 
 	protected abstract void setField(
 		T dto, String jsonParserFieldName, Object jsonParserFieldValue);
+
+	protected BigDecimal[] toBigDecimals(Object[] objects) {
+		BigDecimal[] bigdecimals = new BigDecimal[objects.length];
+
+		for (int i = 0; i < bigdecimals.length; i++) {
+			bigdecimals[i] = new BigDecimal(objects[i].toString());
+		}
+
+		return bigdecimals;
+	}
 
 	protected Date toDate(String string) {
 		try {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-client/src/main/java/com/liferay/headless/commerce/delivery/cart/client/json/BaseJSONParser.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-client/src/main/java/com/liferay/headless/commerce/delivery/cart/client/json/BaseJSONParser.java
@@ -5,6 +5,8 @@
 
 package com.liferay.headless.commerce.delivery.cart.client.json;
 
+import java.math.BigDecimal;
+
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -180,6 +182,16 @@ public abstract class BaseJSONParser<T> {
 
 	protected abstract void setField(
 		T dto, String jsonParserFieldName, Object jsonParserFieldValue);
+
+	protected BigDecimal[] toBigDecimals(Object[] objects) {
+		BigDecimal[] bigdecimals = new BigDecimal[objects.length];
+
+		for (int i = 0; i < bigdecimals.length; i++) {
+			bigdecimals[i] = new BigDecimal(objects[i].toString());
+		}
+
+		return bigdecimals;
+	}
 
 	protected Date toDate(String string) {
 		try {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-client/src/main/java/com/liferay/headless/commerce/delivery/catalog/client/json/BaseJSONParser.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-client/src/main/java/com/liferay/headless/commerce/delivery/catalog/client/json/BaseJSONParser.java
@@ -5,6 +5,8 @@
 
 package com.liferay.headless.commerce.delivery.catalog.client.json;
 
+import java.math.BigDecimal;
+
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -180,6 +182,16 @@ public abstract class BaseJSONParser<T> {
 
 	protected abstract void setField(
 		T dto, String jsonParserFieldName, Object jsonParserFieldValue);
+
+	protected BigDecimal[] toBigDecimals(Object[] objects) {
+		BigDecimal[] bigdecimals = new BigDecimal[objects.length];
+
+		for (int i = 0; i < bigdecimals.length; i++) {
+			bigdecimals[i] = new BigDecimal(objects[i].toString());
+		}
+
+		return bigdecimals;
+	}
 
 	protected Date toDate(String string) {
 		try {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-client/src/main/java/com/liferay/headless/commerce/delivery/order/client/json/BaseJSONParser.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-client/src/main/java/com/liferay/headless/commerce/delivery/order/client/json/BaseJSONParser.java
@@ -5,6 +5,8 @@
 
 package com.liferay.headless.commerce.delivery.order.client.json;
 
+import java.math.BigDecimal;
+
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -180,6 +182,16 @@ public abstract class BaseJSONParser<T> {
 
 	protected abstract void setField(
 		T dto, String jsonParserFieldName, Object jsonParserFieldValue);
+
+	protected BigDecimal[] toBigDecimals(Object[] objects) {
+		BigDecimal[] bigdecimals = new BigDecimal[objects.length];
+
+		for (int i = 0; i < bigdecimals.length; i++) {
+			bigdecimals[i] = new BigDecimal(objects[i].toString());
+		}
+
+		return bigdecimals;
+	}
 
 	protected Date toDate(String string) {
 		try {

--- a/modules/apps/data-engine/data-engine-rest-client/src/main/java/com/liferay/data/engine/rest/client/json/BaseJSONParser.java
+++ b/modules/apps/data-engine/data-engine-rest-client/src/main/java/com/liferay/data/engine/rest/client/json/BaseJSONParser.java
@@ -5,6 +5,8 @@
 
 package com.liferay.data.engine.rest.client.json;
 
+import java.math.BigDecimal;
+
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -180,6 +182,16 @@ public abstract class BaseJSONParser<T> {
 
 	protected abstract void setField(
 		T dto, String jsonParserFieldName, Object jsonParserFieldValue);
+
+	protected BigDecimal[] toBigDecimals(Object[] objects) {
+		BigDecimal[] bigdecimals = new BigDecimal[objects.length];
+
+		for (int i = 0; i < bigdecimals.length; i++) {
+			bigdecimals[i] = new BigDecimal(objects[i].toString());
+		}
+
+		return bigdecimals;
+	}
 
 	protected Date toDate(String string) {
 		try {

--- a/modules/apps/digital-signature/digital-signature-rest-client/src/main/java/com/liferay/digital/signature/rest/client/json/BaseJSONParser.java
+++ b/modules/apps/digital-signature/digital-signature-rest-client/src/main/java/com/liferay/digital/signature/rest/client/json/BaseJSONParser.java
@@ -5,6 +5,8 @@
 
 package com.liferay.digital.signature.rest.client.json;
 
+import java.math.BigDecimal;
+
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -180,6 +182,16 @@ public abstract class BaseJSONParser<T> {
 
 	protected abstract void setField(
 		T dto, String jsonParserFieldName, Object jsonParserFieldValue);
+
+	protected BigDecimal[] toBigDecimals(Object[] objects) {
+		BigDecimal[] bigdecimals = new BigDecimal[objects.length];
+
+		for (int i = 0; i < bigdecimals.length; i++) {
+			bigdecimals[i] = new BigDecimal(objects[i].toString());
+		}
+
+		return bigdecimals;
+	}
 
 	protected Date toDate(String string) {
 		try {

--- a/modules/apps/dispatch/dispatch-rest-client/src/main/java/com/liferay/dispatch/rest/client/json/BaseJSONParser.java
+++ b/modules/apps/dispatch/dispatch-rest-client/src/main/java/com/liferay/dispatch/rest/client/json/BaseJSONParser.java
@@ -5,6 +5,8 @@
 
 package com.liferay.dispatch.rest.client.json;
 
+import java.math.BigDecimal;
+
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -180,6 +182,16 @@ public abstract class BaseJSONParser<T> {
 
 	protected abstract void setField(
 		T dto, String jsonParserFieldName, Object jsonParserFieldValue);
+
+	protected BigDecimal[] toBigDecimals(Object[] objects) {
+		BigDecimal[] bigdecimals = new BigDecimal[objects.length];
+
+		for (int i = 0; i < bigdecimals.length; i++) {
+			bigdecimals[i] = new BigDecimal(objects[i].toString());
+		}
+
+		return bigdecimals;
+	}
 
 	protected Date toDate(String string) {
 		try {

--- a/modules/apps/frontend-view-state/frontend-view-state-rest-client/src/main/java/com/liferay/frontend/view/state/rest/client/json/BaseJSONParser.java
+++ b/modules/apps/frontend-view-state/frontend-view-state-rest-client/src/main/java/com/liferay/frontend/view/state/rest/client/json/BaseJSONParser.java
@@ -5,6 +5,8 @@
 
 package com.liferay.frontend.view.state.rest.client.json;
 
+import java.math.BigDecimal;
+
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -180,6 +182,16 @@ public abstract class BaseJSONParser<T> {
 
 	protected abstract void setField(
 		T dto, String jsonParserFieldName, Object jsonParserFieldValue);
+
+	protected BigDecimal[] toBigDecimals(Object[] objects) {
+		BigDecimal[] bigdecimals = new BigDecimal[objects.length];
+
+		for (int i = 0; i < bigdecimals.length; i++) {
+			bigdecimals[i] = new BigDecimal(objects[i].toString());
+		}
+
+		return bigdecimals;
+	}
 
 	protected Date toDate(String string) {
 		try {

--- a/modules/apps/headless/headless-admin-address/headless-admin-address-client/src/main/java/com/liferay/headless/admin/address/client/json/BaseJSONParser.java
+++ b/modules/apps/headless/headless-admin-address/headless-admin-address-client/src/main/java/com/liferay/headless/admin/address/client/json/BaseJSONParser.java
@@ -5,6 +5,8 @@
 
 package com.liferay.headless.admin.address.client.json;
 
+import java.math.BigDecimal;
+
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -180,6 +182,16 @@ public abstract class BaseJSONParser<T> {
 
 	protected abstract void setField(
 		T dto, String jsonParserFieldName, Object jsonParserFieldValue);
+
+	protected BigDecimal[] toBigDecimals(Object[] objects) {
+		BigDecimal[] bigdecimals = new BigDecimal[objects.length];
+
+		for (int i = 0; i < bigdecimals.length; i++) {
+			bigdecimals[i] = new BigDecimal(objects[i].toString());
+		}
+
+		return bigdecimals;
+	}
 
 	protected Date toDate(String string) {
 		try {

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-client/src/main/java/com/liferay/headless/admin/content/client/json/BaseJSONParser.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-client/src/main/java/com/liferay/headless/admin/content/client/json/BaseJSONParser.java
@@ -5,6 +5,8 @@
 
 package com.liferay.headless.admin.content.client.json;
 
+import java.math.BigDecimal;
+
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -180,6 +182,16 @@ public abstract class BaseJSONParser<T> {
 
 	protected abstract void setField(
 		T dto, String jsonParserFieldName, Object jsonParserFieldValue);
+
+	protected BigDecimal[] toBigDecimals(Object[] objects) {
+		BigDecimal[] bigdecimals = new BigDecimal[objects.length];
+
+		for (int i = 0; i < bigdecimals.length; i++) {
+			bigdecimals[i] = new BigDecimal(objects[i].toString());
+		}
+
+		return bigdecimals;
+	}
 
 	protected Date toDate(String string) {
 		try {

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-client/src/main/java/com/liferay/headless/admin/list/type/client/json/BaseJSONParser.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-client/src/main/java/com/liferay/headless/admin/list/type/client/json/BaseJSONParser.java
@@ -5,6 +5,8 @@
 
 package com.liferay.headless.admin.list.type.client.json;
 
+import java.math.BigDecimal;
+
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -180,6 +182,16 @@ public abstract class BaseJSONParser<T> {
 
 	protected abstract void setField(
 		T dto, String jsonParserFieldName, Object jsonParserFieldValue);
+
+	protected BigDecimal[] toBigDecimals(Object[] objects) {
+		BigDecimal[] bigdecimals = new BigDecimal[objects.length];
+
+		for (int i = 0; i < bigdecimals.length; i++) {
+			bigdecimals[i] = new BigDecimal(objects[i].toString());
+		}
+
+		return bigdecimals;
+	}
 
 	protected Date toDate(String string) {
 		try {

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/json/BaseJSONParser.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/json/BaseJSONParser.java
@@ -5,6 +5,8 @@
 
 package com.liferay.headless.admin.taxonomy.client.json;
 
+import java.math.BigDecimal;
+
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -180,6 +182,16 @@ public abstract class BaseJSONParser<T> {
 
 	protected abstract void setField(
 		T dto, String jsonParserFieldName, Object jsonParserFieldValue);
+
+	protected BigDecimal[] toBigDecimals(Object[] objects) {
+		BigDecimal[] bigdecimals = new BigDecimal[objects.length];
+
+		for (int i = 0; i < bigdecimals.length; i++) {
+			bigdecimals[i] = new BigDecimal(objects[i].toString());
+		}
+
+		return bigdecimals;
+	}
 
 	protected Date toDate(String string) {
 		try {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/json/BaseJSONParser.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/json/BaseJSONParser.java
@@ -5,6 +5,8 @@
 
 package com.liferay.headless.admin.user.client.json;
 
+import java.math.BigDecimal;
+
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -180,6 +182,16 @@ public abstract class BaseJSONParser<T> {
 
 	protected abstract void setField(
 		T dto, String jsonParserFieldName, Object jsonParserFieldValue);
+
+	protected BigDecimal[] toBigDecimals(Object[] objects) {
+		BigDecimal[] bigdecimals = new BigDecimal[objects.length];
+
+		for (int i = 0; i < bigdecimals.length; i++) {
+			bigdecimals[i] = new BigDecimal(objects[i].toString());
+		}
+
+		return bigdecimals;
+	}
 
 	protected Date toDate(String string) {
 		try {

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/json/BaseJSONParser.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/json/BaseJSONParser.java
@@ -5,6 +5,8 @@
 
 package com.liferay.headless.admin.workflow.client.json;
 
+import java.math.BigDecimal;
+
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -180,6 +182,16 @@ public abstract class BaseJSONParser<T> {
 
 	protected abstract void setField(
 		T dto, String jsonParserFieldName, Object jsonParserFieldValue);
+
+	protected BigDecimal[] toBigDecimals(Object[] objects) {
+		BigDecimal[] bigdecimals = new BigDecimal[objects.length];
+
+		for (int i = 0; i < bigdecimals.length; i++) {
+			bigdecimals[i] = new BigDecimal(objects[i].toString());
+		}
+
+		return bigdecimals;
+	}
 
 	protected Date toDate(String string) {
 		try {

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-client/src/main/java/com/liferay/headless/batch/engine/client/json/BaseJSONParser.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-client/src/main/java/com/liferay/headless/batch/engine/client/json/BaseJSONParser.java
@@ -5,6 +5,8 @@
 
 package com.liferay.headless.batch.engine.client.json;
 
+import java.math.BigDecimal;
+
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -180,6 +182,16 @@ public abstract class BaseJSONParser<T> {
 
 	protected abstract void setField(
 		T dto, String jsonParserFieldName, Object jsonParserFieldValue);
+
+	protected BigDecimal[] toBigDecimals(Object[] objects) {
+		BigDecimal[] bigdecimals = new BigDecimal[objects.length];
+
+		for (int i = 0; i < bigdecimals.length; i++) {
+			bigdecimals[i] = new BigDecimal(objects[i].toString());
+		}
+
+		return bigdecimals;
+	}
 
 	protected Date toDate(String string) {
 		try {

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/json/BaseJSONParser.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/json/BaseJSONParser.java
@@ -5,6 +5,8 @@
 
 package com.liferay.headless.delivery.client.json;
 
+import java.math.BigDecimal;
+
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -180,6 +182,16 @@ public abstract class BaseJSONParser<T> {
 
 	protected abstract void setField(
 		T dto, String jsonParserFieldName, Object jsonParserFieldValue);
+
+	protected BigDecimal[] toBigDecimals(Object[] objects) {
+		BigDecimal[] bigdecimals = new BigDecimal[objects.length];
+
+		for (int i = 0; i < bigdecimals.length; i++) {
+			bigdecimals[i] = new BigDecimal(objects[i].toString());
+		}
+
+		return bigdecimals;
+	}
 
 	protected Date toDate(String string) {
 		try {

--- a/modules/apps/headless/headless-form/headless-form-client/src/main/java/com/liferay/headless/form/client/json/BaseJSONParser.java
+++ b/modules/apps/headless/headless-form/headless-form-client/src/main/java/com/liferay/headless/form/client/json/BaseJSONParser.java
@@ -5,6 +5,8 @@
 
 package com.liferay.headless.form.client.json;
 
+import java.math.BigDecimal;
+
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -180,6 +182,16 @@ public abstract class BaseJSONParser<T> {
 
 	protected abstract void setField(
 		T dto, String jsonParserFieldName, Object jsonParserFieldValue);
+
+	protected BigDecimal[] toBigDecimals(Object[] objects) {
+		BigDecimal[] bigdecimals = new BigDecimal[objects.length];
+
+		for (int i = 0; i < bigdecimals.length; i++) {
+			bigdecimals[i] = new BigDecimal(objects[i].toString());
+		}
+
+		return bigdecimals;
+	}
 
 	protected Date toDate(String string) {
 		try {

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-client/src/main/java/com/liferay/headless/portal/instances/client/json/BaseJSONParser.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-client/src/main/java/com/liferay/headless/portal/instances/client/json/BaseJSONParser.java
@@ -5,6 +5,8 @@
 
 package com.liferay.headless.portal.instances.client.json;
 
+import java.math.BigDecimal;
+
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -180,6 +182,16 @@ public abstract class BaseJSONParser<T> {
 
 	protected abstract void setField(
 		T dto, String jsonParserFieldName, Object jsonParserFieldValue);
+
+	protected BigDecimal[] toBigDecimals(Object[] objects) {
+		BigDecimal[] bigdecimals = new BigDecimal[objects.length];
+
+		for (int i = 0; i < bigdecimals.length; i++) {
+			bigdecimals[i] = new BigDecimal(objects[i].toString());
+		}
+
+		return bigdecimals;
+	}
 
 	protected Date toDate(String string) {
 		try {

--- a/modules/apps/headless/headless-site/headless-site-client/src/main/java/com/liferay/headless/site/client/json/BaseJSONParser.java
+++ b/modules/apps/headless/headless-site/headless-site-client/src/main/java/com/liferay/headless/site/client/json/BaseJSONParser.java
@@ -5,6 +5,8 @@
 
 package com.liferay.headless.site.client.json;
 
+import java.math.BigDecimal;
+
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -180,6 +182,16 @@ public abstract class BaseJSONParser<T> {
 
 	protected abstract void setField(
 		T dto, String jsonParserFieldName, Object jsonParserFieldValue);
+
+	protected BigDecimal[] toBigDecimals(Object[] objects) {
+		BigDecimal[] bigdecimals = new BigDecimal[objects.length];
+
+		for (int i = 0; i < bigdecimals.length; i++) {
+			bigdecimals[i] = new BigDecimal(objects[i].toString());
+		}
+
+		return bigdecimals;
+	}
 
 	protected Date toDate(String string) {
 		try {

--- a/modules/apps/headless/headless-user-notification/headless-user-notification-client/src/main/java/com/liferay/headless/user/notification/client/json/BaseJSONParser.java
+++ b/modules/apps/headless/headless-user-notification/headless-user-notification-client/src/main/java/com/liferay/headless/user/notification/client/json/BaseJSONParser.java
@@ -5,6 +5,8 @@
 
 package com.liferay.headless.user.notification.client.json;
 
+import java.math.BigDecimal;
+
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -180,6 +182,16 @@ public abstract class BaseJSONParser<T> {
 
 	protected abstract void setField(
 		T dto, String jsonParserFieldName, Object jsonParserFieldValue);
+
+	protected BigDecimal[] toBigDecimals(Object[] objects) {
+		BigDecimal[] bigdecimals = new BigDecimal[objects.length];
+
+		for (int i = 0; i < bigdecimals.length; i++) {
+			bigdecimals[i] = new BigDecimal(objects[i].toString());
+		}
+
+		return bigdecimals;
+	}
 
 	protected Date toDate(String string) {
 		try {

--- a/modules/apps/notification/notification-rest-client/src/main/java/com/liferay/notification/rest/client/json/BaseJSONParser.java
+++ b/modules/apps/notification/notification-rest-client/src/main/java/com/liferay/notification/rest/client/json/BaseJSONParser.java
@@ -5,6 +5,8 @@
 
 package com.liferay.notification.rest.client.json;
 
+import java.math.BigDecimal;
+
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -180,6 +182,16 @@ public abstract class BaseJSONParser<T> {
 
 	protected abstract void setField(
 		T dto, String jsonParserFieldName, Object jsonParserFieldValue);
+
+	protected BigDecimal[] toBigDecimals(Object[] objects) {
+		BigDecimal[] bigdecimals = new BigDecimal[objects.length];
+
+		for (int i = 0; i < bigdecimals.length; i++) {
+			bigdecimals[i] = new BigDecimal(objects[i].toString());
+		}
+
+		return bigdecimals;
+	}
 
 	protected Date toDate(String string) {
 		try {

--- a/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/json/BaseJSONParser.java
+++ b/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/json/BaseJSONParser.java
@@ -5,6 +5,8 @@
 
 package com.liferay.object.admin.rest.client.json;
 
+import java.math.BigDecimal;
+
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -180,6 +182,16 @@ public abstract class BaseJSONParser<T> {
 
 	protected abstract void setField(
 		T dto, String jsonParserFieldName, Object jsonParserFieldValue);
+
+	protected BigDecimal[] toBigDecimals(Object[] objects) {
+		BigDecimal[] bigdecimals = new BigDecimal[objects.length];
+
+		for (int i = 0; i < bigdecimals.length; i++) {
+			bigdecimals[i] = new BigDecimal(objects[i].toString());
+		}
+
+		return bigdecimals;
+	}
 
 	protected Date toDate(String string) {
 		try {

--- a/modules/apps/portal-search/portal-search-rest-client/src/main/java/com/liferay/portal/search/rest/client/json/BaseJSONParser.java
+++ b/modules/apps/portal-search/portal-search-rest-client/src/main/java/com/liferay/portal/search/rest/client/json/BaseJSONParser.java
@@ -5,6 +5,8 @@
 
 package com.liferay.portal.search.rest.client.json;
 
+import java.math.BigDecimal;
+
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -180,6 +182,16 @@ public abstract class BaseJSONParser<T> {
 
 	protected abstract void setField(
 		T dto, String jsonParserFieldName, Object jsonParserFieldValue);
+
+	protected BigDecimal[] toBigDecimals(Object[] objects) {
+		BigDecimal[] bigdecimals = new BigDecimal[objects.length];
+
+		for (int i = 0; i < bigdecimals.length; i++) {
+			bigdecimals[i] = new BigDecimal(objects[i].toString());
+		}
+
+		return bigdecimals;
+	}
 
 	protected Date toDate(String string) {
 		try {

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-client/src/main/java/com/liferay/headless/commerce/machine/learning/client/json/BaseJSONParser.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-client/src/main/java/com/liferay/headless/commerce/machine/learning/client/json/BaseJSONParser.java
@@ -5,6 +5,8 @@
 
 package com.liferay.headless.commerce.machine.learning.client.json;
 
+import java.math.BigDecimal;
+
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -180,6 +182,16 @@ public abstract class BaseJSONParser<T> {
 
 	protected abstract void setField(
 		T dto, String jsonParserFieldName, Object jsonParserFieldValue);
+
+	protected BigDecimal[] toBigDecimals(Object[] objects) {
+		BigDecimal[] bigdecimals = new BigDecimal[objects.length];
+
+		for (int i = 0; i < bigdecimals.length; i++) {
+			bigdecimals[i] = new BigDecimal(objects[i].toString());
+		}
+
+		return bigdecimals;
+	}
 
 	protected Date toDate(String string) {
 		try {

--- a/modules/dxp/apps/osb/osb-testray/osb-testray-rest-client/src/main/java/com/liferay/osb/testray/rest/client/json/BaseJSONParser.java
+++ b/modules/dxp/apps/osb/osb-testray/osb-testray-rest-client/src/main/java/com/liferay/osb/testray/rest/client/json/BaseJSONParser.java
@@ -5,6 +5,8 @@
 
 package com.liferay.osb.testray.rest.client.json;
 
+import java.math.BigDecimal;
+
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -180,6 +182,16 @@ public abstract class BaseJSONParser<T> {
 
 	protected abstract void setField(
 		T dto, String jsonParserFieldName, Object jsonParserFieldValue);
+
+	protected BigDecimal[] toBigDecimals(Object[] objects) {
+		BigDecimal[] bigdecimals = new BigDecimal[objects.length];
+
+		for (int i = 0; i < bigdecimals.length; i++) {
+			bigdecimals[i] = new BigDecimal(objects[i].toString());
+		}
+
+		return bigdecimals;
+	}
 
 	protected Date toDate(String string) {
 		try {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/json/BaseJSONParser.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/json/BaseJSONParser.java
@@ -5,6 +5,8 @@
 
 package com.liferay.portal.workflow.metrics.rest.client.json;
 
+import java.math.BigDecimal;
+
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -180,6 +182,16 @@ public abstract class BaseJSONParser<T> {
 
 	protected abstract void setField(
 		T dto, String jsonParserFieldName, Object jsonParserFieldValue);
+
+	protected BigDecimal[] toBigDecimals(Object[] objects) {
+		BigDecimal[] bigdecimals = new BigDecimal[objects.length];
+
+		for (int i = 0; i < bigdecimals.length; i++) {
+			bigdecimals[i] = new BigDecimal(objects[i].toString());
+		}
+
+		return bigdecimals;
+	}
 
 	protected Date toDate(String string) {
 		try {

--- a/modules/dxp/apps/saml/saml-admin-rest-client/src/main/java/com/liferay/saml/admin/rest/client/json/BaseJSONParser.java
+++ b/modules/dxp/apps/saml/saml-admin-rest-client/src/main/java/com/liferay/saml/admin/rest/client/json/BaseJSONParser.java
@@ -5,6 +5,8 @@
 
 package com.liferay.saml.admin.rest.client.json;
 
+import java.math.BigDecimal;
+
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -180,6 +182,16 @@ public abstract class BaseJSONParser<T> {
 
 	protected abstract void setField(
 		T dto, String jsonParserFieldName, Object jsonParserFieldValue);
+
+	protected BigDecimal[] toBigDecimals(Object[] objects) {
+		BigDecimal[] bigdecimals = new BigDecimal[objects.length];
+
+		for (int i = 0; i < bigdecimals.length; i++) {
+			bigdecimals[i] = new BigDecimal(objects[i].toString());
+		}
+
+		return bigdecimals;
+	}
 
 	protected Date toDate(String string) {
 		try {

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-client/src/main/java/com/liferay/search/experiences/rest/client/json/BaseJSONParser.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-client/src/main/java/com/liferay/search/experiences/rest/client/json/BaseJSONParser.java
@@ -5,6 +5,8 @@
 
 package com.liferay.search.experiences.rest.client.json;
 
+import java.math.BigDecimal;
+
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -180,6 +182,16 @@ public abstract class BaseJSONParser<T> {
 
 	protected abstract void setField(
 		T dto, String jsonParserFieldName, Object jsonParserFieldValue);
+
+	protected BigDecimal[] toBigDecimals(Object[] objects) {
+		BigDecimal[] bigdecimals = new BigDecimal[objects.length];
+
+		for (int i = 0; i < bigdecimals.length; i++) {
+			bigdecimals[i] = new BigDecimal(objects[i].toString());
+		}
+
+		return bigdecimals;
+	}
 
 	protected Date toDate(String string) {
 		try {

--- a/modules/dxp/apps/segments/segments-asah-rest-client/src/main/java/com/liferay/segments/asah/rest/client/json/BaseJSONParser.java
+++ b/modules/dxp/apps/segments/segments-asah-rest-client/src/main/java/com/liferay/segments/asah/rest/client/json/BaseJSONParser.java
@@ -5,6 +5,8 @@
 
 package com.liferay.segments.asah.rest.client.json;
 
+import java.math.BigDecimal;
+
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -180,6 +182,16 @@ public abstract class BaseJSONParser<T> {
 
 	protected abstract void setField(
 		T dto, String jsonParserFieldName, Object jsonParserFieldValue);
+
+	protected BigDecimal[] toBigDecimals(Object[] objects) {
+		BigDecimal[] bigdecimals = new BigDecimal[objects.length];
+
+		for (int i = 0; i < bigdecimals.length; i++) {
+			bigdecimals[i] = new BigDecimal(objects[i].toString());
+		}
+
+		return bigdecimals;
+	}
 
 	protected Date toDate(String string) {
 		try {

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/client_base_json_parser.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/client_base_json_parser.ftl
@@ -1,5 +1,7 @@
 package ${configYAML.apiPackagePath}.client.json;
 
+import java.math.BigDecimal;
+
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -177,6 +179,16 @@ public abstract class BaseJSONParser<T> {
 	protected abstract T[] createDTOArray(int size);
 
 	protected abstract void setField(T dto, String jsonParserFieldName, Object jsonParserFieldValue);
+
+	protected BigDecimal[] toBigDecimals(Object[] objects) {
+		BigDecimal[] bigdecimals = new BigDecimal[objects.length];
+
+		for (int i = 0; i < bigdecimals.length; i++) {
+			bigdecimals[i] = new BigDecimal(objects[i].toString());
+		}
+
+		return bigdecimals;
+	}
 
 	protected Date toDate(String string) {
 		try {

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/client_serdes.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/client_serdes.ftl
@@ -261,6 +261,8 @@ public class ${schemaName}SerDes {
 
 						<#if stringUtil.equals(propertyType, "BigDecimal")>
 							${schemaVarName}.set${capitalizedPropertyName}(new BigDecimal((String)jsonParserFieldValue));
+						<#elseif stringUtil.equals(propertyType, "BigDecimal[]")>
+							${schemaVarName}.set${capitalizedPropertyName}(toBigDecimals((Object[])jsonParserFieldValue));
 						<#elseif stringUtil.equals(propertyType, "Date")>
 							${schemaVarName}.set${capitalizedPropertyName}(toDate((String)jsonParserFieldValue));
 						<#elseif stringUtil.equals(propertyType, "Date[]")>


### PR DESCRIPTION
Add support to BigDecimal Array on *SerDes.java generated file.

This PR adds a new method (toBigDecimals) on BaseJSONParser file and use it on *SerDes when managing fieldValues with type BigDecimal[]