### PR TITLE
LPS-199157 Running a reindex on Rankings or Synonyms does not reset the index when the database is empty

### DIFF
--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/index/RankingIndexCreator.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/index/RankingIndexCreator.java
@@ -14,6 +14,6 @@ public interface RankingIndexCreator {
 
 	public void create(RankingIndexName rankingIndexName);
 
-	public void delete(RankingIndexName rankingIndexName);
+	public void deleteIfExists(RankingIndexName rankingIndexName);
 
 }

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/index/RankingIndexCreatorImpl.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/index/RankingIndexCreatorImpl.java
@@ -42,7 +42,7 @@ public class RankingIndexCreatorImpl implements RankingIndexCreator {
 	}
 
 	@Override
-	public void delete(RankingIndexName rankingIndexName) {
+	public void deleteIfExists(RankingIndexName rankingIndexName) {
 		IndicesExistsIndexRequest indicesExistsIndexRequest =
 			new IndicesExistsIndexRequest(rankingIndexName.getIndexName());
 

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/index/RankingIndexReindexer.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/index/RankingIndexReindexer.java
@@ -6,17 +6,16 @@
 package com.liferay.portal.search.tuning.rankings.web.internal.index;
 
 import com.liferay.json.storage.service.JSONStorageEntryLocalService;
-import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.module.service.Snapshot;
 import com.liferay.portal.kernel.search.background.task.ReindexStatusMessageSenderUtil;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
-import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.search.capabilities.SearchCapabilities;
 import com.liferay.portal.search.index.SyncReindexManager;
 import com.liferay.portal.search.spi.reindexer.IndexReindexer;
@@ -44,27 +43,14 @@ public class RankingIndexReindexer implements IndexReindexer {
 
 	@Override
 	public void reindex(long companyId, String executionMode) throws Exception {
-		if (!searchCapabilities.isResultRankingsSupported()) {
+		if (!searchCapabilities.isResultRankingsSupported() ||
+			(companyId == CompanyConstants.SYSTEM)) {
+
 			return;
 		}
-
-		List<Long> classPKs = jsonStorageEntryLocalService.getClassPKs(
-			companyId, classNameLocalService.getClassNameId(Ranking.class),
-			QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 
 		RankingIndexName rankingIndexName =
 			rankingIndexNameBuilder.getRankingIndexName(companyId);
-
-		if (ListUtil.isEmpty(classPKs)) {
-			if (_log.isInfoEnabled()) {
-				_log.info(
-					StringBundler.concat(
-						"Not reindexing ", rankingIndexName.getIndexName(),
-						" because the database has no ranking entries"));
-			}
-
-			return;
-		}
 
 		Date date = null;
 
@@ -75,26 +61,29 @@ public class RankingIndexReindexer implements IndexReindexer {
 		}
 		else {
 			if (_log.isInfoEnabled()) {
-				_log.info("Deleting index " + rankingIndexName.getIndexName());
+				_log.info(
+					"Deleting and creating index " +
+						rankingIndexName.getIndexName());
 			}
 
 			try {
 				rankingIndexCreator.delete(rankingIndexName);
+
+				rankingIndexCreator.create(rankingIndexName);
 			}
 			catch (RuntimeException runtimeException) {
 				_log.error(
-					"Unable to delete index " + rankingIndexName.getIndexName(),
+					"Unable to delete or create index " +
+						rankingIndexName.getIndexName(),
 					runtimeException);
+
+				return;
 			}
 		}
 
-		if (!_isExecuteSyncReindex(executionMode)) {
-			if (_log.isInfoEnabled()) {
-				_log.info("Creating index " + rankingIndexName.getIndexName());
-			}
-
-			rankingIndexCreator.create(rankingIndexName);
-		}
+		List<Long> classPKs = jsonStorageEntryLocalService.getClassPKs(
+			companyId, classNameLocalService.getClassNameId(Ranking.class),
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 
 		int sendStatusInterval = Math.max(100, classPKs.size() / 20);
 

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/index/RankingIndexReindexer.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/index/RankingIndexReindexer.java
@@ -67,7 +67,7 @@ public class RankingIndexReindexer implements IndexReindexer {
 			}
 
 			try {
-				rankingIndexCreator.delete(rankingIndexName);
+				rankingIndexCreator.deleteIfExists(rankingIndexName);
 
 				rankingIndexCreator.create(rankingIndexName);
 			}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/index/creation/instance/lifecycle/RankingIndexPortalInstanceLifecycleListener.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/index/creation/instance/lifecycle/RankingIndexPortalInstanceLifecycleListener.java
@@ -61,15 +61,9 @@ public class RankingIndexPortalInstanceLifecycleListener
 			return;
 		}
 
-		RankingIndexName rankingIndexName =
+		_rankingIndexCreator.deleteIfExists(
 			_rankingIndexNameBuilder.getRankingIndexName(
-				company.getCompanyId());
-
-		if (!_rankingIndexReader.isExists(rankingIndexName)) {
-			return;
-		}
-
-		_rankingIndexCreator.deleteIfExists(rankingIndexName);
+				company.getCompanyId()));
 	}
 
 	@Reference

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/index/creation/instance/lifecycle/RankingIndexPortalInstanceLifecycleListener.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/index/creation/instance/lifecycle/RankingIndexPortalInstanceLifecycleListener.java
@@ -69,7 +69,7 @@ public class RankingIndexPortalInstanceLifecycleListener
 			return;
 		}
 
-		_rankingIndexCreator.delete(rankingIndexName);
+		_rankingIndexCreator.deleteIfExists(rankingIndexName);
 	}
 
 	@Reference

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/index/importer/SingleIndexToMultipleIndexImporterImpl.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/index/importer/SingleIndexToMultipleIndexImporterImpl.java
@@ -74,7 +74,7 @@ public class SingleIndexToMultipleIndexImporterImpl
 				_log.info("Deleting index " + SINGLE_INDEX_NAME.getIndexName());
 			}
 
-			_rankingIndexCreator.delete(SINGLE_INDEX_NAME);
+			_rankingIndexCreator.deleteIfExists(SINGLE_INDEX_NAME);
 		}
 	}
 

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/test/java/com/liferay/portal/search/tuning/rankings/web/internal/index/RankingIndexCreatorImplTest.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/test/java/com/liferay/portal/search/tuning/rankings/web/internal/index/RankingIndexCreatorImplTest.java
@@ -58,7 +58,8 @@ public class RankingIndexCreatorImplTest extends BaseRankingsIndexTestCase {
 	public void testDelete() {
 		setUpSearchEngineAdapter((DocumentResponse)null);
 
-		_rankingIndexCreatorImpl.delete(Mockito.mock(RankingIndexName.class));
+		_rankingIndexCreatorImpl.deleteIfExists(
+			Mockito.mock(RankingIndexName.class));
 
 		Mockito.verify(
 			searchEngineAdapter, Mockito.times(1)

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/test/java/com/liferay/portal/search/tuning/rankings/web/internal/index/importer/SingleIndexToMultipleIndexImporterImplTest.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/test/java/com/liferay/portal/search/tuning/rankings/web/internal/index/importer/SingleIndexToMultipleIndexImporterImplTest.java
@@ -85,7 +85,7 @@ public class SingleIndexToMultipleIndexImporterImplTest
 		);
 		Mockito.verify(
 			_rankingIndexCreator, Mockito.times(1)
-		).delete(
+		).deleteIfExists(
 			Mockito.any()
 		);
 	}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/java/com/liferay/portal/search/tuning/synonyms/web/internal/index/SynonymSetIndexCreator.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/java/com/liferay/portal/search/tuning/synonyms/web/internal/index/SynonymSetIndexCreator.java
@@ -14,6 +14,6 @@ public interface SynonymSetIndexCreator {
 
 	public void create(SynonymSetIndexName synonymSetIndexName);
 
-	public void delete(SynonymSetIndexName synonymSetIndexName);
+	public void deleteIfExists(SynonymSetIndexName synonymSetIndexName);
 
 }

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/java/com/liferay/portal/search/tuning/synonyms/web/internal/index/SynonymSetIndexCreatorImpl.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/java/com/liferay/portal/search/tuning/synonyms/web/internal/index/SynonymSetIndexCreatorImpl.java
@@ -41,7 +41,7 @@ public class SynonymSetIndexCreatorImpl implements SynonymSetIndexCreator {
 	}
 
 	@Override
-	public void delete(SynonymSetIndexName synonymSetIndexName) {
+	public void deleteIfExists(SynonymSetIndexName synonymSetIndexName) {
 		IndicesExistsIndexRequest indicesExistsIndexRequest =
 			new IndicesExistsIndexRequest(synonymSetIndexName.getIndexName());
 

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/java/com/liferay/portal/search/tuning/synonyms/web/internal/index/SynonymSetIndexReindexer.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/java/com/liferay/portal/search/tuning/synonyms/web/internal/index/SynonymSetIndexReindexer.java
@@ -6,15 +6,14 @@
 package com.liferay.portal.search.tuning.synonyms.web.internal.index;
 
 import com.liferay.json.storage.service.JSONStorageEntryLocalService;
-import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.module.service.Snapshot;
 import com.liferay.portal.kernel.search.background.task.ReindexStatusMessageSenderUtil;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
-import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.search.capabilities.SearchCapabilities;
 import com.liferay.portal.search.index.SyncReindexManager;
 import com.liferay.portal.search.spi.reindexer.IndexReindexer;
@@ -41,28 +40,14 @@ public class SynonymSetIndexReindexer implements IndexReindexer {
 
 	@Override
 	public void reindex(long companyId, String executionMode) throws Exception {
-		if (!searchCapabilities.isSynonymsSupported()) {
+		if (!searchCapabilities.isSynonymsSupported() ||
+			(companyId == CompanyConstants.SYSTEM)) {
+
 			return;
 		}
-
-		List<Long> classPKs = jsonStorageEntryLocalService.getClassPKs(
-			companyId, classNameLocalService.getClassNameId(SynonymSet.class),
-			QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 
 		SynonymSetIndexName synonymSetIndexName =
 			synonymSetIndexNameBuilder.getSynonymSetIndexName(companyId);
-
-		if (ListUtil.isEmpty(classPKs)) {
-			if (_log.isInfoEnabled()) {
-				_log.info(
-					StringBundler.concat(
-						"Not reindexing ", synonymSetIndexName.getIndexName(),
-						" because the database has no synonym set ",
-						"entries"));
-			}
-
-			return;
-		}
 
 		Date date = null;
 
@@ -74,28 +59,28 @@ public class SynonymSetIndexReindexer implements IndexReindexer {
 		else {
 			if (_log.isInfoEnabled()) {
 				_log.info(
-					"Deleting index " + synonymSetIndexName.getIndexName());
+					"Deleting and creating index " +
+						synonymSetIndexName.getIndexName());
 			}
 
 			try {
 				synonymSetIndexCreator.delete(synonymSetIndexName);
+
+				synonymSetIndexCreator.create(synonymSetIndexName);
 			}
 			catch (RuntimeException runtimeException) {
 				_log.error(
-					"Unable to delete index " +
+					"Unable to delete or create index " +
 						synonymSetIndexName.getIndexName(),
 					runtimeException);
+
+				return;
 			}
 		}
 
-		if (!_isExecuteSyncReindex(executionMode)) {
-			if (_log.isInfoEnabled()) {
-				_log.info(
-					"Creating index " + synonymSetIndexName.getIndexName());
-			}
-
-			synonymSetIndexCreator.create(synonymSetIndexName);
-		}
+		List<Long> classPKs = jsonStorageEntryLocalService.getClassPKs(
+			companyId, classNameLocalService.getClassNameId(SynonymSet.class),
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 
 		int sendStatusInterval = Math.max(100, classPKs.size() / 20);
 

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/java/com/liferay/portal/search/tuning/synonyms/web/internal/index/SynonymSetIndexReindexer.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/java/com/liferay/portal/search/tuning/synonyms/web/internal/index/SynonymSetIndexReindexer.java
@@ -64,7 +64,7 @@ public class SynonymSetIndexReindexer implements IndexReindexer {
 			}
 
 			try {
-				synonymSetIndexCreator.delete(synonymSetIndexName);
+				synonymSetIndexCreator.deleteIfExists(synonymSetIndexName);
 
 				synonymSetIndexCreator.create(synonymSetIndexName);
 			}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/java/com/liferay/portal/search/tuning/synonyms/web/internal/index/creation/instance/lifecycle/SynonymSetIndexPortalInstanceLifecycleListener.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/java/com/liferay/portal/search/tuning/synonyms/web/internal/index/creation/instance/lifecycle/SynonymSetIndexPortalInstanceLifecycleListener.java
@@ -51,15 +51,9 @@ public class SynonymSetIndexPortalInstanceLifecycleListener
 			return;
 		}
 
-		SynonymSetIndexName synonymSetIndexName =
+		_synonymSetIndexCreator.deleteIfExists(
 			_synonymSetIndexNameBuilder.getSynonymSetIndexName(
-				company.getCompanyId());
-
-		if (!_synonymSetIndexReader.isExists(synonymSetIndexName)) {
-			return;
-		}
-
-		_synonymSetIndexCreator.deleteIfExists(synonymSetIndexName);
+				company.getCompanyId()));
 	}
 
 	@Reference

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/java/com/liferay/portal/search/tuning/synonyms/web/internal/index/creation/instance/lifecycle/SynonymSetIndexPortalInstanceLifecycleListener.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/java/com/liferay/portal/search/tuning/synonyms/web/internal/index/creation/instance/lifecycle/SynonymSetIndexPortalInstanceLifecycleListener.java
@@ -59,7 +59,7 @@ public class SynonymSetIndexPortalInstanceLifecycleListener
 			return;
 		}
 
-		_synonymSetIndexCreator.delete(synonymSetIndexName);
+		_synonymSetIndexCreator.deleteIfExists(synonymSetIndexName);
 	}
 
 	@Reference

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/test/java/com/liferay/portal/search/tuning/synonyms/web/internal/index/SynonymSetIndexCreatorImplTest.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/test/java/com/liferay/portal/search/tuning/synonyms/web/internal/index/SynonymSetIndexCreatorImplTest.java
@@ -58,7 +58,7 @@ public class SynonymSetIndexCreatorImplTest extends BaseSynonymsWebTestCase {
 	public void testDelete() {
 		setUpSearchEngineAdapter((DocumentResponse)null);
 
-		_synonymSetIndexCreatorImpl.delete(
+		_synonymSetIndexCreatorImpl.deleteIfExists(
 			Mockito.mock(SynonymSetIndexName.class));
 
 		Mockito.verify(


### PR DESCRIPTION
Tested on https://github.com/liferay-search/liferay-portal/pull/1110