### PR TITLE
LPS-195823 Avoid repeatedly trying to re-add default admin user. When…

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -267,10 +267,27 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 				_addDemoSettings(company);
 			}
 
-			company = _checkCompany(
-				company, mx, defaultAdminPassword, defaultAdminScreenName,
-				defaultAdminEmailAddress, defaultAdminFirstName,
-				defaultAdminMiddleName, defaultAdminLastName, guestUser);
+			company = _checkCompany(company);
+
+			_userLocalService.addDefaultAdminUser(
+				company.getCompanyId(),
+				GetterUtil.getString(
+					defaultAdminPassword, PropsValues.DEFAULT_ADMIN_PASSWORD),
+				GetterUtil.getString(
+					defaultAdminScreenName,
+					PropsValues.DEFAULT_ADMIN_SCREEN_NAME),
+				GetterUtil.getString(
+					defaultAdminEmailAddress,
+					PropsValues.DEFAULT_ADMIN_EMAIL_ADDRESS_PREFIX + "@" + mx),
+				guestUser.getLocale(),
+				GetterUtil.getString(
+					defaultAdminFirstName,
+					PropsValues.DEFAULT_ADMIN_FIRST_NAME),
+				GetterUtil.getString(
+					defaultAdminMiddleName,
+					PropsValues.DEFAULT_ADMIN_MIDDLE_NAME),
+				GetterUtil.getString(
+					defaultAdminLastName, PropsValues.DEFAULT_ADMIN_LAST_NAME));
 
 			// Guest user must have the Guest role
 
@@ -311,32 +328,9 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 	 */
 	@Override
 	public Company checkCompany(String webId) throws PortalException {
-		String mx = webId;
-
-		return checkCompany(webId, mx);
-	}
-
-	/**
-	 * Returns the company with the web domain and mail domain.
-	 *
-	 * The method goes through a series of checks to ensure that the company
-	 * contains default users, groups, etc.
-	 *
-	 * @param  webId the company's web domain
-	 * @param  mx the company's mail domain
-	 * @return the company with the web domain and mail domain
-	 */
-	@Override
-	public Company checkCompany(String webId, String mx)
-		throws PortalException {
-
 		Company company = getCompanyByWebId(webId);
 
-		User guestUser = _userPersistence.fetchByC_T_First(
-			company.getCompanyId(), UserConstants.TYPE_GUEST, null);
-
-		return _checkCompany(
-			company, mx, null, null, null, null, null, null, guestUser);
+		return _checkCompany(company);
 	}
 
 	/**
@@ -1925,13 +1919,7 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 		return guestUser;
 	}
 
-	private Company _checkCompany(
-			Company company, String mx, String defaultAdminPassword,
-			String defaultAdminScreenName, String defaultAdminEmailAddress,
-			String defaultAdminFirstName, String defaultAdminMiddleName,
-			String defaultAdminLastName, User guestUser)
-		throws PortalException {
-
+	private Company _checkCompany(Company company) throws PortalException {
 		Locale localeThreadLocalDefaultLocale =
 			LocaleThreadLocal.getDefaultLocale();
 		Locale localeThreadSiteDefaultLocale =
@@ -1967,35 +1955,6 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 
 			_passwordPolicyLocalService.checkDefaultPasswordPolicy(
 				company.getCompanyId());
-
-			// Default admin
-
-			if (_userPersistence.countByCompanyId(company.getCompanyId()) ==
-					0) {
-
-				_userLocalService.addDefaultAdminUser(
-					company.getCompanyId(),
-					GetterUtil.getString(
-						defaultAdminPassword,
-						PropsValues.DEFAULT_ADMIN_PASSWORD),
-					GetterUtil.getString(
-						defaultAdminScreenName,
-						PropsValues.DEFAULT_ADMIN_SCREEN_NAME),
-					GetterUtil.getString(
-						defaultAdminEmailAddress,
-						PropsValues.DEFAULT_ADMIN_EMAIL_ADDRESS_PREFIX + "@" +
-							mx),
-					guestUser.getLocale(),
-					GetterUtil.getString(
-						defaultAdminFirstName,
-						PropsValues.DEFAULT_ADMIN_FIRST_NAME),
-					GetterUtil.getString(
-						defaultAdminMiddleName,
-						PropsValues.DEFAULT_ADMIN_MIDDLE_NAME),
-					GetterUtil.getString(
-						defaultAdminLastName,
-						PropsValues.DEFAULT_ADMIN_LAST_NAME));
-			}
 
 			// Portlets
 

--- a/portal-kernel/bnd.bnd
+++ b/portal-kernel/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 123.0.1
+Bundle-Version: 124.0.0
 Export-Package:\
 	!com.liferay.portal.kernel.internal.*,\
 	!com.liferay.portal.kernel.module.util,\

--- a/portal-kernel/src/com/liferay/portal/kernel/service/CompanyLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/CompanyLocalService.java
@@ -103,18 +103,6 @@ public interface CompanyLocalService
 	public Company checkCompany(String webId) throws PortalException;
 
 	/**
-	 * Returns the company with the web domain and mail domain.
-	 *
-	 * The method goes through a series of checks to ensure that the company
-	 * contains default users, groups, etc.
-	 *
-	 * @param webId the company's web domain
-	 * @param mx the company's mail domain
-	 * @return the company with the web domain and mail domain
-	 */
-	public Company checkCompany(String webId, String mx) throws PortalException;
-
-	/**
 	 * Checks if the company has an encryption key. It will create a key if one
 	 * does not exist.
 	 *

--- a/portal-kernel/src/com/liferay/portal/kernel/service/CompanyLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/CompanyLocalServiceUtil.java
@@ -93,22 +93,6 @@ public class CompanyLocalServiceUtil {
 	}
 
 	/**
-	 * Returns the company with the web domain and mail domain.
-	 *
-	 * The method goes through a series of checks to ensure that the company
-	 * contains default users, groups, etc.
-	 *
-	 * @param webId the company's web domain
-	 * @param mx the company's mail domain
-	 * @return the company with the web domain and mail domain
-	 */
-	public static Company checkCompany(String webId, String mx)
-		throws PortalException {
-
-		return getService().checkCompany(webId, mx);
-	}
-
-	/**
 	 * Checks if the company has an encryption key. It will create a key if one
 	 * does not exist.
 	 *

--- a/portal-kernel/src/com/liferay/portal/kernel/service/CompanyLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/CompanyLocalServiceWrapper.java
@@ -88,24 +88,6 @@ public class CompanyLocalServiceWrapper
 	}
 
 	/**
-	 * Returns the company with the web domain and mail domain.
-	 *
-	 * The method goes through a series of checks to ensure that the company
-	 * contains default users, groups, etc.
-	 *
-	 * @param webId the company's web domain
-	 * @param mx the company's mail domain
-	 * @return the company with the web domain and mail domain
-	 */
-	@Override
-	public com.liferay.portal.kernel.model.Company checkCompany(
-			String webId, String mx)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		return _companyLocalService.checkCompany(webId, mx);
-	}
-
-	/**
 	 * Checks if the company has an encryption key. It will create a key if one
 	 * does not exist.
 	 *

--- a/portal-kernel/src/com/liferay/portal/kernel/service/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/packageinfo
@@ -1,1 +1,1 @@
-version 25.2.0
+version 26.0.0


### PR DESCRIPTION
… the default admin is removed, it is an user decision. It should stay being deleted, rather than magically readded back on the next bootup.