### PR TITLE
LPS-188134 bump shared-dependencies-guava version to 5.0.0. In order …

### DIFF
--- a/modules/apps/shared-dependencies/shared-dependencies-guava/bnd.bnd
+++ b/modules/apps/shared-dependencies/shared-dependencies-guava/bnd.bnd
@@ -1,4 +1,4 @@
 Bundle-Name: Liferay Shared Dependencies Guava
 Bundle-SymbolicName: com.liferay.shared.dependencies.guava
-Bundle-Version: 1.0.3
+Bundle-Version: 5.0.0
 -exportcontents: com.google.common.*


### PR DESCRIPTION
…to backport shared-dependencies-guava as a new module back to 7.3.x -> 7.0.x, we need to follow this rules https://liferay.atlassian.net/wiki/spaces/QA/pages/2074607646/Backporting+new+modules