### PR TITLE
LPS-197305 Running batch on startup after enabling feature flags

### DIFF
--- a/modules/apps/batch-engine/batch-engine-api/bnd.bnd
+++ b/modules/apps/batch-engine/batch-engine-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Batch Engine API
 Bundle-SymbolicName: com.liferay.batch.engine.api
-Bundle-Version: 23.1.1
+Bundle-Version: 23.2.0
 Export-Package:\
 	com.liferay.batch.engine,\
 	com.liferay.batch.engine.action,\

--- a/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/unit/BundleBatchEngineUnit.java
+++ b/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/unit/BundleBatchEngineUnit.java
@@ -1,0 +1,17 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.batch.engine.unit;
+
+import org.osgi.framework.Bundle;
+
+/**
+ * @author Alejandro Tardín
+ */
+public interface BundleBatchEngineUnit extends BatchEngineUnit {
+
+	public Bundle getBundle();
+
+}

--- a/modules/apps/batch-engine/batch-engine-api/src/main/resources/com/liferay/batch/engine/unit/packageinfo
+++ b/modules/apps/batch-engine/batch-engine-api/src/main/resources/com/liferay/batch/engine/unit/packageinfo
@@ -1,1 +1,1 @@
-version 4.2.0
+version 4.3.0

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/bundle/AdvancedBundleBatchEngineUnitImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/bundle/AdvancedBundleBatchEngineUnitImpl.java
@@ -6,8 +6,8 @@
 package com.liferay.batch.engine.internal.bundle;
 
 import com.liferay.batch.engine.internal.json.AdvancedJSONReader;
-import com.liferay.batch.engine.unit.BatchEngineUnit;
 import com.liferay.batch.engine.unit.BatchEngineUnitConfiguration;
+import com.liferay.batch.engine.unit.BundleBatchEngineUnit;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 
@@ -24,7 +24,8 @@ import org.osgi.framework.Bundle;
  * @author Raymond Augé
  * @author Igor Beslic
  */
-public class AdvancedBundleBatchEngineUnitImpl implements BatchEngineUnit {
+public class AdvancedBundleBatchEngineUnitImpl
+	implements BundleBatchEngineUnit {
 
 	public AdvancedBundleBatchEngineUnitImpl(Bundle bundle, URL url) {
 		_bundle = bundle;
@@ -42,6 +43,11 @@ public class AdvancedBundleBatchEngineUnitImpl implements BatchEngineUnit {
 			return advancedJSONReader.getObject(
 				"configuration", BatchEngineUnitConfiguration.class);
 		}
+	}
+
+	@Override
+	public Bundle getBundle() {
+		return _bundle;
 	}
 
 	@Override

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/bundle/BatchEngineBundleTracker.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/bundle/BatchEngineBundleTracker.java
@@ -10,19 +10,13 @@ import com.liferay.batch.engine.unit.BatchEngineUnit;
 import com.liferay.batch.engine.unit.BatchEngineUnitConfiguration;
 import com.liferay.batch.engine.unit.BatchEngineUnitProcessor;
 import com.liferay.batch.engine.unit.BatchEngineUnitReader;
-import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
-import com.liferay.portal.kernel.util.FileUtil;
-
-import java.io.File;
-import java.io.IOException;
 
 import java.util.ArrayList;
 import java.util.Dictionary;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
@@ -54,33 +48,6 @@ public class BatchEngineBundleTracker {
 	@Deactivate
 	protected void deactivate() {
 		_bundleTracker.close();
-	}
-
-	private boolean _isAlreadyProcessed(Bundle bundle) {
-		String lastModifiedString = String.valueOf(bundle.getLastModified());
-
-		File batchMarkerFile = bundle.getDataFile(
-			".liferay-client-extension-batch");
-
-		try {
-			if ((batchMarkerFile != null) && batchMarkerFile.exists() &&
-				Objects.equals(
-					FileUtil.read(batchMarkerFile), lastModifiedString)) {
-
-				return true;
-			}
-
-			if (!batchMarkerFile.exists()) {
-				batchMarkerFile.createNewFile();
-			}
-
-			FileUtil.write(batchMarkerFile, lastModifiedString, true);
-		}
-		catch (IOException ioException) {
-			ReflectionUtil.throwException(ioException);
-		}
-
-		return false;
 	}
 
 	@Reference
@@ -139,19 +106,15 @@ public class BatchEngineBundleTracker {
 				}
 			}
 
-			boolean alreadyProcessed = _isAlreadyProcessed(bundle);
-
-			if (!alreadyProcessed) {
-				_batchEngineUnitProcessor.processBatchEngineUnits(
-					singleCompanyBatchEngineUnits);
-			}
+			_batchEngineUnitProcessor.processBatchEngineUnits(
+				singleCompanyBatchEngineUnits);
 
 			if (multiCompanyBatchEngineUnits.isEmpty()) {
 				return null;
 			}
 
 			_multiCompanyBatchEngineUnitProcessor.registerBatchEngineUnits(
-				bundle, multiCompanyBatchEngineUnits, !alreadyProcessed);
+				bundle, multiCompanyBatchEngineUnits);
 
 			return bundle;
 		}

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/bundle/ClassicBundleBatchEngineUnitImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/bundle/ClassicBundleBatchEngineUnitImpl.java
@@ -7,8 +7,8 @@ package com.liferay.batch.engine.internal.bundle;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import com.liferay.batch.engine.unit.BatchEngineUnit;
 import com.liferay.batch.engine.unit.BatchEngineUnitConfiguration;
