### PR TITLE
LPS-198160 Add pattern for mvc.command.name

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/MVCCommandNameCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/MVCCommandNameCheck.java
@@ -116,8 +116,8 @@ public class MVCCommandNameCheck extends BaseCheck {
 			"MVCResourceCommand");
 
 		name = StringUtil.replace(
-			name, new String[] {"OAuth", "WeDeploy"},
-			new String[] {"Oauth", "Wedeploy"});
+			name, new String[] {"OAuth", "WebDAV", "WeDeploy"},
+			new String[] {"Oauth", "Webdav", "Wedeploy"});
 
 		Matcher matcher = _classNamePattern.matcher(className);
 


### PR DESCRIPTION
Hi Brian,
This PR can fix SF issues:
```
     [java] java.lang.Exception: Found 2 formatting issues:

     [java] 1: Incorrect value '/users_admin/generate_webdav_password' for 'mvc.command.name', see https://github.com/liferay/liferay-portal/blob/master/modules/util/source-formatter/src/main/resources/documentation/check/mvc_command_name_check.markdown:  ./modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/GenerateWebDAVPasswordMVCActionCommand.java 29 (Checkstyle:MVCCommandNameCheck)
     [java] 2: Incorrect value '/users_admin/generate_webdav_password' for 'mvc.command.name', see https://github.com/liferay/liferay-portal/blob/master/modules/util/source-formatter/src/main/resources/documentation/check/mvc_command_name_check.markdown:  ./modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/GenerateWebDAVPasswordMVCRenderCommand.java 23 (Checkstyle:MVCCommandNameCheck)
```