### PR TITLE
LPS-199368 Set 'USER' attribute of the RESTClientHttpRequest with the current User

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/template/RESTClientTemplateContextContributor.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/template/RESTClientTemplateContextContributor.java
@@ -42,12 +42,17 @@ public class RESTClientTemplateContextContributor
 		Map<String, Object> contextObjects,
 		HttpServletRequest httpServletRequest) {
 
-		contextObjects.put("restClient", new RESTClient(httpServletRequest));
+		contextObjects.put(
+			"restClient", new RESTClient(contextObjects, httpServletRequest));
 	}
 
 	public class RESTClient {
 
-		public RESTClient(HttpServletRequest httpServletRequest) {
+		public RESTClient(
+			Map<String, Object> contextObjects,
+			HttpServletRequest httpServletRequest) {
+
+			_contextObjects = contextObjects;
 			_httpServletRequest = httpServletRequest;
 		}
 
@@ -63,7 +68,7 @@ public class RESTClientTemplateContextContributor
 				new RESTClientHttpResponse(), unsyncStringWriter);
 
 			requestDispatcher.forward(
-				new RESTClientHttpRequest(_httpServletRequest),
+				new RESTClientHttpRequest(_contextObjects, _httpServletRequest),
 				httpServletResponse);
 
 			String responseString = unsyncStringWriter.toString();
@@ -78,6 +83,7 @@ public class RESTClientTemplateContextContributor
 			return responseString;
 		}
 
+		private final Map<String, Object> _contextObjects;
 		private final HttpServletRequest _httpServletRequest;
 
 	}

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/template/servlet/RESTClientHttpRequest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/template/servlet/RESTClientHttpRequest.java
@@ -11,6 +11,7 @@ import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.util.WebKeys;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -21,7 +22,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
-import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
@@ -45,7 +45,20 @@ import javax.servlet.http.Part;
  */
 public class RESTClientHttpRequest implements HttpServletRequest {
 
-	public RESTClientHttpRequest(HttpServletRequest httpServletRequest) {
+	public RESTClientHttpRequest(
+		Map<String, Object> contextObjects,
+		HttpServletRequest httpServletRequest) {
+
+		_attributes = HashMapBuilder.<String, Object>put(
+			WebKeys.USER,
+			() -> {
+				if (contextObjects.containsKey("user")) {
+					return contextObjects.get("user");
+				}
+
+				return null;
+			}
+		).build();
 		_headers = HashMapBuilder.put(
 			HttpHeaders.ACCEPT, ContentTypes.APPLICATION_JSON
 		).put(
@@ -417,7 +430,7 @@ public class RESTClientHttpRequest implements HttpServletRequest {
 		return _httpServletRequest.upgrade(handlerClass);
 	}
 
-	private final Map<String, Object> _attributes = new HashMap<>();
+	private final Map<String, Object> _attributes;
 	private final Map<String, String> _headers;
 	private final HttpServletRequest _httpServletRequest;
 


### PR DESCRIPTION
Forwarded manually from: https://github.com/liferay-headless/liferay-portal/pull/1605

Related ticket: https://liferay.atlassian.net/browse/LPS-199368

---

The purpose of this PR is to fix the usage of RESTClient for non-authenticated users. For that, the `USER` attribute ([WebKeys.USER value](https://github.com/liferay/liferay-portal/blob/162c51db8db2cc4d6bc6534155b0ef0627a5551a/portal-kernel/src/com/liferay/portal/kernel/util/WebKeys.java#L684)) of the RESTClientHttpRequest (a wrapper of the original HttpRequest) is set with the value given by the `user` of the context filled by the others `TemplateContextContributor`.



```
@Override
public void prepare(
	Map<String, Object> contextObjects,
	HttpServletRequest httpServletRequest) {

	super.prepare(contextObjects, httpServletRequest); // <<= Here the User is added to the Map with the 'user' key

	[...]

	// Custom template context contributors

	for (TemplateContextContributor templateContextContributor :
			getTemplateContextContributors()) {

		templateContextContributor.prepare(
			contextObjects, httpServletRequest); // <<= Here the RESTClientTemplateContextContributor uses the User from the context
	}
```

---

**How to reproduce it:**

Follow the steps of the [jira ticket](https://liferay.atlassian.net/browse/LPS-199368)

---

**Before the PR:**

![image](https://github.com/liferay-headless/liferay-portal/assets/32699538/d1210dc6-67df-46e3-8e56-53b6c12159d0)


**After the PR:**

![image](https://github.com/liferay-headless/liferay-portal/assets/32699538/0841fde2-c827-4d6d-8661-8cd92350f90a)

