### PR TITLE
LPS-195473 Add automation test ConfigurationAdminUI#AssertHyperlinkIsNotRenderedInAButton

### DIFF
--- a/modules/apps/configuration-admin/configuration-admin-test/src/testFunctional/tests/ConfigurationAdmin.testcase
+++ b/modules/apps/configuration-admin/configuration-admin-test/src/testFunctional/tests/ConfigurationAdmin.testcase
@@ -1,0 +1,50 @@
+@component-name = "portal-platform-experience-and-design-system"
+definition {
+
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.main.component.name = "System Settings";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		task ("Given signed into portal as admin") {
+			User.firstLoginPG();
+		}
+	}
+
+	tearDown {
+		var testLiferayVirtualInstance = PropsUtil.get("test.liferay.virtual.instance");
+
+		if (${testLiferayVirtualInstance} == "true") {
+			PortalInstances.tearDownCP();
+		}
+	}
+
+	@description = "LPS-194725 - This test asserts that the hyperlink is available within an anchor tag."
+	@priority = 3
+	test AssertHyperlinkIsRendered {
+		task ("When navigate to Bundle Blacklist edit configuration page ") {
+			SystemSettings.openSystemSettingsAdmin();
+
+			SystemSettings.gotoConfiguration(
+				configurationCategory = "Module Container",
+				configurationName = "Bundle Blacklist",
+				configurationScope = "System Scope");
+		}
+
+		task ("Then hyperlink is available within an anchor tag") {
+			AssertElementPresent(
+				key_href = "blacklisting-apps",
+				key_text = "How does bundle",
+				locator1 = "Link#ANY_HREF_2");
+		}
+
+		task ("And Then text of hyperlink says “How does bundle blacklisting work?") {
+			AssertVisible(
+				key_href = "https://learn.liferay.com/dxp/latest/en/system-administration/installing-and-managing-apps/managing-apps/blacklisting-apps.html",
+				key_text = "How does bundle blacklisting work?",
+				locator1 = "Link#ANY_HREF");
+		}
+	}
+}

