### PR TITLE
Revert "LPS-196641 Call _createFeatureFlagsBag only if you have to be…

### DIFF
--- a/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/feature/flag/FeatureFlagsBagProviderImpl.java
+++ b/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/feature/flag/FeatureFlagsBagProviderImpl.java
@@ -77,15 +77,14 @@ public class FeatureFlagsBagProviderImpl
 			return featureFlagsBag;
 		}
 
-		featureFlagsBag = _featureFlagsBags.get(companyId);
-
-		if (featureFlagsBag != null) {
-			return featureFlagsBag;
-		}
-
 		featureFlagsBag = _createFeatureFlagsBag(companyId);
 
-		_featureFlagsBags.putIfAbsent(companyId, featureFlagsBag);
+		FeatureFlagsBag previousFeatureFlagsBag = _featureFlagsBags.putIfAbsent(
+			companyId, featureFlagsBag);
+
+		if (previousFeatureFlagsBag != null) {
+			return previousFeatureFlagsBag;
+		}
 
 		return featureFlagsBag;
 	}


### PR DESCRIPTION
…cause it's"

This reverts commit 404fe5579cf9a7f023b5bb3ac5fcf979d52562c4.

@brianchandotcom this structure is on purpose. Otherwise it could end up returning more than one FeatureFlagsBag instance per companyId which would cause further lose of updates, as caller may modify those FeatureFlagsBags, but only one is truly tracked by the map.

CC @drewbrokke