### PR TITLE
[BLOCKER] LPS-196204 fix "cannot find symbol"

### DIFF
--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/persistence/impl/CTEntryPersistenceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/persistence/impl/CTEntryPersistenceImpl.java
@@ -39,7 +39,7 @@ import com.liferay.portal.kernel.util.ProxyUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
-import com.liferay.portal.kernel.uuid.PortalUUID;
+import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
 
 import java.io.Serializable;
 
@@ -3756,7 +3756,7 @@ public class CTEntryPersistenceImpl
 		ctEntry.setNew(true);
 		ctEntry.setPrimaryKey(ctEntryId);
 
-		String uuid = _portalUUID.generate();
+		String uuid = PortalUUIDUtil.generate();
 
 		ctEntry.setUuid(uuid);
 
@@ -3869,7 +3869,7 @@ public class CTEntryPersistenceImpl
 		CTEntryModelImpl ctEntryModelImpl = (CTEntryModelImpl)ctEntry;
 
 		if (Validator.isNull(ctEntry.getUuid())) {
-			String uuid = _portalUUID.generate();
+			String uuid = PortalUUIDUtil.generate();
 
 			ctEntry.setUuid(uuid);
 		}
@@ -4420,8 +4420,5 @@ public class CTEntryPersistenceImpl
 	protected FinderCache getFinderCache() {
 		return finderCache;
 	}
-
-	@Reference
-	private PortalUUID _portalUUID;
 
 }

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/GenerateWebDAVPasswordMVCActionCommand.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/GenerateWebDAVPasswordMVCActionCommand.java
@@ -11,7 +11,7 @@ import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.security.pwd.PasswordEncryptor;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.uuid.PortalUUID;
+import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
 import com.liferay.users.admin.constants.UsersAdminPortletKeys;
 
 import javax.portlet.ActionRequest;
@@ -40,7 +40,7 @@ public class GenerateWebDAVPasswordMVCActionCommand
 
 		User user = _portal.getUser(actionRequest);
 
-		String plainToken = _portalUUID.generate();
+		String plainToken = PortalUUIDUtil.generate();
 
 		user.setDigest(user.getDigest(plainToken));
 
@@ -54,9 +54,6 @@ public class GenerateWebDAVPasswordMVCActionCommand
 
 	@Reference
 	private Portal _portal;
-
-	@Reference
-	private PortalUUID _portalUUID;
 
 	@Reference
 	private UserLocalService _userLocalService;


### PR DESCRIPTION
Hi Brian,

Before [LPS-196204](https://github.com/brianchandotcom/liferay-portal/commit/7f46e2f5ddf4f8b40b3b04228d560daa3fb1ee7c) is merged, there are other new usages of  `import com.liferay.portal.kernel.uuid.PortalUUID;`, which leads to this blcoker.
I upgrade the code and regenerate to fix the blocker
```
[exec] /opt/dev/projects/github/liferay-portal/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/persistence/impl/CTEntryPersistenceImpl.java:42: error: cannot find symbol
     [exec] import com.liferay.portal.kernel.uuid.PortalUUID;
     [exec]                                      ^
     [exec]   symbol:   class PortalUUID
     [exec]   location: package com.liferay.portal.kernel.uuid
     [exec] /opt/dev/projects/github/liferay-portal/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/persistence/impl/CTEntryPersistenceImpl.java:4425: error: cannot find symbol
     [exec] 	private PortalUUID _portalUUID;
     [exec] 	        ^
     [exec]   symbol:   class PortalUUID
     [exec]   location: class com.liferay.change.tracking.service.persistence.impl.CTEntryPersistenceImpl
     [exec] 
     [exec] > Task :apps:blogs:blogs-web:compileJava
     [exec] 
     [exec] > Task :apps:blogs:blogs-web:copyLibs SKIPPED
     [exec] 
     [exec] > Task :apps:change-tracking:change-tracking-service:compileJava
     [exec] 
     [exec] > Task :apps:blogs:blogs-web:processResources
     [exec] > Task :apps:blogs:blogs-web:classes
     [exec] > Task :apps:blogs:blogs-web:zipZippableResources UP-TO-DATE
     [exec] Note: Some input files use or override a deprecated API.
     [exec] Note: Recompile with -Xlint:deprecation for details.
     [exec] Note: Some input files use unchecked or unsafe operations.
     [exec] Note: Recompile with -Xlint:unchecked for details.
     [exec] 2 errors
```
Thanks for checking!