### PR TITLE
LPS-196306: Tags and Categories are not linked when adding Account Nested objects via API

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -906,7 +906,7 @@ public class DefaultObjectEntryManagerImpl
 
 					_relateNestedObjectEntry(
 						objectDefinition, objectRelationship, primaryKey,
-						nestedObjectEntryId);
+						nestedObjectEntryId, new ServiceContext());
 
 					nestedExternalReferenceCodes.add(
 						systemObjectDefinitionManager.
@@ -948,7 +948,10 @@ public class DefaultObjectEntryManagerImpl
 					if (!manyToOneObjectRelationship) {
 						_relateNestedObjectEntry(
 							objectDefinition, objectRelationship, primaryKey,
-							nestedObjectEntry.getId());
+							nestedObjectEntry.getId(),
+							_createServiceContext(
+								nestedObjectEntry,
+								dtoConverterContext.getUserId()));
 					}
 
 					nestedExternalReferenceCodes.add(
@@ -1025,6 +1028,13 @@ public class DefaultObjectEntryManagerImpl
 					Long::parseLong));
 		}
 
+		if (properties.get("taxonomyCategoryIds") != null) {
+			serviceContext.setAssetCategoryIds(
+				ListUtil.toLongArray(
+					(List<Integer>)properties.get("taxonomyCategoryIds"),
+					Long::valueOf));
+		}
+
 		if (Validator.isNotNull(objectEntry.getKeywords())) {
 			serviceContext.setAssetTagNames(objectEntry.getKeywords());
 		}
@@ -1033,6 +1043,12 @@ public class DefaultObjectEntryManagerImpl
 			serviceContext.setAssetTagNames(
 				ArrayUtil.toStringArray(
 					(List<String>)properties.get("tagNames")));
+		}
+
+		if (properties.get("keywords") != null) {
+			serviceContext.setAssetTagNames(
+				ArrayUtil.toStringArray(
+					(List<String>)properties.get("keywords")));
 		}
 
 		serviceContext.setUserId(userId);
