### PR TITLE
LRCI-3791 Add a custom service for activemq in Jethr0

### DIFF
--- a/workspaces/liferay-jethr0-workspace/client-extensions/liferay-jethr0-activemq/LCP.json
+++ b/workspaces/liferay-jethr0-workspace/client-extensions/liferay-jethr0-activemq/LCP.json
@@ -1,0 +1,32 @@
+{
+	"cpu": 1.0,
+	"id": "activemq",
+	"image": "rmohr/activemq:5.15.9-alpine",
+	"kind": "Deployment",
+	"livenessProbe": {
+		"httpGet": {
+			"path": "/",
+			"port": 8161
+		}
+	},
+	"loadBalancer": {
+		"cdn": false,
+		"targetPort": 8161
+	},
+	"memory": 1024,
+	"ports": [
+		{
+			"external": true,
+			"port": 61616,
+			"protocol": "TCP",
+			"targetPort": 61616
+		}
+	],
+	"readinessProbe": {
+		"httpGet": {
+			"path": "/",
+			"port": 8161
+		}
+	},
+	"scale": 1
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-3791

@brianchandtcom - This is in response to this comment:
https://github.com/brianchandotcom/liferay-portal/pull/140816#issuecomment-1723776510

The one other question I had was about naming the id.  I chose `activemq`, but I'm wondering if it should be `liferay-jethr0-activemq`.

```
{
	...
	"id": "activemq",
	...
}
```