### PR TITLE
[U101 Blocker]  LPS-200501 Portal fails to start with blank database and PortalInstancesConfiguration configured to add a new company

### DIFF
--- a/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
@@ -666,7 +666,9 @@ public class ResourceActionsImpl implements ResourceActions {
 	}
 
 	private void _checkResourceActions(List<String> actionIds, String name) {
-		if (StartupHelperUtil.isDBNew()) {
+		if (StartupHelperUtil.isDBNew() &&
+			!StartupHelperUtil.isStartupFinished()) {
+
 			resourceActionLocalService.checkResourceActions(name, actionIds);
 		}
 		else {

--- a/portal-impl/test.properties
+++ b/portal-impl/test.properties
@@ -33,4 +33,8 @@
         (\
             (operating.system.types == null) OR \
             (operating.system.types ~ "centos")\
+        ) OR \
+        (\
+            (liferay.online.properties == true) AND \
+            (testray.main.component.name == "File Install")\
         )

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/fileinstall/OSGIConfiguration.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/fileinstall/OSGIConfiguration.testcase
@@ -26,6 +26,27 @@ definition {
 		}
 	}
 
+	@description = "This is a test for LPS-200501. Verify if virtual instances can be created via OSGI config file with database partitioning enabled."
+	@priority = 5
+	test CanCreatePartitionedVirtualInstanceViaConfig {
+		property environment.acceptance = "true";
+		property liferay.online.properties = "true";
+		property osgi.module.configuration.file.names = "com.liferay.portal.instances.internal.configuration.PortalInstancesConfiguration~www.able.com.config";
+		property osgi.module.configurations = "mx=\"www.able.com\"${line.separator}virtualHostname=\"www.able.com\"";
+		property test.assert.warning.exceptions = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		PortalInstances.openVirtualInstancesAdmin();
+
+		PortalInstances.viewCP(virtualHost = "www.able.com");
+
+		User.firstLoginUI(
+			password = "test",
+			specificURL = "http://www.able.com:8080",
+			userEmailAddress = "test@www.able.com");
+	}
+
 	@description = "This is a test for LPS-173655. Verify if virtual instances can be created via OSGI config file."
 	@priority = 4
 	test CanCreateVirtualInstanceViaConfig {


### PR DESCRIPTION
Reviewed, test failures are unrelated :heavy_check_mark: 

Sent from: https://github.com/liferay-uniform/liferay-portal/pull/1523

https://liferay.atlassian.net/browse/LPS-200501