### PR TITLE
LPS-195363 Add context back-url-title for Segments

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageLayoutEditorDisplayContext.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageLayoutEditorDisplayContext.java
@@ -415,6 +415,12 @@ public class ContentPageLayoutEditorDisplayContext
 			_editSegmentsEntryURL = layoutLockManager.getUnlockDraftLayoutURL(
 				portal.getLiferayPortletResponse(renderResponse),
 				() -> {
+					Layout layout = themeDisplay.getLayout();
+
+					portletURL.setParameter(
+						"backURLTitle",
+						layout.getName(themeDisplay.getLocale()));
+
 					portletURL.setParameter(
 						"redirect", themeDisplay.getURLCurrent());
 

--- a/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/display/context/EditSegmentsEntryDisplayContext.java
+++ b/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/display/context/EditSegmentsEntryDisplayContext.java
@@ -99,6 +99,17 @@ public class EditSegmentsEntryDisplayContext {
 		return _backURL;
 	}
 
+	public String getBackURLTitle() {
+		String backURLTitle = ParamUtil.getString(
+			_httpServletRequest, "backURLTitle");
+
+		if (Validator.isNotNull(backURLTitle)) {
+			return backURLTitle;
+		}
+
+		return LanguageUtil.get(_httpServletRequest, "segments");
+	}
+
 	public Map<String, Object> getData() throws Exception {
 		if (_data != null) {
 			return _data;

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/edit_segments_entry.jsp
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/edit_segments_entry.jsp
@@ -15,6 +15,7 @@ String backURL = editSegmentsEntryDisplayContext.getBackURL();
 if (Validator.isNotNull(backURL)) {
 	portletDisplay.setShowBackIcon(true);
 	portletDisplay.setURLBack(backURL);
+	portletDisplay.setURLBackTitle(editSegmentsEntryDisplayContext.getBackURLTitle());
 }
 
 renderResponse.setTitle(editSegmentsEntryDisplayContext.getTitle(locale));

--- a/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/portlet/action/GetDataMVCResourceCommand.java
+++ b/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/portlet/action/GetDataMVCResourceCommand.java
@@ -100,6 +100,8 @@ public class GetDataMVCResourceCommand extends BaseMVCResourceCommand {
 
 		try {
 			String backURL = ParamUtil.getString(resourceRequest, "backURL");
+			String backURLTitle = ParamUtil.getString(
+				resourceRequest, "backURLTitle");
 			String redirect = ParamUtil.getString(resourceRequest, "redirect");
 
 			long plid = ParamUtil.getLong(resourceRequest, "plid");
@@ -117,8 +119,8 @@ public class GetDataMVCResourceCommand extends BaseMVCResourceCommand {
 				JSONUtil.put(
 					"context",
 					_getContextJSONObject(
-						backURL, layout, httpServletRequest, redirect,
-						segmentsExperienceId)
+						backURL, backURLTitle, layout, httpServletRequest,
+						redirect, segmentsExperienceId)
 				).put(
 					"props",
 					_getPropsJSONObject(
@@ -203,7 +205,7 @@ public class GetDataMVCResourceCommand extends BaseMVCResourceCommand {
 	}
 
 	private JSONObject _getContextJSONObject(
-			String backURL, Layout layout,
+			String backURL, String backURLTitle, Layout layout,
 			HttpServletRequest httpServletRequest, String redirect,
 			long segmentsExperienceId)
 		throws Exception {
@@ -268,7 +270,8 @@ public class GetDataMVCResourceCommand extends BaseMVCResourceCommand {
 			).put(
 				"editSegmentsVariantLayoutURL",
 				_getEditSegmentsVariantLayoutURL(
-					backURL, layout, redirect, segmentsExperienceId)
+					backURL, backURLTitle, layout, redirect,
+					segmentsExperienceId)
 			).put(
 				"editSegmentsVariantURL",
 				_getSegmentsExperimentActionURL(
@@ -296,7 +299,7 @@ public class GetDataMVCResourceCommand extends BaseMVCResourceCommand {
 	}
 
 	private String _getEditSegmentsVariantLayoutURL(
-		String backURL, Layout layout, String redirect,
+		String backURL, String backURLTitle, Layout layout, String redirect,
 		long segmentsExperienceId) {
 
 		Layout draftLayout = _layoutLocalService.fetchDraftLayout(
@@ -311,15 +314,9 @@ public class GetDataMVCResourceCommand extends BaseMVCResourceCommand {
 				backURL, "segmentsExperienceId", segmentsExperienceId);
 		}
 
-		redirect = HttpComponentsUtil.setParameter(
-			redirect, "p_l_back_url", backURL);
-
-		redirect = HttpComponentsUtil.setParameter(
-			redirect, "p_l_mode", Constants.EDIT);
-		redirect = HttpComponentsUtil.setParameter(
-			redirect, "redirect", redirect);
-
-		return redirect;
+		return HttpComponentsUtil.addParameters(
+			redirect, "p_l_back_url", backURL, "p_l_back_url_title",
+			backURLTitle, "p_l_mode", Constants.EDIT, "redirect", redirect);
 	}
 
 	private long _getLiveGroupId(long groupId) throws Exception {

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/java/com/liferay/segments/experiment/web/internal/product/navigation/control/menu/SegmentsExperimentProductNavigationControlMenuEntry.java
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/java/com/liferay/segments/experiment/web/internal/product/navigation/control/menu/SegmentsExperimentProductNavigationControlMenuEntry.java
@@ -324,6 +324,13 @@ public class SegmentsExperimentProductNavigationControlMenuEntry
 		).setBackURL(
 			layoutURL
 		).setParameter(
+			"backURLTitle",
+			() -> {
+				Layout layout = themeDisplay.getLayout();
+
+				return layout.getName(themeDisplay.getLocale());
+			}
+		).setParameter(
 			"plid", themeDisplay.getPlid()
 		).setParameter(
 			"segmentsExperienceId",


### PR DESCRIPTION
Motivation
=======
The motivation behind this ticket is to use setURLBackTitle method for setting the name of the page when hovering over the back button to give the user more context.
https://liferay.atlassian.net/browse/LPS-195363

Proposed Solution
========
What I did to solve this problem is to use the new setURLBackTitle in the PortletDisplay class for setting this parameter.

Steps to Verify
========
1. Go People -> Segments -> Create a Segment -> Check that the Back button displays "Go to Segments"
2. Go to Page Editor view -> Click on the Selector Experience -> Create New Experience -> Add Segment -> Check that the back button displays "Go the nameOfPage"
3.  Connect to analytics cloud -> open the A/B Testing panel -> Add a Variant -> Go to the Variant Edit View -> Check that the back button displays ""Go the nameOfPage"

cc/ @Stephy6 