### PR TITLE
LPS-153494 Fix allOf support in REST Builder

### DIFF
--- a/modules/apps/analytics/analytics-dxp-entity-rest-impl/rest-config.yaml
+++ b/modules/apps/analytics/analytics-dxp-entity-rest-impl/rest-config.yaml
@@ -1,6 +1,6 @@
 apiDir: "../analytics-dxp-entity-rest-api/src/main/java"
 apiPackagePath: "com.liferay.analytics.dxp.entity.rest"
 author: "Marcos Martins, Rachael Koestartyo, Riccardo Ferrari"
-compatibilityVersion: 3
+compatibilityVersion: 4
 forcePredictableOperationId: true
 liferayEnterpriseApp: true

--- a/modules/apps/analytics/analytics-settings-rest-impl/rest-config.yaml
+++ b/modules/apps/analytics/analytics-settings-rest-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: "Liferay.Analytyics.Settings.REST"
 author: "Riccardo Ferrari"
 clientDir: "../analytics-settings-rest-client/src/main/java"
-compatibilityVersion: 3
+compatibilityVersion: 4
 forcePredictableOperationId: true
 generateBatch: false
 testDir: "../analytics-settings-rest-test/src/testIntegration/java"

--- a/modules/apps/batch-planner/batch-planner-rest-impl/rest-config.yaml
+++ b/modules/apps/batch-planner/batch-planner-rest-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: "Liferay.Batch.Planner.REST"
 author: "Matija Petanjek"
 clientDir: "../batch-planner-rest-client/src/main/java"
-compatibilityVersion: 3
+compatibilityVersion: 4
 forcePredictableOperationId: true
 generateBatch: false
 generateGraphQL: false

--- a/modules/apps/bulk/bulk-rest-impl/rest-config.yaml
+++ b/modules/apps/bulk/bulk-rest-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: "Liferay.Bulk.REST"
 author: "Alejandro Tardín"
 clientDir: "../bulk-rest-client/src/main/java"
-compatibilityVersion: 3
+compatibilityVersion: 4
 forcePredictableOperationId: true
 generateBatch: false
 testDir: "../bulk-rest-test/src/testIntegration/java"

--- a/modules/apps/bulk/bulk-rest-impl/rest-openapi.yaml
+++ b/modules/apps/bulk/bulk-rest-impl/rest-openapi.yaml
@@ -31,6 +31,7 @@ components:
         KeywordBulkSelection:
             allOf:
                 - $ref: "#/components/schemas/DocumentBulkSelection"
+                  x-merge-properties: false
                 - properties:
                       keywordsToAdd:
                           items:
@@ -60,6 +61,7 @@ components:
         TaxonomyCategoryBulkSelection:
             allOf:
                 - $ref: "#/components/schemas/DocumentBulkSelection"
+                  x-merge-properties: false
                 - properties:
                       taxonomyCategoryIdsToAdd:
                           items:

