### PR TITLE
LPS-188958 add aria-labelledby attribute to checkbox in taglib search iterator

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/search/EntriesChecker.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/search/EntriesChecker.java
@@ -166,9 +166,18 @@ public class EntriesChecker extends RowChecker {
 		String checkBoxAllRowIds, String checkBoxPostOnClick,
 		Map<String, Object> data) {
 
-		StringBundler sb = new StringBundler(16);
+		StringBundler sb = new StringBundler(19);
 
 		sb.append("<input ");
+
+		String rowElementId = (String)httpServletRequest.getAttribute(
+			"liferay-ui:search-container-row:rowElementId");
+
+		if (rowElementId != null) {
+			sb.append("aria-labelledby=\"");
+			sb.append(rowElementId);
+			sb.append("\" ");
+		}
 
 		if (checked) {
 			sb.append("checked ");

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/search/EmptyOnClickRowChecker.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/search/EmptyOnClickRowChecker.java
@@ -38,9 +38,18 @@ public class EmptyOnClickRowChecker extends RowChecker {
 		boolean disabled, String name, String value, String checkBoxRowIds,
 		String checkBoxAllRowIds, String checkBoxPostOnClick) {
 
-		StringBundler sb = new StringBundler(15);
+		StringBundler sb = new StringBundler(18);
 
 		sb.append("<input ");
+
+		String rowElementId = (String)httpServletRequest.getAttribute(
+			"liferay-ui:search-container-row:rowElementId");
+
+		if (rowElementId != null) {
+			sb.append("aria-labelledby=\"");
+			sb.append(rowElementId);
+			sb.append("\" ");
+		}
 
 		if (checked) {
 			sb.append("checked ");

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/search/RowChecker.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/search/RowChecker.java
@@ -261,9 +261,18 @@ public class RowChecker {
 		boolean disabled, String name, String value, String checkBoxRowIds,
 		String checkBoxAllRowIds, String checkBoxPostOnClick) {
 
-		StringBundler sb = new StringBundler(14);
+		StringBundler sb = new StringBundler(17);
 
 		sb.append("<label><input ");
+
+		String rowElementId = (String)httpServletRequest.getAttribute(
+			"liferay-ui:search-container-row:rowElementId");
+
+		if (rowElementId != null) {
+			sb.append("aria-labelledby=\"");
+			sb.append(rowElementId);
+			sb.append("\" ");
+		}
 
 		if (checked) {
 			sb.append("checked ");

--- a/portal-web/docroot/html/taglib/ui/search_iterator/deprecated/list.jsp
+++ b/portal-web/docroot/html/taglib/ui/search_iterator/deprecated/list.jsp
@@ -224,6 +224,10 @@ if (iteratorURL != null) {
 
 			boolean rowIsChecked = false;
 
+			String rowElementId = namespace + id + "_" + row.getRowId();
+
+			request.setAttribute("liferay-ui:search-container-row:rowElementId", rowElementId);
+
 			if (rowChecker != null) {
 				rowIsChecked = rowChecker.isChecked(row.getObject());
 
@@ -247,14 +251,7 @@ if (iteratorURL != null) {
 			Map<String, Object> data = row.getData();
 		%>
 
-			<c:choose>
-				<c:when test="<%= Validator.isNotNull(rowIdProperty) %>">
-					<tr class="<%= GetterUtil.getString(row.getClassName()) %> <%= row.getCssClass() %> <%= row.getState() %> <%= rowIsChecked ? "info" : StringPool.BLANK %>" id="<portlet:namespace /><%= id %>_<%= row.getRowId() %>" <%= AUIUtil.buildData(data) %>>
-				</c:when>
-				<c:otherwise>
-					<tr class="<%= GetterUtil.getString(row.getClassName()) %> <%= row.getCssClass() %> <%= row.getState() %> <%= rowIsChecked ? "info" : StringPool.BLANK %>" <%= AUIUtil.buildData(data) %>>
-				</c:otherwise>
-			</c:choose>
+			<tr class="<%= GetterUtil.getString(row.getClassName()) %> <%= row.getCssClass() %> <%= row.getState() %> <%= rowIsChecked ? "info" : StringPool.BLANK %>" id="<%= rowElementId %>" <%= AUIUtil.buildData(data) %>>
 
 			<%
 			for (int j = 0; j < entries.size(); j++) {
@@ -313,6 +310,7 @@ if (iteratorURL != null) {
 			request.removeAttribute(WebKeys.SEARCH_CONTAINER_RESULT_ROW);
 			request.removeAttribute(WebKeys.SEARCH_CONTAINER_RESULT_ROW_ENTRY);
 
+			request.removeAttribute("liferay-ui:search-container-row:rowElementId");
 			request.removeAttribute("liferay-ui:search-container-row:rowId");
 		}
 		%>

--- a/portal-web/docroot/html/taglib/ui/search_iterator/descriptive.jsp
+++ b/portal-web/docroot/html/taglib/ui/search_iterator/descriptive.jsp
@@ -100,9 +100,13 @@
 				if (data == null) {
 					data = new HashMap<String, Object>();
 				}
+
+				String rowElementId = namespace + id + "_" + row.getRowId();
+
+				request.setAttribute("liferay-ui:search-container-row:rowElementId", rowElementId);
 			%>
 
-				<dd class="list-group-item list-group-item-flex <%= GetterUtil.getString(row.getClassName()) %> <%= row.getCssClass() %> <%= rowIsChecked ? "active" : StringPool.BLANK %> <%= Validator.isNotNull(row.getState()) ? "list-group-item-" + row.getState() : StringPool.BLANK %>" data-qa-id="row" <%= AUIUtil.buildData(data) %>>
+				<dd class="list-group-item list-group-item-flex <%= GetterUtil.getString(row.getClassName()) %> <%= row.getCssClass() %> <%= rowIsChecked ? "active" : StringPool.BLANK %> <%= Validator.isNotNull(row.getState()) ? "list-group-item-" + row.getState() : StringPool.BLANK %>" data-qa-id="row" id="<%= rowElementId %>" <%= AUIUtil.buildData(data) %>>
 					<c:if test="<%= rowChecker != null %>">
 						<div class="autofit-col">
 							<div class="checkbox">
@@ -140,6 +144,7 @@
 				request.removeAttribute(WebKeys.SEARCH_CONTAINER_RESULT_ROW);
 				request.removeAttribute(WebKeys.SEARCH_CONTAINER_RESULT_ROW_ENTRY);
 
+				request.removeAttribute("liferay-ui:search-container-row:rowElementId");
 				request.removeAttribute("liferay-ui:search-container-row:rowId");
 			}
 			%>

--- a/portal-web/docroot/html/taglib/ui/search_iterator/icon.jsp
+++ b/portal-web/docroot/html/taglib/ui/search_iterator/icon.jsp
@@ -95,9 +95,13 @@ for (int i = 0; i < resultRowSplitterEntries.size(); i++) {
 			if (Validator.isNull(rowCssClass)) {
 				rowCssClass = "card-page-item card-page-item-asset";
 			}
+
+			String rowElementId = namespace + id + "_" + row.getRowId();
+
+			request.setAttribute("liferay-ui:search-container-row:rowElementId", rowElementId);
 		%>
 
-			<dd class="<%= GetterUtil.getString(row.getClassName()) %> <%= rowCssClass %> <%= rowIsChecked ? "active" : StringPool.BLANK %>" data-qa-id="row" <%= AUIUtil.buildData(data) %>>
+			<dd class="<%= GetterUtil.getString(row.getClassName()) %> <%= rowCssClass %> <%= rowIsChecked ? "active" : StringPool.BLANK %>" data-qa-id="row" id="<%= rowElementId %>" <%= AUIUtil.buildData(data) %>>
 
 				<%
 				for (int k = 0; k < entries.size(); k++) {
@@ -117,6 +121,7 @@ for (int i = 0; i < resultRowSplitterEntries.size(); i++) {
 			request.removeAttribute(WebKeys.SEARCH_CONTAINER_RESULT_ROW);
 			request.removeAttribute(WebKeys.SEARCH_CONTAINER_RESULT_ROW_ENTRY);
 
+			request.removeAttribute("liferay-ui:search-container-row:rowElementId");
 			request.removeAttribute("liferay-ui:search-container-row:rowId");
 		}
 		%>

--- a/portal-web/docroot/html/taglib/ui/search_iterator/init.jsp
+++ b/portal-web/docroot/html/taglib/ui/search_iterator/init.jsp
@@ -19,7 +19,6 @@ boolean fixedHeader = GetterUtil.getBoolean((String)request.getAttribute("lifera
 String markupView = (String)request.getAttribute("liferay-ui:search-iterator:markupView");
 boolean paginate = GetterUtil.getBoolean((String)request.getAttribute("liferay-ui:search-iterator:paginate"));
 ResultRowSplitter resultRowSplitter = (ResultRowSplitter)request.getAttribute("liferay-ui:search-iterator:resultRowSplitter");
-String rowIdProperty = (String)request.getAttribute("liferay-ui:search-container-row:rowIdProperty");
 String searchContainerRowCssClass = GetterUtil.getString((String)request.getAttribute("liferay-ui:search-container-row:cssClass"));
 String searchResultCssClass = (String)request.getAttribute("liferay-ui:search-iterator:searchResultCssClass");
 String type = (String)request.getAttribute("liferay-ui:search:type");

--- a/portal-web/docroot/html/taglib/ui/search_iterator/list.jsp
+++ b/portal-web/docroot/html/taglib/ui/search_iterator/list.jsp
@@ -230,6 +230,10 @@ if (fixedHeader) {
 					boolean rowIsChecked = false;
 					boolean rowIsDisabled = false;
 
+					String rowElementId = namespace + id + "_" + row.getRowId();
+
+					request.setAttribute("liferay-ui:search-container-row:rowElementId", rowElementId);
+
 					if (rowChecker != null) {
 						rowIsChecked = rowChecker.isChecked(row.getObject());
 						rowIsDisabled = rowChecker.isDisabled(row.getObject());
@@ -272,14 +276,7 @@ if (fixedHeader) {
 					}
 				%>
 
-					<c:choose>
-						<c:when test="<%= Validator.isNotNull(rowIdProperty) %>">
-							<tr class="<%= GetterUtil.getString(row.getClassName()) %> <%= row.getCssClass() %> <%= row.getState() %> <%= rowIsChecked ? "active" : StringPool.BLANK %>" data-qa-id="row" id="<portlet:namespace /><%= id %>_<%= row.getRowId() %>" <%= AUIUtil.buildData(data) %>>
-						</c:when>
-						<c:otherwise>
-							<tr class="<%= GetterUtil.getString(row.getClassName()) %> <%= row.getCssClass() %> <%= row.getState() %> <%= rowIsChecked ? "active" : StringPool.BLANK %>" data-qa-id="row" <%= AUIUtil.buildData(data) %>>
-						</c:otherwise>
-					</c:choose>
+					<tr class="<%= GetterUtil.getString(row.getClassName()) %> <%= row.getCssClass() %> <%= row.getState() %> <%= rowIsChecked ? "active" : StringPool.BLANK %>" data-qa-id="row" id="<%= rowElementId %>" <%= AUIUtil.buildData(data) %>>
 
 						<%
 						for (int j = 0; j < entries.size(); j++) {
@@ -353,6 +350,7 @@ if (fixedHeader) {
 					request.removeAttribute(WebKeys.SEARCH_CONTAINER_RESULT_ROW);
 					request.removeAttribute(WebKeys.SEARCH_CONTAINER_RESULT_ROW_ENTRY);
 
+					request.removeAttribute("liferay-ui:search-container-row:rowElementId");
 					request.removeAttribute("liferay-ui:search-container-row:rowId");
 				}
 			}

--- a/util-taglib/src/com/liferay/taglib/ui/SearchContainerRowTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/SearchContainerRowTag.java
@@ -328,12 +328,6 @@ public class SearchContainerRowTag<R>
 					FriendlyURLNormalizerUtil.normalizeWithPeriodsAndSlashes(
 						String.valueOf(rowIdObject));
 			}
-
-			HttpServletRequest httpServletRequest = getRequest();
-
-			httpServletRequest.setAttribute(
-				"liferay-ui:search-container-row:rowIdProperty",
-				_rowIdProperty);
 		}
 
 		_resultRow = new com.liferay.taglib.search.ResultRow(


### PR DESCRIPTION
**>> Sending manually since the forward command is failing due `An error has occurred: com.liferay.jenkins.results.parser.GitHubSecondaryRateLimitRuntimeException.`**

# Description in the original PR

Ticket: [LPS-188958](https://liferay.atlassian.net/browse/LPS-188958)

Motivation
=======
The checkbox in taglib search iterator component has no row information associated with its aria-label attribute. Because of that, screen readers such as JAWS can't tell the user any information that might help making the decision of checking that row.

Proposed Solution
========
After a long discussion (see it [here](https://liferay.slack.com/archives/C04A7NLM7L1/p1691584013482139?thread_ts=1690227135.868729&cid=C04A7NLM7L1)), it was decided to add the `aria-labelledby="rowId"` to the row checkbox attribute. 

The **proposed solution** makes the screen reader say something like (consider that the row info is for a web content) "select web_content_name web_content_description column_3 column_4 actions". Yes, it says more than it's needed. See 
Alternative Solutions that were discarded section below for more context.

Alternative Solution that was discarded
========
The best scenario would be to have the `aria-label="select web_content_name"` attribute in the checkbox, that way the screen readers would say "select my content 1", simple, clean and useful. The problem with this approach is the way the search-iterator works:

1. The client (any JSP page in the portal) calls the search-container component, which uses the search-iterator. For each result from the SearchContainer (passed by the client code), it creates a ResultRow object instance and give it to the client clode (see an example [here](https://github.com/liferay/liferay-portal/blob/ece66430e068f9d986100c239e5c49e66f11a079/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/select_file_entry_type.jsp#L58));
2. For each row, the client code might pass additional data, it would in there where the client code would pass the objectModel.getTitle() (or name). But even if we do that, we couldn't use it inside `*RowChecker.java` without changing the API ([see](https://github.com/liferay/liferay-portal/blob/ece66430e068f9d986100c239e5c49e66f11a079/portal-kernel/src/com/liferay/portal/kernel/dao/search/RowChecker.java#L259)). Changing the API was already rejected by Brian ([see](https://github.com/brianchandotcom/liferay-portal/pull/140663#issuecomment-1719786698)). Also, doing that would require to change 350+ files and future files could just not add this information to the row data.