### PR TITLE
LPS-198679 - Apply --control-menu-container-height css variable to search-experiences.

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/css/_variables.scss
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/css/_variables.scss
@@ -34,7 +34,6 @@ $white: #fff;
 $layoutSectionMainMaxWidth: 1224px;
 $layoutSectionMainMinWidth: 600px;
 
-$controlMenuToolbarHeight: 56px;
 $navigationBarHeight: 56px;
 $pageToolbarHeight: 104px; //navigationBarHeight + tabs navigation bar height
 $previewSidebarWidth: 600px;

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/css/shared/_sidebar.scss
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/css/shared/_sidebar.scss
@@ -71,7 +71,9 @@
 	background-color: $white;
 	display: flex;
 	flex-direction: column;
-	height: calc(100% - #{$controlMenuToolbarHeight} - #{$navigationBarHeight});
+	height: calc(
+		100% - var(--control-menu-container-height) - #{$navigationBarHeight}
+	);
 	margin-top: $navigationBarHeight;
 	position: fixed;
 	right: 0;

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/EditERCModal.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/EditERCModal.js
@@ -91,9 +91,7 @@ export function ERCModal({
 					) {
 						setError(
 							sub(
-								Liferay.Language.get(
-									'the-x-is-already-in-use'
-								),
+								Liferay.Language.get('the-x-is-already-in-use'),
 								[
 									Liferay.Language.get(
 										'external-reference-code'


### PR DESCRIPTION
Manually forwarded from https://github.com/liferay-search/liferay-portal/pull/1105
Test failures look unrelated.

https://liferay.atlassian.net/browse/LPS-198679 - Apply --control-menu-container-height css variable to search-experiences.

This PR is consistently applying the use of the --control-menu-container-height css variable to handle the offset for elements that have a fixed position.

cc: @ethib137