### PR TITLE
LPS-193250 Publish all Children Objects in a row during their Root Object publication. Block standalone publication for children Objects

### DIFF
--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectDefinition.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectDefinition.java
@@ -74,6 +74,10 @@ public interface ObjectDefinition
 
 	public boolean isLinkedToObjectFolder(long objectFolderId);
 
+	public boolean isNode();
+
+	public boolean isRootDescendantNode();
+
 	public boolean isUnmodifiableSystemObject();
 
 }

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectDefinitionWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectDefinitionWrapper.java
@@ -970,6 +970,11 @@ public class ObjectDefinitionWrapper
 		return model.isModifiable();
 	}
 
+	@Override
+	public boolean isNode() {
+		return model.isNode();
+	}
+
 	/**
 	 * Returns <code>true</code> if this object definition is portlet.
 	 *
@@ -978,6 +983,11 @@ public class ObjectDefinitionWrapper
 	@Override
 	public boolean isPortlet() {
 		return model.isPortlet();
+	}
+
+	@Override
+	public boolean isRootDescendantNode() {
+		return model.isRootDescendantNode();
 	}
 
 	/**

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectDefinitionImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectDefinitionImpl.java
@@ -164,6 +164,27 @@ public class ObjectDefinitionImpl extends ObjectDefinitionBaseImpl {
 	}
 
 	@Override
+	public boolean isNode() {
+		if (getRootObjectDefinitionId() != 0) {
+			return true;
+		}
+
+		return false;
+	}
+
+	@Override
+	public boolean isRootDescendantNode() {
+		if (isNode() &&
+			!Objects.equals(
+				getObjectDefinitionId(), getRootObjectDefinitionId())) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	@Override
 	public boolean isUnmodifiableSystemObject() {
 		if (FeatureFlagManagerUtil.isEnabled("LPS-167253")) {
 			if (!isModifiable() && isSystem()) {

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -791,7 +791,28 @@ public class ObjectDefinitionLocalServiceImpl
 			throw new ObjectDefinitionStatusException();
 		}
 
-		return _publishObjectDefinition(userId, objectDefinition);
+		if (!objectDefinition.isNode()) {
+			return _publishObjectDefinition(userId, objectDefinition);
+		}
+
+		if (objectDefinition.isRootDescendantNode()) {
+			throw new ObjectDefinitionStatusException(
+				"Non root object definitions within a hierarchical structure " +
+					"are ineligible for publication");
+		}
+
+		Tree tree = _treeFactory.create(objectDefinitionId);
+
+		Iterator<Node> iterator = tree.iterator();
+
+		while (iterator.hasNext()) {
+			Node node = iterator.next();
+
+			_publishObjectDefinition(
+				userId, getObjectDefinition(node.getObjectDefinitionId()));
+		}
+
+		return getObjectDefinition(objectDefinitionId);
 	}
 
 	@Override

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
@@ -494,7 +494,7 @@ public class ObjectDefinitionLocalServiceTest {
 
 		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
 
-		_deleteObjectDefinitionHierarchy(_objectDefinitionLocalService);
+		_deleteObjectDefinitionHierarchy();
 	}
 
 	@Test
@@ -1251,7 +1251,7 @@ public class ObjectDefinitionLocalServiceTest {
 			_treeFactory.create(objectDefinitionA.getObjectDefinitionId()),
 			_objectDefinitionLocalService);
 
-		_deleteObjectDefinitionHierarchy(_objectDefinitionLocalService);
+		_deleteObjectDefinitionHierarchy();
 	}
 
 	@Test
@@ -1611,7 +1611,7 @@ public class ObjectDefinitionLocalServiceTest {
 
 		Assert.assertEquals(0, objectDefinition.getRootObjectDefinitionId());
 
-		_deleteObjectDefinitionHierarchy(_objectDefinitionLocalService);
+		_deleteObjectDefinitionHierarchy();
 	}
 
 	@Test
@@ -2172,15 +2172,12 @@ public class ObjectDefinitionLocalServiceTest {
 		return objectAction;
 	}
 
-	private void _deleteObjectDefinitionHierarchy(
-			ObjectDefinitionLocalService objectDefinitionLocalService)
-		throws Exception {
-
+	private void _deleteObjectDefinitionHierarchy() throws Exception {
 		for (String objectDefinitionName :
 				new String[] {"C_A", "C_AA", "C_AAA", "C_AAB", "C_AB"}) {
 
 			ObjectDefinition objectDefinition =
-				objectDefinitionLocalService.fetchObjectDefinition(
+				_objectDefinitionLocalService.fetchObjectDefinition(
 					TestPropsValues.getCompanyId(), objectDefinitionName);
 
 			if (objectDefinition == null) {
@@ -2189,10 +2186,10 @@ public class ObjectDefinitionLocalServiceTest {
 
 			if (objectDefinition.getRootObjectDefinitionId() != 0) {
 				TreeTestUtil.unbind(
-					objectDefinitionLocalService, objectDefinitionName);
+					_objectDefinitionLocalService, objectDefinitionName);
 			}
 
-			objectDefinitionLocalService.deleteObjectDefinition(
+			_objectDefinitionLocalService.deleteObjectDefinition(
 				objectDefinition.getObjectDefinitionId());
 		}
 	}

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/util/ObjectDefinitionTestUtil.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/util/ObjectDefinitionTestUtil.java
@@ -6,12 +6,14 @@
 package com.liferay.object.service.test.util;
 
 import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.field.builder.TextObjectFieldBuilder;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
@@ -75,7 +77,15 @@ public class ObjectDefinitionTestUtil {
 			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
 			false, ObjectDefinitionConstants.SCOPE_COMPANY,
 			ObjectDefinitionConstants.STORAGE_TYPE_DEFAULT,
-			Collections.emptyList());
+			Collections.singletonList(
+				new TextObjectFieldBuilder(
+				).userId(
+					TestPropsValues.getUserId()
+				).labelMap(
+					LocalizedMapUtil.getLocalizedMap(StringUtil.randomId())
+				).name(
+					"able"
+				).build()));
 	}
 
 	public static ObjectDefinition addUnmodifiableSystemObjectDefinition(


### PR DESCRIPTION
Related issue: https://issues.liferay.com/browse/LPS-193250