### PR TITLE
Revert "LPS-186362 #sfme, please enforce"

### DIFF
--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/model/listener/CTCollectionModelListener.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/model/listener/CTCollectionModelListener.java
@@ -40,13 +40,14 @@ public class CTCollectionModelListener extends BaseModelListener<CTCollection> {
 			ctCollectionResource.postCTCollection(
 				new com.liferay.change.tracking.rest.client.dto.v1_0.
 					CTCollection() {
-						{
-							description = ctCollection.getDescription();
-							externalReferenceCode =
-								ctCollection.getExternalReferenceCode();
-							name = ctCollection.getName();
-						}
-					});
+
+					{
+						description = ctCollection.getDescription();
+						externalReferenceCode =
+							ctCollection.getExternalReferenceCode();
+						name = ctCollection.getName();
+					}
+				});
 		}
 		catch (Exception exception) {
 			throw new ModelListenerException(exception);
@@ -90,13 +91,14 @@ public class CTCollectionModelListener extends BaseModelListener<CTCollection> {
 				ctCollection.getExternalReferenceCode(),
 				new com.liferay.change.tracking.rest.client.dto.v1_0.
 					CTCollection() {
-						{
-							description = ctCollection.getDescription();
-							externalReferenceCode =
-								ctCollection.getExternalReferenceCode();
-							name = ctCollection.getName();
-						}
-					});
+
+					{
+						description = ctCollection.getDescription();
+						externalReferenceCode =
+							ctCollection.getExternalReferenceCode();
+						name = ctCollection.getName();
+					}
+				});
 		}
 		catch (Exception exception) {
 			throw new ModelListenerException(exception);


### PR DESCRIPTION
This reverts commit 23ee246d841a1e4f9dd51e4fa9c42d5b6a7dff17.

Hi Brian,
Can I revert your changes?

The reason for adding the empty line is because the previous line is exceeded 80.

We do the same thing for if-statement too.
please see:
https://github.com/liferay/liferay-portal/blob/b126f65856a620bf1d6364f7939f347edef797e3/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/display/CTDisplayRendererRegistryImpl.java#L392-L395
```
		if (name.startsWith(
				_resourceActions.getModelResourceNamePrefix())) {

			name = className.getClassName();
		}
```
and

```
		if (ctDisplayRenderer != null) {
			name = ctDisplayRenderer.getTypeName(locale);
		}
```
