### PR TITLE
LPS-195526 Avoid to unrelate elements in the UPSERT strategy when those elements were already related and must keep being related

### DIFF
--- a/modules/apps/account/account-api/bnd.bnd
+++ b/modules/apps/account/account-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Account API
 Bundle-SymbolicName: com.liferay.account.api
-Bundle-Version: 16.4.1
+Bundle-Version: 16.5.0
 Export-Package:\
 	com.liferay.account.configuration,\
 	com.liferay.account.constants,\

--- a/modules/apps/account/account-api/src/main/java/com/liferay/account/model/AccountEntryModel.java
+++ b/modules/apps/account/account-api/src/main/java/com/liferay/account/model/AccountEntryModel.java
@@ -7,6 +7,7 @@ package com.liferay.account.model;
 
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
 import com.liferay.portal.kernel.model.StagedAuditedModel;
@@ -29,8 +30,8 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface AccountEntryModel
-	extends BaseModel<AccountEntry>, MVCCModel, ShardedModel,
-			StagedAuditedModel, WorkflowedModel {
+	extends BaseModel<AccountEntry>, ExternalReferenceCodeModel, MVCCModel,
+			ShardedModel, StagedAuditedModel, WorkflowedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -91,6 +92,7 @@ public interface AccountEntryModel
 	 * @return the external reference code of this account entry
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -98,6 +100,7 @@ public interface AccountEntryModel
 	 *
 	 * @param externalReferenceCode the external reference code of this account entry
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/apps/account/account-api/src/main/java/com/liferay/account/model/AccountGroupModel.java
+++ b/modules/apps/account/account-api/src/main/java/com/liferay/account/model/AccountGroupModel.java
@@ -7,6 +7,7 @@ package com.liferay.account.model;
 
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
 import com.liferay.portal.kernel.model.StagedAuditedModel;
@@ -28,8 +29,8 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface AccountGroupModel
-	extends BaseModel<AccountGroup>, MVCCModel, ShardedModel,
-			StagedAuditedModel {
+	extends BaseModel<AccountGroup>, ExternalReferenceCodeModel, MVCCModel,
+			ShardedModel, StagedAuditedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -90,6 +91,7 @@ public interface AccountGroupModel
 	 * @return the external reference code of this account group
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -97,6 +99,7 @@ public interface AccountGroupModel
 	 *
 	 * @param externalReferenceCode the external reference code of this account group
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/apps/account/account-api/src/main/resources/com/liferay/account/model/packageinfo
+++ b/modules/apps/account/account-api/src/main/resources/com/liferay/account/model/packageinfo
@@ -1,1 +1,1 @@
-version 5.5.0
+version 5.6.0

--- a/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/model/BatchEngineExportTaskModel.java
+++ b/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/model/BatchEngineExportTaskModel.java
@@ -7,6 +7,7 @@ package com.liferay.batch.engine.model;
 
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
 import com.liferay.portal.kernel.model.StagedModel;
@@ -33,8 +34,8 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface BatchEngineExportTaskModel
-	extends BaseModel<BatchEngineExportTask>, MVCCModel, ShardedModel,
-			StagedModel {
+	extends BaseModel<BatchEngineExportTask>, ExternalReferenceCodeModel,
+			MVCCModel, ShardedModel, StagedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -95,6 +96,7 @@ public interface BatchEngineExportTaskModel
 	 * @return the external reference code of this batch engine export task
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -102,6 +104,7 @@ public interface BatchEngineExportTaskModel
 	 *
 	 * @param externalReferenceCode the external reference code of this batch engine export task
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/model/BatchEngineImportTaskModel.java
+++ b/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/model/BatchEngineImportTaskModel.java
@@ -7,6 +7,7 @@ package com.liferay.batch.engine.model;
 
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
 import com.liferay.portal.kernel.model.StagedModel;
@@ -33,8 +34,8 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface BatchEngineImportTaskModel
-	extends BaseModel<BatchEngineImportTask>, MVCCModel, ShardedModel,
-			StagedModel {
+	extends BaseModel<BatchEngineImportTask>, ExternalReferenceCodeModel,
+			MVCCModel, ShardedModel, StagedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -95,6 +96,7 @@ public interface BatchEngineImportTaskModel
 	 * @return the external reference code of this batch engine import task
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -102,6 +104,7 @@ public interface BatchEngineImportTaskModel
 	 *
 	 * @param externalReferenceCode the external reference code of this batch engine import task
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/apps/batch-engine/batch-engine-api/src/main/resources/com/liferay/batch/engine/model/packageinfo
+++ b/modules/apps/batch-engine/batch-engine-api/src/main/resources/com/liferay/batch/engine/model/packageinfo
@@ -1,1 +1,1 @@
-version 6.3.0
+version 6.4.0

--- a/modules/apps/blogs/blogs-api/bnd.bnd
+++ b/modules/apps/blogs/blogs-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Blogs API
 Bundle-SymbolicName: com.liferay.blogs.api
-Bundle-Version: 16.2.3
+Bundle-Version: 16.3.0
 Export-Package:\
 	com.liferay.blogs.configuration,\
 	com.liferay.blogs.configuration.definition,\

--- a/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/model/BlogsEntryModel.java
+++ b/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/model/BlogsEntryModel.java
@@ -7,6 +7,7 @@ package com.liferay.blogs.model;
 
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
 import com.liferay.portal.kernel.model.StagedGroupedModel;
@@ -31,7 +32,8 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface BlogsEntryModel
-	extends BaseModel<BlogsEntry>, CTModel<BlogsEntry>, MVCCModel, ShardedModel,
+	extends BaseModel<BlogsEntry>, CTModel<BlogsEntry>,
+			ExternalReferenceCodeModel, MVCCModel, ShardedModel,
 			StagedGroupedModel, TrashedModel, WorkflowedModel {
 
 	/*
@@ -111,6 +113,7 @@ public interface BlogsEntryModel
 	 * @return the external reference code of this blogs entry
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -118,6 +121,7 @@ public interface BlogsEntryModel
 	 *
 	 * @param externalReferenceCode the external reference code of this blogs entry
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/apps/blogs/blogs-api/src/main/resources/com/liferay/blogs/model/packageinfo
+++ b/modules/apps/blogs/blogs-api/src/main/resources/com/liferay/blogs/model/packageinfo
@@ -1,1 +1,1 @@
-version 7.0.0
+version 7.1.0

--- a/modules/apps/change-tracking/change-tracking-api/bnd.bnd
+++ b/modules/apps/change-tracking/change-tracking-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Change Tracking API
 Bundle-SymbolicName: com.liferay.change.tracking.api
-Bundle-Version: 20.0.1
+Bundle-Version: 20.1.0
 Export-Package:\
 	com.liferay.change.tracking.closure,\
 	com.liferay.change.tracking.configuration,\

--- a/modules/apps/change-tracking/change-tracking-api/src/main/java/com/liferay/change/tracking/model/CTCollectionModel.java
+++ b/modules/apps/change-tracking/change-tracking-api/src/main/java/com/liferay/change/tracking/model/CTCollectionModel.java
@@ -7,6 +7,7 @@ package com.liferay.change.tracking.model;
 
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
 import com.liferay.portal.kernel.model.StagedModel;
@@ -28,7 +29,8 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface CTCollectionModel
-	extends BaseModel<CTCollection>, MVCCModel, ShardedModel, StagedModel {
+	extends BaseModel<CTCollection>, ExternalReferenceCodeModel, MVCCModel,
+			ShardedModel, StagedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -89,6 +91,7 @@ public interface CTCollectionModel
 	 * @return the external reference code of this ct collection
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -96,6 +99,7 @@ public interface CTCollectionModel
 	 *
 	 * @param externalReferenceCode the external reference code of this ct collection
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/apps/change-tracking/change-tracking-api/src/main/resources/com/liferay/change/tracking/model/packageinfo
+++ b/modules/apps/change-tracking/change-tracking-api/src/main/resources/com/liferay/change/tracking/model/packageinfo
@@ -1,1 +1,1 @@
-version 3.6.0
+version 3.7.0

--- a/modules/apps/client-extension/client-extension-api/bnd.bnd
+++ b/modules/apps/client-extension/client-extension-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Client Extension API
 Bundle-SymbolicName: com.liferay.client.extension.api
-Bundle-Version: 10.0.2
+Bundle-Version: 10.1.0
 Export-Package:\
 	com.liferay.client.extension.constants,\
 	com.liferay.client.extension.exception,\

--- a/modules/apps/client-extension/client-extension-api/src/main/java/com/liferay/client/extension/model/ClientExtensionEntryModel.java
+++ b/modules/apps/client-extension/client-extension-api/src/main/java/com/liferay/client/extension/model/ClientExtensionEntryModel.java
@@ -9,6 +9,7 @@ import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.exception.LocaleException;
 import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.model.ContainerModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.LocalizedModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
@@ -36,8 +37,9 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface ClientExtensionEntryModel
 	extends BaseModel<ClientExtensionEntry>, ContainerModel,
-			CTModel<ClientExtensionEntry>, LocalizedModel, MVCCModel,
-			ShardedModel, StagedAuditedModel, WorkflowedModel {
+			CTModel<ClientExtensionEntry>, ExternalReferenceCodeModel,
+			LocalizedModel, MVCCModel, ShardedModel, StagedAuditedModel,
+			WorkflowedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -116,6 +118,7 @@ public interface ClientExtensionEntryModel
 	 * @return the external reference code of this client extension entry
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -123,6 +126,7 @@ public interface ClientExtensionEntryModel
 	 *
 	 * @param externalReferenceCode the external reference code of this client extension entry
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/apps/client-extension/client-extension-api/src/main/java/com/liferay/client/extension/model/ClientExtensionEntryRelModel.java
+++ b/modules/apps/client-extension/client-extension-api/src/main/java/com/liferay/client/extension/model/ClientExtensionEntryRelModel.java
@@ -9,6 +9,7 @@ import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.model.AttachedModel;
 import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.model.ContainerModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
 import com.liferay.portal.kernel.model.StagedGroupedModel;
@@ -32,8 +33,8 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface ClientExtensionEntryRelModel
 	extends AttachedModel, BaseModel<ClientExtensionEntryRel>, ContainerModel,
-			CTModel<ClientExtensionEntryRel>, MVCCModel, ShardedModel,
-			StagedGroupedModel {
+			CTModel<ClientExtensionEntryRel>, ExternalReferenceCodeModel,
+			MVCCModel, ShardedModel, StagedGroupedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -112,6 +113,7 @@ public interface ClientExtensionEntryRelModel
 	 * @return the external reference code of this client extension entry rel
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -119,6 +121,7 @@ public interface ClientExtensionEntryRelModel
 	 *
 	 * @param externalReferenceCode the external reference code of this client extension entry rel
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/apps/client-extension/client-extension-api/src/main/resources/com/liferay/client/extension/model/packageinfo
+++ b/modules/apps/client-extension/client-extension-api/src/main/resources/com/liferay/client/extension/model/packageinfo
@@ -1,1 +1,1 @@
-version 4.1.0
+version 4.2.0

--- a/modules/apps/commerce/commerce-api/bnd.bnd
+++ b/modules/apps/commerce/commerce-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Commerce API
 Bundle-SymbolicName: com.liferay.commerce.api
-Bundle-Version: 77.0.1
+Bundle-Version: 77.1.0
 Export-Package:\
 	com.liferay.commerce.address,\
 	com.liferay.commerce.checkout.helper,\

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/model/CommerceAddressModel.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/model/CommerceAddressModel.java
@@ -8,6 +8,7 @@ package com.liferay.commerce.model;
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.model.AttachedModel;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
@@ -29,8 +30,8 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface CommerceAddressModel
-	extends AttachedModel, BaseModel<CommerceAddress>, GroupedModel, MVCCModel,
-			ShardedModel {
+	extends AttachedModel, BaseModel<CommerceAddress>,
+			ExternalReferenceCodeModel, GroupedModel, MVCCModel, ShardedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -74,6 +75,7 @@ public interface CommerceAddressModel
 	 * @return the external reference code of this commerce address
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -81,6 +83,7 @@ public interface CommerceAddressModel
 	 *
 	 * @param externalReferenceCode the external reference code of this commerce address
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/model/CommerceOrderItemModel.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/model/CommerceOrderItemModel.java
@@ -8,6 +8,7 @@ package com.liferay.commerce.model;
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.exception.LocaleException;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.model.LocalizedModel;
 import com.liferay.portal.kernel.model.MVCCModel;
@@ -35,8 +36,9 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface CommerceOrderItemModel
-	extends BaseModel<CommerceOrderItem>, GroupedModel, LocalizedModel,
-			MVCCModel, ShardedModel, StagedAuditedModel {
+	extends BaseModel<CommerceOrderItem>, ExternalReferenceCodeModel,
+			GroupedModel, LocalizedModel, MVCCModel, ShardedModel,
+			StagedAuditedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -97,6 +99,7 @@ public interface CommerceOrderItemModel
 	 * @return the external reference code of this commerce order item
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -104,6 +107,7 @@ public interface CommerceOrderItemModel
 	 *
 	 * @param externalReferenceCode the external reference code of this commerce order item
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/model/CommerceOrderModel.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/model/CommerceOrderModel.java
@@ -7,6 +7,7 @@ package com.liferay.commerce.model;
 
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
@@ -32,8 +33,8 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface CommerceOrderModel
-	extends BaseModel<CommerceOrder>, GroupedModel, MVCCModel, ShardedModel,
-			StagedAuditedModel, WorkflowedModel {
+	extends BaseModel<CommerceOrder>, ExternalReferenceCodeModel, GroupedModel,
+			MVCCModel, ShardedModel, StagedAuditedModel, WorkflowedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -94,6 +95,7 @@ public interface CommerceOrderModel
 	 * @return the external reference code of this commerce order
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -101,6 +103,7 @@ public interface CommerceOrderModel
 	 *
 	 * @param externalReferenceCode the external reference code of this commerce order
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/model/CommerceOrderNoteModel.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/model/CommerceOrderNoteModel.java
@@ -7,6 +7,7 @@ package com.liferay.commerce.model;
 
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
@@ -29,8 +30,8 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface CommerceOrderNoteModel
-	extends BaseModel<CommerceOrderNote>, GroupedModel, MVCCModel, ShardedModel,
-			StagedAuditedModel {
+	extends BaseModel<CommerceOrderNote>, ExternalReferenceCodeModel,
+			GroupedModel, MVCCModel, ShardedModel, StagedAuditedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -91,6 +92,7 @@ public interface CommerceOrderNoteModel
 	 * @return the external reference code of this commerce order note
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -98,6 +100,7 @@ public interface CommerceOrderNoteModel
 	 *
 	 * @param externalReferenceCode the external reference code of this commerce order note
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/model/CommerceOrderTypeModel.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/model/CommerceOrderTypeModel.java
@@ -8,6 +8,7 @@ package com.liferay.commerce.model;
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.exception.LocaleException;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.LocalizedModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
@@ -33,8 +34,9 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface CommerceOrderTypeModel
-	extends BaseModel<CommerceOrderType>, LocalizedModel, MVCCModel,
-			ShardedModel, StagedAuditedModel, WorkflowedModel {
+	extends BaseModel<CommerceOrderType>, ExternalReferenceCodeModel,
+			LocalizedModel, MVCCModel, ShardedModel, StagedAuditedModel,
+			WorkflowedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -95,6 +97,7 @@ public interface CommerceOrderTypeModel
 	 * @return the external reference code of this commerce order type
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -102,6 +105,7 @@ public interface CommerceOrderTypeModel
 	 *
 	 * @param externalReferenceCode the external reference code of this commerce order type
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/model/CommerceOrderTypeRelModel.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/model/CommerceOrderTypeRelModel.java
@@ -8,6 +8,7 @@ package com.liferay.commerce.model;
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.model.AttachedModel;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
 import com.liferay.portal.kernel.model.StagedAuditedModel;
@@ -29,8 +30,9 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface CommerceOrderTypeRelModel
-	extends AttachedModel, BaseModel<CommerceOrderTypeRel>, MVCCModel,
-			ShardedModel, StagedAuditedModel {
+	extends AttachedModel, BaseModel<CommerceOrderTypeRel>,
+			ExternalReferenceCodeModel, MVCCModel, ShardedModel,
+			StagedAuditedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -91,6 +93,7 @@ public interface CommerceOrderTypeRelModel
 	 * @return the external reference code of this commerce order type rel
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -98,6 +101,7 @@ public interface CommerceOrderTypeRelModel
 	 *
 	 * @param externalReferenceCode the external reference code of this commerce order type rel
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/model/CommerceShipmentItemModel.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/model/CommerceShipmentItemModel.java
@@ -7,6 +7,7 @@ package com.liferay.commerce.model;
 
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
@@ -31,8 +32,8 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface CommerceShipmentItemModel
-	extends BaseModel<CommerceShipmentItem>, GroupedModel, MVCCModel,
-			ShardedModel, StagedAuditedModel {
+	extends BaseModel<CommerceShipmentItem>, ExternalReferenceCodeModel,
+			GroupedModel, MVCCModel, ShardedModel, StagedAuditedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -93,6 +94,7 @@ public interface CommerceShipmentItemModel
 	 * @return the external reference code of this commerce shipment item
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -100,6 +102,7 @@ public interface CommerceShipmentItemModel
 	 *
 	 * @param externalReferenceCode the external reference code of this commerce shipment item
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/model/CommerceShipmentModel.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/model/CommerceShipmentModel.java
@@ -7,6 +7,7 @@ package com.liferay.commerce.model;
 
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
@@ -29,8 +30,8 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface CommerceShipmentModel
-	extends BaseModel<CommerceShipment>, GroupedModel, MVCCModel, ShardedModel,
-			StagedAuditedModel {
+	extends BaseModel<CommerceShipment>, ExternalReferenceCodeModel,
+			GroupedModel, MVCCModel, ShardedModel, StagedAuditedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -91,6 +92,7 @@ public interface CommerceShipmentModel
 	 * @return the external reference code of this commerce shipment
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -98,6 +100,7 @@ public interface CommerceShipmentModel
 	 *
 	 * @param externalReferenceCode the external reference code of this commerce shipment
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/apps/commerce/commerce-api/src/main/resources/com/liferay/commerce/model/packageinfo
+++ b/modules/apps/commerce/commerce-api/src/main/resources/com/liferay/commerce/model/packageinfo
@@ -1,1 +1,1 @@
-version 18.0.0
+version 18.1.0

--- a/modules/apps/commerce/commerce-discount-api/bnd.bnd
+++ b/modules/apps/commerce/commerce-discount-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Commerce Discount API
 Bundle-SymbolicName: com.liferay.commerce.discount.api
-Bundle-Version: 18.0.1
+Bundle-Version: 18.1.0
 Export-Package:\
 	com.liferay.commerce.discount.application.strategy,\
 	com.liferay.commerce.discount.configuration,\

--- a/modules/apps/commerce/commerce-discount-api/src/main/java/com/liferay/commerce/discount/model/CommerceDiscountModel.java
+++ b/modules/apps/commerce/commerce-discount-api/src/main/java/com/liferay/commerce/discount/model/CommerceDiscountModel.java
@@ -7,6 +7,7 @@ package com.liferay.commerce.discount.model;
 
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
 import com.liferay.portal.kernel.model.StagedAuditedModel;
@@ -31,8 +32,8 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface CommerceDiscountModel
-	extends BaseModel<CommerceDiscount>, MVCCModel, ShardedModel,
-			StagedAuditedModel, WorkflowedModel {
+	extends BaseModel<CommerceDiscount>, ExternalReferenceCodeModel, MVCCModel,
+			ShardedModel, StagedAuditedModel, WorkflowedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -93,6 +94,7 @@ public interface CommerceDiscountModel
 	 * @return the external reference code of this commerce discount
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -100,6 +102,7 @@ public interface CommerceDiscountModel
 	 *
 	 * @param externalReferenceCode the external reference code of this commerce discount
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/apps/commerce/commerce-discount-api/src/main/resources/com/liferay/commerce/discount/model/packageinfo
+++ b/modules/apps/commerce/commerce-discount-api/src/main/resources/com/liferay/commerce/discount/model/packageinfo
@@ -1,1 +1,1 @@
-version 6.0.0
+version 6.1.0

--- a/modules/apps/commerce/commerce-inventory-api/src/main/java/com/liferay/commerce/inventory/model/CommerceInventoryReplenishmentItemModel.java
+++ b/modules/apps/commerce/commerce-inventory-api/src/main/java/com/liferay/commerce/inventory/model/CommerceInventoryReplenishmentItemModel.java
@@ -7,6 +7,7 @@ package com.liferay.commerce.inventory.model;
 
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
 import com.liferay.portal.kernel.model.StagedAuditedModel;
@@ -30,8 +31,9 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface CommerceInventoryReplenishmentItemModel
-	extends BaseModel<CommerceInventoryReplenishmentItem>, MVCCModel,
-			ShardedModel, StagedAuditedModel {
+	extends BaseModel<CommerceInventoryReplenishmentItem>,
+			ExternalReferenceCodeModel, MVCCModel, ShardedModel,
+			StagedAuditedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -92,6 +94,7 @@ public interface CommerceInventoryReplenishmentItemModel
 	 * @return the external reference code of this commerce inventory replenishment item
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -99,6 +102,7 @@ public interface CommerceInventoryReplenishmentItemModel
 	 *
 	 * @param externalReferenceCode the external reference code of this commerce inventory replenishment item
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/apps/commerce/commerce-inventory-api/src/main/java/com/liferay/commerce/inventory/model/CommerceInventoryWarehouseItemModel.java
+++ b/modules/apps/commerce/commerce-inventory-api/src/main/java/com/liferay/commerce/inventory/model/CommerceInventoryWarehouseItemModel.java
@@ -7,6 +7,7 @@ package com.liferay.commerce.inventory.model;
 
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
 import com.liferay.portal.kernel.model.StagedAuditedModel;
@@ -30,7 +31,8 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface CommerceInventoryWarehouseItemModel
-	extends BaseModel<CommerceInventoryWarehouseItem>, MVCCModel, ShardedModel,
+	extends BaseModel<CommerceInventoryWarehouseItem>,
+			ExternalReferenceCodeModel, MVCCModel, ShardedModel,
 			StagedAuditedModel {
 
 	/*
@@ -92,6 +94,7 @@ public interface CommerceInventoryWarehouseItemModel
 	 * @return the external reference code of this commerce inventory warehouse item
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -99,6 +102,7 @@ public interface CommerceInventoryWarehouseItemModel
 	 *
 	 * @param externalReferenceCode the external reference code of this commerce inventory warehouse item
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/apps/commerce/commerce-inventory-api/src/main/java/com/liferay/commerce/inventory/model/CommerceInventoryWarehouseModel.java
+++ b/modules/apps/commerce/commerce-inventory-api/src/main/java/com/liferay/commerce/inventory/model/CommerceInventoryWarehouseModel.java
@@ -8,6 +8,7 @@ package com.liferay.commerce.inventory.model;
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.exception.LocaleException;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.LocalizedModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
@@ -32,8 +33,8 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface CommerceInventoryWarehouseModel
-	extends BaseModel<CommerceInventoryWarehouse>, LocalizedModel, MVCCModel,
-			ShardedModel, StagedAuditedModel {
+	extends BaseModel<CommerceInventoryWarehouse>, ExternalReferenceCodeModel,
+			LocalizedModel, MVCCModel, ShardedModel, StagedAuditedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -94,6 +95,7 @@ public interface CommerceInventoryWarehouseModel
 	 * @return the external reference code of this commerce inventory warehouse
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -101,6 +103,7 @@ public interface CommerceInventoryWarehouseModel
 	 *
 	 * @param externalReferenceCode the external reference code of this commerce inventory warehouse
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/apps/commerce/commerce-order-rule-api/bnd.bnd
+++ b/modules/apps/commerce/commerce-order-rule-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Commerce Order Rule API
 Bundle-SymbolicName: com.liferay.commerce.order.rule.api
-Bundle-Version: 7.2.2
+Bundle-Version: 7.3.0
 Export-Package:\
 	com.liferay.commerce.order.rule.configuration,\
 	com.liferay.commerce.order.rule.constants,\

--- a/modules/apps/commerce/commerce-order-rule-api/src/main/java/com/liferay/commerce/order/rule/model/COREntryModel.java
+++ b/modules/apps/commerce/commerce-order-rule-api/src/main/java/com/liferay/commerce/order/rule/model/COREntryModel.java
@@ -7,6 +7,7 @@ package com.liferay.commerce.order.rule.model;
 
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
 import com.liferay.portal.kernel.model.StagedAuditedModel;
@@ -29,8 +30,8 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface COREntryModel
-	extends BaseModel<COREntry>, MVCCModel, ShardedModel, StagedAuditedModel,
-			WorkflowedModel {
+	extends BaseModel<COREntry>, ExternalReferenceCodeModel, MVCCModel,
+			ShardedModel, StagedAuditedModel, WorkflowedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -91,6 +92,7 @@ public interface COREntryModel
 	 * @return the external reference code of this cor entry
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -98,6 +100,7 @@ public interface COREntryModel
 	 *
 	 * @param externalReferenceCode the external reference code of this cor entry
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/apps/commerce/commerce-order-rule-api/src/main/resources/com/liferay/commerce/order/rule/model/packageinfo
+++ b/modules/apps/commerce/commerce-order-rule-api/src/main/resources/com/liferay/commerce/order/rule/model/packageinfo
@@ -1,1 +1,1 @@
-version 4.1.0
+version 4.2.0

--- a/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/model/CommercePriceEntryModel.java
+++ b/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/model/CommercePriceEntryModel.java
@@ -7,6 +7,7 @@ package com.liferay.commerce.price.list.model;
 
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
 import com.liferay.portal.kernel.model.StagedAuditedModel;
@@ -33,7 +34,8 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface CommercePriceEntryModel
 	extends BaseModel<CommercePriceEntry>, CTModel<CommercePriceEntry>,
-			MVCCModel, ShardedModel, StagedAuditedModel, WorkflowedModel {
+			ExternalReferenceCodeModel, MVCCModel, ShardedModel,
+			StagedAuditedModel, WorkflowedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -112,6 +114,7 @@ public interface CommercePriceEntryModel
 	 * @return the external reference code of this commerce price entry
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -119,6 +122,7 @@ public interface CommercePriceEntryModel
 	 *
 	 * @param externalReferenceCode the external reference code of this commerce price entry
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/model/CommercePriceListModel.java
+++ b/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/model/CommercePriceListModel.java
@@ -7,6 +7,7 @@ package com.liferay.commerce.price.list.model;
 
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
 import com.liferay.portal.kernel.model.StagedGroupedModel;
@@ -30,8 +31,9 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface CommercePriceListModel
-	extends BaseModel<CommercePriceList>, CTModel<CommercePriceList>, MVCCModel,
-			ShardedModel, StagedGroupedModel, WorkflowedModel {
+	extends BaseModel<CommercePriceList>, CTModel<CommercePriceList>,
+			ExternalReferenceCodeModel, MVCCModel, ShardedModel,
+			StagedGroupedModel, WorkflowedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -110,6 +112,7 @@ public interface CommercePriceListModel
 	 * @return the external reference code of this commerce price list
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -117,6 +120,7 @@ public interface CommercePriceListModel
 	 *
 	 * @param externalReferenceCode the external reference code of this commerce price list
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/model/CommerceTierPriceEntryModel.java
+++ b/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/model/CommerceTierPriceEntryModel.java
@@ -7,6 +7,7 @@ package com.liferay.commerce.price.list.model;
 
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
 import com.liferay.portal.kernel.model.StagedAuditedModel;
@@ -33,7 +34,8 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface CommerceTierPriceEntryModel
 	extends BaseModel<CommerceTierPriceEntry>, CTModel<CommerceTierPriceEntry>,
-			MVCCModel, ShardedModel, StagedAuditedModel, WorkflowedModel {
+			ExternalReferenceCodeModel, MVCCModel, ShardedModel,
+			StagedAuditedModel, WorkflowedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -112,6 +114,7 @@ public interface CommerceTierPriceEntryModel
 	 * @return the external reference code of this commerce tier price entry
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -119,6 +122,7 @@ public interface CommerceTierPriceEntryModel
 	 *
 	 * @param externalReferenceCode the external reference code of this commerce tier price entry
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/apps/commerce/commerce-pricing-api/bnd.bnd
+++ b/modules/apps/commerce/commerce-pricing-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Commerce Pricing API
 Bundle-SymbolicName: com.liferay.commerce.pricing.api
-Bundle-Version: 14.2.2
+Bundle-Version: 14.3.0
 Export-Package:\
 	com.liferay.commerce.pricing.configuration,\
 	com.liferay.commerce.pricing.constants,\

--- a/modules/apps/commerce/commerce-pricing-api/src/main/java/com/liferay/commerce/pricing/model/CommercePriceModifierModel.java
+++ b/modules/apps/commerce/commerce-pricing-api/src/main/java/com/liferay/commerce/pricing/model/CommercePriceModifierModel.java
@@ -7,6 +7,7 @@ package com.liferay.commerce.pricing.model;
 
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
 import com.liferay.portal.kernel.model.StagedGroupedModel;
@@ -33,7 +34,8 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface CommercePriceModifierModel
 	extends BaseModel<CommercePriceModifier>, CTModel<CommercePriceModifier>,
-			MVCCModel, ShardedModel, StagedGroupedModel, WorkflowedModel {
+			ExternalReferenceCodeModel, MVCCModel, ShardedModel,
+			StagedGroupedModel, WorkflowedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -112,6 +114,7 @@ public interface CommercePriceModifierModel
 	 * @return the external reference code of this commerce price modifier
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -119,6 +122,7 @@ public interface CommercePriceModifierModel
 	 *
 	 * @param externalReferenceCode the external reference code of this commerce price modifier
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/apps/commerce/commerce-pricing-api/src/main/java/com/liferay/commerce/pricing/model/CommercePricingClassModel.java
+++ b/modules/apps/commerce/commerce-pricing-api/src/main/java/com/liferay/commerce/pricing/model/CommercePricingClassModel.java
@@ -8,6 +8,7 @@ package com.liferay.commerce.pricing.model;
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.exception.LocaleException;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.LocalizedModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
@@ -34,7 +35,8 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface CommercePricingClassModel
 	extends BaseModel<CommercePricingClass>, CTModel<CommercePricingClass>,
-			LocalizedModel, MVCCModel, ShardedModel, StagedAuditedModel {
+			ExternalReferenceCodeModel, LocalizedModel, MVCCModel, ShardedModel,
+			StagedAuditedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -113,6 +115,7 @@ public interface CommercePricingClassModel
 	 * @return the external reference code of this commerce pricing class
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -120,6 +123,7 @@ public interface CommercePricingClassModel
 	 *
 	 * @param externalReferenceCode the external reference code of this commerce pricing class
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/apps/commerce/commerce-pricing-api/src/main/resources/com/liferay/commerce/pricing/model/packageinfo
+++ b/modules/apps/commerce/commerce-pricing-api/src/main/resources/com/liferay/commerce/pricing/model/packageinfo
@@ -1,1 +1,1 @@
-version 4.2.0
+version 4.3.0

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/model/CPAttachmentFileEntryModel.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/model/CPAttachmentFileEntryModel.java
@@ -9,6 +9,7 @@ import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.exception.LocaleException;
 import com.liferay.portal.kernel.model.AttachedModel;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.LocalizedModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
@@ -36,8 +37,9 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface CPAttachmentFileEntryModel
 	extends AttachedModel, BaseModel<CPAttachmentFileEntry>,
-			CTModel<CPAttachmentFileEntry>, LocalizedModel, MVCCModel,
-			ShardedModel, StagedGroupedModel, WorkflowedModel {
+			CTModel<CPAttachmentFileEntry>, ExternalReferenceCodeModel,
+			LocalizedModel, MVCCModel, ShardedModel, StagedGroupedModel,
+			WorkflowedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -116,6 +118,7 @@ public interface CPAttachmentFileEntryModel
 	 * @return the external reference code of this cp attachment file entry
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -123,6 +126,7 @@ public interface CPAttachmentFileEntryModel
 	 *
 	 * @param externalReferenceCode the external reference code of this cp attachment file entry
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/model/CPInstanceModel.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/model/CPInstanceModel.java
@@ -7,6 +7,7 @@ package com.liferay.commerce.product.model;
 
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
 import com.liferay.portal.kernel.model.StagedGroupedModel;
@@ -32,7 +33,8 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface CPInstanceModel
-	extends BaseModel<CPInstance>, CTModel<CPInstance>, MVCCModel, ShardedModel,
+	extends BaseModel<CPInstance>, CTModel<CPInstance>,
+			ExternalReferenceCodeModel, MVCCModel, ShardedModel,
 			StagedGroupedModel, WorkflowedModel {
 
 	/*
@@ -112,6 +114,7 @@ public interface CPInstanceModel
 	 * @return the external reference code of this cp instance
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -119,6 +122,7 @@ public interface CPInstanceModel
 	 *
 	 * @param externalReferenceCode the external reference code of this cp instance
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/model/CPMeasurementUnitModel.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/model/CPMeasurementUnitModel.java
@@ -8,6 +8,7 @@ package com.liferay.commerce.product.model;
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.exception.LocaleException;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.LocalizedModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
@@ -34,7 +35,8 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface CPMeasurementUnitModel
 	extends BaseModel<CPMeasurementUnit>, CTModel<CPMeasurementUnit>,
-			LocalizedModel, MVCCModel, ShardedModel, StagedGroupedModel {
+			ExternalReferenceCodeModel, LocalizedModel, MVCCModel, ShardedModel,
+			StagedGroupedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -113,6 +115,7 @@ public interface CPMeasurementUnitModel
 	 * @return the external reference code of this cp measurement unit
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -120,6 +123,7 @@ public interface CPMeasurementUnitModel
 	 *
 	 * @param externalReferenceCode the external reference code of this cp measurement unit
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/model/CPOptionModel.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/model/CPOptionModel.java
@@ -8,6 +8,7 @@ package com.liferay.commerce.product.model;
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.exception.LocaleException;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.LocalizedModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
@@ -33,8 +34,8 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface CPOptionModel
-	extends BaseModel<CPOption>, CTModel<CPOption>, LocalizedModel, MVCCModel,
-			ShardedModel, StagedAuditedModel {
+	extends BaseModel<CPOption>, CTModel<CPOption>, ExternalReferenceCodeModel,
+			LocalizedModel, MVCCModel, ShardedModel, StagedAuditedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -113,6 +114,7 @@ public interface CPOptionModel
 	 * @return the external reference code of this cp option
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -120,6 +122,7 @@ public interface CPOptionModel
 	 *
 	 * @param externalReferenceCode the external reference code of this cp option
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/model/CPOptionValueModel.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/model/CPOptionValueModel.java
@@ -8,6 +8,7 @@ package com.liferay.commerce.product.model;
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.exception.LocaleException;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.LocalizedModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
@@ -33,8 +34,9 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface CPOptionValueModel
-	extends BaseModel<CPOptionValue>, CTModel<CPOptionValue>, LocalizedModel,
-			MVCCModel, ShardedModel, StagedAuditedModel {
+	extends BaseModel<CPOptionValue>, CTModel<CPOptionValue>,
+			ExternalReferenceCodeModel, LocalizedModel, MVCCModel, ShardedModel,
+			StagedAuditedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -113,6 +115,7 @@ public interface CPOptionValueModel
 	 * @return the external reference code of this cp option value
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -120,6 +123,7 @@ public interface CPOptionValueModel
 	 *
 	 * @param externalReferenceCode the external reference code of this cp option value
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/model/CPTaxCategoryModel.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/model/CPTaxCategoryModel.java
@@ -8,6 +8,7 @@ package com.liferay.commerce.product.model;
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.exception.LocaleException;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.LocalizedModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
@@ -33,8 +34,9 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface CPTaxCategoryModel
-	extends BaseModel<CPTaxCategory>, CTModel<CPTaxCategory>, LocalizedModel,
-			MVCCModel, ShardedModel, StagedAuditedModel {
+	extends BaseModel<CPTaxCategory>, CTModel<CPTaxCategory>,
+			ExternalReferenceCodeModel, LocalizedModel, MVCCModel, ShardedModel,
+			StagedAuditedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -113,6 +115,7 @@ public interface CPTaxCategoryModel
 	 * @return the external reference code of this cp tax category
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -120,6 +123,7 @@ public interface CPTaxCategoryModel
 	 *
 	 * @param externalReferenceCode the external reference code of this cp tax category
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/model/CProductModel.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/model/CProductModel.java
@@ -7,6 +7,7 @@ package com.liferay.commerce.product.model;
 
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
@@ -30,8 +31,8 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface CProductModel
-	extends BaseModel<CProduct>, CTModel<CProduct>, GroupedModel, MVCCModel,
-			ShardedModel, StagedAuditedModel {
+	extends BaseModel<CProduct>, CTModel<CProduct>, ExternalReferenceCodeModel,
+			GroupedModel, MVCCModel, ShardedModel, StagedAuditedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -110,6 +111,7 @@ public interface CProductModel
 	 * @return the external reference code of this c product
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -117,6 +119,7 @@ public interface CProductModel
 	 *
 	 * @param externalReferenceCode the external reference code of this c product
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/model/CommerceCatalogModel.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/model/CommerceCatalogModel.java
@@ -7,6 +7,7 @@ package com.liferay.commerce.product.model;
 
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
 import com.liferay.portal.kernel.model.StagedAuditedModel;
@@ -29,8 +30,9 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface CommerceCatalogModel
-	extends BaseModel<CommerceCatalog>, CTModel<CommerceCatalog>, MVCCModel,
-			ShardedModel, StagedAuditedModel {
+	extends BaseModel<CommerceCatalog>, CTModel<CommerceCatalog>,
+			ExternalReferenceCodeModel, MVCCModel, ShardedModel,
+			StagedAuditedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -109,6 +111,7 @@ public interface CommerceCatalogModel
 	 * @return the external reference code of this commerce catalog
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -116,6 +119,7 @@ public interface CommerceCatalogModel
 	 *
 	 * @param externalReferenceCode the external reference code of this commerce catalog
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/model/CommerceChannelModel.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/model/CommerceChannelModel.java
@@ -7,6 +7,7 @@ package com.liferay.commerce.product.model;
 
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
 import com.liferay.portal.kernel.model.StagedAuditedModel;
@@ -29,8 +30,9 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface CommerceChannelModel
-	extends BaseModel<CommerceChannel>, CTModel<CommerceChannel>, MVCCModel,
-			ShardedModel, StagedAuditedModel {
+	extends BaseModel<CommerceChannel>, CTModel<CommerceChannel>,
+			ExternalReferenceCodeModel, MVCCModel, ShardedModel,
+			StagedAuditedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -109,6 +111,7 @@ public interface CommerceChannelModel
 	 * @return the external reference code of this commerce channel
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -116,6 +119,7 @@ public interface CommerceChannelModel
 	 *
 	 * @param externalReferenceCode the external reference code of this commerce channel
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/apps/commerce/commerce-term-api/bnd.bnd
+++ b/modules/apps/commerce/commerce-term-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Commerce Term API
 Bundle-SymbolicName: com.liferay.commerce.term.api
-Bundle-Version: 6.2.2
+Bundle-Version: 6.3.0
 Export-Package:\
 	com.liferay.commerce.term.configuration,\
 	com.liferay.commerce.term.constants,\

--- a/modules/apps/commerce/commerce-term-api/src/main/java/com/liferay/commerce/term/model/CommerceTermEntryModel.java
+++ b/modules/apps/commerce/commerce-term-api/src/main/java/com/liferay/commerce/term/model/CommerceTermEntryModel.java
@@ -7,6 +7,7 @@ package com.liferay.commerce.term.model;
 
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
 import com.liferay.portal.kernel.model.StagedAuditedModel;
@@ -30,8 +31,8 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface CommerceTermEntryModel
-	extends BaseModel<CommerceTermEntry>, MVCCModel, ShardedModel,
-			StagedAuditedModel, WorkflowedModel {
+	extends BaseModel<CommerceTermEntry>, ExternalReferenceCodeModel, MVCCModel,
+			ShardedModel, StagedAuditedModel, WorkflowedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -92,6 +93,7 @@ public interface CommerceTermEntryModel
 	 * @return the external reference code of this commerce term entry
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -99,6 +101,7 @@ public interface CommerceTermEntryModel
 	 *
 	 * @param externalReferenceCode the external reference code of this commerce term entry
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/apps/commerce/commerce-term-api/src/main/resources/com/liferay/commerce/term/model/packageinfo
+++ b/modules/apps/commerce/commerce-term-api/src/main/resources/com/liferay/commerce/term/model/packageinfo
@@ -1,1 +1,1 @@
-version 3.1.0
+version 3.2.0

--- a/modules/apps/dispatch/dispatch-api/bnd.bnd
+++ b/modules/apps/dispatch/dispatch-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Dispatch API
 Bundle-SymbolicName: com.liferay.dispatch.api
-Bundle-Version: 18.2.2
+Bundle-Version: 18.3.0
 Export-Package:\
 	com.liferay.dispatch.configuration,\
 	com.liferay.dispatch.constants,\

--- a/modules/apps/dispatch/dispatch-api/src/main/java/com/liferay/dispatch/model/DispatchTriggerModel.java
+++ b/modules/apps/dispatch/dispatch-api/src/main/java/com/liferay/dispatch/model/DispatchTriggerModel.java
@@ -7,6 +7,7 @@ package com.liferay.dispatch.model;
 
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
 import com.liferay.portal.kernel.model.StagedAuditedModel;
@@ -28,8 +29,8 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface DispatchTriggerModel
-	extends BaseModel<DispatchTrigger>, MVCCModel, ShardedModel,
-			StagedAuditedModel {
+	extends BaseModel<DispatchTrigger>, ExternalReferenceCodeModel, MVCCModel,
+			ShardedModel, StagedAuditedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -90,6 +91,7 @@ public interface DispatchTriggerModel
 	 * @return the external reference code of this dispatch trigger
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -97,6 +99,7 @@ public interface DispatchTriggerModel
 	 *
 	 * @param externalReferenceCode the external reference code of this dispatch trigger
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/apps/dispatch/dispatch-api/src/main/resources/com/liferay/dispatch/model/packageinfo
+++ b/modules/apps/dispatch/dispatch-api/src/main/resources/com/liferay/dispatch/model/packageinfo
@@ -1,1 +1,1 @@
-version 6.3.0
+version 6.4.0

--- a/modules/apps/journal/journal-api/bnd.bnd
+++ b/modules/apps/journal/journal-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Journal API
 Bundle-SymbolicName: com.liferay.journal.api
-Bundle-Version: 33.1.1
+Bundle-Version: 33.2.0
 Export-Package:\
 	com.liferay.journal.configuration,\
 	com.liferay.journal.constants,\

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/model/JournalArticleModel.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/model/JournalArticleModel.java
@@ -8,6 +8,7 @@ package com.liferay.journal.model;
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.model.AttachedModel;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ResourcedModel;
 import com.liferay.portal.kernel.model.ShardedModel;
@@ -34,8 +35,8 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface JournalArticleModel
 	extends AttachedModel, BaseModel<JournalArticle>, CTModel<JournalArticle>,
-			MVCCModel, ResourcedModel, ShardedModel, StagedGroupedModel,
-			TrashedModel, WorkflowedModel {
+			ExternalReferenceCodeModel, MVCCModel, ResourcedModel, ShardedModel,
+			StagedGroupedModel, TrashedModel, WorkflowedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -260,6 +261,7 @@ public interface JournalArticleModel
 	 * @return the external reference code of this journal article
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -267,6 +269,7 @@ public interface JournalArticleModel
 	 *
 	 * @param externalReferenceCode the external reference code of this journal article
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/model/JournalFolderModel.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/model/JournalFolderModel.java
@@ -8,6 +8,7 @@ package com.liferay.journal.model;
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.model.ContainerModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
 import com.liferay.portal.kernel.model.StagedGroupedModel;
@@ -33,8 +34,8 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface JournalFolderModel
 	extends BaseModel<JournalFolder>, ContainerModel, CTModel<JournalFolder>,
-			MVCCModel, ShardedModel, StagedGroupedModel, TrashedModel,
-			WorkflowedModel {
+			ExternalReferenceCodeModel, MVCCModel, ShardedModel,
+			StagedGroupedModel, TrashedModel, WorkflowedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -113,6 +114,7 @@ public interface JournalFolderModel
 	 * @return the external reference code of this journal folder
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -120,6 +122,7 @@ public interface JournalFolderModel
 	 *
 	 * @param externalReferenceCode the external reference code of this journal folder
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/apps/journal/journal-api/src/main/resources/com/liferay/journal/model/packageinfo
+++ b/modules/apps/journal/journal-api/src/main/resources/com/liferay/journal/model/packageinfo
@@ -1,1 +1,1 @@
-version 14.4.0
+version 14.5.0

--- a/modules/apps/knowledge-base/knowledge-base-api/bnd.bnd
+++ b/modules/apps/knowledge-base/knowledge-base-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Knowledge Base API
 Bundle-SymbolicName: com.liferay.knowledge.base.api
-Bundle-Version: 21.0.2
+Bundle-Version: 21.1.0
 Export-Package:\
 	com.liferay.knowledge.base.configuration,\
 	com.liferay.knowledge.base.constants,\

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/model/KBArticleModel.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/model/KBArticleModel.java
@@ -7,6 +7,7 @@ package com.liferay.knowledge.base.model;
 
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ResourcedModel;
 import com.liferay.portal.kernel.model.ShardedModel;
@@ -31,8 +32,9 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface KBArticleModel
-	extends BaseModel<KBArticle>, CTModel<KBArticle>, MVCCModel, ResourcedModel,
-			ShardedModel, StagedGroupedModel, WorkflowedModel {
+	extends BaseModel<KBArticle>, CTModel<KBArticle>,
+			ExternalReferenceCodeModel, MVCCModel, ResourcedModel, ShardedModel,
+			StagedGroupedModel, WorkflowedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -257,6 +259,7 @@ public interface KBArticleModel
 	 * @return the external reference code of this kb article
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -264,6 +267,7 @@ public interface KBArticleModel
 	 *
 	 * @param externalReferenceCode the external reference code of this kb article
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/model/KBFolderModel.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/model/KBFolderModel.java
@@ -7,6 +7,7 @@ package com.liferay.knowledge.base.model;
 
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
 import com.liferay.portal.kernel.model.StagedGroupedModel;
@@ -29,8 +30,8 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface KBFolderModel
-	extends BaseModel<KBFolder>, CTModel<KBFolder>, MVCCModel, ShardedModel,
-			StagedGroupedModel {
+	extends BaseModel<KBFolder>, CTModel<KBFolder>, ExternalReferenceCodeModel,
+			MVCCModel, ShardedModel, StagedGroupedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -109,6 +110,7 @@ public interface KBFolderModel
 	 * @return the external reference code of this kb folder
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -116,6 +118,7 @@ public interface KBFolderModel
 	 *
 	 * @param externalReferenceCode the external reference code of this kb folder
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/resources/com/liferay/knowledge/base/model/packageinfo
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/resources/com/liferay/knowledge/base/model/packageinfo
@@ -1,1 +1,1 @@
-version 4.5.0
+version 4.6.0

--- a/modules/apps/layout/layout-utility-page-api/bnd.bnd
+++ b/modules/apps/layout/layout-utility-page-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Layout Utility Page API
 Bundle-SymbolicName: com.liferay.layout.utility.page.api
-Bundle-Version: 7.2.2
+Bundle-Version: 7.3.0
 Export-Package:\
 	com.liferay.layout.utility.page.constants,\
 	com.liferay.layout.utility.page.converter,\

--- a/modules/apps/layout/layout-utility-page-api/src/main/java/com/liferay/layout/utility/page/model/LayoutUtilityPageEntryModel.java
+++ b/modules/apps/layout/layout-utility-page-api/src/main/java/com/liferay/layout/utility/page/model/LayoutUtilityPageEntryModel.java
@@ -7,6 +7,7 @@ package com.liferay.layout.utility.page.model;
 
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
 import com.liferay.portal.kernel.model.StagedGroupedModel;
@@ -30,7 +31,8 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface LayoutUtilityPageEntryModel
 	extends BaseModel<LayoutUtilityPageEntry>, CTModel<LayoutUtilityPageEntry>,
-			MVCCModel, ShardedModel, StagedGroupedModel {
+			ExternalReferenceCodeModel, MVCCModel, ShardedModel,
+			StagedGroupedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -109,6 +111,7 @@ public interface LayoutUtilityPageEntryModel
 	 * @return the external reference code of this layout utility page entry
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -116,6 +119,7 @@ public interface LayoutUtilityPageEntryModel
 	 *
 	 * @param externalReferenceCode the external reference code of this layout utility page entry
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/apps/layout/layout-utility-page-api/src/main/resources/com/liferay/layout/utility/page/model/packageinfo
+++ b/modules/apps/layout/layout-utility-page-api/src/main/resources/com/liferay/layout/utility/page/model/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0

--- a/modules/apps/list-type/list-type-api/src/main/java/com/liferay/list/type/model/ListTypeDefinitionModel.java
+++ b/modules/apps/list-type/list-type-api/src/main/java/com/liferay/list/type/model/ListTypeDefinitionModel.java
@@ -8,6 +8,7 @@ package com.liferay.list.type.model;
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.exception.LocaleException;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.LocalizedModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
@@ -32,8 +33,8 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface ListTypeDefinitionModel
-	extends BaseModel<ListTypeDefinition>, LocalizedModel, MVCCModel,
-			ShardedModel, StagedAuditedModel {
+	extends BaseModel<ListTypeDefinition>, ExternalReferenceCodeModel,
+			LocalizedModel, MVCCModel, ShardedModel, StagedAuditedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -94,6 +95,7 @@ public interface ListTypeDefinitionModel
 	 * @return the external reference code of this list type definition
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -101,6 +103,7 @@ public interface ListTypeDefinitionModel
 	 *
 	 * @param externalReferenceCode the external reference code of this list type definition
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/apps/list-type/list-type-api/src/main/java/com/liferay/list/type/model/ListTypeEntryModel.java
+++ b/modules/apps/list-type/list-type-api/src/main/java/com/liferay/list/type/model/ListTypeEntryModel.java
@@ -8,6 +8,7 @@ package com.liferay.list.type.model;
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.exception.LocaleException;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.LocalizedModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
@@ -32,8 +33,8 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface ListTypeEntryModel
-	extends BaseModel<ListTypeEntry>, LocalizedModel, MVCCModel, ShardedModel,
-			StagedAuditedModel {
+	extends BaseModel<ListTypeEntry>, ExternalReferenceCodeModel,
+			LocalizedModel, MVCCModel, ShardedModel, StagedAuditedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -94,6 +95,7 @@ public interface ListTypeEntryModel
 	 * @return the external reference code of this list type entry
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -101,6 +103,7 @@ public interface ListTypeEntryModel
 	 *
 	 * @param externalReferenceCode the external reference code of this list type entry
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/apps/message-boards/message-boards-api/bnd.bnd
+++ b/modules/apps/message-boards/message-boards-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Message Boards API
 Bundle-SymbolicName: com.liferay.message.boards.api
-Bundle-Version: 23.1.1
+Bundle-Version: 23.2.0
 Export-Package:\
 	com.liferay.message.boards.configuration,\
 	com.liferay.message.boards.constants,\

--- a/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/model/MBMessageModel.java
+++ b/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/model/MBMessageModel.java
@@ -8,6 +8,7 @@ package com.liferay.message.boards.model;
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.model.AttachedModel;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
 import com.liferay.portal.kernel.model.StagedGroupedModel;
@@ -32,8 +33,9 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface MBMessageModel
-	extends AttachedModel, BaseModel<MBMessage>, CTModel<MBMessage>, MVCCModel,
-			ShardedModel, StagedGroupedModel, TrashedModel, WorkflowedModel {
+	extends AttachedModel, BaseModel<MBMessage>, CTModel<MBMessage>,
+			ExternalReferenceCodeModel, MVCCModel, ShardedModel,
+			StagedGroupedModel, TrashedModel, WorkflowedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -112,6 +114,7 @@ public interface MBMessageModel
 	 * @return the external reference code of this message-boards message
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -119,6 +122,7 @@ public interface MBMessageModel
 	 *
 	 * @param externalReferenceCode the external reference code of this message-boards message
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/apps/message-boards/message-boards-api/src/main/resources/com/liferay/message/boards/model/packageinfo
+++ b/modules/apps/message-boards/message-boards-api/src/main/resources/com/liferay/message/boards/model/packageinfo
@@ -1,1 +1,1 @@
-version 10.2.0
+version 10.3.0

--- a/modules/apps/notification/notification-api/bnd.bnd
+++ b/modules/apps/notification/notification-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Notification API
 Bundle-SymbolicName: com.liferay.notification.api
-Bundle-Version: 15.2.1
+Bundle-Version: 15.3.0
 Export-Package:\
 	com.liferay.notification.constants,\
 	com.liferay.notification.context,\

--- a/modules/apps/notification/notification-api/src/main/java/com/liferay/notification/model/NotificationTemplateModel.java
+++ b/modules/apps/notification/notification-api/src/main/java/com/liferay/notification/model/NotificationTemplateModel.java
@@ -8,6 +8,7 @@ package com.liferay.notification.model;
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.exception.LocaleException;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.LocalizedModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
@@ -32,8 +33,8 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface NotificationTemplateModel
-	extends BaseModel<NotificationTemplate>, LocalizedModel, MVCCModel,
-			ShardedModel, StagedAuditedModel {
+	extends BaseModel<NotificationTemplate>, ExternalReferenceCodeModel,
+			LocalizedModel, MVCCModel, ShardedModel, StagedAuditedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -94,6 +95,7 @@ public interface NotificationTemplateModel
 	 * @return the external reference code of this notification template
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -101,6 +103,7 @@ public interface NotificationTemplateModel
 	 *
 	 * @param externalReferenceCode the external reference code of this notification template
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/apps/notification/notification-api/src/main/resources/com/liferay/notification/model/packageinfo
+++ b/modules/apps/notification/notification-api/src/main/resources/com/liferay/notification/model/packageinfo
@@ -1,1 +1,1 @@
-version 4.2.0
+version 4.3.0

--- a/modules/apps/oauth2-provider/oauth2-provider-api/bnd.bnd
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay OAuth2 Provider API
 Bundle-SymbolicName: com.liferay.oauth2.provider.api
-Bundle-Version: 14.0.2
+Bundle-Version: 14.1.0
 Export-Package:\
 	com.liferay.oauth2.provider.configuration,\
 	com.liferay.oauth2.provider.constants,\

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/model/OAuth2ApplicationModel.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/model/OAuth2ApplicationModel.java
@@ -7,6 +7,7 @@ package com.liferay.oauth2.provider.model;
 
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.ShardedModel;
 import com.liferay.portal.kernel.model.StagedAuditedModel;
 
@@ -27,7 +28,8 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface OAuth2ApplicationModel
-	extends BaseModel<OAuth2Application>, ShardedModel, StagedAuditedModel {
+	extends BaseModel<OAuth2Application>, ExternalReferenceCodeModel,
+			ShardedModel, StagedAuditedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -72,6 +74,7 @@ public interface OAuth2ApplicationModel
 	 * @return the external reference code of this o auth2 application
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -79,6 +82,7 @@ public interface OAuth2ApplicationModel
 	 *
 	 * @param externalReferenceCode the external reference code of this o auth2 application
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/resources/com/liferay/oauth2/provider/model/packageinfo
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/resources/com/liferay/oauth2/provider/model/packageinfo
@@ -1,1 +1,1 @@
-version 4.1.0
+version 4.2.0

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectActionModel.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectActionModel.java
@@ -8,6 +8,7 @@ package com.liferay.object.model;
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.exception.LocaleException;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.LocalizedModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
@@ -32,8 +33,8 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface ObjectActionModel
-	extends BaseModel<ObjectAction>, LocalizedModel, MVCCModel, ShardedModel,
-			StagedAuditedModel {
+	extends BaseModel<ObjectAction>, ExternalReferenceCodeModel, LocalizedModel,
+			MVCCModel, ShardedModel, StagedAuditedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -94,6 +95,7 @@ public interface ObjectActionModel
 	 * @return the external reference code of this object action
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -101,6 +103,7 @@ public interface ObjectActionModel
 	 *
 	 * @param externalReferenceCode the external reference code of this object action
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectDefinitionModel.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectDefinitionModel.java
@@ -8,6 +8,7 @@ package com.liferay.object.model;
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.exception.LocaleException;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.LocalizedModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
@@ -32,8 +33,8 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface ObjectDefinitionModel
-	extends BaseModel<ObjectDefinition>, LocalizedModel, MVCCModel,
-			ShardedModel, StagedAuditedModel {
+	extends BaseModel<ObjectDefinition>, ExternalReferenceCodeModel,
+			LocalizedModel, MVCCModel, ShardedModel, StagedAuditedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -94,6 +95,7 @@ public interface ObjectDefinitionModel
 	 * @return the external reference code of this object definition
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -101,6 +103,7 @@ public interface ObjectDefinitionModel
 	 *
 	 * @param externalReferenceCode the external reference code of this object definition
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectEntryModel.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectEntryModel.java
@@ -7,6 +7,7 @@ package com.liferay.object.model;
 
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
 import com.liferay.portal.kernel.model.StagedGroupedModel;
@@ -29,8 +30,8 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface ObjectEntryModel
-	extends BaseModel<ObjectEntry>, MVCCModel, ShardedModel, StagedGroupedModel,
-			WorkflowedModel {
+	extends BaseModel<ObjectEntry>, ExternalReferenceCodeModel, MVCCModel,
+			ShardedModel, StagedGroupedModel, WorkflowedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -91,6 +92,7 @@ public interface ObjectEntryModel
 	 * @return the external reference code of this object entry
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -98,6 +100,7 @@ public interface ObjectEntryModel
 	 *
 	 * @param externalReferenceCode the external reference code of this object entry
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectFieldModel.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectFieldModel.java
@@ -8,6 +8,7 @@ package com.liferay.object.model;
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.exception.LocaleException;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.LocalizedModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
@@ -32,8 +33,8 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface ObjectFieldModel
-	extends BaseModel<ObjectField>, LocalizedModel, MVCCModel, ShardedModel,
-			StagedAuditedModel {
+	extends BaseModel<ObjectField>, ExternalReferenceCodeModel, LocalizedModel,
+			MVCCModel, ShardedModel, StagedAuditedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -94,6 +95,7 @@ public interface ObjectFieldModel
 	 * @return the external reference code of this object field
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -101,6 +103,7 @@ public interface ObjectFieldModel
 	 *
 	 * @param externalReferenceCode the external reference code of this object field
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectFolderModel.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectFolderModel.java
@@ -8,6 +8,7 @@ package com.liferay.object.model;
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.exception.LocaleException;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.LocalizedModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
@@ -32,8 +33,8 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface ObjectFolderModel
-	extends BaseModel<ObjectFolder>, LocalizedModel, MVCCModel, ShardedModel,
-			StagedAuditedModel {
+	extends BaseModel<ObjectFolder>, ExternalReferenceCodeModel, LocalizedModel,
+			MVCCModel, ShardedModel, StagedAuditedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -94,6 +95,7 @@ public interface ObjectFolderModel
 	 * @return the external reference code of this object folder
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -101,6 +103,7 @@ public interface ObjectFolderModel
 	 *
 	 * @param externalReferenceCode the external reference code of this object folder
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -1233,9 +1233,14 @@ public class DefaultObjectEntryManagerImpl
 				relatedObjectDefinition, objectRelationship,
 				objectDefinition)) {
 
-			return Collections.singletonList(
-				_getManyToOneRelatedModel(
-					objectRelationship, primaryKey, relatedObjectDefinition));
+			BaseModel<?> baseModel = _getManyToOneRelatedModel(
+				objectRelationship, primaryKey, relatedObjectDefinition);
+
+			if (baseModel == null) {
+				return new ArrayList<>();
+			}
+
+			return Collections.singletonList(baseModel);
 		}
 
 		ObjectRelatedModelsProvider<?> objectRelatedModelsProvider =

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -883,6 +883,8 @@ public class DefaultObjectEntryManagerImpl
 				objectRelationshipElementsParser.parse(
 					objectRelationship, properties.get(entry.getKey()));
 
+			List<String> nestedExternalReferenceCodes = new ArrayList<>();
+
 			if (relatedObjectDefinition.isUnmodifiableSystemObject()) {
 				SystemObjectDefinitionManager systemObjectDefinitionManager =
 					_systemObjectDefinitionManagerRegistry.
@@ -893,13 +895,21 @@ public class DefaultObjectEntryManagerImpl
 					Map<String, Object> nestedObjectEntry =
 						(Map<String, Object>)item;
 
-					_relateNestedObjectEntry(
-						objectDefinition, objectRelationship, primaryKey,
+					long nestedObjectEntryId =
 						systemObjectDefinitionManager.upsertBaseModel(
 							String.valueOf(
 								nestedObjectEntry.get("externalReferenceCode")),
 							relatedObjectDefinition.getCompanyId(),
-							dtoConverterContext.getUser(), nestedObjectEntry));
+							dtoConverterContext.getUser(), nestedObjectEntry);
+
+					_relateNestedObjectEntry(
+						objectDefinition, objectRelationship, primaryKey,
+						nestedObjectEntryId);
+
+					nestedExternalReferenceCodes.add(
+						systemObjectDefinitionManager.
+							getBaseModelExternalReferenceCode(
+								nestedObjectEntryId));
 				}
 			}
 			else {
@@ -938,11 +948,11 @@ public class DefaultObjectEntryManagerImpl
 							objectDefinition, objectRelationship, primaryKey,
 							nestedObjectEntry.getId());
 					}
+
+					nestedExternalReferenceCodes.add(
+						nestedObjectEntry.getExternalReferenceCode());
 				}
 			}
-
-			List<String> nestedExternalReferenceCodes = TransformUtil.transform(
-				nestedObjectEntries, this::_getExternalReferenceCode);
 
 			long[] toDisassociatePrimaryKeys =
 				TransformUtil.transformToLongArray(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -245,9 +245,11 @@ public class DefaultObjectEntryManagerImpl
 				relatedObjectDefinition),
 			BaseModel::getPrimaryKeyObj);
 
-		_disassociateRelatedModels(
-			objectDefinition, objectRelationship, primaryKey,
-			relatedPrimaryKeys, relatedObjectDefinition, userId);
+		if (relatedPrimaryKeys.length > 0) {
+			_disassociateRelatedModels(
+				objectDefinition, objectRelationship, primaryKey,
+				relatedPrimaryKeys, relatedObjectDefinition, userId);
+		}
 	}
 
 	@Override

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -907,13 +907,15 @@ public class DefaultObjectEntryManagerImpl
 					_objectEntryManagerRegistry.getObjectEntryManager(
 						relatedObjectDefinition.getStorageType());
 
+				boolean manyToOneObjectRelationship =
+					_isManyToOneObjectRelationship(
+						objectDefinition, objectRelationship,
+						relatedObjectDefinition);
+
 				for (Object item : nestedObjectEntries) {
 					ObjectEntry nestedObjectEntry = (ObjectEntry)item;
 
-					if (_isManyToOneObjectRelationship(
-							objectDefinition, objectRelationship,
-							relatedObjectDefinition)) {
-
+					if (manyToOneObjectRelationship) {
 						Map<String, Object> nestedObjectEntryProperties =
 							nestedObjectEntry.getProperties();
 
@@ -931,10 +933,7 @@ public class DefaultObjectEntryManagerImpl
 						relatedObjectDefinition, nestedObjectEntry,
 						relatedObjectDefinition.getScope());
 
-					if (!_isManyToOneObjectRelationship(
-							objectDefinition, objectRelationship,
-							relatedObjectDefinition)) {
-
+					if (!manyToOneObjectRelationship) {
 						_relateNestedObjectEntry(
 							objectDefinition, objectRelationship, primaryKey,
 							nestedObjectEntry.getId());

--- a/modules/apps/site-navigation/site-navigation-api/bnd.bnd
+++ b/modules/apps/site-navigation/site-navigation-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Site Navigation API
 Bundle-SymbolicName: com.liferay.site.navigation.api
-Bundle-Version: 7.4.1
+Bundle-Version: 7.5.0
 Export-Package:\
 	com.liferay.site.navigation.constants,\
 	com.liferay.site.navigation.exception,\

--- a/modules/apps/site-navigation/site-navigation-api/src/main/java/com/liferay/site/navigation/model/SiteNavigationMenuItemModel.java
+++ b/modules/apps/site-navigation/site-navigation-api/src/main/java/com/liferay/site/navigation/model/SiteNavigationMenuItemModel.java
@@ -7,6 +7,7 @@ package com.liferay.site.navigation.model;
 
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
 import com.liferay.portal.kernel.model.StagedGroupedModel;
@@ -30,7 +31,8 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface SiteNavigationMenuItemModel
 	extends BaseModel<SiteNavigationMenuItem>, CTModel<SiteNavigationMenuItem>,
-			MVCCModel, ShardedModel, StagedGroupedModel {
+			ExternalReferenceCodeModel, MVCCModel, ShardedModel,
+			StagedGroupedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -109,6 +111,7 @@ public interface SiteNavigationMenuItemModel
 	 * @return the external reference code of this site navigation menu item
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -116,6 +119,7 @@ public interface SiteNavigationMenuItemModel
 	 *
 	 * @param externalReferenceCode the external reference code of this site navigation menu item
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/apps/site-navigation/site-navigation-api/src/main/resources/com/liferay/site/navigation/model/packageinfo
+++ b/modules/apps/site-navigation/site-navigation-api/src/main/resources/com/liferay/site/navigation/model/packageinfo
@@ -1,1 +1,1 @@
-version 3.2.0
+version 3.3.0

--- a/modules/apps/wiki/wiki-api/bnd.bnd
+++ b/modules/apps/wiki/wiki-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Wiki API
 Bundle-SymbolicName: com.liferay.wiki.api
-Bundle-Version: 16.2.2
+Bundle-Version: 16.3.0
 Export-Package:\
 	com.liferay.wiki.configuration,\
 	com.liferay.wiki.configuration.definition,\

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/model/WikiNodeModel.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/model/WikiNodeModel.java
@@ -8,6 +8,7 @@ package com.liferay.wiki.model;
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.model.ContainerModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
 import com.liferay.portal.kernel.model.StagedGroupedModel;
@@ -32,8 +33,9 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface WikiNodeModel
-	extends BaseModel<WikiNode>, ContainerModel, CTModel<WikiNode>, MVCCModel,
-			ShardedModel, StagedGroupedModel, TrashedModel, WorkflowedModel {
+	extends BaseModel<WikiNode>, ContainerModel, CTModel<WikiNode>,
+			ExternalReferenceCodeModel, MVCCModel, ShardedModel,
+			StagedGroupedModel, TrashedModel, WorkflowedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -112,6 +114,7 @@ public interface WikiNodeModel
 	 * @return the external reference code of this wiki node
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -119,6 +122,7 @@ public interface WikiNodeModel
 	 *
 	 * @param externalReferenceCode the external reference code of this wiki node
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/model/WikiPageModel.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/model/WikiPageModel.java
@@ -8,6 +8,7 @@ package com.liferay.wiki.model;
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.model.ContainerModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ResourcedModel;
 import com.liferay.portal.kernel.model.ShardedModel;
@@ -33,9 +34,9 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface WikiPageModel
-	extends BaseModel<WikiPage>, ContainerModel, CTModel<WikiPage>, MVCCModel,
-			ResourcedModel, ShardedModel, StagedGroupedModel, TrashedModel,
-			WorkflowedModel {
+	extends BaseModel<WikiPage>, ContainerModel, CTModel<WikiPage>,
+			ExternalReferenceCodeModel, MVCCModel, ResourcedModel, ShardedModel,
+			StagedGroupedModel, TrashedModel, WorkflowedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -260,6 +261,7 @@ public interface WikiPageModel
 	 * @return the external reference code of this wiki page
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -267,6 +269,7 @@ public interface WikiPageModel
 	 *
 	 * @param externalReferenceCode the external reference code of this wiki page
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/apps/wiki/wiki-api/src/main/resources/com/liferay/wiki/model/packageinfo
+++ b/modules/apps/wiki/wiki-api/src/main/resources/com/liferay/wiki/model/packageinfo
@@ -1,1 +1,1 @@
-version 5.1.0
+version 5.2.0

--- a/modules/dxp/apps/search-experiences/search-experiences-api/bnd.bnd
+++ b/modules/dxp/apps/search-experiences/search-experiences-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Search Experiences API
 Bundle-SymbolicName: com.liferay.search.experiences.api
-Bundle-Version: 26.3.1
+Bundle-Version: 26.4.0
 Export-Package:\
 	com.liferay.search.experiences.blueprint.exception,\
 	com.liferay.search.experiences.blueprint.parameter,\

--- a/modules/dxp/apps/search-experiences/search-experiences-api/src/main/java/com/liferay/search/experiences/model/SXPBlueprintModel.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-api/src/main/java/com/liferay/search/experiences/model/SXPBlueprintModel.java
@@ -8,6 +8,7 @@ package com.liferay.search.experiences.model;
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.exception.LocaleException;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.LocalizedModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
@@ -33,8 +34,8 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface SXPBlueprintModel
-	extends BaseModel<SXPBlueprint>, LocalizedModel, MVCCModel, ShardedModel,
-			StagedAuditedModel, WorkflowedModel {
+	extends BaseModel<SXPBlueprint>, ExternalReferenceCodeModel, LocalizedModel,
+			MVCCModel, ShardedModel, StagedAuditedModel, WorkflowedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -95,6 +96,7 @@ public interface SXPBlueprintModel
 	 * @return the external reference code of this sxp blueprint
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -102,6 +104,7 @@ public interface SXPBlueprintModel
 	 *
 	 * @param externalReferenceCode the external reference code of this sxp blueprint
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/dxp/apps/search-experiences/search-experiences-api/src/main/java/com/liferay/search/experiences/model/SXPElementModel.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-api/src/main/java/com/liferay/search/experiences/model/SXPElementModel.java
@@ -8,6 +8,7 @@ package com.liferay.search.experiences.model;
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.exception.LocaleException;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.LocalizedModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
@@ -32,8 +33,8 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface SXPElementModel
-	extends BaseModel<SXPElement>, LocalizedModel, MVCCModel, ShardedModel,
-			StagedAuditedModel {
+	extends BaseModel<SXPElement>, ExternalReferenceCodeModel, LocalizedModel,
+			MVCCModel, ShardedModel, StagedAuditedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -94,6 +95,7 @@ public interface SXPElementModel
 	 * @return the external reference code of this sxp element
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -101,6 +103,7 @@ public interface SXPElementModel
 	 *
 	 * @param externalReferenceCode the external reference code of this sxp element
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/dxp/apps/search-experiences/search-experiences-api/src/main/resources/com/liferay/search/experiences/model/packageinfo
+++ b/modules/dxp/apps/search-experiences/search-experiences-api/src/main/resources/com/liferay/search/experiences/model/packageinfo
@@ -1,1 +1,1 @@
-version 13.0.0
+version 13.1.0

--- a/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/model/ERCCompanyEntryModel.java
+++ b/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/model/ERCCompanyEntryModel.java
@@ -7,6 +7,7 @@ package com.liferay.portal.tools.service.builder.test.model;
 
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.ShardedModel;
 
 import org.osgi.annotation.versioning.ProviderType;
@@ -24,7 +25,8 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface ERCCompanyEntryModel
-	extends BaseModel<ERCCompanyEntry>, ShardedModel {
+	extends BaseModel<ERCCompanyEntry>, ExternalReferenceCodeModel,
+			ShardedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -67,6 +69,7 @@ public interface ERCCompanyEntryModel
 	 * @return the external reference code of this erc company entry
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -74,6 +77,7 @@ public interface ERCCompanyEntryModel
 	 *
 	 * @param externalReferenceCode the external reference code of this erc company entry
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/model/ERCGroupEntryModel.java
+++ b/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/model/ERCGroupEntryModel.java
@@ -7,6 +7,7 @@ package com.liferay.portal.tools.service.builder.test.model;
 
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.ShardedModel;
 
 import org.osgi.annotation.versioning.ProviderType;
@@ -24,7 +25,7 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface ERCGroupEntryModel
-	extends BaseModel<ERCGroupEntry>, ShardedModel {
+	extends BaseModel<ERCGroupEntry>, ExternalReferenceCodeModel, ShardedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -67,6 +68,7 @@ public interface ERCGroupEntryModel
 	 * @return the external reference code of this erc group entry
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -74,6 +76,7 @@ public interface ERCGroupEntryModel
 	 *
 	 * @param externalReferenceCode the external reference code of this erc group entry
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/modules/util/portal-tools-service-builder/src/main/java/com/liferay/portal/tools/service/builder/Entity.java
+++ b/modules/util/portal-tools-service-builder/src/main/java/com/liferay/portal/tools/service/builder/Entity.java
@@ -401,6 +401,10 @@ public class Entity implements Comparable<Entity> {
 			interfaceNames.add("ContainerModel");
 		}
 
+		if (isExternalReferenceCodeModel()) {
+			interfaceNames.add("ExternalReferenceCodeModel");
+		}
+
 		if (isLocalizedModel()) {
 			interfaceNames.add("LocalizedModel");
 		}
@@ -491,6 +495,10 @@ public class Entity implements Comparable<Entity> {
 		if (isChangeTrackingEnabled()) {
 			overrideColumnName.add("ctCollectionId");
 			overrideColumnName.add("primaryKey");
+		}
+
+		if (isExternalReferenceCodeModel()) {
+			overrideColumnName.add("externalReferenceCode");
 		}
 
 		if (isGroupedModel()) {
@@ -1011,6 +1019,16 @@ public class Entity implements Comparable<Entity> {
 
 	public boolean isDynamicUpdateEnabled() {
 		return _dynamicUpdateEnabled;
+	}
+
+	public boolean isExternalReferenceCodeModel() {
+		if (_serviceBuilder.isVersionGTE_7_4_0() &&
+			hasEntityColumn("externalReferenceCode")) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	public boolean isGroupedModel() {

--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/model.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/model.ftl
@@ -16,6 +16,7 @@ import com.liferay.portal.kernel.model.AuditedModel;
 import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.model.CacheModel;
 import com.liferay.portal.kernel.model.ContainerModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.model.LocalizedModel;
 import com.liferay.portal.kernel.model.MVCCModel;

--- a/portal-kernel/src/com/liferay/asset/kernel/model/AssetCategoryModel.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/model/AssetCategoryModel.java
@@ -8,6 +8,7 @@ package com.liferay.asset.kernel.model;
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.exception.LocaleException;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.LocalizedModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
@@ -33,8 +34,9 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface AssetCategoryModel
-	extends BaseModel<AssetCategory>, CTModel<AssetCategory>, LocalizedModel,
-			MVCCModel, ShardedModel, StagedGroupedModel {
+	extends BaseModel<AssetCategory>, CTModel<AssetCategory>,
+			ExternalReferenceCodeModel, LocalizedModel, MVCCModel, ShardedModel,
+			StagedGroupedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -113,6 +115,7 @@ public interface AssetCategoryModel
 	 * @return the external reference code of this asset category
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -120,6 +123,7 @@ public interface AssetCategoryModel
 	 *
 	 * @param externalReferenceCode the external reference code of this asset category
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/portal-kernel/src/com/liferay/asset/kernel/model/AssetVocabularyModel.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/model/AssetVocabularyModel.java
@@ -8,6 +8,7 @@ package com.liferay.asset.kernel.model;
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.exception.LocaleException;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.LocalizedModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
@@ -34,7 +35,8 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface AssetVocabularyModel
 	extends BaseModel<AssetVocabulary>, CTModel<AssetVocabulary>,
-			LocalizedModel, MVCCModel, ShardedModel, StagedGroupedModel {
+			ExternalReferenceCodeModel, LocalizedModel, MVCCModel, ShardedModel,
+			StagedGroupedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -113,6 +115,7 @@ public interface AssetVocabularyModel
 	 * @return the external reference code of this asset vocabulary
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -120,6 +123,7 @@ public interface AssetVocabularyModel
 	 *
 	 * @param externalReferenceCode the external reference code of this asset vocabulary
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/portal-kernel/src/com/liferay/asset/kernel/model/packageinfo
+++ b/portal-kernel/src/com/liferay/asset/kernel/model/packageinfo
@@ -1,1 +1,1 @@
-version 11.0.0
+version 11.1.0

--- a/portal-kernel/src/com/liferay/document/library/kernel/model/DLFileEntryModel.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/model/DLFileEntryModel.java
@@ -8,6 +8,7 @@ package com.liferay.document.library.kernel.model;
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.model.AttachedModel;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
 import com.liferay.portal.kernel.model.StagedGroupedModel;
@@ -32,7 +33,8 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface DLFileEntryModel
 	extends AttachedModel, BaseModel<DLFileEntry>, CTModel<DLFileEntry>,
-			MVCCModel, ShardedModel, StagedGroupedModel, TrashedModel {
+			ExternalReferenceCodeModel, MVCCModel, ShardedModel,
+			StagedGroupedModel, TrashedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -111,6 +113,7 @@ public interface DLFileEntryModel
 	 * @return the external reference code of this document library file entry
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -118,6 +121,7 @@ public interface DLFileEntryModel
 	 *
 	 * @param externalReferenceCode the external reference code of this document library file entry
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/portal-kernel/src/com/liferay/document/library/kernel/model/DLFolderModel.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/model/DLFolderModel.java
@@ -8,6 +8,7 @@ package com.liferay.document.library.kernel.model;
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.model.ContainerModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
 import com.liferay.portal.kernel.model.StagedGroupedModel;
@@ -32,8 +33,9 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface DLFolderModel
-	extends BaseModel<DLFolder>, ContainerModel, CTModel<DLFolder>, MVCCModel,
-			ShardedModel, StagedGroupedModel, TrashedModel, WorkflowedModel {
+	extends BaseModel<DLFolder>, ContainerModel, CTModel<DLFolder>,
+			ExternalReferenceCodeModel, MVCCModel, ShardedModel,
+			StagedGroupedModel, TrashedModel, WorkflowedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -112,6 +114,7 @@ public interface DLFolderModel
 	 * @return the external reference code of this document library folder
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -119,6 +122,7 @@ public interface DLFolderModel
 	 *
 	 * @param externalReferenceCode the external reference code of this document library folder
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/portal-kernel/src/com/liferay/document/library/kernel/model/packageinfo
+++ b/portal-kernel/src/com/liferay/document/library/kernel/model/packageinfo
@@ -1,1 +1,1 @@
-version 8.2.0
+version 8.3.0

--- a/portal-kernel/src/com/liferay/portal/kernel/model/AddressModel.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/AddressModel.java
@@ -25,8 +25,9 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface AddressModel
-	extends AttachedModel, BaseModel<Address>, CTModel<Address>, MVCCModel,
-			ShardedModel, StagedAuditedModel {
+	extends AttachedModel, BaseModel<Address>, CTModel<Address>,
+			ExternalReferenceCodeModel, MVCCModel, ShardedModel,
+			StagedAuditedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -105,6 +106,7 @@ public interface AddressModel
 	 * @return the external reference code of this address
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -112,6 +114,7 @@ public interface AddressModel
 	 *
 	 * @param externalReferenceCode the external reference code of this address
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/portal-kernel/src/com/liferay/portal/kernel/model/ExternalReferenceCodeModel.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/ExternalReferenceCodeModel.java
@@ -1,0 +1,17 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.model;
+
+/**
+ * @author Carlos Correa
+ */
+public interface ExternalReferenceCodeModel {
+
+	public String getExternalReferenceCode();
+
+	public void setExternalReferenceCode(String externalReferenceCode);
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/model/GroupModel.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/GroupModel.java
@@ -28,8 +28,9 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface GroupModel
-	extends AttachedModel, BaseModel<Group>, CTModel<Group>, LocalizedModel,
-			MVCCModel, ShardedModel {
+	extends AttachedModel, BaseModel<Group>, CTModel<Group>,
+			ExternalReferenceCodeModel, LocalizedModel, MVCCModel,
+			ShardedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -106,6 +107,7 @@ public interface GroupModel
 	 * @return the external reference code of this group
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -113,6 +115,7 @@ public interface GroupModel
 	 *
 	 * @param externalReferenceCode the external reference code of this group
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/portal-kernel/src/com/liferay/portal/kernel/model/OrganizationModel.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/OrganizationModel.java
@@ -25,8 +25,9 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface OrganizationModel
-	extends BaseModel<Organization>, CTModel<Organization>, MVCCModel,
-			ShardedModel, StagedAuditedModel {
+	extends BaseModel<Organization>, CTModel<Organization>,
+			ExternalReferenceCodeModel, MVCCModel, ShardedModel,
+			StagedAuditedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -105,6 +106,7 @@ public interface OrganizationModel
 	 * @return the external reference code of this organization
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -112,6 +114,7 @@ public interface OrganizationModel
 	 *
 	 * @param externalReferenceCode the external reference code of this organization
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/portal-kernel/src/com/liferay/portal/kernel/model/UserGroupModel.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/UserGroupModel.java
@@ -25,7 +25,8 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface UserGroupModel
-	extends BaseModel<UserGroup>, CTModel<UserGroup>, MVCCModel, ShardedModel,
+	extends BaseModel<UserGroup>, CTModel<UserGroup>,
+			ExternalReferenceCodeModel, MVCCModel, ShardedModel,
 			StagedAuditedModel {
 
 	/*
@@ -105,6 +106,7 @@ public interface UserGroupModel
 	 * @return the external reference code of this user group
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -112,6 +114,7 @@ public interface UserGroupModel
 	 *
 	 * @param externalReferenceCode the external reference code of this user group
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/portal-kernel/src/com/liferay/portal/kernel/model/UserModel.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/UserModel.java
@@ -25,8 +25,8 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface UserModel
-	extends BaseModel<User>, CTModel<User>, MVCCModel, ShardedModel,
-			StagedModel {
+	extends BaseModel<User>, CTModel<User>, ExternalReferenceCodeModel,
+			MVCCModel, ShardedModel, StagedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -105,6 +105,7 @@ public interface UserModel
 	 * @return the external reference code of this user
 	 */
 	@AutoEscape
+	@Override
 	public String getExternalReferenceCode();
 
 	/**
@@ -112,6 +113,7 @@ public interface UserModel
 	 *
 	 * @param externalReferenceCode the external reference code of this user
 	 */
+	@Override
 	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**

--- a/portal-kernel/src/com/liferay/portal/kernel/model/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/packageinfo
@@ -1,1 +1,1 @@
-version 30.5.0
+version 30.6.0


### PR DESCRIPTION
Related ticket: https://liferay.atlassian.net/browse/LPS-195526

---

Forwarded manually from: https://github.com/liferay-headless/liferay-portal/pull/1492

---

The purpose of this PR is to modify the existing flow in which, when receiving a request for an element and its related elements in the same body, when processing the related elements, all the related elements were first unrelated and then related those that traveled in the body of the message.

This prevents `ObjectEntry` modification events from being generated/invoked with the relationship field empty when the request has not requested to unrelate those elements.

The new interface `ExternalReferenceCodeModel` has been added to the kernel. All the entities created with Service Builder will implement the interface in case the `externalReferenceCode` field exists and the Liferay version is greater or equals to 7.4. That will allow to get the external reference code of a model without using reflection.

---

How to test it:

Follow [the instruccions in the jira ticket](https://liferay.atlassian.net/browse/LPS-195526)


