### PR TITLE
Revert "LPS-199055 Commit license changes", since SF skips checking files that contain `@generated`

### DIFF
--- a/modules/third-party/org-eclipse-osgi/src/main/java/org/eclipse/osgi/container/ModuleReadHook.java
+++ b/modules/third-party/org-eclipse-osgi/src/main/java/org/eclipse/osgi/container/ModuleReadHook.java
@@ -1,15 +1,6 @@
 /**
- * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
- *
- * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free
- * Software Foundation; either version 2.1 of the License, or (at your option)
- * any later version.
- *
- * This library is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
- * details.
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
 package org.eclipse.osgi.container;

--- a/modules/third-party/org-eclipse-osgi/src/main/java/org/eclipse/osgi/framework/util/WeakCacheHook.java
+++ b/modules/third-party/org-eclipse-osgi/src/main/java/org/eclipse/osgi/framework/util/WeakCacheHook.java
@@ -1,15 +1,6 @@
 /**
- * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
- *
- * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free
- * Software Foundation; either version 2.1 of the License, or (at your option)
- * any later version.
- *
- * This library is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
- * details.
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
 package org.eclipse.osgi.framework.util;


### PR DESCRIPTION
This reverts commit 799a5212bef3ee9244096b30430724cd387a9978.

Tested [here](https://github.com/ling-alan-huang/liferay-portal/pull/2201).

SF won't check these two files, because SF skips checking files that contain `@generated`.