--- a/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/BaseKeywordResourceImpl.java
+++ b/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/BaseKeywordResourceImpl.java
@@ -52,7 +52,7 @@ public abstract class BaseKeywordResourceImpl implements KeywordResource {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PATCH' 'http://localhost:8080/o/bulk/v1.0/keywords/batch'  -u 'test@liferay.com:test'
+	 * curl -X 'PATCH' 'http://localhost:8080/o/bulk/v1.0/keywords/batch' -d $'{"documentBulkSelection": ___, "keywordsToAdd": ___, "keywordsToRemove": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.tags.Tags(
 		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Keyword")}
@@ -69,7 +69,7 @@ public abstract class BaseKeywordResourceImpl implements KeywordResource {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/bulk/v1.0/keywords/batch'  -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/bulk/v1.0/keywords/batch' -d $'{"documentBulkSelection": ___, "keywordsToAdd": ___, "keywordsToRemove": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.tags.Tags(
 		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Keyword")}

--- a/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/BaseTaxonomyCategoryResourceImpl.java
+++ b/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/BaseTaxonomyCategoryResourceImpl.java
@@ -49,7 +49,7 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PATCH' 'http://localhost:8080/o/bulk/v1.0/taxonomy-categories/batch'  -u 'test@liferay.com:test'
+	 * curl -X 'PATCH' 'http://localhost:8080/o/bulk/v1.0/taxonomy-categories/batch' -d $'{"documentBulkSelection": ___, "taxonomyCategoryIdsToAdd": ___, "taxonomyCategoryIdsToRemove": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.tags.Tags(
 		value = {
@@ -69,7 +69,7 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/bulk/v1.0/taxonomy-categories/batch'  -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/bulk/v1.0/taxonomy-categories/batch' -d $'{"documentBulkSelection": ___, "taxonomyCategoryIdsToAdd": ___, "taxonomyCategoryIdsToRemove": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.tags.Tags(
 		value = {

--- a/modules/apps/change-tracking/change-tracking-rest-impl/rest-config.yaml
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/rest-config.yaml
@@ -6,6 +6,6 @@ application:
     name: "Liferay.Change.Tracking.REST"
 author: "David Truong"
 clientDir: "../change-tracking-rest-client/src/main/java"
-compatibilityVersion: 3
+compatibilityVersion: 4
 forcePredictableOperationId: true
 testDir: "../change-tracking-rest-test/src/testIntegration/java"

--- a/modules/apps/change-tracking/change-tracking-rest-impl/rest-openapi.yaml
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/rest-openapi.yaml
@@ -206,7 +206,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.change.tracking.rest.client', and version '2.0.1'."
+        'com.liferay.change.tracking.rest.client', and version '2.1.1'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -42,7 +42,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.change.tracking.rest.client', and version '2.0.1'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.change.tracking.rest.client', and version '2.1.1'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/rest-config.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/rest-config.yaml
@@ -6,6 +6,6 @@ application:
     name: "Liferay.Headless.Commerce.Admin.Account"
 author: "Alessio Antonio Rendina"
 clientDir: "../headless-commerce-admin-account-client/src/main/java"
-compatibilityVersion: 3
+compatibilityVersion: 4
 forcePredictableOperationId: false
 testDir: "../headless-commerce-admin-account-test/src/testIntegration/java"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/rest-config.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: "Liferay.Headless.Commerce.Admin.Catalog"
 author: "Zoltán Takács"
 clientDir: "../headless-commerce-admin-catalog-client/src/main/java"
-compatibilityVersion: 3
+compatibilityVersion: 4
 forcePredictableOperationId: true
 forcePredictableSchemaPropertyName: false
 testDir: "../headless-commerce-admin-catalog-test/src/testIntegration/java"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/rest-openapi.yaml
@@ -1995,7 +1995,7 @@ info:
         name: Commerce Team
     description:
         "Liferay Commerce Admin Catalog API. A Java client JAR is available for use with the group ID 'com.liferay',
-        artifact ID 'com.liferay.headless.commerce.admin.catalog.client', and version '4.0.47'."
+        artifact ID 'com.liferay.headless.commerce.admin.catalog.client', and version '4.0.48'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/rest-openapi.yaml
@@ -416,8 +416,7 @@ components:
                         type: string
                     type: object
                 geo:
-                    allOf:
-                        - $ref: "#/components/schemas/Geo"
+                    $ref: "#/components/schemas/Geo"
                     description:
                         A point determined by latitude and longitude.
             type: object
@@ -1037,8 +1036,7 @@ components:
                     readOnly: true
                     type: integer
                 workflowStatusInfo:
-                    allOf:
-                        - $ref: "#/components/schemas/Status"
+                    $ref: "#/components/schemas/Status"
                     readOnly: true
             required:
                 - active

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -42,7 +42,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Liferay Commerce Admin Catalog API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.catalog.client', and version '4.0.47'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Catalog API", version = "v1.0")
+	info = @Info(description = "Liferay Commerce Admin Catalog API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.catalog.client', and version '4.0.48'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Catalog API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/rest-config.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: "Liferay.Headless.Commerce.Admin.Channel"
 author: "Andrea Sbarra"
 clientDir: "../headless-commerce-admin-channel-client/src/main/java"
-compatibilityVersion: 3
+compatibilityVersion: 4
 forcePredictableOperationId: false
 forcePredictableSchemaPropertyName: false
 testDir: "../headless-commerce-admin-channel-test/src/testIntegration/java"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/rest-config.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/rest-config.yaml
@@ -6,6 +6,6 @@ application:
     name: "Liferay.Headless.Commerce.Admin.Inventory"
 author: "Alessio Antonio Rendina"
 clientDir: "../headless-commerce-admin-inventory-client/src/main/java"
-compatibilityVersion: 3
+compatibilityVersion: 4
 forcePredictableSchemaPropertyName: false
 testDir: "../headless-commerce-admin-inventory-test/src/testIntegration/java"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/rest-config.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/rest-config.yaml
@@ -6,6 +6,6 @@ application:
     name: "Liferay.Headless.Commerce.Admin.Order"
 author: "Alessio Antonio Rendina"
 clientDir: "../headless-commerce-admin-order-client/src/main/java"
-compatibilityVersion: 3
+compatibilityVersion: 4
 forcePredictableSchemaPropertyName: false
 testDir: "../headless-commerce-admin-order-test/src/testIntegration/java"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/rest-openapi.yaml
@@ -141,8 +141,7 @@ components:
                         type: string
                     type: object
                 geo:
-                    allOf:
-                        - $ref: "#/components/schemas/Geo"
+                    $ref: "#/components/schemas/Geo"
                     description:
                         A point determined by latitude and longitude.
             type: object
@@ -908,8 +907,7 @@ components:
                     example: "22.50"
                     type: string
                 workflowStatusInfo:
-                    allOf:
-                        - $ref: "#/components/schemas/Status"
+                    $ref: "#/components/schemas/Status"
                     readOnly: true
             required:
                 - name
@@ -1127,8 +1125,7 @@ components:
                         $ref: "#/components/schemas/OrderTypeChannel"
                     type: array
                 workflowStatusInfo:
-                    allOf:
-                        - $ref: "#/components/schemas/Status"
+                    $ref: "#/components/schemas/Status"
                     readOnly: true
             required:
                 - name
@@ -1310,8 +1307,7 @@ components:
                 typeSettings:
                     type: string
                 workflowStatusInfo:
-                    allOf:
-                        - $ref: "#/components/schemas/Status"
+                    $ref: "#/components/schemas/Status"
                     readOnly: true
             required:
                 - name

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/rest-config.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/rest-config.yaml
@@ -6,6 +6,6 @@ application:
     name: "Liferay.Headless.Commerce.Admin.Pricing"
 author: "Zoltán Takács"
 clientDir: "../headless-commerce-admin-pricing-client/src/main/java"
-compatibilityVersion: 3
+compatibilityVersion: 4
 forcePredictableSchemaPropertyName: false
 testDir: "../headless-commerce-admin-pricing-test/src/testIntegration/java"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/rest-openapi-v2.0.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/rest-openapi-v2.0.yaml
@@ -883,8 +883,7 @@ components:
                     example: price-list, promotion, contract
                     type: string
                 workflowStatusInfo:
-                    allOf:
-                        - $ref: "#/components/schemas/Status"
+                    $ref: "#/components/schemas/Status"
                     readOnly: true
             required:
                 - catalogId

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/rest-config.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/rest-config.yaml
@@ -6,6 +6,6 @@ application:
     name: "Liferay.Headless.Commerce.Admin.Shipment"
 author: "Andrea Sbarra"
 clientDir: "../headless-commerce-admin-shipment-client/src/main/java"
-compatibilityVersion: 3
+compatibilityVersion: 4
 forcePredictableSchemaPropertyName: false
 testDir: "../headless-commerce-admin-shipment-test/src/testIntegration/java"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/rest-openapi.yaml
@@ -67,8 +67,7 @@ components:
                         type: string
                     type: object
                 geo:
-                    allOf:
-                        - $ref: "#/components/schemas/Geo"
+                    $ref: "#/components/schemas/Geo"
                     description:
                         A point determined by latitude and longitude.
             type: object
@@ -185,8 +184,7 @@ components:
                     readOnly: true
                     type: string
                 status:
-                    allOf:
-                        - $ref: "#/components/schemas/Status"
+                    $ref: "#/components/schemas/Status"
                     readOnly: true
                 trackingNumber:
                     example: "123AD-asd"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/rest-config.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/rest-config.yaml
@@ -6,6 +6,6 @@ application:
     name: "Liferay.Headless.Commerce.Admin.Site.Setting"
 author: "Zoltán Takács"
 clientDir: "../headless-commerce-admin-site-setting-client/src/main/java"
-compatibilityVersion: 3
+compatibilityVersion: 4
 forcePredictableSchemaPropertyName: false
 testDir: "../headless-commerce-admin-site-setting-test/src/testIntegration/java"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/rest-config.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/rest-config.yaml
@@ -6,6 +6,6 @@ application:
     name: "Liferay.Headless.Commerce.Delivery.Cart"
 author: "Andrea Sbarra"
 clientDir: "../headless-commerce-delivery-cart-client/src/main/java"
-compatibilityVersion: 3
+compatibilityVersion: 4
 forcePredictableSchemaPropertyName: false
 testDir: "../headless-commerce-delivery-cart-test/src/testIntegration/java"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/rest-openapi.yaml
@@ -161,8 +161,7 @@ components:
                         $ref: "#/components/schemas/CartComment"
                     type: array
                 orderStatusInfo:
-                    allOf:
-                        - $ref: "#/components/schemas/Status"
+                    $ref: "#/components/schemas/Status"
                     readOnly: true
                 orderTypeExternalReferenceCode:
                     example: AB-34098-789-N
@@ -183,8 +182,7 @@ components:
                     readOnly: true
                     type: integer
                 paymentStatusInfo:
-                    allOf:
-                        - $ref: "#/components/schemas/Status"
+                    $ref: "#/components/schemas/Status"
                     readOnly: true
                 paymentStatusLabel:
                     readOnly: true
@@ -213,8 +211,7 @@ components:
                     readOnly: true
                     type: boolean
                 workflowStatusInfo:
-                    allOf:
-                        - $ref: "#/components/schemas/Status"
+                    $ref: "#/components/schemas/Status"
                     readOnly: true
             type: object
         CartComment:

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/rest-config.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: "Liferay.Headless.Commerce.Delivery.Catalog"
 author: "Andrea Sbarra"
 clientDir: "../headless-commerce-delivery-catalog-client/src/main/java"
-compatibilityVersion: 3
+compatibilityVersion: 4
 forcePredictableOperationId: true
 forcePredictableSchemaPropertyName: false
 testDir: "../headless-commerce-delivery-catalog-test/src/testIntegration/java"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/rest-openapi.yaml
@@ -957,7 +957,7 @@ components:
 info:
     description:
         "Headless Commerce Delivery Catalog API. A Java client JAR is available for use with the group ID 'com.liferay',
-        artifact ID 'com.liferay.headless.commerce.delivery.catalog.client', and version '4.0.41'."
+        artifact ID 'com.liferay.headless.commerce.delivery.catalog.client', and version '4.0.42'."
     license:
         name: Apache 2.0
         url: http://www.apache.org/licenses/LICENSE-2.0.html

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -42,7 +42,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Headless Commerce Delivery Catalog API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.delivery.catalog.client', and version '4.0.41'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Commerce Delivery Catalog API", version = "v1.0")
+	info = @Info(description = "Headless Commerce Delivery Catalog API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.delivery.catalog.client', and version '4.0.42'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Commerce Delivery Catalog API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/rest-config.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/rest-config.yaml
@@ -6,6 +6,6 @@ application:
     name: "Liferay.Headless.Commerce.Delivery.Order"
 author: "Andrea Sbarra"
 clientDir: "../headless-commerce-delivery-order-client/src/main/java"
-compatibilityVersion: 3
+compatibilityVersion: 4
 forcePredictableSchemaPropertyName: false
 testDir: "../headless-commerce-delivery-order-test/src/testIntegration/java"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/rest-openapi.yaml
@@ -73,8 +73,7 @@ components:
                     readOnly: true
                     type: string
                 orderStatusInfo:
-                    allOf:
-                        - $ref: "#/components/schemas/Status"
+                    $ref: "#/components/schemas/Status"
                     readOnly: true
                 orderTypeExternalReferenceCode:
                     example: AB-34098-789-N
@@ -98,8 +97,7 @@ components:
                     readOnly: true
                     type: integer
                 paymentStatusInfo:
-                    allOf:
-                        - $ref: "#/components/schemas/Status"
+                    $ref: "#/components/schemas/Status"
                     readOnly: true
                 paymentStatusLabel:
                     readOnly: true
@@ -153,8 +151,7 @@ components:
                     readOnly: true
                     type: boolean
                 workflowStatusInfo:
-                    allOf:
-                        - $ref: "#/components/schemas/Status"
+                    $ref: "#/components/schemas/Status"
                     readOnly: true
             type: object
         PlacedOrderAddress:
@@ -396,8 +393,7 @@ components:
                     readOnly: true
                     type: string
                 status:
-                    allOf:
-                        - $ref: "#/components/schemas/Status"
+                    $ref: "#/components/schemas/Status"
                     readOnly: true
                 supplierShipment:
                     readOnly: true

--- a/modules/apps/data-engine/data-engine-rest-impl/rest-config.yaml
+++ b/modules/apps/data-engine/data-engine-rest-impl/rest-config.yaml
@@ -6,6 +6,6 @@ application:
     name: "Liferay.Data.Engine.REST"
 author: "Jeyvison Nascimento"
 clientDir: "../data-engine-rest-client/src/main/java"
-compatibilityVersion: 3
+compatibilityVersion: 4
 forcePredictableOperationId: true
 testDir: "../data-engine-rest-test/src/testIntegration/java"

--- a/modules/apps/data-engine/data-engine-rest-impl/rest-openapi.yaml
+++ b/modules/apps/data-engine/data-engine-rest-impl/rest-openapi.yaml
@@ -28,8 +28,7 @@ components:
                     format: date-time
                     type: string
                 defaultDataLayout:
-                    allOf:
-                        - $ref: "#/components/schemas/DataLayout"
+                    $ref: "#/components/schemas/DataLayout"
                 defaultLanguageId:
                     type: string
                 description:
@@ -109,8 +108,7 @@ components:
         DataDefinitionFieldLink:
             properties:
                 dataDefinition:
-                    allOf:
-                        - $ref: "#/components/schemas/DataDefinition"
+                    $ref: "#/components/schemas/DataDefinition"
                 dataLayouts:
                     items:
                         $ref: "#/components/schemas/DataLayout"

--- a/modules/apps/digital-signature/digital-signature-rest-impl/rest-config.yaml
+++ b/modules/apps/digital-signature/digital-signature-rest-impl/rest-config.yaml
@@ -6,6 +6,6 @@ application:
     name: "Liferay.Digital.Signature.REST"
 author: "José Abelenda"
 clientDir: "../digital-signature-rest-client/src/main/java"
-compatibilityVersion: 3
+compatibilityVersion: 4
 forcePredictableOperationId: true
 testDir: "../digital-signature-rest-test/src/testIntegration/java"

--- a/modules/apps/dispatch/dispatch-rest-impl/rest-config.yaml
+++ b/modules/apps/dispatch/dispatch-rest-impl/rest-config.yaml
@@ -6,6 +6,6 @@ application:
     name: "Liferay.Dispatch.REST"
 author: "Nilton Vieira"
 clientDir: "../dispatch-rest-client/src/main/java"
-compatibilityVersion: 3
+compatibilityVersion: 4
 forcePredictableOperationId: true
 testDir: "../dispatch-rest-test/src/testIntegration/java"

--- a/modules/apps/frontend-view-state/frontend-view-state-rest-impl/rest-config.yaml
+++ b/modules/apps/frontend-view-state/frontend-view-state-rest-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: "Liferay.Frontend.View.State.REST"
 author: "Javier Gamarra"
 clientDir: "../frontend-view-state-rest-client/src/main/java"
-compatibilityVersion: 3
+compatibilityVersion: 4
 forcePredictableOperationId: true
 generateBatch: false
 generateGraphQL: false

--- a/modules/apps/headless/headless-admin-address/headless-admin-address-impl/rest-config.yaml
+++ b/modules/apps/headless/headless-admin-address/headless-admin-address-impl/rest-config.yaml
@@ -6,6 +6,6 @@ application:
     name: "Liferay.Headless.Admin.Address"
 author: "Drew Brokke"
 clientDir: "../headless-admin-address-client/src/main/java"
-compatibilityVersion: 3
+compatibilityVersion: 4
 forcePredictableOperationId: true
 testDir: "../headless-admin-address-test/src/testIntegration/java"

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-impl/rest-config.yaml
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: "Liferay.Headless.Admin.Content"
 author: "Javier Gamarra"
 clientDir: "../headless-admin-content-client/src/main/java"
-compatibilityVersion: 3
+compatibilityVersion: 4
 forcePredictableOperationId: true
 generateBatch: false
 graphQLNamespace: "admin"

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-impl/rest-openapi.yaml
@@ -184,7 +184,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.admin.content.client', and version '2.0.27'."
+        'com.liferay.headless.admin.content.client', and version '2.0.28'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-impl/rest-openapi.yaml
@@ -34,8 +34,7 @@ components:
                     readOnly: true
                     type: array
                 creator:
-                    allOf:
-                        - $ref: "../../headless-delivery/headless-delivery-impl/rest-openapi.yaml#Creator"
+                    $ref: "../../headless-delivery/headless-delivery-impl/rest-openapi.yaml#Creator"
                     description:
                         The Display Page Template's creator.
                     readOnly: true
@@ -176,8 +175,7 @@ components:
                     readOnly: true
                     type: number
                 status:
-                    allOf:
-                        - $ref: "#/components/schemas/Status"
+                    $ref: "#/components/schemas/Status"
                     # @review
                     description:
                         Represents the status of a resource

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -42,7 +42,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.content.client', and version '2.0.27'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin Content", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.content.client', and version '2.0.28'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin Content", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/rest-config.yaml
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/rest-config.yaml
@@ -6,6 +6,6 @@ application:
     name: "Liferay.Headless.Admin.List.Type"
 author: "Gabriel Albuquerque"
 clientDir: "../headless-admin-list-type-client/src/main/java"
-compatibilityVersion: 3
+compatibilityVersion: 4
 forcePredictableOperationId: true
 testDir: "../headless-admin-list-type-test/src/testIntegration/java"

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/rest-config.yaml
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/rest-config.yaml
@@ -6,6 +6,7 @@ application:
     name: "Liferay.Headless.Admin.Taxonomy"
 author: "Javier Gamarra"
 clientDir: "../headless-admin-taxonomy-client/src/main/java"
-compatibilityVersion: 4
+compatibilityVersion: 3
 forcePredictableOperationId: true
+generateActionProviders: true
 testDir: "../headless-admin-taxonomy-test/src/testIntegration/java"

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/rest-config.yaml
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: "Liferay.Headless.Admin.Taxonomy"
 author: "Javier Gamarra"
 clientDir: "../headless-admin-taxonomy-client/src/main/java"
-compatibilityVersion: 3
+compatibilityVersion: 4
 forcePredictableOperationId: true
 generateActionProviders: true
 testDir: "../headless-admin-taxonomy-test/src/testIntegration/java"

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/rest-openapi.yaml
@@ -83,8 +83,7 @@ components:
                     readOnly: true
                     type: string
                 creator:
-                    allOf:
-                        - $ref: "#/components/schemas/Creator"
+                    $ref: "#/components/schemas/Creator"
                     description:
                         The keyword's creator.
                     readOnly: true
@@ -150,8 +149,7 @@ components:
                     readOnly: true
                     type: array
                 creator:
-                    allOf:
-                        - $ref: "#/components/schemas/Creator"
+                    $ref: "#/components/schemas/Creator"
                     description:
                         The category's creator.
                     readOnly: true
@@ -296,8 +294,7 @@ components:
                     readOnly: true
                     type: array
                 creator:
-                    allOf:
-                        - $ref: "#/components/schemas/Creator"
+                    $ref: "#/components/schemas/Creator"
                     description:
                         The vocabulary's creator.
                     readOnly: true

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-config.yaml
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-config.yaml
@@ -6,5 +6,5 @@ application:
     name: "Liferay.Headless.Admin.User"
 author: "Javier Gamarra"
 clientDir: "../headless-admin-user-client/src/main/java"
-compatibilityVersion: 3
+compatibilityVersion: 4
 testDir: "../headless-admin-user-test/src/testIntegration/java"

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml
@@ -448,8 +448,7 @@ components:
                             type: array
                     type: object
                 parentOrganization:
-                    allOf:
-                        - $ref: "#/components/schemas/Organization"
+                    $ref: "#/components/schemas/Organization"
                     description:
                         The organization's parent organization.
                 services:
@@ -627,8 +626,7 @@ components:
                     readOnly: true
                     type: array
                 creator:
-                    allOf:
-                        - $ref: "#/components/schemas/Creator"
+                    $ref: "#/components/schemas/Creator"
                     description:
                         The role's creator.
                     readOnly: true

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/rest-config.yaml
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/rest-config.yaml
@@ -6,5 +6,5 @@ application:
     name: "Liferay.Headless.Admin.Workflow"
 author: "Javier Gamarra"
 clientDir: "../headless-admin-workflow-client/src/main/java"
-compatibilityVersion: 3
+compatibilityVersion: 4
 testDir: "../headless-admin-workflow-test/src/testIntegration/java"

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/rest-openapi.yaml
@@ -132,8 +132,7 @@ components:
                     readOnly: true
                     type: array
                 creator:
-                    allOf:
-                        - $ref: "#/components/schemas/Creator"
+                    $ref: "#/components/schemas/Creator"
                     description:
                         The role's creator.
                     readOnly: true
@@ -292,8 +291,7 @@ components:
                     readOnly: true
                     type: integer
                 objectReviewed:
-                    allOf:
-                        - $ref: "#/components/schemas/ObjectReviewed"
+                    $ref: "#/components/schemas/ObjectReviewed"
                     description:
                         The object/asset that the instance's workflow is managing.
                     readOnly: true
@@ -331,8 +329,7 @@ components:
                 Represents the log containing the workflow's activity history (e.g., transitions, assignees, etc.).
             properties:
                 auditPerson:
-                    allOf:
-                        - $ref: "#/components/schemas/Creator"
+                    $ref: "#/components/schemas/Creator"
                     description:
                         The user account of the person auditing the workflow.
                     readOnly: true
@@ -360,20 +357,17 @@ components:
                     readOnly: true
                     type: integer
                 person:
-                    allOf:
-                        - $ref: "#/components/schemas/Creator"
+                    $ref: "#/components/schemas/Creator"
                     description:
                         The person assigned to the workflow.
                     readOnly: true
                 previousPerson:
-                    allOf:
-                        - $ref: "#/components/schemas/Creator"
+                    $ref: "#/components/schemas/Creator"
                     description:
                         The previous person assigned to the workflow.
                     readOnly: true
                 previousRole:
-                    allOf:
-                        - $ref: "#/components/schemas/Role"
+                    $ref: "#/components/schemas/Role"
                     readOnly: true
                 previousState:
                     description:
@@ -386,8 +380,7 @@ components:
                     readOnly: true
                     type: string
                 role:
-                    allOf:
-                        - $ref: "#/components/schemas/Role"
+                    $ref: "#/components/schemas/Role"
                     readOnly: true
                 state:
                     description:
@@ -424,8 +417,7 @@ components:
                     readOnly: true
                     type: object
                 assigneePerson:
-                    allOf:
-                        - $ref: "#/components/schemas/Creator"
+                    $ref: "#/components/schemas/Creator"
                 assigneeRoles:
                     items:
                         $ref: "#/components/schemas/Role"
@@ -473,8 +465,7 @@ components:
                     readOnly: true
                     type: string
                 objectReviewed:
-                    allOf:
-                        - $ref: "#/components/schemas/ObjectReviewed"
+                    $ref: "#/components/schemas/ObjectReviewed"
                     description:
                         The object/asset that the task's workflow is managing.
                     readOnly: true

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/rest-config.yaml
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: "Liferay.Headless.Batch.Engine"
 author: "Ivica Cardic"
 clientDir: "../headless-batch-engine-client/src/main/java"
-compatibilityVersion: 3
+compatibilityVersion: 4
 forcePredictableOperationId: true
 generateBatch: false
 generateGraphQL: false

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-config.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-config.yaml
@@ -6,6 +6,6 @@ application:
     name: "Liferay.Headless.Delivery"
 author: "Javier Gamarra"
 clientDir: "../headless-delivery-client/src/main/java"
-compatibilityVersion: 3
+compatibilityVersion: 4
 forcePredictableOperationId: true
 testDir: "../headless-delivery-test/src/testIntegration/java"

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -5669,7 +5669,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.delivery.client', and version '4.0.66'."
+        'com.liferay.headless.delivery.client', and version '4.0.67'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -70,8 +70,7 @@ components:
                     readOnly: true
                     type: object
                 aggregateRating:
-                    allOf:
-                        - $ref: "#/components/schemas/AggregateRating"
+                    $ref: "#/components/schemas/AggregateRating"
                     description:
                         The blog post's average rating.
                     readOnly: true
@@ -84,8 +83,7 @@ components:
                         The blog post's body (content).
                     type: string
                 creator:
-                    allOf:
-                        - $ref: "#/components/schemas/Creator"
+                    $ref: "#/components/schemas/Creator"
                     description:
                         The blog post's author.
                     readOnly: true
@@ -411,8 +409,7 @@ components:
                     readOnly: true
                     type: object
                 creator:
-                    allOf:
-                        - $ref: "#/components/schemas/Creator"
+                    $ref: "#/components/schemas/Creator"
                     description:
                         The comment's author.
                     readOnly: true
@@ -554,8 +551,7 @@ components:
                 (e.g., documents, geolocation, etc.).
             properties:
                 contentFieldValue:
-                    allOf:
-                        - $ref: "#/components/schemas/ContentFieldValue"
+                    $ref: "#/components/schemas/ContentFieldValue"
                     description:
                         The field's value.
                 contentFieldValue_i18n:
@@ -612,8 +608,7 @@ components:
                         The field's content for simple types.
                     type: string
                 document:
-                    allOf:
-                        - $ref: "#/components/schemas/ContentDocument"
+                    $ref: "#/components/schemas/ContentDocument"
                     description:
                         A content document element.
                 geo:
@@ -632,8 +627,7 @@ components:
                             type: number
                     type: object
                 image:
-                    allOf:
-                        - $ref: "#/components/schemas/ContentDocument"
+                    $ref: "#/components/schemas/ContentDocument"
                     description:
                         A content document element that stores an image file.
                 link:
@@ -651,8 +645,7 @@ components:
                             readOnly: true
                             type: string
                         embeddedStructuredContent:
-                            allOf:
-                                - $ref: "#/components/schemas/StructuredContent"
+                            $ref: "#/components/schemas/StructuredContent"
                             # @review
                             description:
                                 Optional field with the structured content, can be embedded with nestedFields.
@@ -730,8 +723,7 @@ components:
                     readOnly: true
                     type: array
                 creator:
-                    allOf:
-                        - $ref: "#/components/schemas/Creator"
+                    $ref: "#/components/schemas/Creator"
                     description:
                         The content structure's creator.
                     readOnly: true
@@ -923,8 +915,7 @@ components:
                     format: int64
                     type: integer
                 creator:
-                    allOf:
-                        - $ref: "#/components/schemas/Creator"
+                    $ref: "#/components/schemas/Creator"
                     # @review
                     description:
                         The content template's creator.
@@ -1112,8 +1103,7 @@ components:
                 geolocation, strings, etc.).
             properties:
                 customValue:
-                    allOf:
-                        - $ref: "#/components/schemas/CustomValue"
+                    $ref: "#/components/schemas/CustomValue"
                     description:
                         The field's value.
                 dataType:
@@ -1166,8 +1156,7 @@ components:
                         The localized field's content values for simple types.
                     type: object
                 geo:
-                    allOf:
-                        - $ref: "#/components/schemas/Geo"
+                    $ref: "#/components/schemas/Geo"
                     description:
                         A point determined by latitude and longitude.
             type: object
@@ -1272,8 +1261,7 @@ components:
                     readOnly: true
                     type: array
                 aggregateRating:
-                    allOf:
-                        - $ref: "#/components/schemas/AggregateRating"
+                    $ref: "#/components/schemas/AggregateRating"
                     description:
                         The document's average rating.
                     readOnly: true
@@ -1297,8 +1285,7 @@ components:
                     readOnly: true
                     type: string
                 creator:
-                    allOf:
-                        - $ref: "#/components/schemas/Creator"
+                    $ref: "#/components/schemas/Creator"
                     description:
                         The document's creator.
                     readOnly: true
@@ -1487,8 +1474,7 @@ components:
                     readOnly: true
                     type: string
                 creator:
-                    allOf:
-                        - $ref: "#/components/schemas/Creator"
+                    $ref: "#/components/schemas/Creator"
                     description:
                         The folder's creator.
                     readOnly: true
@@ -1657,14 +1643,12 @@ components:
                     oneOf:
                         - $ref: "#/components/schemas/FragmentMappedValue"
                 onError:
-                    allOf:
-                        - $ref: "#/components/schemas/ActionExecutionResult"
+                    $ref: "#/components/schemas/ActionExecutionResult"
                     # @review
                     description:
                         The action execution result in case the action fails.
                 onSuccess:
-                    allOf:
-                        - $ref: "#/components/schemas/ActionExecutionResult"
+                    $ref: "#/components/schemas/ActionExecutionResult"
                     # @review
                     description:
                         The action execution result in case the action succeeds.
@@ -1682,8 +1666,7 @@ components:
                 Represents a fragment field with a background image.
             properties:
                 backgroundFragmentImage:
-                    allOf:
-                        - $ref: "#/components/schemas/FragmentImage"
+                    $ref: "#/components/schemas/FragmentImage"
                     # @review
                     description:
                         The fragment field's background image.
@@ -1723,14 +1706,12 @@ components:
                 Represents a fragment field with an image.
             properties:
                 fragmentImage:
-                    allOf:
-                        - $ref: "#/components/schemas/FragmentImage"
+                    $ref: "#/components/schemas/FragmentImage"
                     # @review
                     description:
                         The fragment field's image.
                 fragmentLink:
-                    allOf:
-                        - $ref: "#/components/schemas/FragmentLink"
+                    $ref: "#/components/schemas/FragmentLink"
                     # @review
                     description:
                         A link to a fragment.
@@ -1741,8 +1722,7 @@ components:
                 Represents a fragment field with text.
             properties:
                 fragmentLink:
-                    allOf:
-                        - $ref: "#/components/schemas/FragmentLink"
+                    $ref: "#/components/schemas/FragmentLink"
                     # @review
                     description:
                         A link to a fragment.
@@ -1766,8 +1746,7 @@ components:
                     oneOf:
                         - $ref: "#/components/schemas/FragmentInlineValue"
                 fragmentImageClassPKReference:
-                    allOf:
-                        - $ref: "#/components/schemas/FragmentImageClassPKReference"
+                    $ref: "#/components/schemas/FragmentImageClassPKReference"
                     # @review
                     description:
                         A reference to a fragment image class primary key.
@@ -1798,8 +1777,7 @@ components:
                         A map of class primary key references.
                     type: object
                 fragmentImageConfiguration:
-                    allOf:
-                        - $ref: "#/components/schemas/FragmentImageConfiguration"
+                    $ref: "#/components/schemas/FragmentImageConfiguration"
                     # @review
                     description:
                         The fragment image's configuration.
@@ -1858,8 +1836,7 @@ components:
                     enum: [Blank, Parent, Self, Top]
                     type: string
                 value:
-                    allOf:
-                        - $ref: "#/components/schemas/FragmentLinkValue"
+                    $ref: "#/components/schemas/FragmentLinkValue"
                     # @review
                     description:
                         The fragment link's value.
@@ -1894,8 +1871,7 @@ components:
                 Represents a fragment mapped value.
             properties:
                 defaultFragmentInlineValue:
-                    allOf:
-                        - $ref: "#/components/schemas/FragmentInlineValue"
+                    $ref: "#/components/schemas/FragmentInlineValue"
                     # @review
                     description:
                         The default value of the fragment mapped value.
@@ -1966,8 +1942,7 @@ components:
                         The fragment's background color.
                     type: string
                 backgroundFragmentImage:
-                    allOf:
-                        - $ref: "#/components/schemas/FragmentImage"
+                    $ref: "#/components/schemas/FragmentImage"
                     # @review
                     description:
                         The fragment's background image.
@@ -2287,8 +2262,7 @@ components:
                     readOnly: true
                     type: object
                 aggregateRating:
-                    allOf:
-                        - $ref: "#/components/schemas/AggregateRating"
+                    $ref: "#/components/schemas/AggregateRating"
                     description:
                         The article's average rating.
                     readOnly: true
@@ -2297,8 +2271,7 @@ components:
                         The article's main content.
                     type: string
                 creator:
-                    allOf:
-                        - $ref: "#/components/schemas/Creator"
+                    $ref: "#/components/schemas/Creator"
                     description:
                         The article's author.
                     readOnly: true
@@ -2507,8 +2480,7 @@ components:
                     readOnly: true
                     type: object
                 creator:
-                    allOf:
-                        - $ref: "#/components/schemas/Creator"
+                    $ref: "#/components/schemas/Creator"
                     description:
                         The folder's creator.
                     readOnly: true
@@ -2724,8 +2696,7 @@ components:
                     readOnly: true
                     type: object
                 aggregateRating:
-                    allOf:
-                        - $ref: "#/components/schemas/AggregateRating"
+                    $ref: "#/components/schemas/AggregateRating"
                     description:
                         The message's average rating.
                     readOnly: true
@@ -2738,14 +2709,12 @@ components:
                         The message's main content.
                     type: string
                 creator:
-                    allOf:
-                        - $ref: "#/components/schemas/Creator"
+                    $ref: "#/components/schemas/Creator"
                     description:
                         The message's author.
                     readOnly: true
                 creatorStatistics:
-                    allOf:
-                        - $ref: "#/components/schemas/CreatorStatistics"
+                    $ref: "#/components/schemas/CreatorStatistics"
                     # @review
                     description:
                         The message's creator statistics (rank, join date, number of posts, ...)
@@ -2879,8 +2848,7 @@ components:
                     readOnly: true
                     type: object
                 creator:
-                    allOf:
-                        - $ref: "#/components/schemas/Creator"
+                    $ref: "#/components/schemas/Creator"
                     description:
                         The section's creator.
                     readOnly: true
@@ -2972,8 +2940,7 @@ components:
                     readOnly: true
                     type: object
                 aggregateRating:
-                    allOf:
-                        - $ref: "#/components/schemas/AggregateRating"
+                    $ref: "#/components/schemas/AggregateRating"
                     description:
                         The thread's average rating.
                     readOnly: true
@@ -2982,14 +2949,12 @@ components:
                         The thread's main body content (the message written as the thread's description).
                     type: string
                 creator:
-                    allOf:
-                        - $ref: "#/components/schemas/Creator"
+                    $ref: "#/components/schemas/Creator"
                     description:
                         The thread's creator.
                     readOnly: true
                 creatorStatistics:
-                    allOf:
-                        - $ref: "#/components/schemas/CreatorStatistics"
+                    $ref: "#/components/schemas/CreatorStatistics"
                     # @review
                     description:
                         The thread's creator statistics (rank, join date, number of posts, ...)
@@ -3149,8 +3114,7 @@ components:
                 Represents a definition of a submission result of type message.
             properties:
                 message:
-                    allOf:
-                        - $ref: "#/components/schemas/FragmentInlineValue"
+                    $ref: "#/components/schemas/FragmentInlineValue"
                     # @review
                     description:
                         The localized submission of message type.
@@ -3179,8 +3143,7 @@ components:
                     readOnly: true
                     type: object
                 creator:
-                    allOf:
-                        - $ref: "#/components/schemas/Creator"
+                    $ref: "#/components/schemas/Creator"
                     # @review
                     description:
                         The navigation menu's creator.
@@ -3250,9 +3213,8 @@ components:
                         The navigation menu item's content API REST URL.
                     type: string
                 creator:
-                    allOf:
-                        - $ref: "#/components/schemas/Creator"
-                     # @review
+                    $ref: "#/components/schemas/Creator"
+                        # @review
                     description:
                         The navigation menu item's creator.
                     readOnly: true
@@ -3357,8 +3319,7 @@ components:
                         Whether to reload the page after the action is executed.
                     type: boolean
                 text:
-                    allOf:
-                        - $ref: "#/components/schemas/FragmentInlineValue"
+                    $ref: "#/components/schemas/FragmentInlineValue"
                     # @review
                     description:
                         The localized text to display when an action is executed.
@@ -3381,8 +3342,7 @@ components:
                         The localized Open Graph's descriptions.
                     type: object
                 image:
-                    allOf:
-                        - $ref: "#/components/schemas/ContentDocument"
+                    $ref: "#/components/schemas/ContentDocument"
                     # @review
                     description:
                         The Open Graph's image.
@@ -3470,8 +3430,7 @@ components:
                             type: object
                     type: object
                 fragmentStyle:
-                    allOf:
-                        - $ref: "#/components/schemas/FragmentStyle"
+                    $ref: "#/components/schemas/FragmentStyle"
                     # @review
                     description:
                         The fragment style of the page collection.
@@ -3620,8 +3579,7 @@ components:
                 Represent a definition of a Page.
             properties:
                 pageElement:
-                    allOf:
-                        - $ref: "#/components/schemas/PageElement"
+                    $ref: "#/components/schemas/PageElement"
                     # @review
                     description:
                         The page's page element.
@@ -3633,8 +3591,7 @@ components:
                         $ref: "#/components/schemas/PageRule"
                     type: array
                 settings:
-                    allOf:
-                        - $ref: "#/components/schemas/Settings"
+                    $ref: "#/components/schemas/Settings"
                     # @review
                     description:
                         The page's settings.
@@ -3741,8 +3698,7 @@ components:
                             type: object
                     type: object
                 fragmentStyle:
-                    allOf:
-                        - $ref: "#/components/schemas/FragmentStyle"
+                    $ref: "#/components/schemas/FragmentStyle"
                     # @review
                     description:
                         The fragment style of a Page form.
@@ -3824,8 +3780,7 @@ components:
                         $ref: "#/components/schemas/CustomCSSViewport"
                     type: array
                 fragment:
-                    allOf:
-                        - $ref: "#/components/schemas/Fragment"
+                    $ref: "#/components/schemas/Fragment"
                     # @review
                     description:
                         The fragment of the page fragment instance.
@@ -3844,8 +3799,7 @@ components:
                         $ref: "#/components/schemas/FragmentField"
                     type: array
                 fragmentStyle:
-                    allOf:
-                        - $ref: "#/components/schemas/FragmentStyle"
+                    $ref: "#/components/schemas/FragmentStyle"
                     # @review
                     description:
                         The fragment style of the page fragment instance.
@@ -3904,8 +3858,7 @@ components:
                         $ref: "#/components/schemas/CustomCSSViewport"
                     type: array
                 fragmentStyle:
-                    allOf:
-                        - $ref: "#/components/schemas/FragmentStyle"
+                    $ref: "#/components/schemas/FragmentStyle"
                     # @review
                     description:
                         The fragment style of a Page row.
@@ -4018,8 +3971,7 @@ components:
                     deprecated: true
                     type: string
                 backgroundFragmentImage:
-                    allOf:
-                        - $ref: "#/components/schemas/FragmentImage"
+                    $ref: "#/components/schemas/FragmentImage"
                     # @review
                     description:
                         The background fragment image of the page section.
@@ -4064,14 +4016,12 @@ components:
                         $ref: "#/components/schemas/CustomCSSViewport"
                     type: array
                 fragmentLink:
-                    allOf:
-                        - $ref: "#/components/schemas/FragmentLink"
+                    $ref: "#/components/schemas/FragmentLink"
                     # @review
                     description:
                         The fragment link of the page section.
                 fragmentStyle:
-                    allOf:
-                        - $ref: "#/components/schemas/FragmentStyle"
+                    $ref: "#/components/schemas/FragmentStyle"
                     # @review
                     description:
                         The fragment style of the page section.
@@ -4197,20 +4147,17 @@ components:
                         A flag that indicates whether the page is hidden from navigation.
                     type: boolean
                 openGraphSettings:
-                    allOf:
-                        - $ref: "#/components/schemas/OpenGraphSettings"
+                    $ref: "#/components/schemas/OpenGraphSettings"
                     # @review
                     description:
                         The page's Open Graph settings.
                 seoSettings:
-                    allOf:
-                        - $ref: "#/components/schemas/SEOSettings"
+                    $ref: "#/components/schemas/SEOSettings"
                     # @review
                     description:
                         The page's SEO settings.
                 sitePageNavigationMenuSettings:
-                    allOf:
-                        - $ref: "#/components/schemas/SitePageNavigationMenuSettings"
+                    $ref: "#/components/schemas/SitePageNavigationMenuSettings"
                     # @review
                     description:
                         The page's site navigation menu settings.
@@ -4221,8 +4168,7 @@ components:
                 Represents a Page template.
             properties:
                 creator:
-                    allOf:
-                        - $ref: "#/components/schemas/Creator"
+                    $ref: "#/components/schemas/Creator"
                     # @review
                     description:
                         The page template's creator.
@@ -4261,14 +4207,12 @@ components:
                         The page template's name.
                     type: string
                 pageDefinition:
-                    allOf:
-                        - $ref: "#/components/schemas/PageDefinition"
+                    $ref: "#/components/schemas/PageDefinition"
                     # @review
                     description:
                         The page template's definition.
                 pageTemplateCollection:
-                    allOf:
-                        - $ref: "#/components/schemas/PageTemplateCollection"
+                    $ref: "#/components/schemas/PageTemplateCollection"
                     # @review
                     description:
                         The page template's collection.
@@ -4301,8 +4245,7 @@ components:
                 Represents a Page template collection.
             properties:
                 creator:
-                    allOf:
-                        - $ref: "#/components/schemas/Creator"
+                    $ref: "#/components/schemas/Creator"
                     # @review
                     description:
                         The page template collection's creator.
@@ -4369,8 +4312,7 @@ components:
                         $ref: "#/components/schemas/CustomCSSViewport"
                     type: array
                 fragmentStyle:
-                    allOf:
-                        - $ref: "#/components/schemas/FragmentStyle"
+                    $ref: "#/components/schemas/FragmentStyle"
                     # @review
                     description:
                         The fragment style of the page widget instance.
@@ -4387,8 +4329,7 @@ components:
                         The custom name of a Page Widget instance.
                     type: string
                 widgetInstance:
-                    allOf:
-                        - $ref: "#/components/schemas/WidgetInstance"
+                    $ref: "#/components/schemas/WidgetInstance"
                     # @review
                     description:
                         The widget instance of the page widget instance.
@@ -4415,8 +4356,7 @@ components:
                     readOnly: true
                     type: number
                 creator:
-                    allOf:
-                        - $ref: "#/components/schemas/Creator"
+                    $ref: "#/components/schemas/Creator"
                     description:
                         The rating's creator.
                     readOnly: true
@@ -4714,8 +4654,7 @@ components:
                         The page's JavaScript.
                     type: string
                 masterPage:
-                    allOf:
-                        - $ref: "#/components/schemas/MasterPage"
+                    $ref: "#/components/schemas/MasterPage"
                     # @review
                     description:
                         The page's master page.
@@ -4736,8 +4675,7 @@ components:
                             type: string
                     type: object
                 themeCSSClientExtension:
-                    allOf:
-                        - $ref: "#/components/schemas/ClientExtension"
+                    $ref: "#/components/schemas/ClientExtension"
                     # @review
                     description:
                         The Client Extension for the theme css of a page
@@ -4768,8 +4706,7 @@ components:
                     readOnly: true
                     type: object
                 aggregateRating:
-                    allOf:
-                        - $ref: "#/components/schemas/AggregateRating"
+                    $ref: "#/components/schemas/AggregateRating"
                     # @review
                     description:
                         The page's average rating.
@@ -4783,8 +4720,7 @@ components:
                     readOnly: true
                     type: array
                 creator:
-                    allOf:
-                        - $ref: "#/components/schemas/Creator"
+                    $ref: "#/components/schemas/Creator"
                     # @review
                     description:
                         The page's creator.
@@ -4817,8 +4753,7 @@ components:
                     format: date-time
                     type: string
                 experience:
-                    allOf:
-                        - $ref: "#/components/schemas/Experience"
+                    $ref: "#/components/schemas/Experience"
                     # @review
                     description:
                         Experience of the page that it's being retrieved.
@@ -4848,8 +4783,7 @@ components:
                         type: string
                     type: array
                 pageDefinition:
-                    allOf:
-                        - $ref: "#/components/schemas/PageDefinition"
+                    $ref: "#/components/schemas/PageDefinition"
                     # @review
                     description:
                         Optional field with the structure of all the elements of the page. Can be embedded with
@@ -4876,8 +4810,7 @@ components:
                         type: object
                     type: array
                 pageSettings:
-                    allOf:
-                        - $ref: "#/components/schemas/PageSettings"
+                    $ref: "#/components/schemas/PageSettings"
                     # @review
                     description:
                         Settings of the page, such as SEO or OpenGraph.
@@ -4898,8 +4831,7 @@ components:
                             type: string
                     type: object
                 renderedPage:
-                    allOf:
-                        - $ref: "#/components/schemas/RenderedPage"
+                    $ref: "#/components/schemas/RenderedPage"
                     # @review
                     description:
                         Metadata of the page such as it's master page and template.
@@ -4962,8 +4894,7 @@ components:
                 Represents a definition of an action execution of type page.
             properties:
                 itemReference:
-                    allOf:
-                        - $ref: "#/components/schemas/ClassFieldsReference"
+                    $ref: "#/components/schemas/ClassFieldsReference"
                     # @review
                     description:
                         The reference to a page.
@@ -4974,8 +4905,7 @@ components:
                 Represents a definition of a submission result of type page.
             properties:
                 itemReference:
-                    allOf:
-                        - $ref: "#/components/schemas/ClassFieldsReference"
+                    $ref: "#/components/schemas/ClassFieldsReference"
                     # @review
                     description:
                         The localized submission of page type.
@@ -5018,8 +4948,7 @@ components:
                     readOnly: true
                     type: object
                 aggregateRating:
-                    allOf:
-                        - $ref: "#/components/schemas/AggregateRating"
+                    $ref: "#/components/schemas/AggregateRating"
                     description:
                         The structured content's average rating.
                     readOnly: true
@@ -5048,8 +4977,7 @@ components:
                     format: int64
                     type: integer
                 creator:
-                    allOf:
-                        - $ref: "#/components/schemas/Creator"
+                    $ref: "#/components/schemas/Creator"
                     description:
                         The structured content's creator.
                     readOnly: true
@@ -5234,8 +5162,7 @@ components:
                     readOnly: true
                     type: string
                 creator:
-                    allOf:
-                        - $ref: "#/components/schemas/Creator"
+                    $ref: "#/components/schemas/Creator"
                     description:
                         The folder's creator.
                     readOnly: true
@@ -5367,8 +5294,7 @@ components:
                 Represents a definition of an action execution result of type URL.
             properties:
                 url:
-                    allOf:
-                        - $ref: "#/components/schemas/FragmentInlineValue"
+                    $ref: "#/components/schemas/FragmentInlineValue"
                     # @review
                     description:
                         The localized action execution result of type URL.
@@ -5379,8 +5305,7 @@ components:
                 Represents a definition of a submission result of type URL.
             properties:
                 url:
-                    allOf:
-                        - $ref: "#/components/schemas/FragmentInlineValue"
+                    $ref: "#/components/schemas/FragmentInlineValue"
                     # @review
                     description:
                         The localized submission of URL type.
@@ -5483,8 +5408,7 @@ components:
                     readOnly: true
                     type: object
                 creator:
-                    allOf:
-                        - $ref: "#/components/schemas/Creator"
+                    $ref: "#/components/schemas/Creator"
                     description:
                         The wiki node's creator.
                     readOnly: true
@@ -5558,8 +5482,7 @@ components:
                     readOnly: true
                     type: object
                 aggregateRating:
-                    allOf:
-                        - $ref: "#/components/schemas/AggregateRating"
+                    $ref: "#/components/schemas/AggregateRating"
                     description:
                         The blog post's average rating.
                     readOnly: true
@@ -5568,8 +5491,7 @@ components:
                         The wiki page's content.
                     type: string
                 creator:
-                    allOf:
-                        - $ref: "#/components/schemas/Creator"
+                    $ref: "#/components/schemas/Creator"
                     description:
                         The wiki page's creator.
                     readOnly: true

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -42,7 +42,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.delivery.client', and version '4.0.66'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Delivery", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.delivery.client', and version '4.0.67'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Delivery", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-form/headless-form-impl/rest-config.yaml
+++ b/modules/apps/headless/headless-form/headless-form-impl/rest-config.yaml
@@ -6,6 +6,6 @@ application:
     name: "Liferay.Headless.Form"
 author: "Javier Gamarra"
 clientDir: "../headless-form-client/src/main/java"
-compatibilityVersion: 3
+compatibilityVersion: 4
 forcePredictableOperationId: true
 testDir: "../headless-form-test/src/testIntegration/java"

--- a/modules/apps/headless/headless-form/headless-form-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-form/headless-form-impl/rest-openapi.yaml
@@ -79,8 +79,7 @@ components:
                     format: int64
                     type: integer
                 structure:
-                    allOf:
-                        - $ref: "#/components/schemas/FormStructure"
+                    $ref: "#/components/schemas/FormStructure"
                     readOnly: true
                 structureId:
                     format: int64
@@ -298,8 +297,7 @@ components:
             items:
                 properties:
                     formDocument:
-                        allOf:
-                            - $ref: "#/components/schemas/FormDocument"
+                        $ref: "#/components/schemas/FormDocument"
                         readOnly: true
                     formDocumentId:
                         format: int64

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/rest-config.yaml
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: "Liferay.Headless.Portal.Instances"
 author: "Alberto Chaparro"
 clientDir: "../headless-portal-instances-client/src/main/java"
-compatibilityVersion: 3
+compatibilityVersion: 4
 forcePredictableOperationId: true
 generateBatch: false
 generateGraphQL: false

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/rest-openapi.yaml
@@ -29,8 +29,7 @@ components:
                     readOnly: true
                     type: boolean
                 admin:
-                    allOf:
-                        - $ref: "#/components/schemas/Admin"
+                    $ref: "#/components/schemas/Admin"
                     # @review
                     description:
                         The portal instance's administrator. This field is optional and is only used in the portal

--- a/modules/apps/headless/headless-site/headless-site-impl/rest-config.yaml
+++ b/modules/apps/headless/headless-site/headless-site-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: "Liferay.Headless.Site"
 author: "Rubén Pulido"
 clientDir: "../headless-site-client/src/main/java"
-compatibilityVersion: 3
+compatibilityVersion: 4
 forcePredictableOperationId: true
 generateBatch: false
 generateGraphQL: false

--- a/modules/apps/headless/headless-user-notification/headless-user-notification-impl/rest-config.yaml
+++ b/modules/apps/headless/headless-user-notification/headless-user-notification-impl/rest-config.yaml
@@ -6,6 +6,6 @@ application:
     name: "Liferay.Headless.User.Notification"
 author: "Carlos Correa"
 clientDir: "../headless-user-notification-client/src/main/java"
-compatibilityVersion: 3
+compatibilityVersion: 4
 forcePredictableOperationId: true
 testDir: "../headless-user-notification-test/src/testIntegration/java"

--- a/modules/apps/notification/notification-rest-impl/rest-config.yaml
+++ b/modules/apps/notification/notification-rest-impl/rest-config.yaml
@@ -6,6 +6,6 @@ application:
     name: "Liferay.Notification.REST"
 author: "Gabriel Albuquerque"
 clientDir: "../notification-rest-client/src/main/java"
-compatibilityVersion: 3
+compatibilityVersion: 4
 forcePredictableOperationId: true
 testDir: "../notification-rest-test/src/testIntegration/java"

--- a/modules/apps/notification/notification-rest-impl/rest-openapi.yaml
+++ b/modules/apps/notification/notification-rest-impl/rest-openapi.yaml
@@ -116,7 +116,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.notification.rest.client', and version '1.0.23'."
+        'com.liferay.notification.rest.client', and version '1.0.24'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/notification/notification-rest-impl/src/main/java/com/liferay/notification/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/notification/notification-rest-impl/src/main/java/com/liferay/notification/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -42,7 +42,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.notification.rest.client', and version '1.0.23'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.notification.rest.client', and version '1.0.24'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/object/object-admin-rest-impl/rest-config.yaml
+++ b/modules/apps/object/object-admin-rest-impl/rest-config.yaml
@@ -6,6 +6,6 @@ application:
     name: "Liferay.Object.Admin.REST"
 author: "Javier Gamarra"
 clientDir: "../object-admin-rest-client/src/main/java"
-compatibilityVersion: 3
+compatibilityVersion: 4
 forcePredictableOperationId: true
 testDir: "../object-admin-rest-test/src/testIntegration/java"

--- a/modules/apps/object/object-rest-impl/rest-config.yaml
+++ b/modules/apps/object/object-rest-impl/rest-config.yaml
@@ -1,6 +1,6 @@
 apiDir: "../object-rest-api/src/main/java"
 apiPackagePath: "com.liferay.object.rest"
 author: "Javier Gamarra"
-compatibilityVersion: 3
+compatibilityVersion: 4
 forcePredictableOperationId: true
 generateOpenAPI: false

--- a/modules/apps/object/object-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-rest-impl/rest-openapi.yaml
@@ -8,8 +8,7 @@ components:
                     readOnly: true
                     type: array
                 creator:
-                    allOf:
-                        - $ref: "../../headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml#Creator"
+                    $ref: "../../headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml#Creator"
                     readOnly: true
                 dateCreated:
                     format: date
@@ -80,8 +79,7 @@ components:
                     readOnly: true
                     type: array
                 creator:
-                    allOf:
-                        - $ref: "../../headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml#Creator"
+                    $ref: "../../headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml#Creator"
                     readOnly: true
                 dateCreated:
                     format: date

--- a/modules/apps/portal-search/portal-search-rest-impl/rest-config.yaml
+++ b/modules/apps/portal-search/portal-search-rest-impl/rest-config.yaml
@@ -6,6 +6,6 @@ application:
     name: "Liferay.Portal.Search.REST"
 author: "Petteri Karttunen"
 clientDir: "../portal-search-rest-client/src/main/java"
-compatibilityVersion: 3
+compatibilityVersion: 4
 forcePredictableOperationId: true
 testDir: "../portal-search-rest-test/src/testIntegration/java"

--- a/modules/dxp/apps/commerce-punchout/headless/headless-commerce-punchout-impl/rest-config.yaml
+++ b/modules/dxp/apps/commerce-punchout/headless/headless-commerce-punchout-impl/rest-config.yaml
@@ -5,6 +5,6 @@ application:
     className: "HeadlessCommercePunchOutApplication"
     name: "Liferay.Headless.Commerce.PunchOut"
 author: "Jaclyn Ong"
-compatibilityVersion: 3
+compatibilityVersion: 4
 forcePredictableSchemaPropertyName: false
 generateGraphQL: false

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/rest-config.yaml
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/rest-config.yaml
@@ -6,6 +6,6 @@ application:
     name: "Liferay.Headless.Commerce.Machine.Learning"
 author: "Riccardo Ferrari"
 clientDir: "../headless-commerce-machine-learning-client/src/main/java"
-compatibilityVersion: 3
+compatibilityVersion: 4
 forcePredictableSchemaPropertyName: true
 testDir: "../headless-commerce-machine-learning-test/src/testIntegration/java"

--- a/modules/dxp/apps/osb/osb-testray/osb-testray-rest-impl/rest-config.yaml
+++ b/modules/dxp/apps/osb/osb-testray/osb-testray-rest-impl/rest-config.yaml
@@ -6,6 +6,6 @@ application:
     name: "OsbTestrayRest"
 author: "José Abelenda"
 clientDir: "../osb-testray-rest-client/src/main/java"
-compatibilityVersion: 3
+compatibilityVersion: 4
 forcePredictableOperationId: true
 testDir: "../osb-testray-rest-test/src/testIntegration/java"

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/rest-config.yaml
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/rest-config.yaml
@@ -6,6 +6,6 @@ application:
     name: "Liferay.Portal.Workflow.Metrics.REST"
 author: "Rafael Praxedes"
 clientDir: "../portal-workflow-metrics-rest-client/src/main/java"
-compatibilityVersion: 3
+compatibilityVersion: 4
 forcePredictableOperationId: true
 testDir: "../portal-workflow-metrics-rest-test/src/testIntegration/java"

--- a/modules/dxp/apps/saml/saml-admin-rest-impl/rest-config.yaml
+++ b/modules/dxp/apps/saml/saml-admin-rest-impl/rest-config.yaml
@@ -6,6 +6,6 @@ application:
     name: "Liferay.Saml.Admin.REST"
 author: "Stian Sigvartsen"
 clientDir: "../saml-admin-rest-client/src/main/java"
-compatibilityVersion: 3
+compatibilityVersion: 4
 forcePredictableOperationId: true
 testDir: "../saml-admin-rest-test/src/testIntegration/java"

--- a/modules/dxp/apps/scim/scim-rest-api/bnd.bnd
+++ b/modules/dxp/apps/scim/scim-rest-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay SCIM REST API
 Bundle-SymbolicName: com.liferay.scim.rest.api
-Bundle-Version: 1.0.2
+Bundle-Version: 2.0.0
 Export-Package:\
 	com.liferay.scim.rest.dto.v1_0,\
 	com.liferay.scim.rest.resource.v1_0

--- a/modules/dxp/apps/scim/scim-rest-api/src/main/java/com/liferay/scim/rest/dto/v1_0/User.java
+++ b/modules/dxp/apps/scim/scim-rest-api/src/main/java/com/liferay/scim/rest/dto/v1_0/User.java
@@ -110,35 +110,6 @@ public class User implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Object[] addresses;
 
-	@Schema
-	@Valid
-	public BaseScim getBaseScim() {
-		return baseScim;
-	}
-
-	public void setBaseScim(BaseScim baseScim) {
-		this.baseScim = baseScim;
-	}
-
-	@JsonIgnore
-	public void setBaseScim(
-		UnsafeSupplier<BaseScim, Exception> baseScimUnsafeSupplier) {
-
-		try {
-			baseScim = baseScimUnsafeSupplier.get();
-		}
-		catch (RuntimeException re) {
-			throw re;
-		}
-		catch (Exception e) {
-			throw new RuntimeException(e);
-		}
-	}
-
-	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
-	protected BaseScim baseScim;
-
 	@Schema(
 		description = "The name of the user, suitable for display to end-users."
 	)
@@ -236,6 +207,38 @@ public class User implements Serializable {
 	protected MultiValuedAttribute[] entitlements;
 
 	@Schema(
+		description = "A String that is an identifier for the resource as defined by the provisioning client."
+	)
+	public String getExternalId() {
+		return externalId;
+	}
+
+	public void setExternalId(String externalId) {
+		this.externalId = externalId;
+	}
+
+	@JsonIgnore
+	public void setExternalId(
+		UnsafeSupplier<String, Exception> externalIdUnsafeSupplier) {
+
+		try {
+			externalId = externalIdUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField(
+		description = "A String that is an identifier for the resource as defined by the provisioning client."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String externalId;
+
+	@Schema(
 		description = "A list of groups to which the user belongs, either through direct membership, through nested groups, or dynamically calculated."
 	)
 	@Valid
@@ -268,6 +271,36 @@ public class User implements Serializable {
 	)
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected MultiValuedAttribute[] groups;
+
+	@Schema(
+		description = "A unique identifier for a SCIM resource as defined by the service provider."
+	)
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	@JsonIgnore
+	public void setId(UnsafeSupplier<String, Exception> idUnsafeSupplier) {
+		try {
+			id = idUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField(
+		description = "A unique identifier for a SCIM resource as defined by the service provider."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String id;
 
 	@Schema(description = "Instant messaging address for the user.")
 	@Valid
@@ -329,6 +362,33 @@ public class User implements Serializable {
 	)
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String locale;
+
+	@Schema
+	@Valid
+	public Meta getMeta() {
+		return meta;
+	}
+
+	public void setMeta(Meta meta) {
+		this.meta = meta;
+	}
+
+	@JsonIgnore
+	public void setMeta(UnsafeSupplier<Meta, Exception> metaUnsafeSupplier) {
+		try {
+			meta = metaUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Meta meta;
 
 	@Schema(description = "The components of the user's name.")
 	@Valid
@@ -801,16 +861,6 @@ public class User implements Serializable {
 			sb.append("]");
 		}
 
-		if (baseScim != null) {
-			if (sb.length() > 1) {
-				sb.append(", ");
-			}
-
-			sb.append("\"baseScim\": ");
-
-			sb.append(String.valueOf(baseScim));
-		}
-
 		if (displayName != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -865,6 +915,20 @@ public class User implements Serializable {
 			sb.append("]");
 		}
 
+		if (externalId != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"externalId\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(externalId));
+
+			sb.append("\"");
+		}
+
 		if (groups != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -883,6 +947,20 @@ public class User implements Serializable {
 			}
 
 			sb.append("]");
+		}
+
+		if (id != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"id\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(id));
+
+			sb.append("\"");
 		}
 
 		if (ims != null) {
@@ -917,6 +995,16 @@ public class User implements Serializable {
 			sb.append(_escape(locale));
 
 			sb.append("\"");
+		}
+
+		if (meta != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"meta\": ");
+
+			sb.append(String.valueOf(meta));
 		}
 
 		if (name != null) {

--- a/modules/dxp/apps/scim/scim-rest-api/src/main/resources/com/liferay/scim/rest/dto/v1_0/packageinfo
+++ b/modules/dxp/apps/scim/scim-rest-api/src/main/resources/com/liferay/scim/rest/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 2.0.0

--- a/modules/dxp/apps/scim/scim-rest-client/src/main/java/com/liferay/scim/rest/client/dto/v1_0/User.java
+++ b/modules/dxp/apps/scim/scim-rest-client/src/main/java/com/liferay/scim/rest/client/dto/v1_0/User.java
@@ -67,27 +67,6 @@ public class User implements Cloneable, Serializable {
 
 	protected Object[] addresses;
 
-	public BaseScim getBaseScim() {
-		return baseScim;
-	}
-
-	public void setBaseScim(BaseScim baseScim) {
-		this.baseScim = baseScim;
-	}
-
-	public void setBaseScim(
-		UnsafeSupplier<BaseScim, Exception> baseScimUnsafeSupplier) {
-
-		try {
-			baseScim = baseScimUnsafeSupplier.get();
-		}
-		catch (Exception e) {
-			throw new RuntimeException(e);
-		}
-	}
-
-	protected BaseScim baseScim;
-
 	public String getDisplayName() {
 		return displayName;
 	}
@@ -153,6 +132,27 @@ public class User implements Cloneable, Serializable {
 
 	protected MultiValuedAttribute[] entitlements;
 
+	public String getExternalId() {
+		return externalId;
+	}
+
+	public void setExternalId(String externalId) {
+		this.externalId = externalId;
+	}
+
+	public void setExternalId(
+		UnsafeSupplier<String, Exception> externalIdUnsafeSupplier) {
+
+		try {
+			externalId = externalIdUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String externalId;
+
 	public MultiValuedAttribute[] getGroups() {
 		return groups;
 	}
@@ -174,6 +174,25 @@ public class User implements Cloneable, Serializable {
 	}
 
 	protected MultiValuedAttribute[] groups;
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public void setId(UnsafeSupplier<String, Exception> idUnsafeSupplier) {
+		try {
+			id = idUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String id;
 
 	public MultiValuedAttribute[] getIms() {
 		return ims;
@@ -216,6 +235,25 @@ public class User implements Cloneable, Serializable {
 	}
 
 	protected String locale;
+
+	public Meta getMeta() {
+		return meta;
+	}
+
+	public void setMeta(Meta meta) {
+		this.meta = meta;
+	}
+
+	public void setMeta(UnsafeSupplier<Meta, Exception> metaUnsafeSupplier) {
+		try {
+			meta = metaUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Meta meta;
 
 	public Name getName() {
 		return name;

--- a/modules/dxp/apps/scim/scim-rest-client/src/main/java/com/liferay/scim/rest/client/serdes/v1_0/UserSerDes.java
+++ b/modules/dxp/apps/scim/scim-rest-client/src/main/java/com/liferay/scim/rest/client/serdes/v1_0/UserSerDes.java
@@ -79,16 +79,6 @@ public class UserSerDes {
 			sb.append("]");
 		}
 
-		if (user.getBaseScim() != null) {
-			if (sb.length() > 1) {
-				sb.append(", ");
-			}
-
-			sb.append("\"baseScim\": ");
-
-			sb.append(String.valueOf(user.getBaseScim()));
-		}
-
 		if (user.getDisplayName() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -143,6 +133,20 @@ public class UserSerDes {
 			sb.append("]");
 		}
 
+		if (user.getExternalId() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"externalId\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(user.getExternalId()));
+
+			sb.append("\"");
+		}
+
 		if (user.getGroups() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -161,6 +165,20 @@ public class UserSerDes {
 			}
 
 			sb.append("]");
+		}
+
+		if (user.getId() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"id\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(user.getId()));
+
+			sb.append("\"");
 		}
 
 		if (user.getIms() != null) {
@@ -195,6 +213,16 @@ public class UserSerDes {
 			sb.append(_escape(user.getLocale()));
 
 			sb.append("\"");
+		}
+
+		if (user.getMeta() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"meta\": ");
+
+			sb.append(String.valueOf(user.getMeta()));
 		}
 
 		if (user.getName() != null) {
@@ -431,13 +459,6 @@ public class UserSerDes {
 			map.put("addresses", String.valueOf(user.getAddresses()));
 		}
 
-		if (user.getBaseScim() == null) {
-			map.put("baseScim", null);
-		}
-		else {
-			map.put("baseScim", String.valueOf(user.getBaseScim()));
-		}
-
 		if (user.getDisplayName() == null) {
 			map.put("displayName", null);
 		}
@@ -459,11 +480,25 @@ public class UserSerDes {
 			map.put("entitlements", String.valueOf(user.getEntitlements()));
 		}
 
+		if (user.getExternalId() == null) {
+			map.put("externalId", null);
+		}
+		else {
+			map.put("externalId", String.valueOf(user.getExternalId()));
+		}
+
 		if (user.getGroups() == null) {
 			map.put("groups", null);
 		}
 		else {
 			map.put("groups", String.valueOf(user.getGroups()));
+		}
+
+		if (user.getId() == null) {
+			map.put("id", null);
+		}
+		else {
+			map.put("id", String.valueOf(user.getId()));
 		}
 
 		if (user.getIms() == null) {
@@ -478,6 +513,13 @@ public class UserSerDes {
 		}
 		else {
 			map.put("locale", String.valueOf(user.getLocale()));
+		}
+
+		if (user.getMeta() == null) {
+			map.put("meta", null);
+		}
+		else {
+			map.put("meta", String.valueOf(user.getMeta()));
 		}
 
 		if (user.getName() == null) {
@@ -604,12 +646,6 @@ public class UserSerDes {
 					user.setAddresses((Object[])jsonParserFieldValue);
 				}
 			}
-			else if (Objects.equals(jsonParserFieldName, "baseScim")) {
-				if (jsonParserFieldValue != null) {
-					user.setBaseScim(
-						BaseScimSerDes.toDTO((String)jsonParserFieldValue));
-				}
-			}
 			else if (Objects.equals(jsonParserFieldName, "displayName")) {
 				if (jsonParserFieldValue != null) {
 					user.setDisplayName((String)jsonParserFieldValue);
@@ -647,6 +683,11 @@ public class UserSerDes {
 					user.setEntitlements(entitlementsArray);
 				}
 			}
+			else if (Objects.equals(jsonParserFieldName, "externalId")) {
+				if (jsonParserFieldValue != null) {
+					user.setExternalId((String)jsonParserFieldValue);
+				}
+			}
 			else if (Objects.equals(jsonParserFieldName, "groups")) {
 				if (jsonParserFieldValue != null) {
 					Object[] jsonParserFieldValues =
@@ -661,6 +702,11 @@ public class UserSerDes {
 					}
 
 					user.setGroups(groupsArray);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "id")) {
+				if (jsonParserFieldValue != null) {
+					user.setId((String)jsonParserFieldValue);
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "ims")) {
@@ -682,6 +728,12 @@ public class UserSerDes {
 			else if (Objects.equals(jsonParserFieldName, "locale")) {
 				if (jsonParserFieldValue != null) {
 					user.setLocale((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "meta")) {
+				if (jsonParserFieldValue != null) {
+					user.setMeta(
+						MetaSerDes.toDTO((String)jsonParserFieldValue));
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "name")) {

--- a/modules/dxp/apps/scim/scim-rest-impl/rest-config.yaml
+++ b/modules/dxp/apps/scim/scim-rest-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: "Liferay.Scim.REST"
 author: "Olivér Kecskeméty"
 clientDir: "../scim-rest-client/src/main/java"
-compatibilityVersion: 3
+compatibilityVersion: 4
 forcePredictableOperationId: false
 generateGraphQL: false
 testDir: "../scim-rest-test/src/testIntegration/java"

--- a/modules/dxp/apps/scim/scim-rest-impl/rest-openapi.yaml
+++ b/modules/dxp/apps/scim/scim-rest-impl/rest-openapi.yaml
@@ -294,7 +294,7 @@ components:
 info:
     description:
         "Liferay SCIM endpoints. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.scim.rest.client', and version '1.0.0'."
+        'com.liferay.scim.rest.client', and version '1.0.2'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/resource/v1_0/BaseUserResourceImpl.java
+++ b/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/resource/v1_0/BaseUserResourceImpl.java
@@ -87,7 +87,7 @@ public abstract class BaseUserResourceImpl implements UserResource {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/scim/v1.0/v2/Users'  -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/scim/v1.0/v2/Users' -d $'{"active": ___, "addresses": ___, "displayName": ___, "emails": ___, "entitlements": ___, "externalId": ___, "groups": ___, "ims": ___, "locale": ___, "meta": ___, "name": ___, "nickName": ___, "password": ___, "phoneNumbers": ___, "photos": ___, "preferredLanguage": ___, "profileUrl": ___, "roles": ___, "timezone": ___, "title": ___, "userName": ___, "userType": ___, "x509Certificates": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(description = "Creates a user.")
 	@io.swagger.v3.oas.annotations.tags.Tags(
@@ -190,7 +190,7 @@ public abstract class BaseUserResourceImpl implements UserResource {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/scim/v1.0/v2/Users/{id}'  -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/scim/v1.0/v2/Users/{id}' -d $'{"active": ___, "addresses": ___, "displayName": ___, "emails": ___, "entitlements": ___, "externalId": ___, "groups": ___, "ims": ___, "locale": ___, "meta": ___, "name": ___, "nickName": ___, "password": ___, "phoneNumbers": ___, "photos": ___, "preferredLanguage": ___, "profileUrl": ___, "roles": ___, "timezone": ___, "title": ___, "userName": ___, "userType": ___, "x509Certificates": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(description = "Updates a user.")
 	@io.swagger.v3.oas.annotations.Parameters(

--- a/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -42,7 +42,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Liferay SCIM endpoints. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.scim.rest.client', and version '1.0.0'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "System for Cross-domain Identity Management", version = "v1.0")
+	info = @Info(description = "Liferay SCIM endpoints. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.scim.rest.client', and version '1.0.2'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "System for Cross-domain Identity Management", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/dxp/apps/scim/scim-rest-test/src/testIntegration/java/com/liferay/scim/rest/resource/v1_0/test/BaseUserResourceTestCase.java
+++ b/modules/dxp/apps/scim/scim-rest-test/src/testIntegration/java/com/liferay/scim/rest/resource/v1_0/test/BaseUserResourceTestCase.java
@@ -170,6 +170,8 @@ public abstract class BaseUserResourceTestCase {
 		User user = randomUser();
 
 		user.setDisplayName(regex);
+		user.setExternalId(regex);
+		user.setId(regex);
 		user.setLocale(regex);
 		user.setNickName(regex);
 		user.setPassword(regex);
@@ -187,6 +189,8 @@ public abstract class BaseUserResourceTestCase {
 		user = UserSerDes.toDTO(json);
 
 		Assert.assertEquals(regex, user.getDisplayName());
+		Assert.assertEquals(regex, user.getExternalId());
+		Assert.assertEquals(regex, user.getId());
 		Assert.assertEquals(regex, user.getLocale());
 		Assert.assertEquals(regex, user.getNickName());
 		Assert.assertEquals(regex, user.getPassword());
@@ -215,7 +219,36 @@ public abstract class BaseUserResourceTestCase {
 
 	@Test
 	public void testDeleteV2User() throws Exception {
-		Assert.assertTrue(false);
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		User user = testDeleteV2User_addUser();
+
+		assertHttpResponseStatusCode(
+			204, userResource.deleteV2UserHttpResponse(user.getId()));
+
+		assertHttpResponseStatusCode(
+			404,
+			userResource.getV2UserHttpResponse(
+				testDeleteV2User_getCount(), testDeleteV2User_getStartIndex()));
+
+		assertHttpResponseStatusCode(
+			404,
+			userResource.getV2UserHttpResponse(
+				testDeleteV2User_getCount(), testDeleteV2User_getStartIndex()));
+	}
+
+	protected Integer testDeleteV2User_getCount() throws Exception {
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected Integer testDeleteV2User_getStartIndex() throws Exception {
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected User testDeleteV2User_addUser() throws Exception {
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test
@@ -226,6 +259,11 @@ public abstract class BaseUserResourceTestCase {
 	@Test
 	public void testPutV2User() throws Exception {
 		Assert.assertTrue(false);
+	}
+
+	protected User testGraphQLUser_addUser() throws Exception {
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected void assertContains(User user, List<User> users) {
@@ -289,6 +327,10 @@ public abstract class BaseUserResourceTestCase {
 	protected void assertValid(User user) throws Exception {
 		boolean valid = true;
 
+		if (user.getId() == null) {
+			valid = false;
+		}
+
 		for (String additionalAssertFieldName :
 				getAdditionalAssertFieldNames()) {
 
@@ -302,14 +344,6 @@ public abstract class BaseUserResourceTestCase {
 
 			if (Objects.equals("addresses", additionalAssertFieldName)) {
 				if (user.getAddresses() == null) {
-					valid = false;
-				}
-
-				continue;
-			}
-
-			if (Objects.equals("baseScim", additionalAssertFieldName)) {
-				if (user.getBaseScim() == null) {
 					valid = false;
 				}
 
@@ -340,6 +374,14 @@ public abstract class BaseUserResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals("externalId", additionalAssertFieldName)) {
+				if (user.getExternalId() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("groups", additionalAssertFieldName)) {
 				if (user.getGroups() == null) {
 					valid = false;
@@ -358,6 +400,14 @@ public abstract class BaseUserResourceTestCase {
 
 			if (Objects.equals("locale", additionalAssertFieldName)) {
 				if (user.getLocale() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("meta", additionalAssertFieldName)) {
+				if (user.getMeta() == null) {
 					valid = false;
 				}
 
@@ -602,16 +652,6 @@ public abstract class BaseUserResourceTestCase {
 				continue;
 			}
 
-			if (Objects.equals("baseScim", additionalAssertFieldName)) {
-				if (!Objects.deepEquals(
-						user1.getBaseScim(), user2.getBaseScim())) {
-
-					return false;
-				}
-
-				continue;
-			}
-
 			if (Objects.equals("displayName", additionalAssertFieldName)) {
 				if (!Objects.deepEquals(
 						user1.getDisplayName(), user2.getDisplayName())) {
@@ -640,8 +680,26 @@ public abstract class BaseUserResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals("externalId", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						user1.getExternalId(), user2.getExternalId())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("groups", additionalAssertFieldName)) {
 				if (!Objects.deepEquals(user1.getGroups(), user2.getGroups())) {
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("id", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(user1.getId(), user2.getId())) {
 					return false;
 				}
 
@@ -658,6 +716,14 @@ public abstract class BaseUserResourceTestCase {
 
 			if (Objects.equals("locale", additionalAssertFieldName)) {
 				if (!Objects.deepEquals(user1.getLocale(), user2.getLocale())) {
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("meta", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(user1.getMeta(), user2.getMeta())) {
 					return false;
 				}
 
@@ -903,11 +969,6 @@ public abstract class BaseUserResourceTestCase {
 				"Invalid entity field " + entityFieldName);
 		}
 
-		if (entityFieldName.equals("baseScim")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
-		}
-
 		if (entityFieldName.equals("displayName")) {
 			Object object = user.getDisplayName();
 
@@ -964,9 +1025,101 @@ public abstract class BaseUserResourceTestCase {
 				"Invalid entity field " + entityFieldName);
 		}
 
+		if (entityFieldName.equals("externalId")) {
+			Object object = user.getExternalId();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
 		if (entityFieldName.equals("groups")) {
 			throw new IllegalArgumentException(
 				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("id")) {
+			Object object = user.getId();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("ims")) {
@@ -1018,6 +1171,11 @@ public abstract class BaseUserResourceTestCase {
 			}
 
 			return sb.toString();
+		}
+
+		if (entityFieldName.equals("meta")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
 		}
 
 		if (entityFieldName.equals("name")) {
@@ -1460,6 +1618,9 @@ public abstract class BaseUserResourceTestCase {
 				active = RandomTestUtil.randomBoolean();
 				displayName = StringUtil.toLowerCase(
 					RandomTestUtil.randomString());
+				externalId = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				id = StringUtil.toLowerCase(RandomTestUtil.randomString());
 				locale = StringUtil.toLowerCase(RandomTestUtil.randomString());
 				nickName = StringUtil.toLowerCase(
 					RandomTestUtil.randomString());

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/rest-config.yaml
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/rest-config.yaml
@@ -6,6 +6,6 @@ application:
     name: "Liferay.Search.Experiences.REST"
 author: "Brian Wing Shun Chan"
 clientDir: "../search-experiences-rest-client/src/main/java"
-compatibilityVersion: 3
+compatibilityVersion: 4
 forcePredictableOperationId: true
 testDir: "../search-experiences-rest-test/src/testIntegration/java"

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/rest-openapi.yaml
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/rest-openapi.yaml
@@ -595,7 +595,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.search.experiences.rest.client', and version '3.0.22'."
+        'com.liferay.search.experiences.rest.client', and version '3.0.23'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -42,7 +42,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.search.experiences.rest.client', and version '3.0.22'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.search.experiences.rest.client', and version '3.0.23'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/dxp/apps/segments/segments-asah-rest-impl/rest-config.yaml
+++ b/modules/dxp/apps/segments/segments-asah-rest-impl/rest-config.yaml
@@ -6,6 +6,6 @@ application:
     name: "Liferay.Segments.Asah.REST"
 author: "Javier Gamarra"
 clientDir: "../segments-asah-rest-client/src/main/java"
-compatibilityVersion: 3
+compatibilityVersion: 4
 forcePredictableOperationId: true
 testDir: "../segments-asah-rest-test/src/testIntegration/java"

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/RESTBuilder.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/RESTBuilder.java
@@ -24,7 +24,6 @@ import com.liferay.portal.kernel.util.Validator_IW;
 import com.liferay.portal.tools.rest.builder.internal.freemarker.tool.FreeMarkerTool;
 import com.liferay.portal.tools.rest.builder.internal.freemarker.tool.java.JavaMethodSignature;
 import com.liferay.portal.tools.rest.builder.internal.freemarker.tool.java.parser.util.OpenAPIParserUtil;
-import com.liferay.portal.tools.rest.builder.internal.freemarker.util.ConfigUtil;
 import com.liferay.portal.tools.rest.builder.internal.freemarker.util.FreeMarkerUtil;
 import com.liferay.portal.tools.rest.builder.internal.freemarker.util.OpenAPIUtil;
 import com.liferay.portal.tools.rest.builder.internal.util.FileUtil;
@@ -352,7 +351,7 @@ public class RESTBuilder {
 						context, escapedVersion, schemaName);
 				}
 
-				if (ConfigUtil.isVersionCompatible(_configYAML, 4)) {
+				if (_configYAML.isGenerateActionProviders()) {
 					_createBaseDTOActionMetadataProviderFile(
 						context, escapedVersion, schemaName);
 					_createDTOActionMetadataProviderFile(

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/RESTBuilder.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/RESTBuilder.java
@@ -235,7 +235,7 @@ public class RESTBuilder {
 			context.put("escapedVersion", escapedVersion);
 
 			Map<String, Schema> globalEnumSchemas =
-				OpenAPIUtil.getGlobalEnumSchemas(openAPIYAML);
+				OpenAPIUtil.getGlobalEnumSchemas(allSchemas);
 
 			context.put("globalEnumSchemas", globalEnumSchemas);
 

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/RESTBuilder.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/RESTBuilder.java
@@ -220,10 +220,10 @@ public class RESTBuilder {
 			OpenAPIYAML openAPIYAML = _loadOpenAPIYAML(yamlString);
 
 			Map<String, Schema> allSchemas = OpenAPIUtil.getAllSchemas(
-				openAPIYAML);
+				_configYAML, openAPIYAML);
 
 			Map<String, Schema> allExternalSchemas =
-				OpenAPIUtil.getAllExternalSchemas(openAPIYAML);
+				OpenAPIUtil.getAllExternalSchemas(_configYAML, openAPIYAML);
 
 			context.put("allExternalSchemas", allExternalSchemas);
 
@@ -234,7 +234,7 @@ public class RESTBuilder {
 			context.put("escapedVersion", escapedVersion);
 
 			Map<String, Schema> globalEnumSchemas =
-				OpenAPIUtil.getGlobalEnumSchemas(allSchemas);
+				OpenAPIUtil.getGlobalEnumSchemas(_configYAML, allSchemas);
 
 			context.put("globalEnumSchemas", globalEnumSchemas);
 
@@ -463,7 +463,8 @@ public class RESTBuilder {
 		}
 
 		if (_configYAML.isForcePredictableOperationId()) {
-			yamlString = _fixOpenAPIOperationIds(freeMarkerTool, yamlString);
+			yamlString = _fixOpenAPIOperationIds(
+				_configYAML, freeMarkerTool, yamlString);
 		}
 
 		if (_configYAML.isForcePredictableContentApplicationXML()) {
@@ -1344,7 +1345,8 @@ public class RESTBuilder {
 	}
 
 	private String _fixOpenAPIOperationIds(
-			FreeMarkerTool freeMarkerTool, String yamlString)
+			ConfigYAML configYAML, FreeMarkerTool freeMarkerTool,
+			String yamlString)
 		throws Exception {
 
 		OpenAPIYAML openAPIYAML = _loadOpenAPIYAML(yamlString);
@@ -1352,7 +1354,7 @@ public class RESTBuilder {
 		yamlString = yamlString.replaceAll("\n\\s+operationId:.+", "");
 
 		Map<String, Schema> allExternalSchemas =
-			OpenAPIUtil.getAllExternalSchemas(openAPIYAML);
+			OpenAPIUtil.getAllExternalSchemas(configYAML, openAPIYAML);
 		Map<String, Schema> schemas = freeMarkerTool.getSchemas(openAPIYAML);
 
 		MapUtil.merge(allExternalSchemas, schemas);

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
@@ -303,21 +303,26 @@ public class FreeMarkerTool {
 	}
 
 	public Map<String, String> getDTOProperties(
-		ConfigYAML configYAML, OpenAPIYAML openAPIYAML, Schema schema) {
+		ConfigYAML configYAML, OpenAPIYAML openAPIYAML, Schema schema,
+		Map<String, Schema> schemas) {
 
 		return DTOOpenAPIParser.getProperties(
-			configYAML, false, openAPIYAML, schema);
+			configYAML, false, openAPIYAML, schema, schemas);
 	}
 
 	public Map<String, String> getDTOProperties(
-		ConfigYAML configYAML, OpenAPIYAML openAPIYAML, String schemaName) {
+		ConfigYAML configYAML, OpenAPIYAML openAPIYAML, String schemaName,
+		Map<String, Schema> schemas) {
 
 		return DTOOpenAPIParser.getProperties(
-			configYAML, openAPIYAML, schemaName);
+			configYAML, openAPIYAML, schemaName, schemas);
 	}
 
-	public Schema getDTOPropertySchema(String propertyName, Schema schema) {
-		return DTOOpenAPIParser.getPropertySchema(propertyName, schema);
+	public Schema getDTOPropertySchema(
+		String propertyName, Schema schema, Map<String, Schema> schemas) {
+
+		return DTOOpenAPIParser.getPropertySchema(
+			propertyName, schema, schemas);
 	}
 
 	public String getEnumFieldName(String value) {
@@ -392,10 +397,10 @@ public class FreeMarkerTool {
 
 	public String getGraphQLJavaParameterName(
 		ConfigYAML configYAML, OpenAPIYAML openAPIYAML, String schemaName,
-		JavaMethodParameter javaMethodParameter) {
+		Map<String, Schema> schemas, JavaMethodParameter javaMethodParameter) {
 
 		Map<String, String> properties = getDTOProperties(
-			configYAML, openAPIYAML, schemaName);
+			configYAML, openAPIYAML, schemaName, schemas);
 
 		return _getParentProperty(
 			schemaName, javaMethodParameter, properties.keySet());
@@ -840,10 +845,11 @@ public class FreeMarkerTool {
 	}
 
 	public Map<String, String> getWritableDTOProperties(
-		ConfigYAML configYAML, OpenAPIYAML openAPIYAML, Schema schema) {
+		ConfigYAML configYAML, OpenAPIYAML openAPIYAML, Schema schema,
+		Map<String, Schema> schemas) {
 
 		return DTOOpenAPIParser.getProperties(
-			configYAML, true, openAPIYAML, schema);
+			configYAML, true, openAPIYAML, schema, schemas);
 	}
 
 	public boolean hasHTTPMethod(
@@ -998,10 +1004,9 @@ public class FreeMarkerTool {
 	}
 
 	public boolean isDTOSchemaProperty(
-		OpenAPIYAML openAPIYAML, String propertyName, Schema schema) {
+		String propertyName, Schema schema, Map<String, Schema> schemas) {
 
-		return DTOOpenAPIParser.isSchemaProperty(
-			openAPIYAML, propertyName, schema);
+		return DTOOpenAPIParser.isSchemaProperty(propertyName, schema, schemas);
 	}
 
 	public boolean isParameter(

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
@@ -751,11 +751,11 @@ public class FreeMarkerTool {
 	}
 
 	public String getResourceParameters(
-		List<JavaMethodParameter> javaMethodParameters, OpenAPIYAML openAPIYAML,
-		Operation operation, boolean annotation) {
+		List<JavaMethodParameter> javaMethodParameters, Operation operation,
+		Map<String, Schema> schemas, boolean annotation) {
 
 		return ResourceOpenAPIParser.getParameters(
-			javaMethodParameters, openAPIYAML, operation, annotation);
+			javaMethodParameters, operation, schemas, annotation);
 	}
 
 	public String getResourceTestCaseArguments(
@@ -772,11 +772,11 @@ public class FreeMarkerTool {
 	}
 
 	public String getResourceTestCaseParameters(
-		List<JavaMethodParameter> javaMethodParameters, OpenAPIYAML openAPIYAML,
-		Operation operation, boolean annotation) {
+		List<JavaMethodParameter> javaMethodParameters, Operation operation,
+		Map<String, Schema> schemas, boolean annotation) {
 
 		return ResourceTestCaseOpenAPIParser.getParameters(
-			javaMethodParameters, openAPIYAML, operation, annotation);
+			javaMethodParameters, operation, schemas, annotation);
 	}
 
 	public String getRESTMethodJavadoc(

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
@@ -305,7 +305,8 @@ public class FreeMarkerTool {
 	public Map<String, String> getDTOProperties(
 		ConfigYAML configYAML, OpenAPIYAML openAPIYAML, Schema schema) {
 
-		return DTOOpenAPIParser.getProperties(configYAML, openAPIYAML, schema);
+		return DTOOpenAPIParser.getProperties(
+			configYAML, false, openAPIYAML, schema);
 	}
 
 	public Map<String, String> getDTOProperties(

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
@@ -268,9 +268,9 @@ public class FreeMarkerTool {
 	}
 
 	public Map<String, Schema> getDTOEnumSchemas(
-		OpenAPIYAML openAPIYAML, Schema schema) {
+		ConfigYAML configYAML, OpenAPIYAML openAPIYAML, Schema schema) {
 
-		return DTOOpenAPIParser.getEnumSchemas(openAPIYAML, schema);
+		return DTOOpenAPIParser.getEnumSchemas(configYAML, openAPIYAML, schema);
 	}
 
 	public String getDTOParentClassName(
@@ -319,10 +319,11 @@ public class FreeMarkerTool {
 	}
 
 	public Schema getDTOPropertySchema(
-		String propertyName, Schema schema, Map<String, Schema> schemas) {
+		ConfigYAML configYAML, String propertyName, Schema schema,
+		Map<String, Schema> schemas) {
 
 		return DTOOpenAPIParser.getPropertySchema(
-			propertyName, schema, schemas);
+			configYAML, propertyName, schema, schemas);
 	}
 
 	public String getEnumFieldName(String value) {
@@ -751,11 +752,11 @@ public class FreeMarkerTool {
 	}
 
 	public String getResourceParameters(
-		List<JavaMethodParameter> javaMethodParameters, Operation operation,
-		Map<String, Schema> schemas, boolean annotation) {
+		ConfigYAML configYAML, List<JavaMethodParameter> javaMethodParameters,
+		Operation operation, Map<String, Schema> schemas, boolean annotation) {
 
 		return ResourceOpenAPIParser.getParameters(
-			javaMethodParameters, operation, schemas, annotation);
+			configYAML, javaMethodParameters, operation, schemas, annotation);
 	}
 
 	public String getResourceTestCaseArguments(
@@ -772,11 +773,11 @@ public class FreeMarkerTool {
 	}
 
 	public String getResourceTestCaseParameters(
-		List<JavaMethodParameter> javaMethodParameters, Operation operation,
-		Map<String, Schema> schemas, boolean annotation) {
+		ConfigYAML configYAML, List<JavaMethodParameter> javaMethodParameters,
+		Operation operation, Map<String, Schema> schemas, boolean annotation) {
 
 		return ResourceTestCaseOpenAPIParser.getParameters(
-			javaMethodParameters, operation, schemas, annotation);
+			configYAML, javaMethodParameters, operation, schemas, annotation);
 	}
 
 	public String getRESTMethodJavadoc(
@@ -1004,9 +1005,11 @@ public class FreeMarkerTool {
 	}
 
 	public boolean isDTOSchemaProperty(
-		String propertyName, Schema schema, Map<String, Schema> schemas) {
+		ConfigYAML configYAML, String propertyName, Schema schema,
+		Map<String, Schema> schemas) {
 
-		return DTOOpenAPIParser.isSchemaProperty(propertyName, schema, schemas);
+		return DTOOpenAPIParser.isSchemaProperty(
+			configYAML, propertyName, schema, schemas);
 	}
 
 	public boolean isParameter(

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/DTOOpenAPIParser.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/DTOOpenAPIParser.java
@@ -85,19 +85,13 @@ public class DTOOpenAPIParser {
 	}
 
 	public static Map<String, String> getProperties(
-		ConfigYAML configYAML, OpenAPIYAML openAPIYAML, Schema schema) {
-
-		return getProperties(configYAML, false, openAPIYAML, schema);
-	}
-
-	public static Map<String, String> getProperties(
 		ConfigYAML configYAML, OpenAPIYAML openAPIYAML, String schemaName) {
 
 		Map<String, Schema> schemas = OpenAPIUtil.getAllSchemas(openAPIYAML);
 
 		Schema schema = schemas.get(schemaName);
 
-		return getProperties(configYAML, openAPIYAML, schema);
+		return getProperties(configYAML, false, openAPIYAML, schema);
 	}
 
 	public static Schema getPropertySchema(String propertyName, Schema schema) {

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/DTOOpenAPIParser.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/DTOOpenAPIParser.java
@@ -28,7 +28,7 @@ import java.util.TreeMap;
 public class DTOOpenAPIParser {
 
 	public static Map<String, Schema> getEnumSchemas(
-		OpenAPIYAML openAPIYAML, Schema schema) {
+		ConfigYAML configYAML, OpenAPIYAML openAPIYAML, Schema schema) {
 
 		Map<String, Schema> propertySchemas = schema.getPropertySchemas();
 
@@ -47,7 +47,7 @@ public class DTOOpenAPIParser {
 				String propertySchemaName = entry.getKey();
 
 				enumSchemas.put(
-					_getEnumName(openAPIYAML, propertySchemaName),
+					_getEnumName(configYAML, openAPIYAML, propertySchemaName),
 					propertySchema);
 			}
 		}
@@ -64,7 +64,7 @@ public class DTOOpenAPIParser {
 		Map<String, String> properties = new TreeMap<>();
 
 		Map<String, Schema> propertySchemas = _getPropertySchemas(
-			schema, schemas);
+			configYAML, schema, schemas);
 
 		for (Map.Entry<String, Schema> entry : propertySchemas.entrySet()) {
 			Schema propertySchema = entry.getValue();
@@ -78,7 +78,7 @@ public class DTOOpenAPIParser {
 			properties.put(
 				_getPropertyName(propertySchema, propertySchemaName),
 				_getPropertyType(
-					javaDataTypeMap, openAPIYAML, propertySchema,
+					configYAML, javaDataTypeMap, openAPIYAML, propertySchema,
 					propertySchemaName));
 		}
 
@@ -94,10 +94,11 @@ public class DTOOpenAPIParser {
 	}
 
 	public static Schema getPropertySchema(
-		String propertyName, Schema schema, Map<String, Schema> schemas) {
+		ConfigYAML configYAML, String propertyName, Schema schema,
+		Map<String, Schema> schemas) {
 
 		Map<String, Schema> propertySchemas = _getPropertySchemas(
-			schema, schemas);
+			configYAML, schema, schemas);
 
 		for (Map.Entry<String, Schema> entry : propertySchemas.entrySet()) {
 			String propertySchemaName = entry.getKey();
@@ -115,10 +116,11 @@ public class DTOOpenAPIParser {
 	}
 
 	public static boolean isSchemaProperty(
-		String propertyName, Schema schema, Map<String, Schema> schemas) {
+		ConfigYAML configYAML, String propertyName, Schema schema,
+		Map<String, Schema> schemas) {
 
 		Map<String, Schema> propertySchemas = _getPropertySchemas(
-			schema, schemas);
+			configYAML, schema, schemas);
 
 		for (Map.Entry<String, Schema> entry : propertySchemas.entrySet()) {
 			String propertySchemaName = entry.getKey();
@@ -136,9 +138,11 @@ public class DTOOpenAPIParser {
 	}
 
 	private static String _getEnumName(
-		OpenAPIYAML openAPIYAML, String propertySchemaName) {
+		ConfigYAML configYAML, OpenAPIYAML openAPIYAML,
+		String propertySchemaName) {
 
-		Map<String, Schema> schemas = OpenAPIUtil.getAllSchemas(openAPIYAML);
+		Map<String, Schema> schemas = OpenAPIUtil.getAllSchemas(
+			configYAML, openAPIYAML);
 
 		for (String schemaName : schemas.keySet()) {
 			if (propertySchemaName.length() <= schemaName.length()) {
@@ -176,7 +180,7 @@ public class DTOOpenAPIParser {
 	}
 
 	private static Map<String, Schema> _getPropertySchemas(
-		Schema schema, Map<String, Schema> schemas) {
+		ConfigYAML configYAML, Schema schema, Map<String, Schema> schemas) {
 
 		Map<String, Schema> propertySchemas = null;
 
@@ -187,7 +191,7 @@ public class DTOOpenAPIParser {
 		}
 		else if (schema.getAllOfSchemas() != null) {
 			propertySchemas = OpenAPIParserUtil.getAllOfPropertySchemas(
-				schema, schemas);
+				configYAML, schema, schemas);
 		}
 		else {
 			propertySchemas = schema.getPropertySchemas();
@@ -210,13 +214,14 @@ public class DTOOpenAPIParser {
 	}
 
 	private static String _getPropertyType(
-		Map<String, String> javaDataTypeMap, OpenAPIYAML openAPIYAML,
-		Schema propertySchema, String propertySchemaName) {
+		ConfigYAML configYAML, Map<String, String> javaDataTypeMap,
+		OpenAPIYAML openAPIYAML, Schema propertySchema,
+		String propertySchemaName) {
 
 		List<String> enumValues = propertySchema.getEnumValues();
 
 		if ((enumValues != null) && !enumValues.isEmpty()) {
-			return _getEnumName(openAPIYAML, propertySchemaName);
+			return _getEnumName(configYAML, openAPIYAML, propertySchemaName);
 		}
 
 		Items items = propertySchema.getItems();

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/DTOOpenAPIParser.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/DTOOpenAPIParser.java
@@ -57,13 +57,14 @@ public class DTOOpenAPIParser {
 
 	public static Map<String, String> getProperties(
 		ConfigYAML configYAML, boolean excludeReadOnly, OpenAPIYAML openAPIYAML,
-		Schema schema) {
+		Schema schema, Map<String, Schema> schemas) {
 
 		Map<String, String> javaDataTypeMap =
 			OpenAPIParserUtil.getJavaDataTypeMap(configYAML, openAPIYAML);
 		Map<String, String> properties = new TreeMap<>();
 
-		Map<String, Schema> propertySchemas = _getPropertySchemas(schema);
+		Map<String, Schema> propertySchemas = _getPropertySchemas(
+			schema, schemas);
 
 		for (Map.Entry<String, Schema> entry : propertySchemas.entrySet()) {
 			Schema propertySchema = entry.getValue();
@@ -85,17 +86,18 @@ public class DTOOpenAPIParser {
 	}
 
 	public static Map<String, String> getProperties(
-		ConfigYAML configYAML, OpenAPIYAML openAPIYAML, String schemaName) {
+		ConfigYAML configYAML, OpenAPIYAML openAPIYAML, String schemaName,
+		Map<String, Schema> schemas) {
 
-		Map<String, Schema> schemas = OpenAPIUtil.getAllSchemas(openAPIYAML);
-
-		Schema schema = schemas.get(schemaName);
-
-		return getProperties(configYAML, false, openAPIYAML, schema);
+		return getProperties(
+			configYAML, false, openAPIYAML, schemas.get(schemaName), schemas);
 	}
 
-	public static Schema getPropertySchema(String propertyName, Schema schema) {
-		Map<String, Schema> propertySchemas = _getPropertySchemas(schema);
+	public static Schema getPropertySchema(
+		String propertyName, Schema schema, Map<String, Schema> schemas) {
+
+		Map<String, Schema> propertySchemas = _getPropertySchemas(
+			schema, schemas);
 
 		for (Map.Entry<String, Schema> entry : propertySchemas.entrySet()) {
 			String propertySchemaName = entry.getKey();
@@ -113,9 +115,10 @@ public class DTOOpenAPIParser {
 	}
 
 	public static boolean isSchemaProperty(
-		OpenAPIYAML openAPIYAML, String propertyName, Schema schema) {
+		String propertyName, Schema schema, Map<String, Schema> schemas) {
 
-		Map<String, Schema> propertySchemas = _getPropertySchemas(schema);
+		Map<String, Schema> propertySchemas = _getPropertySchemas(
+			schema, schemas);
 
 		for (Map.Entry<String, Schema> entry : propertySchemas.entrySet()) {
 			String propertySchemaName = entry.getKey();
@@ -172,7 +175,9 @@ public class DTOOpenAPIParser {
 		return name;
 	}
 
-	private static Map<String, Schema> _getPropertySchemas(Schema schema) {
+	private static Map<String, Schema> _getPropertySchemas(
+		Schema schema, Map<String, Schema> schemas) {
+
 		Map<String, Schema> propertySchemas = null;
 
 		Items items = schema.getItems();
@@ -181,7 +186,8 @@ public class DTOOpenAPIParser {
 			propertySchemas = items.getPropertySchemas();
 		}
 		else if (schema.getAllOfSchemas() != null) {
-			propertySchemas = OpenAPIParserUtil.getAllOfPropertySchemas(schema);
+			propertySchemas = OpenAPIParserUtil.getAllOfPropertySchemas(
+				schema, schemas);
 		}
 		else {
 			propertySchemas = schema.getPropertySchemas();

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/GraphQLOpenAPIParser.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/GraphQLOpenAPIParser.java
@@ -51,7 +51,8 @@ public class GraphQLOpenAPIParser {
 			schemas.putAll(components.getSchemas());
 		}
 
-		schemas.putAll(OpenAPIUtil.getAllExternalSchemas(openAPIYAML));
+		schemas.putAll(
+			OpenAPIUtil.getAllExternalSchemas(configYAML, openAPIYAML));
 
 		for (String schemaName : schemas.keySet()) {
 			javaMethodSignatures.addAll(

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/ResourceOpenAPIParser.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/ResourceOpenAPIParser.java
@@ -282,8 +282,8 @@ public class ResourceOpenAPIParser {
 	}
 
 	public static String getParameters(
-		List<JavaMethodParameter> javaMethodParameters, Operation operation,
-		Map<String, Schema> schemas, boolean annotation) {
+		ConfigYAML configYAML, List<JavaMethodParameter> javaMethodParameters,
+		Operation operation, Map<String, Schema> schemas, boolean annotation) {
 
 		StringBuilder sb = new StringBuilder();
 
@@ -292,7 +292,7 @@ public class ResourceOpenAPIParser {
 
 			if (annotation) {
 				parameterAnnotation = _getParameterAnnotation(
-					javaMethodParameter, operation, schemas);
+					configYAML, javaMethodParameter, operation, schemas);
 			}
 
 			sb.append(
@@ -686,7 +686,7 @@ public class ResourceOpenAPIParser {
 	}
 
 	private static String _getDefaultValue(
-		Schema schema, Map<String, Schema> schemas) {
+		ConfigYAML configYAML, Schema schema, Map<String, Schema> schemas) {
 
 		if (schema.getDefault() != null) {
 			return schema.getDefault();
@@ -699,7 +699,7 @@ public class ResourceOpenAPIParser {
 
 			if (referenceSchema == null) {
 				Map<String, Schema> enumSchemas =
-					OpenAPIUtil.getGlobalEnumSchemas(schemas);
+					OpenAPIUtil.getGlobalEnumSchemas(configYAML, schemas);
 
 				referenceSchema = enumSchemas.get(referenceName);
 			}
@@ -1055,8 +1055,8 @@ public class ResourceOpenAPIParser {
 	}
 
 	private static String _getParameterAnnotation(
-		JavaMethodParameter javaMethodParameter, Operation operation,
-		Map<String, Schema> schemas) {
+		ConfigYAML configYAML, JavaMethodParameter javaMethodParameter,
+		Operation operation, Map<String, Schema> schemas) {
 
 		List<Parameter> parameters = operation.getParameters();
 
@@ -1106,7 +1106,7 @@ public class ResourceOpenAPIParser {
 			StringBundler sb = new StringBundler(11);
 
 			String defaultValue = _getDefaultValue(
-				parameter.getSchema(), schemas);
+				configYAML, parameter.getSchema(), schemas);
 
 			if (defaultValue != null) {
 				sb.append("@javax.ws.rs.DefaultValue(\"");

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/ResourceOpenAPIParser.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/ResourceOpenAPIParser.java
@@ -282,8 +282,8 @@ public class ResourceOpenAPIParser {
 	}
 
 	public static String getParameters(
-		List<JavaMethodParameter> javaMethodParameters, OpenAPIYAML openAPIYAML,
-		Operation operation, boolean annotation) {
+		List<JavaMethodParameter> javaMethodParameters, Operation operation,
+		Map<String, Schema> schemas, boolean annotation) {
 
 		StringBuilder sb = new StringBuilder();
 
@@ -292,7 +292,7 @@ public class ResourceOpenAPIParser {
 
 			if (annotation) {
 				parameterAnnotation = _getParameterAnnotation(
-					javaMethodParameter, openAPIYAML, operation);
+					javaMethodParameter, operation, schemas);
 			}
 
 			sb.append(
@@ -686,15 +686,12 @@ public class ResourceOpenAPIParser {
 	}
 
 	private static String _getDefaultValue(
-		OpenAPIYAML openAPIYAML, Schema schema) {
+		Schema schema, Map<String, Schema> schemas) {
 
 		if (schema.getDefault() != null) {
 			return schema.getDefault();
 		}
 		else if (schema.getReference() != null) {
-			Map<String, Schema> schemas = OpenAPIUtil.getAllSchemas(
-				openAPIYAML);
-
 			String referenceName = OpenAPIParserUtil.getReferenceName(
 				schema.getReference());
 
@@ -702,7 +699,7 @@ public class ResourceOpenAPIParser {
 
 			if (referenceSchema == null) {
 				Map<String, Schema> enumSchemas =
-					OpenAPIUtil.getGlobalEnumSchemas(openAPIYAML);
+					OpenAPIUtil.getGlobalEnumSchemas(schemas);
 
 				referenceSchema = enumSchemas.get(referenceName);
 			}
@@ -1058,8 +1055,8 @@ public class ResourceOpenAPIParser {
 	}
 
 	private static String _getParameterAnnotation(
-		JavaMethodParameter javaMethodParameter, OpenAPIYAML openAPIYAML,
-		Operation operation) {
+		JavaMethodParameter javaMethodParameter, Operation operation,
+		Map<String, Schema> schemas) {
 
 		List<Parameter> parameters = operation.getParameters();
 
@@ -1109,7 +1106,7 @@ public class ResourceOpenAPIParser {
 			StringBundler sb = new StringBundler(11);
 
 			String defaultValue = _getDefaultValue(
-				openAPIYAML, parameter.getSchema());
+				parameter.getSchema(), schemas);
 
 			if (defaultValue != null) {
 				sb.append("@javax.ws.rs.DefaultValue(\"");

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/ResourceTestCaseOpenAPIParser.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/ResourceTestCaseOpenAPIParser.java
@@ -16,6 +16,7 @@ import com.liferay.portal.tools.rest.builder.internal.yaml.openapi.Info;
 import com.liferay.portal.tools.rest.builder.internal.yaml.openapi.OpenAPIYAML;
 import com.liferay.portal.tools.rest.builder.internal.yaml.openapi.Operation;
 import com.liferay.portal.tools.rest.builder.internal.yaml.openapi.RequestBody;
+import com.liferay.portal.tools.rest.builder.internal.yaml.openapi.Schema;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -58,11 +59,11 @@ public class ResourceTestCaseOpenAPIParser {
 	}
 
 	public static String getParameters(
-		List<JavaMethodParameter> javaMethodParameters, OpenAPIYAML openAPIYAML,
-		Operation operation, boolean annotation) {
+		List<JavaMethodParameter> javaMethodParameters, Operation operation,
+		Map<String, Schema> schemas, boolean annotation) {
 
 		return ResourceOpenAPIParser.getParameters(
-			javaMethodParameters, openAPIYAML, operation, annotation);
+			javaMethodParameters, operation, schemas, annotation);
 	}
 
 	private static String _getMethodName(

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/ResourceTestCaseOpenAPIParser.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/ResourceTestCaseOpenAPIParser.java
@@ -59,11 +59,11 @@ public class ResourceTestCaseOpenAPIParser {
 	}
 
 	public static String getParameters(
-		List<JavaMethodParameter> javaMethodParameters, Operation operation,
-		Map<String, Schema> schemas, boolean annotation) {
+		ConfigYAML configYAML, List<JavaMethodParameter> javaMethodParameters,
+		Operation operation, Map<String, Schema> schemas, boolean annotation) {
 
 		return ResourceOpenAPIParser.getParameters(
-			javaMethodParameters, operation, schemas, annotation);
+			configYAML, javaMethodParameters, operation, schemas, annotation);
 	}
 
 	private static String _getMethodName(

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/util/OpenAPIParserUtil.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/util/OpenAPIParserUtil.java
@@ -52,7 +52,9 @@ import java.util.TreeSet;
  */
 public class OpenAPIParserUtil {
 
-	public static Map<String, Schema> getAllOfPropertySchemas(Schema schema) {
+	public static Map<String, Schema> getAllOfPropertySchemas(
+		Schema schema, Map<String, Schema> schemas) {
+
 		List<Schema> allOfSchemas = schema.getAllOfSchemas();
 
 		if (allOfSchemas.size() == 1) {
@@ -63,16 +65,10 @@ public class OpenAPIParserUtil {
 
 		for (Schema allOfSchema : allOfSchemas) {
 			if (allOfSchema.getReference() != null) {
-				Schema itemSchema = new Schema();
+				allOfSchema = schemas.get(
+					getReferenceName(allOfSchema.getReference()));
 
-				String reference = allOfSchema.getReference();
-
-				itemSchema.setReference(reference);
-
-				propertySchemas.put(
-					StringUtil.lowerCaseFirstLetter(
-						getReferenceName(reference)),
-					itemSchema);
+				propertySchemas.putAll(allOfSchema.getPropertySchemas());
 			}
 			else {
 				propertySchemas.putAll(allOfSchema.getPropertySchemas());

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/util/OpenAPIParserUtil.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/util/OpenAPIParserUtil.java
@@ -11,6 +11,7 @@ import com.liferay.portal.kernel.util.TextFormatter;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.tools.rest.builder.internal.freemarker.tool.java.JavaMethodParameter;
 import com.liferay.portal.tools.rest.builder.internal.freemarker.tool.java.JavaMethodSignature;
+import com.liferay.portal.tools.rest.builder.internal.freemarker.util.ConfigUtil;
 import com.liferay.portal.tools.rest.builder.internal.freemarker.util.OpenAPIUtil;
 import com.liferay.portal.tools.rest.builder.internal.util.FileUtil;
 import com.liferay.portal.tools.rest.builder.internal.yaml.YAMLUtil;
@@ -53,7 +54,7 @@ import java.util.TreeSet;
 public class OpenAPIParserUtil {
 
 	public static Map<String, Schema> getAllOfPropertySchemas(
-		Schema schema, Map<String, Schema> schemas) {
+		ConfigYAML configYAML, Schema schema, Map<String, Schema> schemas) {
 
 		List<Schema> allOfSchemas = schema.getAllOfSchemas();
 
@@ -65,10 +66,26 @@ public class OpenAPIParserUtil {
 
 		for (Schema allOfSchema : allOfSchemas) {
 			if (allOfSchema.getReference() != null) {
-				allOfSchema = schemas.get(
-					getReferenceName(allOfSchema.getReference()));
+				if (allOfSchema.isMergeProperties() &&
+					ConfigUtil.isVersionCompatible(configYAML, 4)) {
 
-				propertySchemas.putAll(allOfSchema.getPropertySchemas());
+					allOfSchema = schemas.get(
+						getReferenceName(allOfSchema.getReference()));
+
+					propertySchemas.putAll(allOfSchema.getPropertySchemas());
+				}
+				else {
+					Schema itemSchema = new Schema();
+
+					String reference = allOfSchema.getReference();
+
+					itemSchema.setReference(reference);
+
+					propertySchemas.put(
+						StringUtil.lowerCaseFirstLetter(
+							getReferenceName(reference)),
+						itemSchema);
+				}
 			}
 			else {
 				propertySchemas.putAll(allOfSchema.getPropertySchemas());
@@ -199,7 +216,7 @@ public class OpenAPIParserUtil {
 	}
 
 	public static Map<String, Schema> getExternalSchemas(
-			OpenAPIYAML openAPIYAML)
+			ConfigYAML configYAML, OpenAPIYAML openAPIYAML)
 		throws Exception {
 
 		Map<String, Schema> externalReferencesMap = new HashMap<>();
@@ -224,7 +241,7 @@ public class OpenAPIParserUtil {
 				FileUtil.read(new File(path)));
 
 			externalReferencesMap.putAll(
-				OpenAPIUtil.getAllSchemas(openAPIYAML));
+				OpenAPIUtil.getAllSchemas(configYAML, openAPIYAML));
 
 			for (String curExternalReference :
 					getExternalReferences(openAPIYAML)) {
@@ -334,7 +351,8 @@ public class OpenAPIParserUtil {
 			throw new RuntimeException(ioException);
 		}
 
-		Map<String, Schema> allSchemas = OpenAPIUtil.getAllSchemas(openAPIYAML);
+		Map<String, Schema> allSchemas = OpenAPIUtil.getAllSchemas(
+			configYAML, openAPIYAML);
 
 		for (String schemaName : allSchemas.keySet()) {
 			StringBuilder sb = new StringBuilder();
@@ -371,7 +389,7 @@ public class OpenAPIParserUtil {
 		}
 
 		Map<String, Schema> globalEnumSchemas =
-			OpenAPIUtil.getGlobalEnumSchemas(allSchemas);
+			OpenAPIUtil.getGlobalEnumSchemas(configYAML, allSchemas);
 
 		for (String schemaName : globalEnumSchemas.keySet()) {
 			javaDataTypeMap.put(

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/util/OpenAPIParserUtil.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/util/OpenAPIParserUtil.java
@@ -371,7 +371,7 @@ public class OpenAPIParserUtil {
 		}
 
 		Map<String, Schema> globalEnumSchemas =
-			OpenAPIUtil.getGlobalEnumSchemas(openAPIYAML);
+			OpenAPIUtil.getGlobalEnumSchemas(allSchemas);
 
 		for (String schemaName : globalEnumSchemas.keySet()) {
 			javaDataTypeMap.put(

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/util/OpenAPIUtil.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/util/OpenAPIUtil.java
@@ -182,6 +182,31 @@ public class OpenAPIUtil {
 					propertySchemas = items.getPropertySchemas();
 				}
 				else if (schema.getAllOfSchemas() != null) {
+					boolean anyMissing = false;
+
+					for (Schema allOfSchema : schema.getAllOfSchemas()) {
+						if (allOfSchema.getReference() == null) {
+							continue;
+						}
+
+						if (!allSchemas.containsKey(
+								OpenAPIParserUtil.getReferenceName(
+									allOfSchema.getReference()))) {
+
+							anyMissing = true;
+
+							break;
+						}
+					}
+
+					if (anyMissing) {
+						queue.add(
+							Collections.singletonMap(
+								entry.getKey(), entry.getValue()));
+
+						continue;
+					}
+
 					propertySchemas = OpenAPIParserUtil.getAllOfPropertySchemas(
 						schema, allSchemas);
 				}

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/util/OpenAPIUtil.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/util/OpenAPIUtil.java
@@ -183,7 +183,7 @@ public class OpenAPIUtil {
 				}
 				else if (schema.getAllOfSchemas() != null) {
 					propertySchemas = OpenAPIParserUtil.getAllOfPropertySchemas(
-						schema);
+						schema, allSchemas);
 				}
 				else {
 					propertySchemas = schema.getPropertySchemas();
@@ -254,7 +254,7 @@ public class OpenAPIUtil {
 			}
 			else if (schema.getAllOfSchemas() != null) {
 				propertySchemas = OpenAPIParserUtil.getAllOfPropertySchemas(
-					schema);
+					schema, schemas);
 			}
 			else {
 				propertySchemas = schema.getPropertySchemas();

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/util/OpenAPIUtil.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/util/OpenAPIUtil.java
@@ -182,24 +182,7 @@ public class OpenAPIUtil {
 					propertySchemas = items.getPropertySchemas();
 				}
 				else if (schema.getAllOfSchemas() != null) {
-					boolean anyMissing = false;
-
-					for (Schema allOfSchema : schema.getAllOfSchemas()) {
-						if (allOfSchema.getReference() == null) {
-							continue;
-						}
-
-						if (!allSchemas.containsKey(
-								OpenAPIParserUtil.getReferenceName(
-									allOfSchema.getReference()))) {
-
-							anyMissing = true;
-
-							break;
-						}
-					}
-
-					if (anyMissing) {
+					if (_isAnyAllOfSchemasMissing(schema, allSchemas)) {
 						queue.add(
 							Collections.singletonMap(
 								entry.getKey(), entry.getValue()));
@@ -209,6 +192,9 @@ public class OpenAPIUtil {
 
 					propertySchemas = OpenAPIParserUtil.getAllOfPropertySchemas(
 						schema, allSchemas);
+
+					schema.setAllOfSchemas(null);
+					schema.setPropertySchemas(propertySchemas);
 				}
 				else {
 					propertySchemas = schema.getPropertySchemas();
@@ -316,6 +302,37 @@ public class OpenAPIUtil {
 			allExternalSchemas.putAll(externalSchemaMap);
 			queue.add(externalSchemaMap);
 		}
+	}
+
+	private static boolean _isAnyAllOfSchemasMissing(
+		Schema schema, Map<String, Schema> schemas) {
+
+		if (schema.getAllOfSchemas() != null) {
+			for (Schema allOfSchema : schema.getAllOfSchemas()) {
+				if (allOfSchema.getReference() == null) {
+					continue;
+				}
+
+				if (!schemas.containsKey(
+						OpenAPIParserUtil.getReferenceName(
+							allOfSchema.getReference()))) {
+
+					return true;
+				}
+			}
+		}
+
+		if (schema.getPropertySchemas() != null) {
+			Map<String, Schema> propertySchemas = schema.getPropertySchemas();
+
+			for (Schema propertySchema : propertySchemas.values()) {
+				if (_isAnyAllOfSchemasMissing(propertySchema, schemas)) {
+					return true;
+				}
+			}
+		}
+
+		return false;
 	}
 
 	private static final Pattern _leadingUnderscorePattern = Pattern.compile(

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/util/OpenAPIUtil.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/util/OpenAPIUtil.java
@@ -241,17 +241,9 @@ public class OpenAPIUtil {
 	}
 
 	public static Map<String, Schema> getGlobalEnumSchemas(
-		OpenAPIYAML openAPIYAML) {
+		Map<String, Schema> schemas) {
 
 		Map<String, Schema> globalEnumSchemas = new TreeMap<>();
-
-		Components components = openAPIYAML.getComponents();
-
-		if (components == null) {
-			return globalEnumSchemas;
-		}
-
-		Map<String, Schema> schemas = components.getSchemas();
 
 		for (Map.Entry<String, Schema> entry : schemas.entrySet()) {
 			Schema schema = entry.getValue();

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/util/OpenAPIUtil.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/util/OpenAPIUtil.java
@@ -8,6 +8,7 @@ package com.liferay.portal.tools.rest.builder.internal.freemarker.util;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.tools.rest.builder.internal.freemarker.tool.java.parser.util.OpenAPIParserUtil;
+import com.liferay.portal.tools.rest.builder.internal.yaml.config.ConfigYAML;
 import com.liferay.portal.tools.rest.builder.internal.yaml.openapi.Components;
 import com.liferay.portal.tools.rest.builder.internal.yaml.openapi.Info;
 import com.liferay.portal.tools.rest.builder.internal.yaml.openapi.Items;
@@ -76,13 +77,13 @@ public class OpenAPIUtil {
 	}
 
 	public static Map<String, Schema> getAllExternalSchemas(
-			OpenAPIYAML openAPIYAML)
+			ConfigYAML configYAML, OpenAPIYAML openAPIYAML)
 		throws Exception {
 
 		Map<String, Schema> allExternalSchemas = new HashMap<>();
 
 		Map<String, Schema> externalSchemas =
-			OpenAPIParserUtil.getExternalSchemas(openAPIYAML);
+			OpenAPIParserUtil.getExternalSchemas(configYAML, openAPIYAML);
 
 		List<String> externalReferences =
 			OpenAPIParserUtil.getExternalReferences(openAPIYAML);
@@ -155,7 +156,9 @@ public class OpenAPIUtil {
 		return allExternalSchemas;
 	}
 
-	public static Map<String, Schema> getAllSchemas(OpenAPIYAML openAPIYAML) {
+	public static Map<String, Schema> getAllSchemas(
+		ConfigYAML configYAML, OpenAPIYAML openAPIYAML) {
+
 		Map<String, Schema> allSchemas = new TreeMap<>();
 
 		Components components = openAPIYAML.getComponents();
@@ -191,10 +194,14 @@ public class OpenAPIUtil {
 					}
 
 					propertySchemas = OpenAPIParserUtil.getAllOfPropertySchemas(
-						schema, allSchemas);
+						configYAML, schema, allSchemas);
 
-					schema.setAllOfSchemas(null);
-					schema.setPropertySchemas(propertySchemas);
+					if (schema.isMergeProperties() &&
+						ConfigUtil.isVersionCompatible(configYAML, 4)) {
+
+						schema.setAllOfSchemas(null);
+						schema.setPropertySchemas(propertySchemas);
+					}
 				}
 				else {
 					propertySchemas = schema.getPropertySchemas();
@@ -241,7 +248,7 @@ public class OpenAPIUtil {
 	}
 
 	public static Map<String, Schema> getGlobalEnumSchemas(
-		Map<String, Schema> schemas) {
+		ConfigYAML configYAML, Map<String, Schema> schemas) {
 
 		Map<String, Schema> globalEnumSchemas = new TreeMap<>();
 
@@ -257,7 +264,7 @@ public class OpenAPIUtil {
 			}
 			else if (schema.getAllOfSchemas() != null) {
 				propertySchemas = OpenAPIParserUtil.getAllOfPropertySchemas(
-					schema, schemas);
+					configYAML, schema, schemas);
 			}
 			else {
 				propertySchemas = schema.getPropertySchemas();

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/yaml/YAMLUtil.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/yaml/YAMLUtil.java
@@ -171,10 +171,14 @@ public class YAMLUtil {
 		schemaTypeDescription.addPropertyParameters("required", String.class);
 
 		schemaTypeDescription.substituteProperty(
-			"x-json-map", boolean.class, "getJsonMap", "setJsonMap");
+			"x-json-map", boolean.class, "isJsonMap", "setJsonMap");
 
 		schemaTypeDescription.substituteProperty(
-			"x-json-string", boolean.class, "getJsonString", "setJsonString");
+			"x-json-string", boolean.class, "isJsonString", "setJsonString");
+
+		schemaTypeDescription.substituteProperty(
+			"x-merge-properties", boolean.class, "isMergeProperties",
+			"setMergeProperties");
 
 		schemaTypeDescription.substituteProperty(
 			"xml", XML.class, "getXML", "setXML");

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/yaml/config/ConfigYAML.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/yaml/config/ConfigYAML.java
@@ -78,6 +78,10 @@ public class ConfigYAML {
 		return _forcePredictableSchemaPropertyName;
 	}
 
+	public boolean isGenerateActionProviders() {
+		return _generateActionProviders;
+	}
+
 	public boolean isGenerateBatch() {
 		return _generateBatch;
 	}
@@ -156,6 +160,10 @@ public class ConfigYAML {
 			forcePredictableSchemaPropertyName;
 	}
 
+	public void setGenerateActionProviders(boolean generateActionProviders) {
+		_generateActionProviders = generateActionProviders;
+	}
+
 	public void setGenerateBatch(boolean generateBatch) {
 		_generateBatch = generateBatch;
 	}
@@ -215,6 +223,7 @@ public class ConfigYAML {
 	private boolean _forcePredictableContentApplicationXML = true;
 	private boolean _forcePredictableOperationId;
 	private boolean _forcePredictableSchemaPropertyName = true;
+	private boolean _generateActionProviders;
 	private boolean _generateBatch = true;
 	private boolean _generateGraphQL = true;
 	private boolean _generateOpenAPI = true;

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/yaml/openapi/Schema.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/yaml/openapi/Schema.java
@@ -114,6 +114,10 @@ public class Schema {
 		return _jsonString;
 	}
 
+	public boolean isMergeProperties() {
+		return _mergeProperties;
+	}
+
 	public boolean isReadOnly() {
 		return _readOnly;
 	}
@@ -178,6 +182,10 @@ public class Schema {
 		_maxLength = maxLength;
 	}
 
+	public void setMergeProperties(boolean mergeProperties) {
+		_mergeProperties = mergeProperties;
+	}
+
 	public void setMinimum(Double minimum) {
 		_minimum = minimum;
 	}
@@ -238,6 +246,7 @@ public class Schema {
 	private boolean _jsonString;
 	private Double _maximum;
 	private Integer _maxLength;
+	private boolean _mergeProperties = true;
 	private Double _minimum;
 	private Integer _minLength;
 	private String _name;

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
@@ -179,7 +179,7 @@ public abstract class Base${schemaName}ResourceImpl
 		</#if>
 		@Override
 		${freeMarkerTool.getResourceMethodAnnotations(javaMethodSignature)}
-		public ${javaMethodSignature.returnType} ${javaMethodSignature.methodName}(${freeMarkerTool.getResourceParameters(javaMethodSignature.javaMethodParameters, javaMethodSignature.operation, allSchemas, true)}) throws Exception {
+		public ${javaMethodSignature.returnType} ${javaMethodSignature.methodName}(${freeMarkerTool.getResourceParameters(configYAML, javaMethodSignature.javaMethodParameters, javaMethodSignature.operation, allSchemas, true)}) throws Exception {
 			<#if stringUtil.equals(javaMethodSignature.returnType, "boolean")>
 				return false;
 			<#elseif generateBatch && stringUtil.equals(javaMethodSignature.methodName, "delete" + schemaName + "Batch")>
@@ -382,9 +382,9 @@ public abstract class Base${schemaName}ResourceImpl
 				<#assign properties = freeMarkerTool.getWritableDTOProperties(configYAML, openAPIYAML, schema, allSchemas) />
 
 				<#list properties?keys as propertyName>
-					<#if !freeMarkerTool.isDTOSchemaProperty(propertyName, schema, allSchemas) && !stringUtil.equals(propertyName, "id")>
+					<#if !freeMarkerTool.isDTOSchemaProperty(configYAML, propertyName, schema, allSchemas) && !stringUtil.equals(propertyName, "id")>
 						if (${schemaVarName}.get${propertyName?cap_first}() != null) {
-							<#assign dtoPropertySchema = freeMarkerTool.getDTOPropertySchema(propertyName, schema, allSchemas) />
+							<#assign dtoPropertySchema = freeMarkerTool.getDTOPropertySchema(configYAML, propertyName, schema, allSchemas) />
 
 							<#if dtoPropertySchema.isJsonMap()>
 								${properties[propertyName]} ${propertyName} = existing${schemaName}.get${propertyName?cap_first}();

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
@@ -379,12 +379,12 @@ public abstract class Base${schemaName}ResourceImpl
 					</#list>
 				);
 
-				<#assign properties = freeMarkerTool.getWritableDTOProperties(configYAML, openAPIYAML, schema) />
+				<#assign properties = freeMarkerTool.getWritableDTOProperties(configYAML, openAPIYAML, schema, allSchemas) />
 
 				<#list properties?keys as propertyName>
-					<#if !freeMarkerTool.isDTOSchemaProperty(openAPIYAML, propertyName, schema) && !stringUtil.equals(propertyName, "id")>
+					<#if !freeMarkerTool.isDTOSchemaProperty(propertyName, schema, allSchemas) && !stringUtil.equals(propertyName, "id")>
 						if (${schemaVarName}.get${propertyName?cap_first}() != null) {
-							<#assign dtoPropertySchema = freeMarkerTool.getDTOPropertySchema(propertyName, schema) />
+							<#assign dtoPropertySchema = freeMarkerTool.getDTOPropertySchema(propertyName, schema, allSchemas) />
 
 							<#if dtoPropertySchema.isJsonMap()>
 								${properties[propertyName]} ${propertyName} = existing${schemaName}.get${propertyName?cap_first}();
@@ -426,7 +426,7 @@ public abstract class Base${schemaName}ResourceImpl
 
 	<#if generateBatch>
 		<#assign
-			properties = freeMarkerTool.getDTOProperties(configYAML, openAPIYAML, schema)
+			properties = freeMarkerTool.getDTOProperties(configYAML, openAPIYAML, schema, allSchemas)
 
 			createStrategies = freeMarkerTool.getVulcanBatchImplementationCreateStrategies(javaMethodSignatures, properties)
 			updateStrategies = freeMarkerTool.getVulcanBatchImplementationUpdateStrategies(javaMethodSignatures)

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
@@ -179,7 +179,7 @@ public abstract class Base${schemaName}ResourceImpl
 		</#if>
 		@Override
 		${freeMarkerTool.getResourceMethodAnnotations(javaMethodSignature)}
-		public ${javaMethodSignature.returnType} ${javaMethodSignature.methodName}(${freeMarkerTool.getResourceParameters(javaMethodSignature.javaMethodParameters, openAPIYAML, javaMethodSignature.operation, true)}) throws Exception {
+		public ${javaMethodSignature.returnType} ${javaMethodSignature.methodName}(${freeMarkerTool.getResourceParameters(javaMethodSignature.javaMethodParameters, javaMethodSignature.operation, allSchemas, true)}) throws Exception {
 			<#if stringUtil.equals(javaMethodSignature.returnType, "boolean")>
 				return false;
 			<#elseif generateBatch && stringUtil.equals(javaMethodSignature.methodName, "delete" + schemaName + "Batch")>

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
@@ -162,7 +162,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 		GroupTestUtil.deleteGroup(testGroup);
 	}
 
-	<#assign properties = freeMarkerTool.getDTOProperties(configYAML, openAPIYAML, schema) />
+	<#assign properties = freeMarkerTool.getDTOProperties(configYAML, openAPIYAML, schema, allSchemas) />
 
 	<#if javaDataTypeMap?keys?seq_contains(schemaName)>
 		@Test
@@ -1963,7 +1963,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 
 	<#list relatedSchemaNames as relatedSchemaName>
 		<#assign
-			relatedSchemaProperties = freeMarkerTool.getDTOProperties(configYAML, openAPIYAML, relatedSchemaName)
+			relatedSchemaProperties = freeMarkerTool.getDTOProperties(configYAML, openAPIYAML, relatedSchemaName, allSchemas)
 			relatedSchemaVarName = freeMarkerTool.getSchemaVarName(relatedSchemaName)
 		/>
 
@@ -2202,7 +2202,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 
 	<#list relatedSchemaNames as relatedSchemaName>
 		<#assign
-			relatedSchemaProperties = freeMarkerTool.getDTOProperties(configYAML, openAPIYAML, relatedSchemaName)
+			relatedSchemaProperties = freeMarkerTool.getDTOProperties(configYAML, openAPIYAML, relatedSchemaName, allSchemas)
 			relatedSchemaVarName = freeMarkerTool.getSchemaVarName(relatedSchemaName)
 		/>
 
@@ -2336,7 +2336,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 
 	<#list relatedSchemaNames as relatedSchemaName>
 		<#assign
-			relatedSchemaProperties = freeMarkerTool.getDTOProperties(configYAML, openAPIYAML, relatedSchemaName)
+			relatedSchemaProperties = freeMarkerTool.getDTOProperties(configYAML, openAPIYAML, relatedSchemaName, allSchemas)
 			relatedSchemaVarName = freeMarkerTool.getSchemaVarName(relatedSchemaName)
 		/>
 
@@ -2520,7 +2520,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 
 	<#list relatedSchemaNames as relatedSchemaName>
 		<#assign
-			relatedSchemaProperties = freeMarkerTool.getDTOProperties(configYAML, openAPIYAML, relatedSchemaName)
+			relatedSchemaProperties = freeMarkerTool.getDTOProperties(configYAML, openAPIYAML, relatedSchemaName, allSchemas)
 			relatedSchemaVarName = freeMarkerTool.getSchemaVarName(relatedSchemaName)
 		/>
 
@@ -2775,7 +2775,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 		protected ${relatedSchemaName} random${relatedSchemaName}() throws Exception {
 			return new ${relatedSchemaName}() {
 				{
-					<#assign relatedSchemaProperties = freeMarkerTool.getDTOProperties(configYAML, openAPIYAML, relatedSchemaName) />
+					<#assign relatedSchemaProperties = freeMarkerTool.getDTOProperties(configYAML, openAPIYAML, relatedSchemaName, allSchemas) />
 
 					<#list relatedSchemaProperties?keys as propertyName>
 						<#if randomDataTypes?seq_contains(relatedSchemaProperties[propertyName])>

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
@@ -239,7 +239,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 	</#if>
 
 	<#assign
-		enumSchemas = freeMarkerTool.getDTOEnumSchemas(openAPIYAML, schema)
+		enumSchemas = freeMarkerTool.getDTOEnumSchemas(configYAML, openAPIYAML, schema)
 		generateGetMultipartFilesMethod = false
 		generateSearchTestRule = false
 		randomDataTypes = ["Boolean", "Double", "Integer", "Long", "String"]
@@ -248,7 +248,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 	<#list javaMethodSignatures as javaMethodSignature>
 		<#assign
 			arguments = freeMarkerTool.getResourceTestCaseArguments(javaMethodSignature.javaMethodParameters)
-			parameters = freeMarkerTool.getResourceTestCaseParameters(javaMethodSignature.javaMethodParameters, javaMethodSignature.operation, allSchemas, false)
+			parameters = freeMarkerTool.getResourceTestCaseParameters(configYAML, javaMethodSignature.javaMethodParameters, javaMethodSignature.operation, allSchemas, false)
 		/>
 
 		<#if stringUtil.endsWith(javaMethodSignature.methodName, schemaName + "Batch") || stringUtil.endsWith(javaMethodSignature.methodName, schemaNames + "PageExportBatch")>

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
@@ -248,7 +248,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 	<#list javaMethodSignatures as javaMethodSignature>
 		<#assign
 			arguments = freeMarkerTool.getResourceTestCaseArguments(javaMethodSignature.javaMethodParameters)
-			parameters = freeMarkerTool.getResourceTestCaseParameters(javaMethodSignature.javaMethodParameters, openAPIYAML, javaMethodSignature.operation, false)
+			parameters = freeMarkerTool.getResourceTestCaseParameters(javaMethodSignature.javaMethodParameters, javaMethodSignature.operation, allSchemas, false)
 		/>
 
 		<#if stringUtil.endsWith(javaMethodSignature.methodName, schemaName + "Batch") || stringUtil.endsWith(javaMethodSignature.methodName, schemaNames + "PageExportBatch")>

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/client_dto.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/client_dto.ftl
@@ -38,7 +38,7 @@ public class ${schemaName} implements Cloneable, Serializable {
 
 	<#assign
 		enumSchemas = freeMarkerTool.getDTOEnumSchemas(openAPIYAML, schema)
-		properties = freeMarkerTool.getDTOProperties(configYAML, openAPIYAML, schema)
+		properties = freeMarkerTool.getDTOProperties(configYAML, openAPIYAML, schema, allSchemas)
 	/>
 
 	<#list properties?keys as propertyName>

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/client_dto.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/client_dto.ftl
@@ -37,7 +37,7 @@ public class ${schemaName} implements Cloneable, Serializable {
 	}
 
 	<#assign
-		enumSchemas = freeMarkerTool.getDTOEnumSchemas(openAPIYAML, schema)
+		enumSchemas = freeMarkerTool.getDTOEnumSchemas(configYAML, openAPIYAML, schema)
 		properties = freeMarkerTool.getDTOProperties(configYAML, openAPIYAML, schema, allSchemas)
 	/>
 

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/client_serdes.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/client_serdes.ftl
@@ -57,7 +57,7 @@ public class ${schemaName}SerDes {
 		sb.append("{");
 
 		<#assign
-			enumSchemas = freeMarkerTool.getDTOEnumSchemas(openAPIYAML, schema)
+			enumSchemas = freeMarkerTool.getDTOEnumSchemas(configYAML, openAPIYAML, schema)
 			properties = freeMarkerTool.getDTOProperties(configYAML, openAPIYAML, schema, allSchemas)
 		/>
 
@@ -74,7 +74,7 @@ public class ${schemaName}SerDes {
 		<#list properties?keys as propertyName>
 			<#assign
 				capitalizedPropertyName = propertyName?cap_first
-				propertySchema = freeMarkerTool.getDTOPropertySchema(propertyName, schema, allSchemas)
+				propertySchema = freeMarkerTool.getDTOPropertySchema(configYAML, propertyName, schema, allSchemas)
 			/>
 
 			<#if enumSchemas?keys?seq_contains(properties[propertyName])>
@@ -192,7 +192,7 @@ public class ${schemaName}SerDes {
 		<#list properties?keys as propertyName>
 			<#assign
 				capitalizedPropertyName = propertyName?cap_first
-				propertySchema = freeMarkerTool.getDTOPropertySchema(propertyName, schema, allSchemas)
+				propertySchema = freeMarkerTool.getDTOPropertySchema(configYAML, propertyName, schema, allSchemas)
 			/>
 
 			<#if enumSchemas?keys?seq_contains(properties[propertyName])>
@@ -237,7 +237,7 @@ public class ${schemaName}SerDes {
 		@Override
 		protected void setField(${schemaName} ${schemaVarName}, String jsonParserFieldName, Object jsonParserFieldValue) {
 			<#list properties?keys as propertyName>
-				<#assign propertySchema = freeMarkerTool.getDTOPropertySchema(propertyName, schema, allSchemas) />
+				<#assign propertySchema = freeMarkerTool.getDTOPropertySchema(configYAML, propertyName, schema, allSchemas) />
 
 				<#if !propertyName?is_first>
 					else

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/client_serdes.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/client_serdes.ftl
@@ -58,7 +58,7 @@ public class ${schemaName}SerDes {
 
 		<#assign
 			enumSchemas = freeMarkerTool.getDTOEnumSchemas(openAPIYAML, schema)
-			properties = freeMarkerTool.getDTOProperties(configYAML, openAPIYAML, schema)
+			properties = freeMarkerTool.getDTOProperties(configYAML, openAPIYAML, schema, allSchemas)
 		/>
 
 		<#list properties?keys as propertyName>
@@ -74,7 +74,7 @@ public class ${schemaName}SerDes {
 		<#list properties?keys as propertyName>
 			<#assign
 				capitalizedPropertyName = propertyName?cap_first
-				propertySchema = freeMarkerTool.getDTOPropertySchema(propertyName, schema)
+				propertySchema = freeMarkerTool.getDTOPropertySchema(propertyName, schema, allSchemas)
 			/>
 
 			<#if enumSchemas?keys?seq_contains(properties[propertyName])>
@@ -192,7 +192,7 @@ public class ${schemaName}SerDes {
 		<#list properties?keys as propertyName>
 			<#assign
 				capitalizedPropertyName = propertyName?cap_first
-				propertySchema = freeMarkerTool.getDTOPropertySchema(propertyName, schema)
+				propertySchema = freeMarkerTool.getDTOPropertySchema(propertyName, schema, allSchemas)
 			/>
 
 			<#if enumSchemas?keys?seq_contains(properties[propertyName])>
@@ -237,7 +237,7 @@ public class ${schemaName}SerDes {
 		@Override
 		protected void setField(${schemaName} ${schemaVarName}, String jsonParserFieldName, Object jsonParserFieldValue) {
 			<#list properties?keys as propertyName>
-				<#assign propertySchema = freeMarkerTool.getDTOPropertySchema(propertyName, schema) />
+				<#assign propertySchema = freeMarkerTool.getDTOPropertySchema(propertyName, schema, allSchemas) />
 
 				<#if !propertyName?is_first>
 					else

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/dto.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/dto.ftl
@@ -130,12 +130,12 @@ public class ${schemaName} <#if dtoParentClassName?has_content>extends ${dtoPare
 	<#assign
 		enumSchemas = freeMarkerTool.getDTOEnumSchemas(openAPIYAML, schema)
 		jsonMapPropertyNames = []
-		properties = freeMarkerTool.getDTOProperties(configYAML, openAPIYAML, schema)
+		properties = freeMarkerTool.getDTOProperties(configYAML, openAPIYAML, schema, allSchemas)
 	/>
 
 	<#list properties?keys as propertyName>
 		<#assign
-			propertySchema = freeMarkerTool.getDTOPropertySchema(propertyName, schema)
+			propertySchema = freeMarkerTool.getDTOPropertySchema(propertyName, schema, allSchemas)
 			propertyType = properties[propertyName]
 			sizeParameters = []
 		/>
@@ -335,7 +335,7 @@ public class ${schemaName} <#if dtoParentClassName?has_content>extends ${dtoPare
 
 		<#list properties?keys as propertyName>
 			<#assign
-				propertySchema = freeMarkerTool.getDTOPropertySchema(propertyName, schema)
+				propertySchema = freeMarkerTool.getDTOPropertySchema(propertyName, schema, allSchemas)
 				propertyType = properties[propertyName]
 			/>
 

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/dto.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/dto.ftl
@@ -128,14 +128,14 @@ public class ${schemaName} <#if dtoParentClassName?has_content>extends ${dtoPare
 	}
 
 	<#assign
-		enumSchemas = freeMarkerTool.getDTOEnumSchemas(openAPIYAML, schema)
+		enumSchemas = freeMarkerTool.getDTOEnumSchemas(configYAML, openAPIYAML, schema)
 		jsonMapPropertyNames = []
 		properties = freeMarkerTool.getDTOProperties(configYAML, openAPIYAML, schema, allSchemas)
 	/>
 
 	<#list properties?keys as propertyName>
 		<#assign
-			propertySchema = freeMarkerTool.getDTOPropertySchema(propertyName, schema, allSchemas)
+			propertySchema = freeMarkerTool.getDTOPropertySchema(configYAML, propertyName, schema, allSchemas)
 			propertyType = properties[propertyName]
 			sizeParameters = []
 		/>
@@ -335,7 +335,7 @@ public class ${schemaName} <#if dtoParentClassName?has_content>extends ${dtoPare
 
 		<#list properties?keys as propertyName>
 			<#assign
-				propertySchema = freeMarkerTool.getDTOPropertySchema(propertyName, schema, allSchemas)
+				propertySchema = freeMarkerTool.getDTOPropertySchema(configYAML, propertyName, schema, allSchemas)
 				propertyType = properties[propertyName]
 			/>
 

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/graphql_query.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/graphql_query.ftl
@@ -125,14 +125,14 @@ public class Query {
 						Query.this::_populateResourceContext,
 						${freeMarkerTool.getSchemaVarName(javaMethodSignature.schemaName)}Resource ->
 							new ${javaMethodSignature.schemaName}Page(
-								${freeMarkerTool.getSchemaVarName(javaMethodSignature.schemaName)}Resource.${javaMethodSignature.methodName}(_${javaMethodSignature.parentSchemaName?uncap_first}.get${freeMarkerTool.getGraphQLJavaParameterName(configYAML, openAPIYAML, javaMethodSignature.parentSchemaName, javaMethodSignature.javaMethodParameters[0])}()
+								${freeMarkerTool.getSchemaVarName(javaMethodSignature.schemaName)}Resource.${javaMethodSignature.methodName}(_${javaMethodSignature.parentSchemaName?uncap_first}.get${freeMarkerTool.getGraphQLJavaParameterName(configYAML, openAPIYAML, javaMethodSignature.parentSchemaName, allSchemas, javaMethodSignature.javaMethodParameters[0])}()
 
 								<#if arguments?has_content>
 									, ${arguments}
 								</#if>)));
 				<#else>
 					return _applyComponentServiceObjects(_${freeMarkerTool.getSchemaVarName(javaMethodSignature.schemaName)}ResourceComponentServiceObjects, Query.this::_populateResourceContext, ${freeMarkerTool.getSchemaVarName(javaMethodSignature.schemaName)}Resource -> ${freeMarkerTool.getSchemaVarName(javaMethodSignature.schemaName)}Resource.${javaMethodSignature.methodName}(
-						_${javaMethodSignature.parentSchemaName?uncap_first}.get${freeMarkerTool.getGraphQLJavaParameterName(configYAML, openAPIYAML, javaMethodSignature.parentSchemaName, javaMethodSignature.javaMethodParameters[0])}()
+						_${javaMethodSignature.parentSchemaName?uncap_first}.get${freeMarkerTool.getGraphQLJavaParameterName(configYAML, openAPIYAML, javaMethodSignature.parentSchemaName, allSchemas, javaMethodSignature.javaMethodParameters[0])}()
 
 						<#if arguments?has_content>
 							, ${arguments}

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/properties.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/properties.ftl
@@ -17,7 +17,7 @@ openapi.resource.path=${configYAML.application.baseURI}
 batch.engine.entity.class.name=${javaDataType}
 batch.engine.task.item.delegate=true
 batch.planner.export.enabled=${freeMarkerTool.hasReadVulcanBatchImplementation(javaMethodSignatures)?c}
-batch.planner.import.enabled=${freeMarkerTool.getVulcanBatchImplementationCreateStrategies(javaMethodSignatures, freeMarkerTool.getDTOProperties(configYAML, openAPIYAML, schema))?has_content?c}
+batch.planner.import.enabled=${freeMarkerTool.getVulcanBatchImplementationCreateStrategies(javaMethodSignatures, freeMarkerTool.getDTOProperties(configYAML, openAPIYAML, schema, allSchemas))?has_content?c}
 </#if>
 <#if javaDataType?has_content>
 entity.class.name=${javaDataType}

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/resource.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/resource.ftl
@@ -61,7 +61,7 @@ public interface ${schemaName}Resource {
 	/>
 
 	<#list javaMethodSignatures as javaMethodSignature>
-		public ${javaMethodSignature.returnType} ${javaMethodSignature.methodName}(${freeMarkerTool.getResourceParameters(javaMethodSignature.javaMethodParameters, javaMethodSignature.operation, allSchemas, false)}) throws Exception;
+		public ${javaMethodSignature.returnType} ${javaMethodSignature.methodName}(${freeMarkerTool.getResourceParameters(configYAML, javaMethodSignature.javaMethodParameters, javaMethodSignature.operation, allSchemas, false)}) throws Exception;
 	</#list>
 
 	public default void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/resource.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/resource.ftl
@@ -61,7 +61,7 @@ public interface ${schemaName}Resource {
 	/>
 
 	<#list javaMethodSignatures as javaMethodSignature>
-		public ${javaMethodSignature.returnType} ${javaMethodSignature.methodName}(${freeMarkerTool.getResourceParameters(javaMethodSignature.javaMethodParameters, openAPIYAML, javaMethodSignature.operation, false)}) throws Exception;
+		public ${javaMethodSignature.returnType} ${javaMethodSignature.methodName}(${freeMarkerTool.getResourceParameters(javaMethodSignature.javaMethodParameters, javaMethodSignature.operation, allSchemas, false)}) throws Exception;
 	</#list>
 
 	public default void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/ExceedMaxLineLength.testyaml
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/ExceedMaxLineLength.testyaml
@@ -6,8 +6,7 @@ components:
                 (https://www.schema.org/Role) specification.
             properties:
                 creator:
-                    allOf:
-                        - $ref: "#/components/schemas/Creator"
+                    $ref: "#/components/schemas/Creator"
                     description:
                         The role's creator.
                     readOnly: true

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/ExceedMaxLineLength.testyaml
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/ExceedMaxLineLength.testyaml
@@ -6,8 +6,7 @@ components:
                 (https://www.schema.org/Role) specification.
             properties:
                 creator:
-                    allOf:
-                        - $ref: "#/components/schemas/Creator"
+                    $ref: "#/components/schemas/Creator"
                     description:
                         The role's creator.
                     readOnly: true


### PR DESCRIPTION
Forwarded manually from: https://github.com/liferay-headless/liferay-portal/pull/1632

---

Related ticket: https://liferay.atlassian.net/browse/LPS-153494

---

The purpose of this PR is to fix the allOf support in REST Builder.

For that, the properties that are created in the DTO that contains the `allOf` property have been modified.

---

Given the following rest-openapi.yaml fragment:

```yaml
components:
    schemas:
        BaseScim:
            [...]
            properties:
                externalId:
                    description:
                        A String that is an identifier for the resource as defined by the provisioning client.
                    type: string
                [...]
            type: object
        [...]
        User:
            allOf:
                - $ref: "#/components/schemas/BaseScim"
                - properties:
                      active:
                          description:
                              A Boolean value indicating the user's administrative status.
                          type: boolean
                      [...]
```

**Before the PR:**

The code generated in the DTO User contains a reference to a `BaseScim` attribute:

```java
public class User implements Serializable {

	[...]

	@Schema(
		description = "A Boolean value indicating the user's administrative status."
	)
	public Boolean getActive() {
		return active;
	}

	public void setActive(Boolean active) {
		this.active = active;
	}

	@JsonIgnore
	public void setActive(
		UnsafeSupplier<Boolean, Exception> activeUnsafeSupplier) {

		try {
			active = activeUnsafeSupplier.get();
		}
		catch (RuntimeException re) {
			throw re;
		}
		catch (Exception e) {
			throw new RuntimeException(e);
		}
	}

	@GraphQLField(
		description = "A Boolean value indicating the user's administrative status."
	)
	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
	protected Boolean active;

	[...]

	@Schema
	@Valid
	public BaseScim getBaseScim() {
		return baseScim;
	}

	public void setBaseScim(BaseScim baseScim) {
		this.baseScim = baseScim;
	}

	@JsonIgnore
	public void setBaseScim(
		UnsafeSupplier<BaseScim, Exception> baseScimUnsafeSupplier) {

		try {
			baseScim = baseScimUnsafeSupplier.get();
		}
		catch (RuntimeException re) {
			throw re;
		}
		catch (Exception e) {
			throw new RuntimeException(e);
		}
	}

	@GraphQLField
	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
	protected BaseScim baseScim;

	[...]
}
```


**After the PR:**

The code generated in the DTO User contains all the properties merged:

```java
public class User implements Serializable {

	[...]

	@Schema(
		description = "A Boolean value indicating the user's administrative status."
	)
	public Boolean getActive() {
		return active;
	}

	public void setActive(Boolean active) {
		this.active = active;
	}

	@JsonIgnore
	public void setActive(
		UnsafeSupplier<Boolean, Exception> activeUnsafeSupplier) {

		try {
			active = activeUnsafeSupplier.get();
		}
		catch (RuntimeException re) {
			throw re;
		}
		catch (Exception e) {
			throw new RuntimeException(e);
		}
	}

	@GraphQLField(
		description = "A Boolean value indicating the user's administrative status."
	)
	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
	protected Boolean active;

	[...]

	@Schema(
		description = "A String that is an identifier for the resource as defined by the provisioning client."
	)
	public String getExternalId() {
		return externalId;
	}

	public void setExternalId(String externalId) {
		this.externalId = externalId;
	}

	@JsonIgnore
	public void setExternalId(
		UnsafeSupplier<String, Exception> externalIdUnsafeSupplier) {

		try {
			externalId = externalIdUnsafeSupplier.get();
		}
		catch (RuntimeException re) {
			throw re;
		}
		catch (Exception e) {
			throw new RuntimeException(e);
		}
	}

	@GraphQLField(
		description = "A String that is an identifier for the resource as defined by the provisioning client."
	)
	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
	protected String externalId;


	[...]
	
}
```

**NOTE: This will be applied by default for all the REST APIs created with REST Builder whose `compatibilityVersion >= 4`.** In order to avoid it, it is just necessary to set the `x-merge-properties` property to false at the same level than the `$ref` parameter. For example:

```yaml
allOf:
    - $ref: "#/components/schemas/DocumentBulkSelection"
      x-merge-properties: false
```
