### PR TITLE
LPS-199503 Support export of Object entries at site level

### DIFF
--- a/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/jaxrs/uri/BatchEngineUriInfo.java
+++ b/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/jaxrs/uri/BatchEngineUriInfo.java
@@ -150,7 +150,13 @@ public class BatchEngineUriInfo implements UriInfo {
 
 	private BatchEngineUriInfo(Builder builder) {
 		_pathParameters = builder._pathParameters;
+
 		_queryParameters = builder._queryParameters;
+
+		if (_queryParameters.containsKey("siteId")) {
+			_queryParameters.add(
+				"scopeKey", _queryParameters.getFirst("siteId"));
+		}
 	}
 
 	private final MultivaluedHashMap<String, String> _pathParameters;

--- a/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/jaxrs/uri/BatchEngineUriInfo.java
+++ b/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/jaxrs/uri/BatchEngineUriInfo.java
@@ -150,13 +150,7 @@ public class BatchEngineUriInfo implements UriInfo {
 
 	private BatchEngineUriInfo(Builder builder) {
 		_pathParameters = builder._pathParameters;
-
 		_queryParameters = builder._queryParameters;
-
-		if (_queryParameters.containsKey("siteId")) {
-			_queryParameters.add(
-				"scopeKey", _queryParameters.getFirst("siteId"));
-		}
 	}
 
 	private final MultivaluedHashMap<String, String> _pathParameters;

--- a/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/SiteScopeResourceImpl.java
+++ b/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/SiteScopeResourceImpl.java
@@ -74,9 +74,9 @@ public class SiteScopeResourceImpl extends BaseSiteScopeResourceImpl {
 		return Page.of(_getSiteScopes(entityScopes));
 	}
 
-	private List<String> _getObjectScope(String name) {
+	private List<String> _getObjectScope(String name) throws Exception {
 		ObjectDefinition objectDefinition =
-			_objectDefinitionLocalService.fetchObjectDefinition(
+			_objectDefinitionLocalService.getObjectDefinition(
 				contextCompany.getCompanyId(), name);
 
 		return Collections.singletonList(objectDefinition.getScope());

--- a/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/SiteScopeResourceImpl.java
+++ b/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/SiteScopeResourceImpl.java
@@ -45,14 +45,15 @@ public class SiteScopeResourceImpl extends BaseSiteScopeResourceImpl {
 			String internalClassNameKey, Boolean export)
 		throws Exception {
 
-		int index = internalClassNameKey.indexOf(StringPool.POUND);
+		if (internalClassNameKey.contains(StringPool.POUND)) {
+			ObjectDefinition objectDefinition =
+				_objectDefinitionLocalService.getObjectDefinition(
+					contextCompany.getCompanyId(),
+					TaskItemUtil.getTaskItemDelegateName(internalClassNameKey));
 
-		if (index > 0) {
 			return Page.of(
 				_getSiteScopes(
-					_getObjectScope(
-						TaskItemUtil.getTaskItemDelegateName(
-							internalClassNameKey))));
+					Collections.singletonList(objectDefinition.getScope())));
 		}
 
 		List<String> entityScopes = null;
@@ -72,14 +73,6 @@ public class SiteScopeResourceImpl extends BaseSiteScopeResourceImpl {
 		}
 
 		return Page.of(_getSiteScopes(entityScopes));
-	}
-
-	private List<String> _getObjectScope(String name) throws Exception {
-		ObjectDefinition objectDefinition =
-			_objectDefinitionLocalService.getObjectDefinition(
-				contextCompany.getCompanyId(), name);
-
-		return Collections.singletonList(objectDefinition.getScope());
 	}
 
 	private List<SiteScope> _getSiteScopes(List<String> entityScopes)

--- a/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/SiteScopeResourceImpl.java
+++ b/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/SiteScopeResourceImpl.java
@@ -8,6 +8,8 @@ package com.liferay.batch.planner.rest.internal.resource.v1_0;
 import com.liferay.batch.planner.rest.dto.v1_0.SiteScope;
 import com.liferay.batch.planner.rest.internal.vulcan.yaml.openapi.OpenAPIYAMLProvider;
 import com.liferay.batch.planner.rest.resource.v1_0.SiteScopeResource;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.model.Company;
@@ -20,6 +22,7 @@ import com.liferay.portal.vulcan.util.OpenAPIUtil;
 import com.liferay.portal.vulcan.yaml.openapi.OpenAPIYAML;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -41,6 +44,15 @@ public class SiteScopeResourceImpl extends BaseSiteScopeResourceImpl {
 			String internalClassNameKey, Boolean export)
 		throws Exception {
 
+		int index = internalClassNameKey.indexOf(StringPool.POUND);
+
+		if (index > 0) {
+			return Page.of(
+				_getSiteScopes(
+					_getObjectScope(
+						internalClassNameKey.substring(index + 1))));
+		}
+
 		List<String> entityScopes = null;
 
 		OpenAPIYAML openAPIYAML = _openAPIYAMLProvider.getOpenAPIYAML(
@@ -59,6 +71,14 @@ public class SiteScopeResourceImpl extends BaseSiteScopeResourceImpl {
 		}
 
 		return Page.of(_getSiteScopes(entityScopes));
+	}
+
+	private List<String> _getObjectScope(String name) {
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.fetchObjectDefinition(
+				contextCompany.getCompanyId(), name);
+
+		return Collections.singletonList(objectDefinition.getScope());
 	}
 
 	private List<SiteScope> _getSiteScopes(List<String> entityScopes)
@@ -95,6 +115,9 @@ public class SiteScopeResourceImpl extends BaseSiteScopeResourceImpl {
 
 	@Reference
 	private GroupService _groupService;
+
+	@Reference
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
 
 	@Reference
 	private OpenAPIYAMLProvider _openAPIYAMLProvider;

--- a/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/SiteScopeResourceImpl.java
+++ b/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/SiteScopeResourceImpl.java
@@ -5,6 +5,7 @@
 
 package com.liferay.batch.planner.rest.internal.resource.v1_0;
 
+import com.liferay.batch.planner.batch.engine.task.TaskItemUtil;
 import com.liferay.batch.planner.rest.dto.v1_0.SiteScope;
 import com.liferay.batch.planner.rest.internal.vulcan.yaml.openapi.OpenAPIYAMLProvider;
 import com.liferay.batch.planner.rest.resource.v1_0.SiteScopeResource;
@@ -50,7 +51,8 @@ public class SiteScopeResourceImpl extends BaseSiteScopeResourceImpl {
 			return Page.of(
 				_getSiteScopes(
 					_getObjectScope(
-						internalClassNameKey.substring(index + 1))));
+						TaskItemUtil.getTaskItemDelegateName(
+							internalClassNameKey))));
 		}
 
 		List<String> entityScopes = null;
@@ -58,16 +60,15 @@ public class SiteScopeResourceImpl extends BaseSiteScopeResourceImpl {
 		OpenAPIYAML openAPIYAML = _openAPIYAMLProvider.getOpenAPIYAML(
 			contextCompany.getCompanyId(), internalClassNameKey);
 
-		String simpleInternalClassName = internalClassNameKey.substring(
-			internalClassNameKey.lastIndexOf(StringPool.PERIOD) + 1);
-
 		if (GetterUtil.getBoolean(export)) {
 			entityScopes = OpenAPIUtil.getReadEntityScopes(
-				simpleInternalClassName, openAPIYAML);
+				TaskItemUtil.getSimpleClassName(internalClassNameKey),
+				openAPIYAML);
 		}
 		else {
 			entityScopes = OpenAPIUtil.getCreateEntityScopes(
-				simpleInternalClassName, openAPIYAML);
+				TaskItemUtil.getSimpleClassName(internalClassNameKey),
+				openAPIYAML);
 		}
 
 		return Page.of(_getSiteScopes(entityScopes));

--- a/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/vulcan/batch/engine/FieldProvider.java
+++ b/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/vulcan/batch/engine/FieldProvider.java
@@ -5,6 +5,7 @@
 
 package com.liferay.batch.planner.rest.internal.vulcan.batch.engine;
 
+import com.liferay.batch.planner.batch.engine.task.TaskItemUtil;
 import com.liferay.batch.planner.rest.internal.vulcan.yaml.openapi.OpenAPIYAMLProvider;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.rest.openapi.v1_0.ObjectEntryOpenAPIResource;
@@ -13,7 +14,6 @@ import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.ListUtil;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.vulcan.batch.engine.Field;
 import com.liferay.portal.vulcan.util.OpenAPIUtil;
@@ -66,14 +66,14 @@ public class FieldProvider {
 
 			return ListUtil.fromMapValues(
 				OpenAPIUtil.getDTOEntityFields(
-					StringUtil.extractLast(
-						internalClassNameKey, StringPool.PERIOD),
+					TaskItemUtil.getSimpleClassName(internalClassNameKey),
 					openAPIYAML));
 		}
 
 		ObjectDefinition objectDefinition =
 			_objectDefinitionLocalService.fetchObjectDefinition(
-				companyId, internalClassNameKey.substring(index + 1));
+				companyId,
+				TaskItemUtil.getTaskItemDelegateName(internalClassNameKey));
 
 		ObjectEntryOpenAPIResource objectEntryOpenAPIResource =
 			_objectEntryOpenAPIResourceProvider.getObjectEntryOpenAPIResource(

--- a/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/vulcan/yaml/openapi/OpenAPIYAMLProvider.java
+++ b/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/vulcan/yaml/openapi/OpenAPIYAMLProvider.java
@@ -13,6 +13,7 @@ import com.liferay.portal.vulcan.yaml.openapi.OpenAPIYAML;
 
 import java.util.Collections;
 
+import javax.ws.rs.NotFoundException;
 import javax.ws.rs.core.Response;
 
 import org.osgi.service.component.annotations.Component;
@@ -32,6 +33,10 @@ public class OpenAPIYAMLProvider {
 			_vulcanBatchEngineTaskItemDelegateRegistry.
 				getVulcanBatchEngineTaskItemDelegate(
 					companyId, internalClassNameKey);
+
+		if (vulcanBatchEngineTaskItemDelegate == null) {
+			throw new NotFoundException();
+		}
 
 		Response response = _openAPIResource.getOpenAPI(
 			Collections.singleton(

--- a/modules/apps/batch-planner/batch-planner-rest-test/src/testIntegration/java/com/liferay/batch/planner/rest/resource/v1_0/test/SiteScopeResourceTest.java
+++ b/modules/apps/batch-planner/batch-planner-rest-test/src/testIntegration/java/com/liferay/batch/planner/rest/resource/v1_0/test/SiteScopeResourceTest.java
@@ -8,6 +8,7 @@ package com.liferay.batch.planner.rest.resource.v1_0.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.batch.planner.batch.engine.task.TaskItemUtil;
 import com.liferay.batch.planner.rest.client.dto.v1_0.SiteScope;
+import com.liferay.batch.planner.rest.client.http.HttpInvoker;
 import com.liferay.batch.planner.rest.client.pagination.Page;
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.field.util.ObjectFieldUtil;
@@ -39,6 +40,29 @@ public class SiteScopeResourceTest extends BaseSiteScopeResourceTestCase {
 	public void testGetPlanInternalClassNameKeySiteScopesPage()
 		throws Exception {
 
+		// Internal class name key not found
+
+		String internalClassNameKey = RandomTestUtil.randomString();
+
+		_testGetPlanInternalClassNameKeySiteScopesPageNotFound(
+			null, internalClassNameKey);
+		_testGetPlanInternalClassNameKeySiteScopesPageNotFound(
+			false, internalClassNameKey);
+		_testGetPlanInternalClassNameKeySiteScopesPageNotFound(
+			true, internalClassNameKey);
+
+		internalClassNameKey = URLCodec.encodeURL(
+			TaskItemUtil.getInternalClassNameKey(
+				"com.liferay.object.rest.dto.v1_0.ObjectEntry",
+				RandomTestUtil.randomString()));
+
+		_testGetPlanInternalClassNameKeySiteScopesPageNotFound(
+			null, internalClassNameKey);
+		_testGetPlanInternalClassNameKeySiteScopesPageNotFound(
+			false, internalClassNameKey);
+		_testGetPlanInternalClassNameKeySiteScopesPageNotFound(
+			true, internalClassNameKey);
+
 		Group group = GroupTestUtil.addGroupToCompany(
 			testCompany.getCompanyId());
 
@@ -53,8 +77,7 @@ public class SiteScopeResourceTest extends BaseSiteScopeResourceTestCase {
 						"a" + RandomTestUtil.randomString(), false)),
 				ObjectDefinitionConstants.SCOPE_COMPANY);
 
-		String internalClassNameKey = _getInternalClassNameKey(
-			objectDefinition1);
+		internalClassNameKey = _getInternalClassNameKey(objectDefinition1);
 
 		_testGetPlanInternalClassNameKeySiteScopesPage(
 			Collections.emptyList(), null, internalClassNameKey);
@@ -158,6 +181,18 @@ public class SiteScopeResourceTest extends BaseSiteScopeResourceTestCase {
 			assertEquals(
 				_toSiteScope(group), _getSiteScope(group.getGroupKey(), page));
 		}
+	}
+
+	private void _testGetPlanInternalClassNameKeySiteScopesPageNotFound(
+			Boolean export, String internalClassNameKey)
+		throws Exception {
+
+		HttpInvoker.HttpResponse httpResponse =
+			siteScopeResource.
+				getPlanInternalClassNameKeySiteScopesPageHttpResponse(
+					internalClassNameKey, export);
+
+		Assert.assertEquals(404, httpResponse.getStatusCode());
 	}
 
 	private SiteScope _toSiteScope(Group group) {

--- a/modules/apps/batch-planner/batch-planner-rest-test/src/testIntegration/java/com/liferay/batch/planner/rest/resource/v1_0/test/SiteScopeResourceTest.java
+++ b/modules/apps/batch-planner/batch-planner-rest-test/src/testIntegration/java/com/liferay/batch/planner/rest/resource/v1_0/test/SiteScopeResourceTest.java
@@ -6,14 +6,167 @@
 package com.liferay.batch.planner.rest.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.batch.planner.batch.engine.task.TaskItemUtil;
+import com.liferay.batch.planner.rest.client.dto.v1_0.SiteScope;
+import com.liferay.batch.planner.rest.client.pagination.Page;
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.field.util.ObjectFieldUtil;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.rest.test.util.ObjectDefinitionTestUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.URLCodec;
 
-import org.junit.Ignore;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
  * @author Matija Petanjek
+ * @author Carlos Correa
  */
-@Ignore
 @RunWith(Arquillian.class)
 public class SiteScopeResourceTest extends BaseSiteScopeResourceTestCase {
+
+	@Override
+	@Test
+	public void testGetPlanInternalClassNameKeySiteScopesPage()
+		throws Exception {
+
+		Group group = GroupTestUtil.addGroupToCompany(
+			testCompany.getCompanyId());
+
+		// Object definition (company scoped)
+
+		ObjectDefinition objectDefinition1 =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				Collections.singletonList(
+					ObjectFieldUtil.createObjectField(
+						"Text", "String", true, true, null,
+						RandomTestUtil.randomString(),
+						"a" + RandomTestUtil.randomString(), false)),
+				ObjectDefinitionConstants.SCOPE_COMPANY);
+
+		String internalClassNameKey = _getInternalClassNameKey(
+			objectDefinition1);
+
+		_testGetPlanInternalClassNameKeySiteScopesPage(
+			Collections.emptyList(), null, internalClassNameKey);
+
+		_testGetPlanInternalClassNameKeySiteScopesPage(
+			Collections.emptyList(), false, internalClassNameKey);
+
+		_testGetPlanInternalClassNameKeySiteScopesPage(
+			Collections.emptyList(), true, internalClassNameKey);
+
+		// Object definition (site scoped)
+
+		ObjectDefinition objectDefinition2 =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				Collections.singletonList(
+					ObjectFieldUtil.createObjectField(
+						"Text", "String", true, true, null,
+						RandomTestUtil.randomString(),
+						"a" + RandomTestUtil.randomString(), false)),
+				ObjectDefinitionConstants.SCOPE_SITE);
+
+		internalClassNameKey = _getInternalClassNameKey(objectDefinition2);
+
+		_testGetPlanInternalClassNameKeySiteScopesPage(
+			Arrays.asList(group, testGroup), null, internalClassNameKey);
+
+		_testGetPlanInternalClassNameKeySiteScopesPage(
+			Arrays.asList(group, testGroup), false, internalClassNameKey);
+
+		_testGetPlanInternalClassNameKeySiteScopesPage(
+			Arrays.asList(group, testGroup), true, internalClassNameKey);
+
+		// Service builder entity (company scoped)
+
+		internalClassNameKey =
+			"com.liferay.headless.admin.user.dto.v1_0.UserAccount";
+
+		_testGetPlanInternalClassNameKeySiteScopesPage(
+			Collections.emptyList(), null, internalClassNameKey);
+
+		_testGetPlanInternalClassNameKeySiteScopesPage(
+			Collections.emptyList(), false, internalClassNameKey);
+
+		_testGetPlanInternalClassNameKeySiteScopesPage(
+			Collections.singletonList(testGroup), true, internalClassNameKey);
+
+		// Service builder entity (site scoped)
+
+		internalClassNameKey =
+			"com.liferay.headless.delivery.dto.v1_0.BlogPosting";
+
+		_testGetPlanInternalClassNameKeySiteScopesPage(
+			Arrays.asList(group, testGroup), null, internalClassNameKey);
+
+		_testGetPlanInternalClassNameKeySiteScopesPage(
+			Arrays.asList(group, testGroup), false, internalClassNameKey);
+
+		_testGetPlanInternalClassNameKeySiteScopesPage(
+			Arrays.asList(group, testGroup), true, internalClassNameKey);
+	}
+
+	@Override
+	protected String[] getAdditionalAssertFieldNames() {
+		return new String[] {"label", "value"};
+	}
+
+	private String _getInternalClassNameKey(ObjectDefinition objectDefinition) {
+		return URLCodec.encodeURL(
+			TaskItemUtil.getInternalClassNameKey(
+				"com.liferay.object.rest.dto.v1_0.ObjectEntry",
+				objectDefinition.getName()));
+	}
+
+	private SiteScope _getSiteScope(String name, Page<SiteScope> page) {
+		for (SiteScope siteScope : page.getItems()) {
+			if (StringUtil.equals(siteScope.getLabel(), name)) {
+				return siteScope;
+			}
+		}
+
+		return null;
+	}
+
+	private void _testGetPlanInternalClassNameKeySiteScopesPage(
+			List<Group> expectedGroups, Boolean export,
+			String internalClassNameKey)
+		throws Exception {
+
+		Page<SiteScope> page =
+			siteScopeResource.getPlanInternalClassNameKeySiteScopesPage(
+				internalClassNameKey, export);
+
+		if (expectedGroups.isEmpty()) {
+			Assert.assertEquals(0, page.getTotalCount());
+		}
+		else {
+			Assert.assertTrue(page.getTotalCount() >= expectedGroups.size());
+		}
+
+		for (Group group : expectedGroups) {
+			assertEquals(
+				_toSiteScope(group), _getSiteScope(group.getGroupKey(), page));
+		}
+	}
+
+	private SiteScope _toSiteScope(Group group) {
+		SiteScope siteScope = new SiteScope();
+
+		siteScope.setLabel(group.getGroupKey());
+		siteScope.setValue(group.getGroupId());
+
+		return siteScope;
+	}
+
 }

--- a/modules/apps/batch-planner/batch-planner-test/src/testIntegration/java/com/liferay/batch/planner/batch/engine/broker/test/BatchEngineBrokerTest.java
+++ b/modules/apps/batch-planner/batch-planner-test/src/testIntegration/java/com/liferay/batch/planner/batch/engine/broker/test/BatchEngineBrokerTest.java
@@ -183,8 +183,7 @@ public class BatchEngineBrokerTest {
 
 		ObjectEntry objectEntry1 = _addObjectEntry(
 			TestPropsValues.getCompanyId(), TestPropsValues.getGroupId(),
-			_objectDefinition1,
-			TestPropsValues.getUserId());
+			_objectDefinition1, TestPropsValues.getUserId());
 
 		long companyId = _counterLocalService.increment();
 
@@ -381,15 +380,13 @@ public class BatchEngineBrokerTest {
 
 		ObjectEntry objectEntry1 = _addObjectEntry(
 			TestPropsValues.getCompanyId(), TestPropsValues.getGroupId(),
-			_objectDefinition1,
-			TestPropsValues.getUserId());
+			_objectDefinition1, TestPropsValues.getUserId());
 
 		Group group = GroupTestUtil.addGroup();
 
 		_addObjectEntry(
 			TestPropsValues.getCompanyId(), group.getGroupId(),
-			_objectDefinition1,
-			TestPropsValues.getUserId());
+			_objectDefinition1, TestPropsValues.getUserId());
 
 		BatchPlannerPlan batchPlannerPlan =
 			_batchPlannerPlanLocalService.addBatchPlannerPlan(
@@ -653,16 +650,6 @@ public class BatchEngineBrokerTest {
 		}
 	}
 
-	private long _getGroupId(long groupId, ObjectDefinition objectDefinition) {
-		if (!Objects.equals(
-			objectDefinition.getScope(), ObjectDefinitionConstants.SCOPE_SITE)) {
-
-			return 0;
-		}
-
-		return groupId;
-	}
-
 	private void _assertActions(JsonNode fieldJsonNode, String fieldName) {
 		JsonNode jsonNode = fieldJsonNode.get(fieldName);
 
@@ -916,6 +903,17 @@ public class BatchEngineBrokerTest {
 
 			Thread.sleep(1000);
 		}
+	}
+
+	private long _getGroupId(long groupId, ObjectDefinition objectDefinition) {
+		if (!Objects.equals(
+				objectDefinition.getScope(),
+				ObjectDefinitionConstants.SCOPE_SITE)) {
+
+			return 0;
+		}
+
+		return groupId;
 	}
 
 	private ZipInputStream _getZipInputStream(InputStream inputStream)

--- a/modules/apps/batch-planner/batch-planner-test/src/testIntegration/java/com/liferay/batch/planner/batch/engine/broker/test/BatchEngineBrokerTest.java
+++ b/modules/apps/batch-planner/batch-planner-test/src/testIntegration/java/com/liferay/batch/planner/batch/engine/broker/test/BatchEngineBrokerTest.java
@@ -183,7 +183,7 @@ public class BatchEngineBrokerTest {
 
 		ObjectEntry objectEntry1 = _addObjectEntry(
 			TestPropsValues.getCompanyId(), TestPropsValues.getGroupId(),
-			_objectDefinition1.getObjectDefinitionId(),
+			_objectDefinition1,
 			TestPropsValues.getUserId());
 
 		long companyId = _counterLocalService.increment();
@@ -199,7 +199,7 @@ public class BatchEngineBrokerTest {
 
 			_addObjectEntry(
 				_company2.getCompanyId(), _company2.getGroupId(),
-				_objectDefinition2.getObjectDefinitionId(), user.getUserId());
+				_objectDefinition2, user.getUserId());
 
 			BatchPlannerPlan batchPlannerPlan =
 				_batchPlannerPlanLocalService.addBatchPlannerPlan(
@@ -381,14 +381,14 @@ public class BatchEngineBrokerTest {
 
 		ObjectEntry objectEntry1 = _addObjectEntry(
 			TestPropsValues.getCompanyId(), TestPropsValues.getGroupId(),
-			_objectDefinition1.getObjectDefinitionId(),
+			_objectDefinition1,
 			TestPropsValues.getUserId());
 
 		Group group = GroupTestUtil.addGroup();
 
 		_addObjectEntry(
 			TestPropsValues.getCompanyId(), group.getGroupId(),
-			_objectDefinition1.getObjectDefinitionId(),
+			_objectDefinition1,
 			TestPropsValues.getUserId());
 
 		BatchPlannerPlan batchPlannerPlan =
@@ -589,7 +589,8 @@ public class BatchEngineBrokerTest {
 	}
 
 	private ObjectEntry _addObjectEntry(
-			long companyId, long groupId, long objectDefinitionId, long userId)
+			long companyId, long groupId, ObjectDefinition objectDefinition,
+			long userId)
 		throws Exception {
 
 		String originalName = PrincipalThreadLocal.getName();
@@ -608,7 +609,8 @@ public class BatchEngineBrokerTest {
 			DLFileEntry dlFileEntry = _addDLFileEntry(groupId, userId);
 
 			return _objectEntryLocalService.addObjectEntry(
-				userId, groupId, objectDefinitionId,
+				userId, _getGroupId(groupId, objectDefinition),
+				objectDefinition.getObjectDefinitionId(),
 				HashMapBuilder.<String, Serializable>put(
 					"testAttachmentField", dlFileEntry.getFileEntryId()
 				).put(
@@ -649,6 +651,16 @@ public class BatchEngineBrokerTest {
 				originalPermissionChecker);
 			PrincipalThreadLocal.setName(originalName);
 		}
+	}
+
+	private long _getGroupId(long groupId, ObjectDefinition objectDefinition) {
+		if (!Objects.equals(
+			objectDefinition.getScope(), ObjectDefinitionConstants.SCOPE_SITE)) {
+
+			return 0;
+		}
+
+		return groupId;
 	}
 
 	private void _assertActions(JsonNode fieldJsonNode, String fieldName) {

--- a/modules/apps/batch-planner/batch-planner-test/src/testIntegration/java/com/liferay/batch/planner/batch/engine/broker/test/BatchEngineBrokerTest.java
+++ b/modules/apps/batch-planner/batch-planner-test/src/testIntegration/java/com/liferay/batch/planner/batch/engine/broker/test/BatchEngineBrokerTest.java
@@ -88,6 +88,7 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.petra.string.StringUtil;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.PortletCategory;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
@@ -99,6 +100,7 @@ import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.constants.TestDataConstants;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -177,7 +179,7 @@ public class BatchEngineBrokerTest {
 	public void testExportCompanyScopeObjectEntry() throws Exception {
 		_objectDefinition1 = _publishObjectDefinition(
 			TestPropsValues.getCompanyId(), "TestObject",
-			TestPropsValues.getUser());
+			ObjectDefinitionConstants.SCOPE_COMPANY, TestPropsValues.getUser());
 
 		ObjectEntry objectEntry1 = _addObjectEntry(
 			TestPropsValues.getCompanyId(), TestPropsValues.getGroupId(),
@@ -192,7 +194,8 @@ public class BatchEngineBrokerTest {
 			User user = UserTestUtil.getAdminUser(_company2.getCompanyId());
 
 			_objectDefinition2 = _publishObjectDefinition(
-				_company2.getCompanyId(), "TestObject", user);
+				_company2.getCompanyId(), "TestObject",
+				ObjectDefinitionConstants.SCOPE_COMPANY, user);
 
 			_addObjectEntry(
 				_company2.getCompanyId(), _company2.getGroupId(),
@@ -259,7 +262,7 @@ public class BatchEngineBrokerTest {
 	public void testExportObjectDefinition() throws Exception {
 		_objectDefinition1 = _publishObjectDefinition(
 			TestPropsValues.getCompanyId(), "TestObject1",
-			TestPropsValues.getUser());
+			ObjectDefinitionConstants.SCOPE_COMPANY, TestPropsValues.getUser());
 
 		_objectActionLocalService.addObjectAction(
 			RandomTestUtil.randomString(), TestPropsValues.getUserId(),
@@ -291,7 +294,7 @@ public class BatchEngineBrokerTest {
 
 		_objectDefinition2 = _publishObjectDefinition(
 			TestPropsValues.getCompanyId(), "TestObject2",
-			TestPropsValues.getUser());
+			ObjectDefinitionConstants.SCOPE_COMPANY, TestPropsValues.getUser());
 
 		_objectRelationshipLocalService.addObjectRelationship(
 			TestPropsValues.getUserId(),
@@ -371,10 +374,78 @@ public class BatchEngineBrokerTest {
 	}
 
 	@Test
+	public void testExportSiteScopeObjectEntry() throws Exception {
+		_objectDefinition1 = _publishObjectDefinition(
+			TestPropsValues.getCompanyId(), "TestObject",
+			ObjectDefinitionConstants.SCOPE_SITE, TestPropsValues.getUser());
+
+		ObjectEntry objectEntry1 = _addObjectEntry(
+			TestPropsValues.getCompanyId(), TestPropsValues.getGroupId(),
+			_objectDefinition1.getObjectDefinitionId(),
+			TestPropsValues.getUserId());
+
+		Group group = GroupTestUtil.addGroup();
+
+		_addObjectEntry(
+			TestPropsValues.getCompanyId(), group.getGroupId(),
+			_objectDefinition1.getObjectDefinitionId(),
+			TestPropsValues.getUserId());
+
+		BatchPlannerPlan batchPlannerPlan =
+			_batchPlannerPlanLocalService.addBatchPlannerPlan(
+				TestPropsValues.getUserId(), true,
+				BatchPlannerPlanConstants.EXTERNAL_TYPE_JSON, StringPool.SLASH,
+				"com.liferay.object.rest.dto.v1_0.ObjectEntry",
+				RandomTestUtil.randomString(), 0, "C_TestObject", false);
+
+		for (String fieldName : _objectEntryExportFieldNames) {
+			_batchPlannerMappingLocalService.addBatchPlannerMapping(
+				TestPropsValues.getUserId(),
+				batchPlannerPlan.getBatchPlannerPlanId(), fieldName, "String",
+				fieldName, "String", StringPool.BLANK);
+		}
+
+		_batchPlannerPolicyLocalService.addBatchPlannerPolicy(
+			TestPropsValues.getUserId(),
+			batchPlannerPlan.getBatchPlannerPlanId(), "siteId",
+			String.valueOf(TestPropsValues.getGroupId()));
+
+		_batchEngineBroker.submit(batchPlannerPlan.getBatchPlannerPlanId());
+
+		BatchEngineExportTask batchEngineExportTask =
+			_getFinishedBatchEngineExportTask(
+				batchPlannerPlan.getBatchPlannerPlanId());
+
+		_objectMapper.setFilterProvider(
+			new SimpleFilterProvider() {
+				{
+					addFilter(
+						"Liferay.Vulcan",
+						VulcanPropertyFilter.of(
+							new HashSet<>(_objectEntryExportFieldNames), null));
+				}
+			});
+
+		JsonNode expectedJsonNode = _getExpectedJsonNode(
+			_objectDefinition1, objectEntry1.getObjectEntryId());
+
+		JsonNode jsonNode = _objectMapper.readTree(
+			_getZipInputStream(
+				_batchEngineExportTaskLocalService.openContentInputStream(
+					batchEngineExportTask.getBatchEngineExportTaskId())));
+
+		Assert.assertTrue(jsonNode.isArray());
+		Assert.assertEquals(1, jsonNode.size());
+
+		_assertEqualsExport(
+			expectedJsonNode, _objectEntryExportFieldNames, jsonNode.get(0));
+	}
+
+	@Test
 	public void testImportCompanyScopeObjectEntry() throws Exception {
 		_objectDefinition1 = _publishObjectDefinition(
 			TestPropsValues.getCompanyId(), "TestObject",
-			TestPropsValues.getUser());
+			ObjectDefinitionConstants.SCOPE_COMPANY, TestPropsValues.getUser());
 
 		File file = _createImportFile(
 			_addDLFileEntry(
@@ -454,7 +525,7 @@ public class BatchEngineBrokerTest {
 
 		_objectDefinition2 = _publishObjectDefinition(
 			TestPropsValues.getCompanyId(), "TestObject2",
-			TestPropsValues.getUser());
+			ObjectDefinitionConstants.SCOPE_COMPANY, TestPropsValues.getUser());
 
 		_objectDefinition2 =
 			_objectDefinitionLocalService.updateExternalReferenceCode(
@@ -537,7 +608,7 @@ public class BatchEngineBrokerTest {
 			DLFileEntry dlFileEntry = _addDLFileEntry(groupId, userId);
 
 			return _objectEntryLocalService.addObjectEntry(
-				userId, 0, objectDefinitionId,
+				userId, groupId, objectDefinitionId,
 				HashMapBuilder.<String, Serializable>put(
 					"testAttachmentField", dlFileEntry.getFileEntryId()
 				).put(
@@ -846,7 +917,7 @@ public class BatchEngineBrokerTest {
 	}
 
 	private ObjectDefinition _publishObjectDefinition(
-			long companyId, String name, User user)
+			long companyId, String name, String scope, User user)
 		throws Exception {
 
 		String originalName = PrincipalThreadLocal.getName();
@@ -888,7 +959,7 @@ public class BatchEngineBrokerTest {
 					name, null, null,
 					LocalizedMapUtil.getLocalizedMap(
 						RandomTestUtil.randomString()),
-					false, ObjectDefinitionConstants.SCOPE_COMPANY,
+					false, scope,
 					ObjectDefinitionConstants.STORAGE_TYPE_DEFAULT,
 					Arrays.asList(
 						new AttachmentObjectFieldBuilder(

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionLocalService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionLocalService.java
@@ -308,6 +308,10 @@ public interface ObjectDefinitionLocalService
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public ObjectDefinition getObjectDefinition(long companyId, String name)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public ObjectDefinition getObjectDefinitionByExternalReferenceCode(
 			String externalReferenceCode, long companyId)
 		throws PortalException;

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionLocalServiceUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionLocalServiceUtil.java
@@ -384,6 +384,13 @@ public class ObjectDefinitionLocalServiceUtil {
 		return getService().getObjectDefinition(objectDefinitionId);
 	}
 
+	public static ObjectDefinition getObjectDefinition(
+			long companyId, String name)
+		throws PortalException {
+
+		return getService().getObjectDefinition(companyId, name);
+	}
+
 	public static ObjectDefinition getObjectDefinitionByExternalReferenceCode(
 			String externalReferenceCode, long companyId)
 		throws PortalException {

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionLocalServiceWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionLocalServiceWrapper.java
@@ -444,6 +444,15 @@ public class ObjectDefinitionLocalServiceWrapper
 	}
 
 	@Override
+	public com.liferay.object.model.ObjectDefinition getObjectDefinition(
+			long companyId, String name)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _objectDefinitionLocalService.getObjectDefinition(
+			companyId, name);
+	}
+
+	@Override
 	public com.liferay.object.model.ObjectDefinition
 			getObjectDefinitionByExternalReferenceCode(
 				String externalReferenceCode, long companyId)

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
@@ -210,17 +210,10 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 			_objectEntryManagerRegistry.getObjectEntryManager(
 				_objectDefinition.getStorageType());
 
-		String filterString = null;
-
-		if (contextHttpServletRequest != null) {
-			filterString = ParamUtil.getString(
-				contextHttpServletRequest, "filter");
-		}
-
 		return objectEntryManager.getObjectEntries(
 			contextCompany.getCompanyId(), _objectDefinition, null, aggregation,
-			_getDTOConverterContext(null), filterString, pagination, search,
-			sorts);
+			_getDTOConverterContext(null), _getFilterString(), pagination,
+			search, sorts);
 	}
 
 	@Override
@@ -260,16 +253,9 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 			_objectEntryManagerRegistry.getObjectEntryManager(
 				_objectDefinition.getStorageType());
 
-		String filterString = null;
-
-		if (contextHttpServletRequest != null) {
-			filterString = ParamUtil.getString(
-				contextHttpServletRequest, "filter");
-		}
-
 		return objectEntryManager.getObjectEntries(
 			contextCompany.getCompanyId(), _objectDefinition, scopeKey,
-			aggregation, _getDTOConverterContext(null), filterString,
+			aggregation, _getDTOConverterContext(null), _getFilterString(),
 			pagination, search, sorts);
 	}
 
@@ -575,6 +561,14 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 			_dtoConverterRegistry, contextHttpServletRequest, objectEntryId,
 			contextAcceptLanguage.getPreferredLocale(), contextUriInfo,
 			contextUser);
+	}
+
+	private String _getFilterString() {
+		if (contextHttpServletRequest == null) {
+			return null;
+		}
+
+		return ParamUtil.getString(contextHttpServletRequest, "filter");
 	}
 
 	private long _getPrimaryKey(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
@@ -260,10 +260,16 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 			_objectEntryManagerRegistry.getObjectEntryManager(
 				_objectDefinition.getStorageType());
 
+		String filterString = null;
+
+		if (contextHttpServletRequest != null) {
+			filterString = ParamUtil.getString(
+				contextHttpServletRequest, "filter");
+		}
+
 		return objectEntryManager.getObjectEntries(
 			contextCompany.getCompanyId(), _objectDefinition, scopeKey,
-			aggregation, _getDTOConverterContext(null),
-			ParamUtil.getString(contextHttpServletRequest, "filter"),
+			aggregation, _getDTOConverterContext(null), filterString,
 			pagination, search, sorts);
 	}
 

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
@@ -97,13 +97,13 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 
 			if (StringUtil.equalsIgnoreCase(createStrategy, "INSERT")) {
 				objectEntryUnsafeFunction = objectEntry -> postScopeScopeKey(
-					(String)parameters.get("scopeKey"), objectEntry);
+					_getScopeKey(parameters), objectEntry);
 			}
 
 			if (StringUtil.equalsIgnoreCase(createStrategy, "UPSERT")) {
 				objectEntryUnsafeFunction =
 					objectEntry -> putScopeScopeKeyByExternalReferenceCode(
-						(String)parameters.get("scopeKey"),
+						_getScopeKey(parameters),
 						objectEntry.getExternalReferenceCode(), objectEntry);
 			}
 
@@ -503,7 +503,7 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 
 		if (objectScopeProvider.isGroupAware()) {
 			return getScopeScopeKeyPage(
-				(String)parameters.get("scopeKey"),
+				_getScopeKey(parameters),
 				Boolean.parseBoolean((String)parameters.get("flatten")), search,
 				null, filter, pagination, sorts);
 		}
@@ -630,6 +630,18 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 		}
 
 		return objectEntry;
+	}
+
+	private String _getScopeKey(Map<String, Serializable> parameters) {
+		if (parameters.containsKey("scopeKey")) {
+			return String.valueOf(parameters.get("scopeKey"));
+		}
+
+		if (parameters.containsKey("siteId")) {
+			return String.valueOf(parameters.get("siteId"));
+		}
+
+		return null;
 	}
 
 	private void _loadObjectDefinition(Map<String, Serializable> parameters)

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -736,6 +736,13 @@ public class ObjectDefinitionLocalServiceImpl
 	}
 
 	@Override
+	public ObjectDefinition getObjectDefinition(long companyId, String name)
+		throws PortalException {
+
+		return objectDefinitionPersistence.findByC_N(companyId, name);
+	}
+
+	@Override
 	public List<ObjectDefinition> getObjectDefinitions(
 		long companyId, boolean active, boolean system, int status) {
 


### PR DESCRIPTION
Forwarded manually from: https://github.com/liferay-headless/liferay-portal/pull/1618

---

Related ticket: https://liferay.atlassian.net/browse/LPS-199503

See: https://github.com/liferay-headless/liferay-portal/pull/1608

---

The purpose of this PR is to show the site combobox when a site scoped Object is selected when the Export task is selected in the Data Migration Center.

**How to test it:**

- Set the feature flag `feature.flag.COMMERCE-8087=true`
- Create an Object Definition scoped by Site called `SiteObject` with a text field called `textField`
- Go to Applications -> Data Migration Center -> Import / Export tab
- Create a new Export task by clicking [+] -> Export task
- Select the Entity Type "C_SiteObject", wait until the fields are loaded. Select the desired site and export it.

**Before the PR:**

![image](https://github.com/liferay-headless/liferay-portal/assets/32699538/8dfd9f2d-9dce-4bbb-96e0-f8079fc126e7)

**After the PR:**

![image](https://github.com/liferay-headless/liferay-portal/assets/32699538/e5c05527-0cb3-48f7-b95a-a2973790e2fc)