--- a/modules/apps/configuration-admin/configuration-admin-test/src/testFunctional/tests/ConfigurationAdminUI.testcase
+++ b/modules/apps/configuration-admin/configuration-admin-test/src/testFunctional/tests/ConfigurationAdminUI.testcase
@@ -4,6 +4,7 @@ definition {
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property testray.main.component.name = "System Settings";
+	property testray.component.name = "Configuration Admin UI";
 
 	setUp {
 		TestCase.setUpPortalInstance();
@@ -21,9 +22,9 @@ definition {
 		}
 	}
 
-	@description = "LPS-194725 - This test asserts that the hyperlink is available within an anchor tag."
+	@description = "LPS-194725 - configuration admin UI can autogenerate a doc link"
 	@priority = 3
-	test AssertHyperlinkIsRendered {
+	test CanRenderADocLink {
 		task ("When navigate to Bundle Blacklist edit configuration page ") {
 			SystemSettings.openSystemSettingsAdmin();
 

--- a/modules/apps/configuration-admin/configuration-admin-test/src/testFunctional/tests/ConfigurationAdminUI.testcase
+++ b/modules/apps/configuration-admin/configuration-admin-test/src/testFunctional/tests/ConfigurationAdminUI.testcase
@@ -36,16 +36,16 @@ definition {
 
 		task ("Then hyperlink is available within an anchor tag") {
 			AssertElementPresent(
-				key_href = "blacklisting-apps",
+				key_href = "https://learn.liferay.com/dxp/latest/en/system-administration/installing-and-managing-apps/managing-apps/blacklisting-apps.html",
 				key_text = "How does bundle",
-				locator1 = "Link#ANY_HREF_2");
+				locator1 = "Link#ANY_HREF");
 		}
 
 		task ("And Then text of hyperlink says “How does bundle blacklisting work?") {
 			AssertVisible(
-				key_href = "https://learn.liferay.com/dxp/latest/en/system-administration/installing-and-managing-apps/managing-apps/blacklisting-apps.html",
+				key_href = "blacklisting-apps",
 				key_text = "How does bundle blacklisting work?",
-				locator1 = "Link#ANY_HREF");
+				locator1 = "Link#ANY_HREF_2");
 		}
 	}
 }

--- a/modules/apps/configuration-admin/configuration-admin-test/src/testFunctional/tests/ConfigurationAdminUI.testcase
+++ b/modules/apps/configuration-admin/configuration-admin-test/src/testFunctional/tests/ConfigurationAdminUI.testcase
@@ -1,10 +1,11 @@
 @component-name = "portal-platform-experience-and-design-system"
 definition {
 
+	property ci.retries.disabled = "true";
 	property portal.release = "true";
 	property portal.upstream = "true";
-	property testray.main.component.name = "System Settings";
 	property testray.component.name = "Configuration Admin UI";
+	property testray.main.component.name = "System Settings";
 
 	setUp {
 		TestCase.setUpPortalInstance();
@@ -25,6 +26,9 @@ definition {
 	@description = "LPS-194725 - configuration admin UI can autogenerate a doc link"
 	@priority = 3
 	test CanRenderADocLink {
+		property portal.acceptance = "false";
+		property test.liferay.virtual.instance = "false";
+
 		task ("When navigate to Bundle Blacklist edit configuration page ") {
 			SystemSettings.openSystemSettingsAdmin();
 
@@ -46,6 +50,9 @@ definition {
 				key_href = "blacklisting-apps",
 				key_text = "How does bundle blacklisting work?",
 				locator1 = "Link#ANY_HREF_2");
+
+			takeScreenshot();
 		}
 	}
+
 }

--- a/portal-web/poshi.properties
+++ b/portal-web/poshi.properties
@@ -12,6 +12,7 @@ test.dirs=\
     ../modules/apps/calendar/calendar-web-test/src/testFunctional,\
     ../modules/apps/click-to-chat/click-to-chat-test/src/testFunctional,\
     ../modules/apps/commerce/commerce-product-test/src/testFunctional,\
+    ../modules/apps/configuration-admin/configuration-admin-test/src/testFunctional,\
     ../modules/apps/data-engine/data-engine-test/src/testFunctional,\
     ../modules/apps/depot/depot-test/src/testFunctional,\
     ../modules/apps/digital-signature/digital-signature-test/src/testFunctional,\

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/administration/portalconfiguration/systemmanagement/SystemSettings.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/administration/portalconfiguration/systemmanagement/SystemSettings.testcase
@@ -21,33 +21,6 @@ definition {
 		}
 	}
 
-	@description = "LPS-194725 - This test asserts that the hyperlink is available within an anchor tag."
-	@priority = 3
-	test AssertHyperlinkIsRendered {
-		task ("When navigate to Bundle Blacklist edit configuration page ") {
-			SystemSettings.openSystemSettingsAdmin();
-
-			SystemSettings.gotoConfiguration(
-				configurationCategory = "Module Container",
-				configurationName = "Bundle Blacklist",
-				configurationScope = "System Scope");
-		}
-
-		task ("Then hyperlink is available within an anchor tag") {
-			AssertElementPresent(
-				key_href = "blacklisting-apps",
-				key_text = "How does bundle",
-				locator1 = "Link#ANY_HREF_2");
-		}
-
-		task ("And Then text of hyperlink says “How does bundle blacklisting work?") {
-			AssertVisible(
-				key_href = "https://learn.liferay.com/dxp/latest/en/system-administration/installing-and-managing-apps/managing-apps/blacklisting-apps.html",
-				key_text = "How does bundle blacklisting work?",
-				locator1 = "Link#ANY_HREF");
-		}
-	}
-
 	@priority = 5
 	test CanOverrideValueSetInConfigFile {
 		property custom.properties = "configuration.override.com.liferay.journal.configuration.JournalServiceConfiguration_articleCommentsEnabled=B\"false\"";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/administration/portalconfiguration/systemmanagement/SystemSettings.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/administration/portalconfiguration/systemmanagement/SystemSettings.testcase
@@ -8,7 +8,9 @@ definition {
 	setUp {
 		TestCase.setUpPortalInstance();
 
-		User.firstLoginPG();
+		task ("Given signed into portal as admin") {
+			User.firstLoginPG();
+		}
 	}
 
 	tearDown {
@@ -22,15 +24,8 @@ definition {
 	@description = "LPS-194725 - This test asserts that the hyperlink is available within an anchor tag."
 	@priority = 3
 	test AssertHyperlinkIsRendered {
-		task ("Given signed into portal as admin") {
-			Navigator.openURL();
-		}
-
 		task ("When navigate to Bundle Blacklist edit configuration page ") {
-			ApplicationsMenu.gotoPortlet(
-				category = "Configuration",
-				panel = "Control Panel",
-				portlet = "System Settings");
+			SystemSettings.openSystemSettingsAdmin();
 
 			SystemSettings.gotoConfiguration(
 				configurationCategory = "Module Container",
@@ -40,15 +35,16 @@ definition {
 
 		task ("Then hyperlink is available within an anchor tag") {
 			AssertElementPresent(
-				key_text = "How does bundle blacklisting work?",
-				locator1 = "Link#ANY");
+				key_href = "blacklisting-apps",
+				key_text = "How does bundle",
+				locator1 = "Link#ANY_HREF_2");
 		}
 
 		task ("And Then text of hyperlink says “How does bundle blacklisting work?") {
-			AssertTextEquals(
+			AssertVisible(
+				key_href = "https://learn.liferay.com/dxp/latest/en/system-administration/installing-and-managing-apps/managing-apps/blacklisting-apps.html",
 				key_text = "How does bundle blacklisting work?",
-				locator1 = "Link#ANY",
-				value1 = ${key_text});
+				locator1 = "Link#ANY_HREF");
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/administration/portalconfiguration/systemmanagement/SystemSettings.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/administration/portalconfiguration/systemmanagement/SystemSettings.testcase
@@ -19,6 +19,39 @@ definition {
 		}
 	}
 
+	@description = "LPS-194725 - This test asserts that the hyperlink is available within an anchor tag."
+	@priority = 3
+	test AssertHyperlinkIsRendered {
+		task ("Given signed into portal as admin") {
+			Navigator.openURL();
+		}
+
+		task ("When navigate to Bundle Blacklist edit configuration page ") {
+			ApplicationsMenu.gotoPortlet(
+				category = "Configuration",
+				panel = "Control Panel",
+				portlet = "System Settings");
+
+			SystemSettings.gotoConfiguration(
+				configurationCategory = "Module Container",
+				configurationName = "Bundle Blacklist",
+				configurationScope = "System Scope");
+		}
+
+		task ("Then hyperlink is available within an anchor tag") {
+			AssertElementPresent(
+				key_text = "How does bundle blacklisting work?",
+				locator1 = "Link#ANY");
+		}
+
+		task ("And Then text of hyperlink says “How does bundle blacklisting work?") {
+			AssertTextEquals(
+				key_text = "How does bundle blacklisting work?",
+				locator1 = "Link#ANY",
+				value1 = ${key_text});
+		}
+	}
+
 	@priority = 5
 	test CanOverrideValueSetInConfigFile {
 		property custom.properties = "configuration.override.com.liferay.journal.configuration.JournalServiceConfiguration_articleCommentsEnabled=B\"false\"";


### PR DESCRIPTION
Manually forwarded due to issues with `ci:forward`. Test failures not related.
cc/ @eltonccdantas

----

[original message]

[Ticket](https://liferay.atlassian.net/browse/LPS-195473)

Test scenario:
Priority: 3

Given signed into portal as admin
When navigate to to Bundle Blacklist edit configuration page
// use Navigator.openSpecificURL to navigate to System Settings > Module Container > Bundle Blacklist
Then hyperlink is available within an anchor tag
And Then text of hyperlink says “How does bundle blacklist work?”

Run this as part of modules/apps/*/configuration-admin-web relevant suite.