### PR TITLE
check index before using it for substring

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-favicon-servlet/src/main/java/com/liferay/frontend/theme/favicon/servlet/internal/FaviconServlet.java
+++ b/modules/apps/frontend-theme/frontend-theme-favicon-servlet/src/main/java/com/liferay/frontend/theme/favicon/servlet/internal/FaviconServlet.java
@@ -144,8 +144,10 @@ public class FaviconServlet extends HttpServlet {
 				0, fileEntryFriendlyURL.indexOf(CharPool.SLASH, 1));
 		}
 		else {
-			groupFriendlyURL = groupFriendlyURL.substring(
-				0, groupFriendlyURL.indexOf(CharPool.SLASH, 1));
+			pos = groupFriendlyURL.indexOf(CharPool.SLASH, 1);
+			if (pos > 0) {
+				groupFriendlyURL = groupFriendlyURL.substring(0, pos);
+			}
 		}
 
 		Group group = _groupLocalService.fetchFriendlyURLGroup(


### PR DESCRIPTION
We're getting exceptions here, the code assumes there are more slashes, but that doesn't have to be the case (it's controlled by the user after all).

```
2023-11-10 01:43:29.660 ERROR [ajp-nio-127.0.0.1-8009-exec-438][CTCollectionPreviewFilter:53] java.lang.StringIndexOutOfBoundsException: begin 0, end -1, length 12
java.lang.StringIndexOutOfBoundsException: begin 0, end -1, length 12
        at java.lang.String.checkBoundsBeginEnd(String.java:3319) ~[?:?]
        at java.lang.String.substring(String.java:1874) ~[?:?]
        at com.liferay.frontend.theme.favicon.servlet.internal.FaviconServlet._getLayoutSet(FaviconServlet.java:147) ~[?:?]
        at com.liferay.frontend.theme.favicon.servlet.internal.FaviconServlet.doGet(FaviconServlet.java:78) ~[?:?]
```