### PR TITLE
LPS-194720 - Additional Commits

### DIFF
--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-web/src/main/java/com/liferay/multi/factor/authentication/web/internal/servlet/filter/MFAFilter.java
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-web/src/main/java/com/liferay/multi/factor/authentication/web/internal/servlet/filter/MFAFilter.java
@@ -32,8 +32,7 @@ import org.osgi.service.component.annotations.Reference;
 @Component(
 	property = {
 		"dispatcher=FORWARD", "dispatcher=REQUEST", "servlet-context-name=",
-		"servlet-filter-name=MFA Filter",
-		"url-pattern=/c/portal/update_password*"
+		"servlet-filter-name=MFA Filter", "url-pattern=/*"
 	},
 	service = Filter.class
 )
@@ -45,13 +44,18 @@ public class MFAFilter extends BaseFilter implements TryFilter {
 			HttpServletResponse httpServletResponse)
 		throws Exception {
 
-		boolean mfaEnabled = _mfaPolicy.isMFAEnabled(
-			GetterUtil.getLong(
-				httpServletRequest.getAttribute(WebKeys.COMPANY_ID)));
+		String path = (String)httpServletRequest.getAttribute(
+			WebKeys.INVOKER_FILTER_URI);
 
-		HttpSession httpSession = httpServletRequest.getSession();
+		if (path.contains("/c/portal/update_password")) {
+			boolean mfaEnabled = _mfaPolicy.isMFAEnabled(
+				GetterUtil.getLong(
+					httpServletRequest.getAttribute(WebKeys.COMPANY_ID)));
 
-		httpSession.setAttribute(WebKeys.MFA_ENABLED, mfaEnabled);
+			HttpSession httpSession = httpServletRequest.getSession();
+
+			httpSession.setAttribute(WebKeys.MFA_ENABLED, mfaEnabled);
+		}
 
 		return true;
 	}


### PR DESCRIPTION
Additional commits for LPS-194720 (https://github.com/liferay-appsec/liferay-portal/pull/1341) as the solution did not pass QA testing.

Original pull request approved by the product team: https://github.com/liferay-appsec/liferay-portal/pull/1391 

### Reproduction steps:

1. Setup DXP environment with a fake SMTP service
2. Configure the standard ‘out of the box’ Multi Factor One Time Password
For this, first check if it is not disabled at Control Panel > System Settings > Security > Multi-Factor Authentication (If it is unchecked, then it is enabled)
Then navigate to Control Panel > Instance Settings > Security > Multi-Factor Authentication > Multi-Factor Authentication and Email One-Time Password Configuration
3. Navigate to Time-Based One-Time Password Configuration option > Enable and Save
4. Navigate to User Profile Menu > Account Settings > Multi-Factor Authentication tab > Connect the user with an authenticator app (e.g. Google Authenticator) - use the QR code or the Shared Secret > After paired, enter the time based code to the portal
_Checkpoint:_ if it is successful, you will see a huge red info container after the page re-render itself
To make sure it is working > Log out > Log in, and use the authenticator app for the time-based code
5. If it is working, log out again > At logging in, select Forgot Password > Fill out the necessary information
6. Receive 'Forgot Password' email
7. Select the link in the email beware the "dot" (.) at the end of the link, set up new password > Submit

**Results:**
 _Expected:_ The user is redirected to the login page to be able to sign in, after the password change.
_Actual:_ The user is not redirected to the login page to be able to sign in after the password change. They just got auto signed in to the portal.

### Implementation details: 
It looks like when [setting the url path inside the filter's component properties url-pattern](https://github.com/liferay-appsec/liferay-portal/pull/1341/commits/66afe2d710f0b886bee527256ab768bec5f95987), the filter class is not called at all. 

### Commits included:
- LPS-194720 Revert "LPS-194720 Set url path inside the filter's component properties url-pattern"