### PR TITLE
LPS-199905 LPS-199908 Client extension deployment process has a compl…

### DIFF
--- a/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/portlet/CustomElementCETPortlet.java
+++ b/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/portlet/CustomElementCETPortlet.java
@@ -56,6 +56,8 @@ public class CustomElementCETPortlet extends BaseCETPortlet<CustomElementCET> {
 				"com.liferay.portlet.css-class-wrapper",
 				"portlet-client-extension"
 			).put(
+				"com.liferay.portlet.deploy.parallel", false
+			).put(
 				"com.liferay.portlet.display-category",
 				cet.getPortletCategoryName()
 			).put(

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-tracker/src/main/java/com/liferay/portal/osgi/web/portlet/tracker/internal/PortletTracker.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-tracker/src/main/java/com/liferay/portal/osgi/web/portlet/tracker/internal/PortletTracker.java
@@ -188,7 +188,12 @@ public class PortletTracker
 					return addedPortletModel;
 				});
 
-		if (_parallel) {
+		if (_parallel &&
+			GetterUtil.getBoolean(
+				serviceReference.getProperty(
+					"com.liferay.portlet.deploy.parallel"),
+				true)) {
+
 			ExecutorService executorService =
 				SystemExecutorServiceUtil.getExecutorService();
 


### PR DESCRIPTION
…ex tx usage. On HSQL by the time it runs into CustomElementCETPortlet deployment, the forked deployer thread got blocked by appserver worker thread due the row locks it holds. Add this workaround to allow CustomElementCETPortlet deploys in a syncrhonized way to avoid running into lock conflicts. We will need to revisit to simplify the tx usage.