+import com.liferay.batch.engine.unit.BundleBatchEngineUnit;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -24,7 +24,7 @@ import org.osgi.framework.Bundle;
  * @author Raymond Augé
  * @author Igor Beslic
  */
-public class ClassicBundleBatchEngineUnitImpl implements BatchEngineUnit {
+public class ClassicBundleBatchEngineUnitImpl implements BundleBatchEngineUnit {
 
 	public ClassicBundleBatchEngineUnitImpl(Bundle bundle, List<URL> urls) {
 		_bundle = bundle;
@@ -54,6 +54,11 @@ public class ClassicBundleBatchEngineUnitImpl implements BatchEngineUnit {
 			return objectMapper.readValue(
 				inputStream, BatchEngineUnitConfiguration.class);
 		}
+	}
+
+	@Override
+	public Bundle getBundle() {
+		return _bundle;
 	}
 
 	@Override

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/bundle/CompanyBatchEngineUnitWrapper.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/bundle/CompanyBatchEngineUnitWrapper.java
@@ -7,15 +7,18 @@ package com.liferay.batch.engine.internal.bundle;
 
 import com.liferay.batch.engine.unit.BatchEngineUnit;
 import com.liferay.batch.engine.unit.BatchEngineUnitConfiguration;
+import com.liferay.batch.engine.unit.BundleBatchEngineUnit;
 import com.liferay.portal.kernel.model.Company;
 
 import java.io.IOException;
 import java.io.InputStream;
 
+import org.osgi.framework.Bundle;
+
 /**
  * @author Alejandro Tardín
  */
-public class CompanyBatchEngineUnitWrapper implements BatchEngineUnit {
+public class CompanyBatchEngineUnitWrapper implements BundleBatchEngineUnit {
 
 	public CompanyBatchEngineUnitWrapper(
 		BatchEngineUnit batchEngineUnit, Company company) {
@@ -46,6 +49,15 @@ public class CompanyBatchEngineUnitWrapper implements BatchEngineUnit {
 				setVersion(batchEngineUnitConfiguration.getVersion());
 			}
 		};
+	}
+
+	@Override
+	public Bundle getBundle() {
+		if (_batchEngineUnit instanceof BundleBatchEngineUnit) {
+			return ((BundleBatchEngineUnit)_batchEngineUnit).getBundle();
+		}
+
+		return null;
 	}
 
 	@Override

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/unit/BatchEngineUnitProcessorImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/unit/BatchEngineUnitProcessorImpl.java
@@ -336,7 +336,11 @@ public class BatchEngineUnitProcessorImpl implements BatchEngineUnitProcessor {
 		Map<String, Serializable> parameters =
 			batchEngineUnitConfiguration.getParameters();
 
-		String featureFlag = (String)parameters.get("featureFlag");
+		String featureFlag = null;
+
+		if (parameters != null) {
+			featureFlag = (String)parameters.get("featureFlag");
+		}
 
 		if ((Validator.isNotNull(featureFlag) &&
 			 !FeatureFlagManagerUtil.isEnabled(featureFlag)) ||

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/unit/BatchEngineUnitProcessorImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/unit/BatchEngineUnitProcessorImpl.java
@@ -269,10 +269,14 @@ public class BatchEngineUnitProcessorImpl implements BatchEngineUnitProcessor {
 						"processed"),
 					"."));
 
+			if (batchMarkerFile == null) {
+				return false;
+			}
+
 			String lastModifiedString = String.valueOf(
 				bundle.getLastModified());
 
-			if ((batchMarkerFile != null) && batchMarkerFile.exists() &&
+			if (batchMarkerFile.exists() &&
 				Objects.equals(
 					FileUtil.read(batchMarkerFile), lastModifiedString)) {
 

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/unit/BatchEngineUnitProcessorImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/unit/BatchEngineUnitProcessorImpl.java
@@ -17,9 +17,11 @@ import com.liferay.batch.engine.unit.BatchEngineUnit;
 import com.liferay.batch.engine.unit.BatchEngineUnitConfiguration;
 import com.liferay.batch.engine.unit.BatchEngineUnitProcessor;
 import com.liferay.batch.engine.unit.BatchEngineUnitThreadLocal;
+import com.liferay.batch.engine.unit.BundleBatchEngineUnit;
 import com.liferay.petra.executor.PortalExecutorManager;
 import com.liferay.petra.io.StreamUtil;
 import com.liferay.petra.io.unsync.UnsyncByteArrayOutputStream;
+import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -30,24 +32,29 @@ import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.File;
+import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegateAdaptorFactory;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
+import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.annotations.Activate;
@@ -217,6 +224,14 @@ public class BatchEngineUnitProcessorImpl implements BatchEngineUnitProcessor {
 		serviceTracker.close();
 	}
 
+	private Bundle _getBundle(BatchEngineUnit batchEngineUnit) {
+		if (!(batchEngineUnit instanceof BundleBatchEngineUnit)) {
+			return null;
+		}
+
+		return ((BundleBatchEngineUnit)batchEngineUnit).getBundle();
+	}
+
 	private String _getObjectEntryClassName(
 		BatchEngineUnitConfiguration batchEngineUnitConfiguration) {
 
@@ -231,6 +246,52 @@ public class BatchEngineUnitProcessorImpl implements BatchEngineUnitProcessor {
 		}
 
 		return className;
+	}
+
+	private boolean _isProcessed(BatchEngineUnit batchEngineUnit) {
+		Bundle bundle = _getBundle(batchEngineUnit);
+
+		if (bundle == null) {
+			return false;
+		}
+
+		try {
+			BatchEngineUnitConfiguration batchEngineUnitConfiguration =
+				batchEngineUnit.getBatchEngineUnitConfiguration();
+
+			String dataFileName = batchEngineUnit.getDataFileName();
+
+			java.io.File batchMarkerFile = bundle.getDataFile(
+				com.liferay.petra.string.StringUtil.merge(
+					Arrays.asList(
+						dataFileName.replaceAll("\\W+", "."),
+						batchEngineUnitConfiguration.getCompanyId(),
+						"processed"),
+					"."));
+
+			String lastModifiedString = String.valueOf(
+				bundle.getLastModified());
+
+			if ((batchMarkerFile != null) && batchMarkerFile.exists() &&
+				Objects.equals(
+					FileUtil.read(batchMarkerFile), lastModifiedString)) {
+
+				return true;
+			}
+
+			if (!batchMarkerFile.exists()) {
+				batchMarkerFile.createNewFile();
+			}
+
+			FileUtil.write(batchMarkerFile, lastModifiedString, true);
+
+			return false;
+		}
+		catch (IOException ioException) {
+			ReflectionUtil.throwException(ioException);
+		}
+
+		return false;
 	}
 
 	private CompletableFuture<Void> _processBatchEngineUnit(
@@ -277,8 +338,9 @@ public class BatchEngineUnitProcessorImpl implements BatchEngineUnitProcessor {
 
 		String featureFlag = (String)parameters.get("featureFlag");
 
-		if (Validator.isNotNull(featureFlag) &&
-			!FeatureFlagManagerUtil.isEnabled(featureFlag)) {
+		if ((Validator.isNotNull(featureFlag) &&
+			 !FeatureFlagManagerUtil.isEnabled(featureFlag)) ||
+			_isProcessed(batchEngineUnit)) {
 
 			return null;
 		}

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/unit/MultiCompanyBatchEngineUnitProcessor.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/unit/MultiCompanyBatchEngineUnitProcessor.java
@@ -43,15 +43,12 @@ public class MultiCompanyBatchEngineUnitProcessor {
 	}
 
 	public void registerBatchEngineUnits(
-		Bundle bundle, List<BatchEngineUnit> batchEngineUnits,
-		boolean process) {
+		Bundle bundle, List<BatchEngineUnit> batchEngineUnits) {
 
 		_bundleBatchEngineUnits.put(bundle, batchEngineUnits);
 
-		if (process) {
-			_companyLocalService.forEachCompany(
-				company -> _processBatchEngineUnits(bundle, company));
-		}
+		_companyLocalService.forEachCompany(
+			company -> _processBatchEngineUnits(bundle, company));
 	}
 
 	public void unregister(Bundle bundle) {

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BatchEngineBundleTrackerTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BatchEngineBundleTrackerTest.java
@@ -6,8 +6,9 @@
 package com.liferay.batch.engine.internal.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
-import com.liferay.batch.engine.unit.BatchEngineUnit;
-import com.liferay.batch.engine.unit.BatchEngineUnitProcessor;
+import com.liferay.batch.engine.BatchEngineImportTaskExecutor;
+import com.liferay.batch.engine.BatchEngineTaskItemDelegate;
+import com.liferay.batch.engine.model.BatchEngineImportTask;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Company;
@@ -15,9 +16,7 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
-import com.liferay.portal.kernel.util.BooleanWrapper;
 import com.liferay.portal.kernel.util.IntegerWrapper;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.zip.ZipWriter;
 import com.liferay.portal.kernel.zip.ZipWriterFactory;
 import com.liferay.portal.test.rule.Inject;
@@ -29,7 +28,6 @@ import java.io.InputStream;
 import java.net.URL;
 
 import java.util.Enumeration;
-import java.util.concurrent.CompletableFuture;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -86,10 +84,7 @@ public class BatchEngineBundleTrackerTest {
 			String dirName, int expectedCount)
 		throws Exception {
 
-		Bundle bundle = _bundleContext.installBundle(
-			RandomTestUtil.randomString(), _toInputStream(dirName));
-
-		Class<?> clazz = _batchEngineUnitProcessor.getClass();
+		Class<?> clazz = _batchEngineImportTaskExecutor.getClass();
 
 		ComponentDescriptionDTO componentDescriptionDTO =
 			_serviceComponentRuntime.getComponentDescriptionDTO(
@@ -101,27 +96,34 @@ public class BatchEngineBundleTrackerTest {
 		promise.getValue();
 
 		IntegerWrapper actualCount = new IntegerWrapper();
-		BooleanWrapper processed = new BooleanWrapper();
 
-		ServiceRegistration<BatchEngineUnitProcessor> serviceRegistration =
+		ServiceRegistration<BatchEngineImportTaskExecutor> serviceRegistration =
 			_bundleContext.registerService(
-				BatchEngineUnitProcessor.class,
-				batchEngineUnits -> {
-					for (BatchEngineUnit batchEngineUnit : batchEngineUnits) {
-						if (batchEngineUnit.isValid() &&
-							StringUtil.startsWith(
-								batchEngineUnit.getDataFileName(),
-								"/" + dirName)) {
+				BatchEngineImportTaskExecutor.class,
+				new BatchEngineImportTaskExecutor() {
 
-							actualCount.increment();
-						}
+					@Override
+					public void execute(
+						BatchEngineImportTask batchEngineImportTask) {
+
+						actualCount.increment();
 					}
 
-					processed.setValue(true);
+					@Override
+					public void execute(
+						BatchEngineImportTask batchEngineImportTask,
+						BatchEngineTaskItemDelegate<?>
+							batchEngineTaskItemDelegate,
+						boolean checkPermissions) {
 
-					return CompletableFuture.completedFuture(null);
+						actualCount.increment();
+					}
+
 				},
 				null);
+
+		Bundle bundle = _bundleContext.installBundle(
+			RandomTestUtil.randomString(), _toInputStream(dirName));
 
 		try {
 			bundle.start();
@@ -129,9 +131,6 @@ public class BatchEngineBundleTrackerTest {
 			Thread.sleep(2000);
 
 			Assert.assertEquals(expectedCount, actualCount.getValue());
-			Assert.assertTrue(processed.getValue());
-
-			processed.setValue(false);
 
 			bundle.stop();
 
@@ -140,7 +139,6 @@ public class BatchEngineBundleTrackerTest {
 			Thread.sleep(2000);
 
 			Assert.assertEquals(expectedCount, actualCount.getValue());
-			Assert.assertFalse(processed.getValue());
 		}
 		finally {
 			bundle.uninstall();
@@ -187,7 +185,7 @@ public class BatchEngineBundleTrackerTest {
 	}
 
 	@Inject
-	private BatchEngineUnitProcessor _batchEngineUnitProcessor;
+	private BatchEngineImportTaskExecutor _batchEngineImportTaskExecutor;
 
 	private Bundle _bundle;
 	private BundleContext _bundleContext;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-197305.

By marking units as proccessed only when actually run we ensure the API Builder batch file is not marked as processed until the feature flag is actually enabled.

This way the object definitions are created after enabling the feature flag and restarting the portal.