### PR TITLE
fix JournalArticle smallImageSource not updated when using smallImageURL

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v6_1_0/JournalArticleSmallImageSourceUpgradeProcess.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v6_1_0/JournalArticleSmallImageSourceUpgradeProcess.java
@@ -32,6 +32,13 @@ public class JournalArticleSmallImageSourceUpgradeProcess
 				JournalArticleConstants.SMALL_IMAGE_SOURCE_USER_COMPUTER,
 				" where smallImage = [$TRUE$] and (smallImageURL is null or ",
 				"smallImageURL = '')"));
+		
+		runSQL(
+			StringBundler.concat(
+				"update JournalArticle set smallImageSource = ",
+				JournalArticleConstants.SMALL_IMAGE_SOURCE_URL,
+				" where smallImage = [$TRUE$] and not (smallImageURL is null or ",
+				"smallImageURL = '')"));
 	}
 
 }


### PR DESCRIPTION
The new `smallImageSource` field is never set to `SMALL_IMAGE_SOURCE_URL` during the upgrade process when a url is used.

I'm not sure if the line above was supposed to do this, or if it's meant to catch some edge case
In my testing the `smallImageId` is always >0 when it is uploaded from computer, so it would be redundant. Doesn't hurt though, so I left it in.