### PR TITLE
LPS-199836 API Builder should not be displayed in the Category Sample porlet

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-web/src/main/java/com/liferay/headless/builder/web/internal/portlet/HeadlessBuilderPortlet.java
+++ b/modules/apps/headless/headless-builder/headless-builder-web/src/main/java/com/liferay/headless/builder/web/internal/portlet/HeadlessBuilderPortlet.java
@@ -28,7 +28,6 @@ import org.osgi.service.component.annotations.Reference;
 	property = {
 		"com.liferay.portlet.add-default-resource=true",
 		"com.liferay.portlet.display-category=category.hidden",
-		"com.liferay.portlet.display-category=category.sample",
 		"com.liferay.portlet.header-portlet-css=/css/main.css",
 		"com.liferay.portlet.instanceable=true",
 		"com.liferay.portlet.preferences-owned-by-group=true",


### PR DESCRIPTION
**What is new?**
- Delete property `"com.liferay.portlet.display-category=category.sample"` to not show this porlet in the Content Sample as a Widget

**JIRA Related Ticket**
https://liferay.atlassian.net/browse/LPS-199836