@@ -1462,7 +1478,7 @@ public class DefaultObjectEntryManagerImpl
 	private void _relateNestedObjectEntry(
 			ObjectDefinition objectDefinition,
 			ObjectRelationship objectRelationship, long primaryKey,
-			long relatedPrimaryKey)
+			long relatedPrimaryKey, ServiceContext serviceContext)
 		throws Exception {
 
 		long primaryKey1 = relatedPrimaryKey;
@@ -1477,7 +1493,7 @@ public class DefaultObjectEntryManagerImpl
 
 		_objectRelationshipService.addObjectRelationshipMappingTableValues(
 			objectRelationship.getObjectRelationshipId(), primaryKey1,
-			primaryKey2, new ServiceContext());
+			primaryKey2, serviceContext);
 	}
 
 	private Date _toDate(Locale locale, String valueString) {

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -32,6 +32,7 @@ import com.liferay.object.rest.internal.petra.sql.dsl.expression.OrderByExpressi
 import com.liferay.object.rest.internal.resource.v1_0.ObjectEntryRelatedObjectsResourceImpl;
 import com.liferay.object.rest.internal.resource.v1_0.ObjectEntryResourceImpl;
 import com.liferay.object.rest.internal.util.ObjectEntryValuesUtil;
+import com.liferay.object.rest.internal.util.ServiceContextUtil;
 import com.liferay.object.rest.manager.v1_0.BaseObjectEntryManager;
 import com.liferay.object.rest.manager.v1_0.DefaultObjectEntryManager;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
@@ -72,12 +73,10 @@ import com.liferay.portal.kernel.service.PersistedModelLocalService;
 import com.liferay.portal.kernel.service.PersistedModelLocalServiceRegistry;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
-import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.GroupThreadLocal;
 import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.odata.filter.expression.Expression;
@@ -145,7 +144,7 @@ public class DefaultObjectEntryManagerImpl
 				_toObjectValues(
 					dtoConverterContext.getUserId(), objectDefinition,
 					objectEntry, dtoConverterContext.getLocale()),
-				_createServiceContext(
+				ServiceContextUtil.createServiceContext(
 					objectEntry, dtoConverterContext.getUserId()));
 
 		return _toObjectEntry(
@@ -783,7 +782,7 @@ public class DefaultObjectEntryManagerImpl
 			_toObjectValues(
 				dtoConverterContext.getUserId(), objectDefinition, objectEntry,
 				dtoConverterContext.getLocale()),
-			_createServiceContext(
+			ServiceContextUtil.createServiceContext(
 				objectEntry, dtoConverterContext.getUserId()));
 
 		return _toObjectEntry(
@@ -806,7 +805,7 @@ public class DefaultObjectEntryManagerImpl
 
 		long groupId = getGroupId(objectDefinition, scopeKey);
 
-		ServiceContext serviceContext = _createServiceContext(
+		ServiceContext serviceContext = ServiceContextUtil.createServiceContext(
 			objectEntry, dtoConverterContext.getUserId());
 
 		serviceContext.setCompanyId(companyId);
@@ -949,7 +948,7 @@ public class DefaultObjectEntryManagerImpl
 						_relateNestedObjectEntry(
 							objectDefinition, objectRelationship, primaryKey,
 							nestedObjectEntry.getId(),
-							_createServiceContext(
+							ServiceContextUtil.createServiceContext(
 								nestedObjectEntry,
 								dtoConverterContext.getUserId()));
 					}
@@ -1003,62 +1002,6 @@ public class DefaultObjectEntryManagerImpl
 
 			throw new NoSuchObjectEntryException();
 		}
-	}
-
-	private ServiceContext _createServiceContext(
-		ObjectEntry objectEntry, long userId) {
-
-		ServiceContext serviceContext = new ServiceContext();
-
-		serviceContext.setAddGroupPermissions(true);
-		serviceContext.setAddGuestPermissions(true);
-
-		if (Validator.isNotNull(objectEntry.getTaxonomyCategoryIds())) {
-			serviceContext.setAssetCategoryIds(
-				ArrayUtil.toArray(objectEntry.getTaxonomyCategoryIds()));
-			serviceContext.setAssetTagNames(objectEntry.getKeywords());
-		}
-
-		Map<String, Object> properties = objectEntry.getProperties();
-
-		if (properties.get("categoryIds") != null) {
-			serviceContext.setAssetCategoryIds(
-				ListUtil.toLongArray(
-					(List<String>)properties.get("categoryIds"),
-					Long::parseLong));
-		}
-
-		if (properties.get("taxonomyCategoryIds") != null) {
-			serviceContext.setAssetCategoryIds(
-				ListUtil.toLongArray(
-					(List<Integer>)properties.get("taxonomyCategoryIds"),
-					Long::valueOf));
-		}
-
-		if (Validator.isNotNull(objectEntry.getKeywords())) {
-			serviceContext.setAssetTagNames(objectEntry.getKeywords());
-		}
-
-		if (properties.get("tagNames") != null) {
-			serviceContext.setAssetTagNames(
-				ArrayUtil.toStringArray(
-					(List<String>)properties.get("tagNames")));
-		}
-
-		if (properties.get("keywords") != null) {
-			serviceContext.setAssetTagNames(
-				ArrayUtil.toStringArray(
-					(List<String>)properties.get("keywords")));
-		}
-
-		serviceContext.setUserId(userId);
-
-		if (_isObjectEntryDraft(objectEntry.getStatus())) {
-			serviceContext.setWorkflowAction(
-				WorkflowConstants.ACTION_SAVE_DRAFT);
-		}
-
-		return serviceContext;
 	}
 
 	private void _disassociateRelatedModels(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/util/ServiceContextUtil.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/util/ServiceContextUtil.java
@@ -43,13 +43,6 @@ public class ServiceContextUtil {
 					Long::parseLong));
 		}
 
-		if (properties.get("taxonomyCategoryIds") != null) {
-			serviceContext.setAssetCategoryIds(
-				ListUtil.toLongArray(
-					(List<Integer>)properties.get("taxonomyCategoryIds"),
-					Long::valueOf));
-		}
-
 		if (Validator.isNotNull(objectEntry.getKeywords())) {
 			serviceContext.setAssetTagNames(objectEntry.getKeywords());
 		}
@@ -58,12 +51,6 @@ public class ServiceContextUtil {
 			serviceContext.setAssetTagNames(
 				ArrayUtil.toStringArray(
 					(List<String>)properties.get("tagNames")));
-		}
-
-		if (properties.get("keywords") != null) {
-			serviceContext.setAssetTagNames(
-				ArrayUtil.toStringArray(
-					(List<String>)properties.get("keywords")));
 		}
 
 		serviceContext.setUserId(userId);

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/util/ServiceContextUtil.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/util/ServiceContextUtil.java
@@ -1,0 +1,89 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.rest.internal.util;
+
+import com.liferay.object.rest.dto.v1_0.ObjectEntry;
+import com.liferay.object.rest.dto.v1_0.Status;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Sergio Jiménez del Coso
+ */
+public class ServiceContextUtil {
+
+	public static ServiceContext createServiceContext(
+		ObjectEntry objectEntry, long userId) {
+
+		ServiceContext serviceContext = new ServiceContext();
+
+		serviceContext.setAddGroupPermissions(true);
+		serviceContext.setAddGuestPermissions(true);
+
+		if (Validator.isNotNull(objectEntry.getTaxonomyCategoryIds())) {
+			serviceContext.setAssetCategoryIds(
+				ArrayUtil.toArray(objectEntry.getTaxonomyCategoryIds()));
+		}
+
+		Map<String, Object> properties = objectEntry.getProperties();
+
+		if (properties.get("categoryIds") != null) {
+			serviceContext.setAssetCategoryIds(
+				ListUtil.toLongArray(
+					(List<String>)properties.get("categoryIds"),
+					Long::parseLong));
+		}
+
+		if (properties.get("taxonomyCategoryIds") != null) {
+			serviceContext.setAssetCategoryIds(
+				ListUtil.toLongArray(
+					(List<Integer>)properties.get("taxonomyCategoryIds"),
+					Long::valueOf));
+		}
+
+		if (Validator.isNotNull(objectEntry.getKeywords())) {
+			serviceContext.setAssetTagNames(objectEntry.getKeywords());
+		}
+
+		if (properties.get("tagNames") != null) {
+			serviceContext.setAssetTagNames(
+				ArrayUtil.toStringArray(
+					(List<String>)properties.get("tagNames")));
+		}
+
+		if (properties.get("keywords") != null) {
+			serviceContext.setAssetTagNames(
+				ArrayUtil.toStringArray(
+					(List<String>)properties.get("keywords")));
+		}
+
+		serviceContext.setUserId(userId);
+
+		if (_isObjectEntryDraft(objectEntry.getStatus())) {
+			serviceContext.setWorkflowAction(
+				WorkflowConstants.ACTION_SAVE_DRAFT);
+		}
+
+		return serviceContext;
+	}
+
+	private static boolean _isObjectEntryDraft(Status status) {
+		if ((status != null) &&
+			(status.getCode() == WorkflowConstants.STATUS_DRAFT)) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+}

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/util/ServiceContextUtil.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/util/ServiceContextUtil.java
@@ -9,12 +9,8 @@ import com.liferay.object.rest.dto.v1_0.ObjectEntry;
 import com.liferay.object.rest.dto.v1_0.Status;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-
-import java.util.List;
-import java.util.Map;
 
 /**
  * @author Sergio Jiménez del Coso
@@ -34,23 +30,8 @@ public class ServiceContextUtil {
 				ArrayUtil.toArray(objectEntry.getTaxonomyCategoryIds()));
 		}
 
-		Map<String, Object> properties = objectEntry.getProperties();
-
-		if (properties.get("categoryIds") != null) {
-			serviceContext.setAssetCategoryIds(
-				ListUtil.toLongArray(
-					(List<String>)properties.get("categoryIds"),
-					Long::parseLong));
-		}
-
 		if (Validator.isNotNull(objectEntry.getKeywords())) {
 			serviceContext.setAssetTagNames(objectEntry.getKeywords());
-		}
-
-		if (properties.get("tagNames") != null) {
-			serviceContext.setAssetTagNames(
-				ArrayUtil.toStringArray(
-					(List<String>)properties.get("tagNames")));
 		}
 
 		serviceContext.setUserId(userId);

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/ObjectRelationshipExtensionProvider.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/ObjectRelationshipExtensionProvider.java
@@ -11,6 +11,7 @@ import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.related.models.ObjectRelatedModelsProviderRegistry;
 import com.liferay.object.relationship.util.ObjectRelationshipUtil;
 import com.liferay.object.rest.dto.v1_0.ObjectEntry;
+import com.liferay.object.rest.dto.v1_0.Status;
 import com.liferay.object.rest.manager.v1_0.DefaultObjectEntryManager;
 import com.liferay.object.rest.manager.v1_0.DefaultObjectEntryManagerProvider;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
@@ -23,8 +24,12 @@ import com.liferay.object.service.ObjectRelationshipService;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
 import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
 import com.liferay.portal.vulcan.extension.ExtensionProvider;
@@ -230,6 +235,9 @@ public class ObjectRelationshipExtensionProvider
 				relatedObjectDefinition, userId);
 
 			for (ObjectEntry nestedObjectEntry : nestedObjectEntries) {
+				ServiceContext serviceContext = _createServiceContext(
+					nestedObjectEntry, userId);
+
 				nestedObjectEntry = objectEntryManager.updateObjectEntry(
 					objectDefinition.getCompanyId(),
 					_getDefaultDTOConverterContext(
@@ -240,11 +248,67 @@ public class ObjectRelationshipExtensionProvider
 
 				_relateNestedObjectEntry(
 					objectDefinition, objectRelationship, primaryKey,
-					nestedObjectEntry.getId());
+					nestedObjectEntry.getId(), serviceContext);
 			}
 
 			NestedFieldsSupplier.addFieldName(entry.getKey());
 		}
+	}
+
+	private ServiceContext _createServiceContext(
+		ObjectEntry objectEntry, long userId) {
+
+		ServiceContext serviceContext = new ServiceContext();
+
+		serviceContext.setAddGroupPermissions(true);
+		serviceContext.setAddGuestPermissions(true);
+
+		if (Validator.isNotNull(objectEntry.getTaxonomyCategoryIds())) {
+			serviceContext.setAssetCategoryIds(
+				ArrayUtil.toArray(objectEntry.getTaxonomyCategoryIds()));
+			serviceContext.setAssetTagNames(objectEntry.getKeywords());
+		}
+
+		Map<String, Object> properties = objectEntry.getProperties();
+
+		if (properties.get("categoryIds") != null) {
+			serviceContext.setAssetCategoryIds(
+				ListUtil.toLongArray(
+					(List<String>)properties.get("categoryIds"),
+					Long::parseLong));
+		}
+
+		if (properties.get("taxonomyCategoryIds") != null) {
+			serviceContext.setAssetCategoryIds(
+				ListUtil.toLongArray(
+					(List<Integer>)properties.get("taxonomyCategoryIds"),
+					Long::valueOf));
+		}
+
+		if (Validator.isNotNull(objectEntry.getKeywords())) {
+			serviceContext.setAssetTagNames(objectEntry.getKeywords());
+		}
+
+		if (properties.get("tagNames") != null) {
+			serviceContext.setAssetTagNames(
+				ArrayUtil.toStringArray(
+					(List<String>)properties.get("tagNames")));
+		}
+
+		if (properties.get("keywords") != null) {
+			serviceContext.setAssetTagNames(
+				ArrayUtil.toStringArray(
+					(List<String>)properties.get("keywords")));
+		}
+
+		serviceContext.setUserId(userId);
+
+		if (_isObjectEntryDraft(objectEntry.getStatus())) {
+			serviceContext.setWorkflowAction(
+				WorkflowConstants.ACTION_SAVE_DRAFT);
+		}
+
+		return serviceContext;
 	}
 
 	private DefaultDTOConverterContext _getDefaultDTOConverterContext(
@@ -298,10 +362,20 @@ public class ObjectRelationshipExtensionProvider
 		return false;
 	}
 
+	private boolean _isObjectEntryDraft(Status status) {
+		if ((status != null) &&
+			(status.getCode() == WorkflowConstants.STATUS_DRAFT)) {
+
+			return true;
+		}
+
+		return false;
+	}
+
 	private void _relateNestedObjectEntry(
 			ObjectDefinition objectDefinition,
 			ObjectRelationship objectRelationship, long primaryKey,
-			long relatedPrimaryKey)
+			long relatedPrimaryKey, ServiceContext serviceContext)
 		throws Exception {
 
 		long primaryKey1 = relatedPrimaryKey;
@@ -316,7 +390,7 @@ public class ObjectRelationshipExtensionProvider
 
 		_objectRelationshipService.addObjectRelationshipMappingTableValues(
 			objectRelationship.getObjectRelationshipId(), primaryKey1,
-			primaryKey2, new ServiceContext());
+			primaryKey2, serviceContext);
 	}
 
 	@Reference

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/ObjectRelationshipExtensionProvider.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/ObjectRelationshipExtensionProvider.java
@@ -11,7 +11,7 @@ import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.related.models.ObjectRelatedModelsProviderRegistry;
 import com.liferay.object.relationship.util.ObjectRelationshipUtil;
 import com.liferay.object.rest.dto.v1_0.ObjectEntry;
-import com.liferay.object.rest.dto.v1_0.Status;
+import com.liferay.object.rest.internal.util.ServiceContextUtil;
 import com.liferay.object.rest.manager.v1_0.DefaultObjectEntryManager;
 import com.liferay.object.rest.manager.v1_0.DefaultObjectEntryManagerProvider;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
@@ -24,12 +24,8 @@ import com.liferay.object.service.ObjectRelationshipService;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
-import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.kernel.util.Validator;
-import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
 import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
 import com.liferay.portal.vulcan.extension.ExtensionProvider;
@@ -235,9 +231,6 @@ public class ObjectRelationshipExtensionProvider
 				relatedObjectDefinition, userId);
 
 			for (ObjectEntry nestedObjectEntry : nestedObjectEntries) {
-				ServiceContext serviceContext = _createServiceContext(
-					nestedObjectEntry, userId);
-
 				nestedObjectEntry = objectEntryManager.updateObjectEntry(
 					objectDefinition.getCompanyId(),
 					_getDefaultDTOConverterContext(
@@ -248,67 +241,13 @@ public class ObjectRelationshipExtensionProvider
 
 				_relateNestedObjectEntry(
 					objectDefinition, objectRelationship, primaryKey,
-					nestedObjectEntry.getId(), serviceContext);
+					nestedObjectEntry.getId(),
+					ServiceContextUtil.createServiceContext(
+						nestedObjectEntry, userId));
 			}
 
 			NestedFieldsSupplier.addFieldName(entry.getKey());
 		}
-	}
-
-	private ServiceContext _createServiceContext(
-		ObjectEntry objectEntry, long userId) {
-
-		ServiceContext serviceContext = new ServiceContext();
-
-		serviceContext.setAddGroupPermissions(true);
-		serviceContext.setAddGuestPermissions(true);
-
-		if (Validator.isNotNull(objectEntry.getTaxonomyCategoryIds())) {
-			serviceContext.setAssetCategoryIds(
-				ArrayUtil.toArray(objectEntry.getTaxonomyCategoryIds()));
-			serviceContext.setAssetTagNames(objectEntry.getKeywords());
-		}
-
-		Map<String, Object> properties = objectEntry.getProperties();
-
-		if (properties.get("categoryIds") != null) {
-			serviceContext.setAssetCategoryIds(
-				ListUtil.toLongArray(
-					(List<String>)properties.get("categoryIds"),
-					Long::parseLong));
-		}
-
-		if (properties.get("taxonomyCategoryIds") != null) {
-			serviceContext.setAssetCategoryIds(
-				ListUtil.toLongArray(
-					(List<Integer>)properties.get("taxonomyCategoryIds"),
-					Long::valueOf));
-		}
-
-		if (Validator.isNotNull(objectEntry.getKeywords())) {
-			serviceContext.setAssetTagNames(objectEntry.getKeywords());
-		}
-
-		if (properties.get("tagNames") != null) {
-			serviceContext.setAssetTagNames(
-				ArrayUtil.toStringArray(
-					(List<String>)properties.get("tagNames")));
-		}
-
-		if (properties.get("keywords") != null) {
-			serviceContext.setAssetTagNames(
-				ArrayUtil.toStringArray(
-					(List<String>)properties.get("keywords")));
-		}
-
-		serviceContext.setUserId(userId);
-
-		if (_isObjectEntryDraft(objectEntry.getStatus())) {
-			serviceContext.setWorkflowAction(
-				WorkflowConstants.ACTION_SAVE_DRAFT);
-		}
-
-		return serviceContext;
 	}
 
 	private DefaultDTOConverterContext _getDefaultDTOConverterContext(
@@ -355,16 +294,6 @@ public class ObjectRelationshipExtensionProvider
 				relatedObjectDefinition.getObjectDefinitionId()) &&
 			(objectRelationship.getObjectDefinitionId2() ==
 				objectDefinition.getObjectDefinitionId())) {
-
-			return true;
-		}
-
-		return false;
-	}
-
-	private boolean _isObjectEntryDraft(Status status) {
-		if ((status != null) &&
-			(status.getCode() == WorkflowConstants.STATUS_DRAFT)) {
 
 			return true;
 		}

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/ObjectRelationshipExtensionProvider.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/ObjectRelationshipExtensionProvider.java
@@ -23,9 +23,12 @@ import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.object.service.ObjectRelationshipService;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
 import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
 import com.liferay.portal.vulcan.extension.ExtensionProvider;
@@ -102,7 +105,7 @@ public class ObjectRelationshipExtensionProvider
 					return defaultObjectEntryManager.
 						fetchRelatedManyToOneObjectEntry(
 							_getDefaultDTOConverterContext(
-								objectDefinition, primaryKey, null),
+								objectDefinition, primaryKey, null, null),
 							objectDefinition, primaryKey,
 							objectRelationship.getName());
 				}
@@ -116,7 +119,7 @@ public class ObjectRelationshipExtensionProvider
 					defaultObjectEntryManager.
 						getObjectEntryRelatedObjectEntries(
 							_getDefaultDTOConverterContext(
-								objectDefinition, primaryKey, null),
+								objectDefinition, primaryKey, null, null),
 							objectDefinition, primaryKey,
 							objectRelationship.getName(),
 							Pagination.of(
@@ -226,7 +229,7 @@ public class ObjectRelationshipExtensionProvider
 
 			defaultObjectEntryManager.disassociateRelatedModels(
 				_getDefaultDTOConverterContext(
-					objectDefinition, primaryKey, null),
+					objectDefinition, primaryKey, null, userId),
 				objectDefinition, objectRelationship, primaryKey,
 				relatedObjectDefinition, userId);
 
@@ -234,7 +237,7 @@ public class ObjectRelationshipExtensionProvider
 				nestedObjectEntry = objectEntryManager.updateObjectEntry(
 					objectDefinition.getCompanyId(),
 					_getDefaultDTOConverterContext(
-						objectDefinition, primaryKey, null),
+						objectDefinition, primaryKey, null, userId),
 					nestedObjectEntry.getExternalReferenceCode(),
 					relatedObjectDefinition, nestedObjectEntry,
 					relatedObjectDefinition.getScope());
@@ -251,15 +254,22 @@ public class ObjectRelationshipExtensionProvider
 	}
 
 	private DefaultDTOConverterContext _getDefaultDTOConverterContext(
-		ObjectDefinition objectDefinition, Long objectEntryId,
-		UriInfo uriInfo) {
+			ObjectDefinition objectDefinition, Long objectEntryId,
+			UriInfo uriInfo, Long userId)
+		throws Exception {
+
+		User user = null;
+
+		if (Validator.isNotNull(userId)) {
+			user = _userLocalService.getUser(userId);
+		}
 
 		DefaultDTOConverterContext defaultDTOConverterContext =
 			new DefaultDTOConverterContext(
 				false, null, _dtoConverterRegistry, objectEntryId,
 				LocaleUtil.fromLanguageId(
 					objectDefinition.getDefaultLanguageId(), true, false),
-				uriInfo, null);
+				uriInfo, user);
 
 		defaultDTOConverterContext.setAttribute("addActions", Boolean.FALSE);
 
@@ -344,5 +354,8 @@ public class ObjectRelationshipExtensionProvider
 
 	@Reference
 	private ObjectRelationshipService _objectRelationshipService;
+
+	@Reference
+	private UserLocalService _userLocalService;
 
 }

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_entries/object_entry/form.jsp
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_entries/object_entry/form.jsp
@@ -175,15 +175,15 @@ portletDisplay.setURLBack(backURL);
 								values = Object.assign(
 									values,
 									{
-										['taxonomyCategoryIds']: <portlet:namespace />getInputValues(
-											categoriesContent,
-											'input[name^="<portlet:namespace />assetCategoryIds"]'
-										),
-									},
-									{
 										['keywords']: <portlet:namespace />getInputValues(
 											categoriesContent,
 											'input[name^="<portlet:namespace />assetTagNames"]'
+										),
+									},
+									{
+										['taxonomyCategoryIds']: <portlet:namespace />getInputValues(
+											categoriesContent,
+											'input[name^="<portlet:namespace />assetCategoryIds"]'
 										),
 									}
 								);

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_entries/object_entry/form.jsp
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_entries/object_entry/form.jsp
@@ -175,13 +175,13 @@ portletDisplay.setURLBack(backURL);
 								values = Object.assign(
 									values,
 									{
-										['categoryIds']: <portlet:namespace />getInputValues(
+										['taxonomyCategoryIds']: <portlet:namespace />getInputValues(
 											categoriesContent,
 											'input[name^="<portlet:namespace />assetCategoryIds"]'
 										),
 									},
 									{
-										['tagNames']: <portlet:namespace />getInputValues(
+										['keywords']: <portlet:namespace />getInputValues(
 											categoriesContent,
 											'input[name^="<portlet:namespace />assetTagNames"]'
 										),


### PR DESCRIPTION
Forwarded manually from: https://github.com/liferay-headless/liferay-portal/pull/1539

cc/ @sergiojimcos

---

**What is new?**
- Create ServiceContextUtil in order to reuse it in the `ObjectRelationshipExtensionProvider` and `DefaultObjectEntryManager`.
- Update `_getDefaultDTOConverterContext` in order to set the userId, this ie because the keywords properties is going to be added depending from the value of the userId from the `DTOConverterContext` that is going to be injected in the `ObjectRelationshipExtensionProvider`

**How to test this**
1. Create one new object: “Sample” with a field “sampleField” and enable categorization for this Object.
2. Create one Vocabulary with one Category (ID=12345 as example)
3. Create relationship Account ← 1:n (oneToMany) → Sample. Relationship named “accountSamples”
4. Access the headless-commerce-admin-account API:/o/api/?endpoint=http://localhost:8080/o/headless-commerce-admin-account/v1.0/openapi.json
5. Execute this payload:

```json
{
    "active": true,
    "externalReferenceCode": "TEST01",
    "name": "TEST01",
    "root": true,
    "type": 2,
    "accountSamples": [
      {
        "externalReferenceCode": "SAMPLE01",
        "name": "SAMPLE01",
        "sampleField": "A value 01"
        "taxonomyCategoryIds": [12345],
        "keywords": ["tag example"]
      }
    ]
  }

```
**JIRA Related TIcket**
https://liferay.atlassian.net/browse/LPS-196306 

cc/ @sergiojimcos 