### PR TITLE
LPS-196165 Add section label for fragment options

### DIFF
--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/renderer/ContentFlagsFragmentRenderer.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/renderer/ContentFlagsFragmentRenderer.java
@@ -63,7 +63,13 @@ public class ContentFlagsFragmentRenderer
 							"name", "message"
 						).put(
 							"type", "text"
-						))))
+						))
+				).put(
+					"label",
+					_language.format(
+						fragmentRendererContext.getLocale(), "x-options",
+						"content-flags", true)
+				))
 		).toString();
 	}
 

--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/renderer/ContentObjectFragmentRenderer.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/renderer/ContentObjectFragmentRenderer.java
@@ -77,7 +77,13 @@ public class ContentObjectFragmentRenderer implements FragmentRenderer {
 						).put(
 							"typeOptions",
 							JSONUtil.put("enableSelectTemplate", true)
-						))))
+						))
+				).put(
+					"label",
+					_language.format(
+						fragmentRendererContext.getLocale(), "x-options",
+						"content-display", true)
+				))
 		).toString();
 	}
 

--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/renderer/ContentRatingsFragmentRenderer.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/renderer/ContentRatingsFragmentRenderer.java
@@ -51,7 +51,13 @@ public class ContentRatingsFragmentRenderer
 							"name", "itemSelector"
 						).put(
 							"type", "itemSelector"
-						))))
+						))
+				).put(
+					"label",
+					_language.format(
+						fragmentRendererContext.getLocale(), "x-options",
+						"content-ratings", true)
+				))
 		).toString();
 	}
 


### PR DESCRIPTION
Motivation
=======
Add title of the section in the fragment configuration for  fragments: Content Display, Content Flags and Content Ratings
[Link to story or ticket](https://liferay.atlassian.net/browse/LPS-196165)

Steps to Verify:
----------------
1. Go to page editor
1. Add fragments Content Display, Content Flags and Content Ratings
1. Check that in their configuration options there is a section with title "Fragment-Name Options"

cc/ @claraizquierdo 