### PR TITLE
LPS-198799 source-formatter: adds missing double-quotes

### DIFF
--- a/modules/util/source-formatter/src/main/resources/documentation/check/static_block_check.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/check/static_block_check.markdown
@@ -22,7 +22,7 @@ private static final Map<String, String> _vegetableMap =
     new HashMap<String, String>() {
         {
             put("Beet", "Red");
-            put("Carrot, "Orange");
+            put("Carrot", "Orange");
             put("Eggplant", "Purple");
             put("Potato", "Yellow");
             put("Spinach", "Green");
@@ -44,7 +44,7 @@ static {
     _fruitMap.put("Strawberry", "Red");
 
     _vegetableMap.put("Beet", "Red");
-    _vegetableMap.put("Carrot, "Orange");
+    _vegetableMap.put("Carrot", "Orange");
     _vegetableMap.put("Eggplant", "Purple");
     _vegetableMap.put("Potato", "Yellow");
     _vegetableMap.put("Spinach", "Green");


### PR DESCRIPTION
/cc @drewbrokke

Tested [here](https://github.com/drewbrokke/liferay-portal/pull/1520), unrelated failures.