### PR TITLE
LPS-135308 Upgrade recharts version

### DIFF
--- a/modules/apps/content-dashboard/content-dashboard-web/package.json
+++ b/modules/apps/content-dashboard/content-dashboard-web/package.json
@@ -23,7 +23,7 @@
 		"prop-types": "15.7.2",
 		"react": "16.12.0",
 		"react-dom": "16.12.0",
-		"recharts": "2.4.3"
+		"recharts": "^2.8.0"
 	},
 	"jest": {
 		"modulePathIgnorePatterns": [

--- a/modules/apps/data-engine/data-engine-js-components-web/package.json
+++ b/modules/apps/data-engine/data-engine-js-components-web/package.json
@@ -27,7 +27,7 @@
 		"react-dnd": "11.1.1",
 		"react-dnd-html5-backend": "11.1.1",
 		"react-dom": "16.12.0",
-		"recharts": "2.4.3"
+		"recharts": "^2.8.0"
 	},
 	"jest": {
 		"collectCoverageFrom": [

--- a/modules/apps/data-engine/data-engine-js-components-web/test/js/custom/form-report/components/chart/pie/__snapshots__/PieChart.js.snap
+++ b/modules/apps/data-engine/data-engine-js-components-web/test/js/custom/form-report/components/chart/pie/__snapshots__/PieChart.js.snap
@@ -8,7 +8,7 @@ exports[`PieChart renders 1`] = `
   >
     <div
       class="recharts-responsive-container"
-      style="width: 700px; height: 300px;"
+      style="width: 700px; height: 300px; min-width: 0;"
     >
       <div
         class="recharts-wrapper"

--- a/modules/apps/frontend-js/frontend-js-recharts/package.json
+++ b/modules/apps/frontend-js/frontend-js-recharts/package.json
@@ -1,6 +1,6 @@
 {
 	"dependencies": {
-		"recharts": "2.4.3"
+		"recharts": "^2.8.0"
 	},
 	"devDependencies": {
 		"@liferay/npm-bundler": "3.1.0"

--- a/modules/dxp/apps/analytics/analytics-reports-web/package.json
+++ b/modules/dxp/apps/analytics/analytics-reports-web/package.json
@@ -18,7 +18,7 @@
 		"frontend-js-web": "*",
 		"prop-types": "15.7.2",
 		"react": "16.12.0",
-		"recharts": "2.4.3"
+		"recharts": "^2.8.0"
 	},
 	"jest": {
 		"setupFiles": [

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/package.json
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/package.json
@@ -34,7 +34,7 @@
 		"react-dom": "16.12.0",
 		"react-router-dom": "5.0.1",
 		"react-text-mask": "5.4.3",
-		"recharts": "2.4.3",
+		"recharts": "^2.8.0",
 		"text-mask-addons": "3.8.0"
 	},
 	"jest": {

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -6977,10 +6977,10 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
-fast-equals@^2.0.0:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/fast-equals/-/fast-equals-2.0.4.tgz#3add9410585e2d7364c2deeb6a707beadb24b927"
-  integrity sha512-caj/ZmjHljPrZtbzJ3kfH5ia/k4mTJe/qSiXAGzxZWRZgsgDV0cvNaQULqUX8t0/JVlzzEdYOwCN5DmzTxoD4w==
+fast-equals@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/fast-equals/-/fast-equals-5.0.1.tgz#a4eefe3c5d1c0d021aeed0bc10ba5e0c12ee405d"
+  integrity sha512-WF1Wi8PwwSY7/6Kx0vKXtw8RwuSGoM1bvDaJbu7MxDlR1vovZjIAKrnzyrThgAjm6JDTu0fVgWXDlMGspodfoQ==
 
 fast-glob@^3.0.3, fast-glob@^3.1.1:
   version "3.1.1"
@@ -13147,10 +13147,10 @@ react-redux@^7.2.4, react-redux@^7.2.6:
     prop-types "^15.7.2"
     react-is "^17.0.2"
 
-react-resize-detector@^7.1.2:
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/react-resize-detector/-/react-resize-detector-7.1.2.tgz#8ef975dd8c3d56f9a5160ac382ef7136dcd2d86c"
-  integrity sha512-zXnPJ2m8+6oq9Nn8zsep/orts9vQv3elrpA+R8XTcW7DVVUJ9vwDwMXaBtykAYjMnkCIaOoK9vObyR7ZgFNlOw==
+react-resize-detector@^8.0.4:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/react-resize-detector/-/react-resize-detector-8.1.0.tgz#1c7817db8bc886e2dbd3fbe3b26ea8e56be0524a"
+  integrity sha512-S7szxlaIuiy5UqLhLL1KY3aoyGHbZzsTpYal9eYMwCyKqoqoVLCmIgAgNyIM1FhnP2KyBygASJxdhejrzjMb+w==
   dependencies:
     lodash "^4.17.21"
 
@@ -13188,12 +13188,12 @@ react-side-effect@^2.1.0:
   resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-2.1.1.tgz#66c5701c3e7560ab4822a4ee2742dee215d72eb3"
   integrity sha512-2FoTQzRNTncBVtnzxFOk2mCpcfxQpenBMbk5kSVBg5UcPqV9fRbgY2zhb7GTWWOlpFmAxhClBDlIq8Rsubz1yQ==
 
-react-smooth@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/react-smooth/-/react-smooth-2.0.1.tgz#74c7309916d6ccca182c4b30c8992f179e6c5a05"
-  integrity sha512-Own9TA0GPPf3as4vSwFhDouVfXP15ie/wIHklhyKBH5AN6NFtdk0UpHBnonV11BtqDkAWlt40MOUc+5srmW7NA==
+react-smooth@^2.0.2:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/react-smooth/-/react-smooth-2.0.4.tgz#95187126265970a1490e2aea5690365203ee555f"
+  integrity sha512-OkFsrrMBTvQUwEJthE1KXSOj79z57yvEWeFefeXPib+RmQEI9B1Ub1PgzlzzUyBOvl/TjXt5nF2hmD4NsgAh8A==
   dependencies:
-    fast-equals "^2.0.0"
+    fast-equals "^5.0.0"
     react-transition-group "2.9.0"
 
 react-syntax-highlighter@^15.4.5:
@@ -13392,17 +13392,17 @@ recharts-scale@^0.4.4:
   dependencies:
     decimal.js-light "^2.4.1"
 
-recharts@2.4.3:
-  version "2.4.3"
-  resolved "https://registry.yarnpkg.com/recharts/-/recharts-2.4.3.tgz#23b7cd988423449b04a826baa057675b833789b1"
-  integrity sha512-/hkRHTQShEOKDYd2OlKLIvGA0X9v/XVO/mNeRoDHg0lgFRL2KbGzeqVnStI3mMfORUZ6Hak4JbQ+uDiin1Foqg==
+recharts@^2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/recharts/-/recharts-2.8.0.tgz#90c95136e2cb6930224c94a51adce607701284fc"
+  integrity sha512-nciXqQDh3aW8abhwUlA4EBOBusRHLNiKHfpRZiG/yjups1x+auHb2zWPuEcTn/IMiN47vVMMuF8Sr+vcQJtsmw==
   dependencies:
     classnames "^2.2.5"
     eventemitter3 "^4.0.1"
     lodash "^4.17.19"
     react-is "^16.10.2"
-    react-resize-detector "^7.1.2"
-    react-smooth "^2.0.1"
+    react-resize-detector "^8.0.4"
+    react-smooth "^2.0.2"
     recharts-scale "^0.4.4"
     reduce-css-calc "^2.1.8"
     victory-vendor "^36.6.8"
@@ -15680,9 +15680,9 @@ typical@^5.0.0, typical@^5.2.0:
   integrity sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==
 
 ua-parser-js@^0.7.30:
-  version "0.7.35"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.35.tgz#8bda4827be4f0b1dda91699a29499575a1f1d307"
-  integrity sha512-veRf7dawaj9xaWEu9HoTVn5Pggtc/qj+kqTOFvNiN1l0YdxwC1kvel57UCjThjGa3BHBihE8/UJAHI+uQHmd/g==
+  version "0.7.36"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.36.tgz#382c5d6fc09141b6541be2cae446ecfcec284db2"
+  integrity sha512-CPPLoCts2p7D8VbybttE3P2ylv0OBZEAy7a12DsulIEcAiMtWJy+PBgMXgWDI80D5UwqE8oQPHYnk13tm38M2Q==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"


### PR DESCRIPTION
Manual forward of https://github.com/liferay-frontend/liferay-portal/pull/3718

🟢 [Greenlit by QA](https://github.com/liferay-frontend/liferay-portal/pull/3718#issuecomment-1764370410)

## Original description
[Jira ticket](https://liferay.atlassian.net/browse/LPS-135308)

Running `yarn why d3-color` inside `modules` returns a mention of version `1.2.3` which is due to `frontend-taglib-chart`'s dependency on `clay-charts` - I left my thoughts and conclusion in the Jira ticket comment