### PR TITLE
[TS] LPS-195096 sort by title on Layout

### DIFF
--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/spi/model/index/contributor/LayoutModelDocumentContributor.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/spi/model/index/contributor/LayoutModelDocumentContributor.java
@@ -12,6 +12,7 @@ import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Localization;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
 
@@ -57,6 +58,13 @@ public class LayoutModelDocumentContributor
 				layout.getName(locale));
 		}
 
+		document.addLocalizedKeyword(
+			"localized_title",
+			_localization.populateLocalizationMap(
+				layout.getNameMap(), layout.getDefaultLanguageId(),
+				layout.getGroupId()),
+			true, true);
+
 		List<LayoutLocalization> layoutLocalizations =
 			_layoutLocalizationLocalService.getLayoutLocalizations(
 				layout.getPlid());
@@ -82,5 +90,8 @@ public class LayoutModelDocumentContributor
 
 	@Reference
 	private LayoutLocalizationLocalService _layoutLocalizationLocalService;
+
+	@Reference
+	private Localization _localization;
 
 }

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/search/test/LayoutIndexerIndexedFieldsTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/search/test/LayoutIndexerIndexedFieldsTest.java
@@ -216,11 +216,10 @@ public class LayoutIndexerIndexedFieldsTest {
 		for (Locale locale :
 				LanguageUtil.getAvailableLocales(layout.getGroupId())) {
 
-			map.put(
-				"localized_" +
-					LocalizationUtil.getLocalizedName(
-						Field.TITLE, LocaleUtil.toLanguageId(locale)),
-				layout.getName(locale));
+			String key = LocalizationUtil.getLocalizedName(
+				Field.TITLE, LocaleUtil.toLanguageId(locale));
+
+			map.put("localized_" + key, layout.getName(locale));
 		}
 	}
 

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/search/test/LayoutIndexerIndexedFieldsTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/search/test/LayoutIndexerIndexedFieldsTest.java
@@ -191,8 +191,9 @@ public class LayoutIndexerIndexedFieldsTest {
 
 		indexedFieldsFixture.populateUID(layout, map);
 
-		_populateName(layout, map);
 		_populateDates(layout, map);
+		_populateLocalizedTitle(layout, map);
+		_populateName(layout, map);
 		_populateRoles(layout, map);
 
 		return map;
@@ -203,6 +204,24 @@ public class LayoutIndexerIndexedFieldsTest {
 			Field.MODIFIED_DATE, layout.getModifiedDate(), map);
 		indexedFieldsFixture.populateDate(
 			Field.CREATE_DATE, layout.getCreateDate(), map);
+	}
+
+	private void _populateLocalizedTitle(
+		Layout layout, Map<String, String> map) {
+
+		map.put(
+			"localized_" + Field.TITLE,
+			layout.getName(layout.getDefaultLanguageId()));
+
+		for (Locale locale :
+				LanguageUtil.getAvailableLocales(layout.getGroupId())) {
+
+			map.put(
+				"localized_" +
+					LocalizationUtil.getLocalizedName(
+						Field.TITLE, LocaleUtil.toLanguageId(locale)),
+				layout.getName(locale));
+		}
 	}
 
 	private void _populateName(Layout layout, Map<String, String> map) {
@@ -233,6 +252,11 @@ public class LayoutIndexerIndexedFieldsTest {
 			document.remove(
 				LocalizationUtil.getLocalizedName(
 					Field.CONTENT, LocaleUtil.toLanguageId(locale)));
+
+			String key = LocalizationUtil.getLocalizedName(
+				Field.TITLE, LocaleUtil.toLanguageId(locale));
+
+			document.remove("localized_" + key + "_sortable");
 		}
 	}
 

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/search/test/LayoutMultiLanguageSearchTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/search/test/LayoutMultiLanguageSearchTest.java
@@ -28,6 +28,7 @@ import java.util.Locale;
 import java.util.Map;
 
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -82,6 +83,19 @@ public class LayoutMultiLanguageSearchTest {
 	@Test
 	public void testJapaneseTitle() throws Exception {
 		_testLocaleKeywords(LocaleUtil.JAPAN, _JAPANESE_KEYWORD, _TITLE);
+	}
+
+	@Test
+	public void testLocalizedFields() throws Exception {
+		setTestLocale(LocaleUtil.US);
+
+		_addLayoutMultiLanguage();
+
+		Document document = layoutIndexerFixture.searchOnlyOne(
+			_ENGLISH_KEYWORD, LocaleUtil.US);
+
+		Assert.assertEquals(
+			_ENGLISH_KEYWORD, document.get("localized_title_en_US"));
 	}
 
 	protected void assertFieldValues(


### PR DESCRIPTION
Tested here: https://github.com/liferay-search/liferay-portal/pull/1057

https://liferay.atlassian.net/browse/LPS-195096

**Author**: @joshuacords
**Reviewer**: @gustavolimav

For all Assets, [AssetEntryDocumentContributor](https://github.com/liferay/liferay-portal/blob/3eb74d2174290686650931d7518263eef612dbfd/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/search/AssetEntryDocumentContributor.java#L111-L116) will add the necessary localized_title_[locale]_sortable fields, but because Layouts aren't assets and don't use Titles, they need to be responsible for adding the field themselves.