### PR TITLE
LPS-199525 Style adjustments for version tab of web contents

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/servlet/taglib/util/JournalArticleActionDropdownItemsProvider.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/servlet/taglib/util/JournalArticleActionDropdownItemsProvider.java
@@ -378,6 +378,8 @@ public class JournalArticleActionDropdownItemsProvider {
 								 WorkflowConstants.STATUS_SCHEDULED)),
 						_getExpireArticleActionConsumer(articleId)
 					).build());
+
+				dropdownGroupItem.setSeparator(true);
 			}
 		).build();
 	}

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/info_panel.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/info_panel.jsp
@@ -50,7 +50,7 @@ Map<String, Object> componentContext = journalDisplayContext.getComponentContext
 				>
 					<h1 class="component-title"><%= (folder != null) ? HtmlUtil.escape(folder.getName()) : LanguageUtil.get(request, "home") %></h1>
 
-					<h2 class="component-subtitle">
+					<h2 class="c-mt-3 text-3 text-secondary text-weight-normal">
 						<liferay-ui:message key="folder" />
 					</h2>
 				</clay:content-col>
@@ -161,7 +161,7 @@ Map<String, Object> componentContext = journalDisplayContext.getComponentContext
 					DDMStructure ddmStructure = article.getDDMStructure();
 					%>
 
-					<h2 class="component-subtitle">
+					<h2 class="c-mt-3 text-3 text-secondary text-weight-normal">
 						<%= HtmlUtil.escape(ddmStructure.getName(locale)) %>
 					</h2>
 				</clay:content-col>
@@ -188,25 +188,19 @@ Map<String, Object> componentContext = journalDisplayContext.getComponentContext
 			</clay:content-row>
 
 			<c:if test='<%= FeatureFlagManagerUtil.isEnabled("LPS-197307") %>'>
-				<clay:content-row
-					cssClass="c-mt-2"
-				>
-					<clay:content-col>
-						<div>
-							<clay:label
-								displayType="info"
-								label='<%= LanguageUtil.format(request, "version-x", article.getVersion()) %>'
-							/>
-						</div>
-					</clay:content-col>
-
-					<clay:content-col>
-						<liferay-portal-workflow:status
-							showStatusLabel="<%= false %>"
-							status="<%= article.getStatus() %>"
+				<div class="d-flex">
+					<div>
+						<clay:label
+							displayType="info"
+							label='<%= LanguageUtil.format(request, "version-x", article.getVersion()) %>'
 						/>
-					</clay:content-col>
-				</clay:content-row>
+					</div>
+
+					<liferay-portal-workflow:status
+						showStatusLabel="<%= false %>"
+						status="<%= article.getStatus() %>"
+					/>
+				</div>
 			</c:if>
 		</div>
 

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/subscribe.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/subscribe.jsp
@@ -76,21 +76,24 @@ String unsubscribeActionName = StringPool.BLANK;
 
 						<clay:link
 							aria-label='<%= LanguageUtil.get(request, "unsubscribe") %>'
-							cssClass="align-items-center d-flex icon-monospaced lfr-portal-tooltip"
+							borderless="<%= true %>"
+							cssClass="lfr-portal-tooltip"
+							displayType="secondary"
 							href="<%= unsubscribeURL %>"
 							icon="bell-off"
+							monospaced="<%= true %>"
+							small="<%= true %>"
 							title='<%= LanguageUtil.get(request, "unsubscribe") %>'
+							type="button"
 						/>
 					</c:when>
 					<c:otherwise>
-						<span class="align-items-center lfr-portal-tooltip" title="<%= LanguageUtil.get(request, "subscribed-to-a-parent-folder") %>">
-							<clay:icon
-								aria-label='<%= LanguageUtil.get(request, "subscribed-to-a-parent-folder") %>'
-								cssClass="icon-monospaced mt-0"
-								symbol="bell-off"
-								title='<%= LanguageUtil.get(request, "subscribed-to-a-parent-folder") %>'
-							/>
-						</span>
+						<clay:icon
+							aria-label='<%= LanguageUtil.get(request, "subscribed-to-a-parent-folder") %>'
+							cssClass="icon-monospaced lfr-portal-tooltip mt-0"
+							symbol="bell-off"
+							title='<%= LanguageUtil.get(request, "subscribed-to-a-parent-folder") %>'
+						/>
 					</c:otherwise>
 				</c:choose>
 			</c:when>
@@ -113,10 +116,15 @@ String unsubscribeActionName = StringPool.BLANK;
 
 				<clay:link
 					aria-label='<%= LanguageUtil.get(request, "subscribe") %>'
-					cssClass="align-items-center d-flex icon-monospaced lfr-portal-tooltip mt-1"
+					borderless="<%= true %>"
+					cssClass="lfr-portal-tooltip"
+					displayType="secondary"
 					href="<%= subscribeURL %>"
 					icon="bell-on"
+					monospaced="<%= true %>"
+					small="<%= true %>"
 					title='<%= LanguageUtil.get(request, "subscribe") %>'
+					type="button"
 				/>
 			</c:otherwise>
 		</c:choose>


### PR DESCRIPTION
Motivation
=======
What is the problem this work solves, including
[Link to story or ticket](https://liferay.atlassian.net/browse/LPS-199525)

Proposed Solution
========
- We did not change the style of the tabs because light tabs are deprecated and there is already an issue in Clay to fix the undesired border bottom.
- We added a separator between versions actions
- We improved the alignment of the icons in the sidebar header
- We change the styles and spacing of the subtype text

Steps to Verify:
----------------
1. Set feature flag LPS-197307 to true
2. Go to Content and Data -> Web Content
1. Create a web content
1. Select the web content and open its information panel


Screenshots:
-----------------------

<img width="322" alt="Captura de pantalla 2023-10-23 a las 21 57 48" src="https://github.com/liferay-echo/liferay-portal/assets/3276218/09dcce30-9ae2-46f5-9f85-5204ff6a765e">

