### PR TITLE
LPS-200105 | Add property unique to ObjectField

### DIFF
--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/ProductConfigurationResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/ProductConfigurationResourceImpl.java
@@ -15,7 +15,6 @@ import com.liferay.headless.commerce.admin.catalog.dto.v1_0.Product;
 import com.liferay.headless.commerce.admin.catalog.dto.v1_0.ProductConfiguration;
 import com.liferay.headless.commerce.admin.catalog.internal.util.v1_0.ProductConfigurationUtil;
 import com.liferay.headless.commerce.admin.catalog.resource.v1_0.ProductConfigurationResource;
-import com.liferay.headless.commerce.core.util.ServiceContextHelper;
 import com.liferay.portal.kernel.change.tracking.CTAware;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
@@ -159,8 +158,5 @@ public class ProductConfigurationResourceImpl
 	)
 	private DTOConverter<CPDefinitionInventory, ProductConfiguration>
 		_productConfigurationDTOConverter;
-
-	@Reference
-	private ServiceContextHelper _serviceContextHelper;
 
 }

--- a/modules/apps/list-type/list-type-test/src/testIntegration/java/com/liferay/list/type/service/test/ListTypeEntryLocalServiceTest.java
+++ b/modules/apps/list-type/list-type-test/src/testIntegration/java/com/liferay/list/type/service/test/ListTypeEntryLocalServiceTest.java
@@ -86,8 +86,7 @@ public class ListTypeEntryLocalServiceTest {
 		String externalReferenceCode =
 			_listTypeEntry.getExternalReferenceCode();
 
-		Assert.assertEquals(
-			_listTypeEntry.getUuid(), externalReferenceCode);
+		Assert.assertEquals(_listTypeEntry.getUuid(), externalReferenceCode);
 
 		AssertUtils.assertFailure(
 			DuplicateListTypeEntryException.class, "Duplicate key able",

--- a/modules/apps/object/object-admin-rest-api/bnd.bnd
+++ b/modules/apps/object/object-admin-rest-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Object Admin REST API
 Bundle-SymbolicName: com.liferay.object.admin.rest.api
-Bundle-Version: 19.2.1
+Bundle-Version: 19.3.0
 Export-Package:\
 	com.liferay.object.admin.rest.dto.v1_0,\
 	com.liferay.object.admin.rest.dto.v1_0.util,\

--- a/modules/apps/object/object-admin-rest-api/src/main/java/com/liferay/object/admin/rest/dto/v1_0/ObjectField.java
+++ b/modules/apps/object/object-admin-rest-api/src/main/java/com/liferay/object/admin/rest/dto/v1_0/ObjectField.java
@@ -730,6 +730,34 @@ public class ObjectField implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Type type;
 
+	@Schema
+	public Boolean getUnique() {
+		return unique;
+	}
+
+	public void setUnique(Boolean unique) {
+		this.unique = unique;
+	}
+
+	@JsonIgnore
+	public void setUnique(
+		UnsafeSupplier<Boolean, Exception> uniqueUnsafeSupplier) {
+
+		try {
+			unique = uniqueUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Boolean unique;
+
 	@Override
 	public boolean equals(Object object) {
 		if (this == object) {
@@ -1029,6 +1057,16 @@ public class ObjectField implements Serializable {
 			sb.append(type);
 
 			sb.append("\"");
+		}
+
+		if (unique != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"unique\": ");
+
+			sb.append(unique);
 		}
 
 		sb.append("}");

--- a/modules/apps/object/object-admin-rest-api/src/main/resources/com/liferay/object/admin/rest/dto/v1_0/packageinfo
+++ b/modules/apps/object/object-admin-rest-api/src/main/resources/com/liferay/object/admin/rest/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 7.18.0
+version 7.19.0

--- a/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/dto/v1_0/ObjectField.java
+++ b/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/dto/v1_0/ObjectField.java
@@ -536,6 +536,27 @@ public class ObjectField implements Cloneable, Serializable {
 
 	protected Type type;
 
+	public Boolean getUnique() {
+		return unique;
+	}
+
+	public void setUnique(Boolean unique) {
+		this.unique = unique;
+	}
+
+	public void setUnique(
+		UnsafeSupplier<Boolean, Exception> uniqueUnsafeSupplier) {
+
+		try {
+			unique = uniqueUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Boolean unique;
+
 	@Override
 	public ObjectField clone() throws CloneNotSupportedException {
 		return (ObjectField)super.clone();

--- a/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/serdes/v1_0/ObjectFieldSerDes.java
+++ b/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/serdes/v1_0/ObjectFieldSerDes.java
@@ -326,6 +326,16 @@ public class ObjectFieldSerDes {
 			sb.append("\"");
 		}
 
+		if (objectField.getUnique() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"unique\": ");
+
+			sb.append(objectField.getUnique());
+		}
+
 		sb.append("}");
 
 		return sb.toString();
@@ -518,6 +528,13 @@ public class ObjectFieldSerDes {
 			map.put("type", String.valueOf(objectField.getType()));
 		}
 
+		if (objectField.getUnique() == null) {
+			map.put("unique", null);
+		}
+		else {
+			map.put("unique", String.valueOf(objectField.getUnique()));
+		}
+
 		return map;
 	}
 
@@ -691,6 +708,11 @@ public class ObjectFieldSerDes {
 				if (jsonParserFieldValue != null) {
 					objectField.setType(
 						ObjectField.Type.create((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "unique")) {
+				if (jsonParserFieldValue != null) {
+					objectField.setUnique((Boolean)jsonParserFieldValue);
 				}
 			}
 		}

--- a/modules/apps/object/object-admin-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-admin-rest-impl/rest-openapi.yaml
@@ -222,6 +222,9 @@ components:
                     deprecated: true
                     enum: [BigDecimal, Boolean, Clob, Date, DateTime, Double, Integer, Long, String]
                     type: string
+                unique:
+                    readOnly: true
+                    type: boolean
         ObjectFieldSetting:
             properties:
                 id:

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/dto/v1_0/converter/ObjectFieldDTOConverter.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/dto/v1_0/converter/ObjectFieldDTOConverter.java
@@ -84,6 +84,10 @@ public class ObjectFieldDTOConverter
 				state = objectField.isState();
 				system = objectField.getSystem();
 				type = ObjectField.Type.create(objectField.getDBType());
+				unique =
+					com.liferay.object.field.setting.util.
+						ObjectFieldSettingUtil.isUnique(
+							objectField.getObjectFieldSettings());
 
 				setListTypeDefinitionExternalReferenceCode(
 					() -> {

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/graphql/query/v1_0/Query.java
@@ -316,7 +316,7 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {objectField(objectFieldId: ___){DBType, actions, businessType, defaultValue, externalReferenceCode, id, indexed, indexedAsKeyword, indexedLanguageId, label, listTypeDefinitionExternalReferenceCode, listTypeDefinitionId, localized, name, objectFieldSettings, readOnly, readOnlyConditionExpression, relationshipType, required, state, system, type}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {objectField(objectFieldId: ___){DBType, actions, businessType, defaultValue, externalReferenceCode, id, indexed, indexedAsKeyword, indexedLanguageId, label, listTypeDefinitionExternalReferenceCode, listTypeDefinitionId, localized, name, objectFieldSettings, readOnly, readOnlyConditionExpression, relationshipType, required, state, system, type, unique}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField
 	public ObjectField objectField(

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/odata/entity/v1_0/ObjectFieldEntityModel.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/odata/entity/v1_0/ObjectFieldEntityModel.java
@@ -22,6 +22,7 @@ public class ObjectFieldEntityModel implements EntityModel {
 	public ObjectFieldEntityModel() {
 		_entityFieldsMap = EntityModel.toEntityFieldsMap(
 			new BooleanEntityField("state", locale -> "state"),
+			new BooleanEntityField("unique", locale -> "unique"),
 			new StringEntityField(
 				"label",
 				locale -> Field.getSortableFieldName(

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectFieldResourceTestCase.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectFieldResourceTestCase.java
@@ -1520,6 +1520,14 @@ public abstract class BaseObjectFieldResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals("unique", additionalAssertFieldName)) {
+				if (objectField.getUnique() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
 			throw new IllegalArgumentException(
 				"Invalid additional assert field name " +
 					additionalAssertFieldName);
@@ -1881,6 +1889,16 @@ public abstract class BaseObjectFieldResourceTestCase {
 			if (Objects.equals("type", additionalAssertFieldName)) {
 				if (!Objects.deepEquals(
 						objectField1.getType(), objectField2.getType())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("unique", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						objectField1.getUnique(), objectField2.getUnique())) {
 
 					return false;
 				}
@@ -2348,6 +2366,11 @@ public abstract class BaseObjectFieldResourceTestCase {
 				"Invalid entity field " + entityFieldName);
 		}
 
+		if (entityFieldName.equals("unique")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
 		throw new IllegalArgumentException(
 			"Invalid entity field " + entityFieldName);
 	}
@@ -2411,6 +2434,7 @@ public abstract class BaseObjectFieldResourceTestCase {
 				required = RandomTestUtil.randomBoolean();
 				state = RandomTestUtil.randomBoolean();
 				system = RandomTestUtil.randomBoolean();
+				unique = RandomTestUtil.randomBoolean();
 			}
 		};
 	}

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectFieldResourceTest.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectFieldResourceTest.java
@@ -7,13 +7,16 @@ package com.liferay.object.admin.rest.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.object.admin.rest.client.dto.v1_0.ObjectField;
+import com.liferay.object.admin.rest.client.dto.v1_0.ObjectFieldSetting;
 import com.liferay.object.admin.rest.client.pagination.Page;
 import com.liferay.object.admin.rest.client.pagination.Pagination;
 import com.liferay.object.admin.rest.resource.v1_0.test.util.ObjectDefinitionTestUtil;
+import com.liferay.object.constants.ObjectFieldSettingConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.test.rule.Inject;
 
@@ -291,6 +294,51 @@ public class ObjectFieldResourceTest extends BaseObjectFieldResourceTestCase {
 		assertContains(objectField1, (List<ObjectField>)page3.getItems());
 		assertContains(objectField2, (List<ObjectField>)page3.getItems());
 		assertContains(objectField3, (List<ObjectField>)page3.getItems());
+	}
+
+	@Override
+	@Test
+	public void testGetObjectField() throws Exception {
+		super.testGetObjectField();
+
+		// Set unique value
+
+		ObjectField objectField = randomObjectField();
+
+		objectField.setObjectFieldSettings(
+			new ObjectFieldSetting[] {
+				new ObjectFieldSetting() {
+					{
+						name = ObjectFieldSettingConstants.NAME_UNIQUE_VALUES;
+						value = "true";
+					}
+				}
+			});
+
+		objectField = objectFieldResource.postObjectDefinitionObjectField(
+			_objectDefinition.getObjectDefinitionId(), objectField);
+
+		Assert.assertTrue(objectField.getUnique());
+
+		// Filtering by unique
+
+		Page<ObjectField> page1 =
+			objectFieldResource.getObjectDefinitionObjectFieldsPage(
+				_objectDefinition.getObjectDefinitionId(), null,
+				"unique eq true", Pagination.of(1, 2), null);
+
+		assertEquals(
+			Collections.singletonList(objectField),
+			(List<ObjectField>)page1.getItems());
+
+		Page<ObjectField> page2 =
+			objectFieldResource.getObjectDefinitionObjectFieldsPage(
+				_objectDefinition.getObjectDefinitionId(), null,
+				"unique eq false", Pagination.of(1, 2), null);
+
+		Assert.assertFalse(
+			ListUtil.exists(
+				(List<ObjectField>)page2.getItems(), ObjectField::getUnique));
 	}
 
 	@Ignore

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/field/setting/util/ObjectFieldSettingUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/field/setting/util/ObjectFieldSettingUtil.java
@@ -17,6 +17,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 
@@ -109,6 +110,15 @@ public class ObjectFieldSettingUtil {
 
 	public static String getValue(String name, ObjectField objectField) {
 		return getValue(name, objectField.getObjectFieldSettings());
+	}
+
+	public static boolean isUnique(
+		List<ObjectFieldSetting> objectFieldSetting) {
+
+		return GetterUtil.getBoolean(
+			getValue(
+				ObjectFieldSettingConstants.NAME_UNIQUE_VALUES,
+				objectFieldSetting));
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/field/setting/util/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/field/setting/util/packageinfo
@@ -1,1 +1,1 @@
-version 1.2.0
+version 1.3.0

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectFieldModelDocumentContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectFieldModelDocumentContributor.java
@@ -5,10 +5,11 @@
 
 package com.liferay.object.internal.search.spi.model.index.contributor;
 
+import com.liferay.object.field.setting.util.ObjectFieldSettingUtil;
 import com.liferay.object.model.ObjectField;
+import com.liferay.object.service.ObjectFieldSettingLocalService;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
-import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.util.Localization;
 import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
 
@@ -38,14 +39,20 @@ public class ObjectFieldModelDocumentContributor
 		document.addKeyword(
 			"objectDefinitionId", objectField.getObjectDefinitionId());
 		document.addKeyword("state", objectField.isState());
+		document.addKeyword(
+			"unique",
+			ObjectFieldSettingUtil.isUnique(
+				_objectFieldSettingLocalService.
+					getObjectFieldObjectFieldSettings(
+						objectField.getObjectFieldId())));
 
 		document.remove(Field.USER_NAME);
 	}
 
 	@Reference
-	protected ClassNameLocalService classNameLocalService;
+	private Localization _localization;
 
 	@Reference
-	private Localization _localization;
+	private ObjectFieldSettingLocalService _objectFieldSettingLocalService;
 
 }


### PR DESCRIPTION
Forwarded manually from: https://github.com/liferay-headless/liferay-portal/pull/1627

Desciption: Add property unique to the ObjectField of Schema to filter by objectFields that only contain unique data

Jira Ticket https://liferay.atlassian.net/browse/LPS-200105