### PR TITLE
LPS-196149 Renaming property for clarity

### DIFF
--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -139,9 +139,9 @@
     # collected for a longer time, which may produce high memory usage and
     # potentially out of memory errors.
     #
-    # Env: LIFERAY_UPGRADE_PERIOD_CONCURRENT_PERIOD_PROCESS_PERIOD_LIST_PERIOD_MAX_PERIOD_SIZE
+    # Env: LIFERAY_UPGRADE_PERIOD_CONCURRENT_PERIOD_PROCESS_PERIOD_FUTURE_PERIOD_LIST_PERIOD_MAX_PERIOD_SIZE
     #
-    upgrade.concurrent.process.list.max.size=1000
+    upgrade.concurrent.process.future.list.max.size=1000
 
     #
     # Set this to true to execute the upgrade process when the portal starts and

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -2708,7 +2708,7 @@ public interface PropsKeys {
 		"upgrade.concurrent.fetch.size";
 
 	public static final String UPGRADE_CONCURRENT_PROCESS_FUTURE_LIST_MAX_SIZE =
-		"upgrade.concurrent.process.list.max.size";
+		"upgrade.concurrent.process.future.list.max.size";
 
 	public static final String UPGRADE_DATABASE_AUTO_RUN =
 		"upgrade.database.auto.run";


### PR DESCRIPTION
Manually forwarding as test failures are unrelated :heavy_check_mark: 

https://liferay.atlassian.net/browse/LPS-196149

Sent from: https://github.com/liferay-uniform/liferay-portal/pull/1421