### PR TITLE
LPS-197807 Return false instead of null when the user does not have permission to view the content

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/workflow/permission/WorkflowPermissionUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/workflow/permission/WorkflowPermissionUtil.java
@@ -101,7 +101,7 @@ public class WorkflowPermissionUtil {
 				permissionChecker, workflowInstance);
 
 			if (!hasPermission && actionId.equals(ActionKeys.VIEW)) {
-				return null;
+				return Boolean.FALSE;
 			}
 
 			return hasPermission;


### PR DESCRIPTION
CI [errors](https://github.com/liferay-workflow/liferay-portal/pull/1008#issuecomment-1782357721) are unrelated.