### PR TITLE
LPS-201030: Allow to retrieve System Object Fields assign as API Properties in GET endpoints

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-impl/build.gradle
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/build.gradle
@@ -9,6 +9,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:headless:headless-builder:headless-builder-api")
+	compileOnly project(":apps:headless:headless-delivery:headless-delivery-api")
 	compileOnly project(":apps:info:info-api")
 	compileOnly project(":apps:object:object-api")
 	compileOnly project(":apps:object:object-rest-api")

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/helper/EndpointHelper.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/helper/EndpointHelper.java
@@ -132,7 +132,11 @@ public class EndpointHelper {
 		).put(
 			"createDate", objectEntry.getDateCreated()
 		).put(
+			"creator", objectEntry.getCreator()
+		).put(
 			"externalReferenceCode", objectEntry.getExternalReferenceCode()
+		).put(
+			"id", objectEntry.getId()
 		).put(
 			"modifiedDate", objectEntry.getDateModified()
 		).build();

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
@@ -1542,6 +1542,48 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 			JSONCompareMode.LENIENT);
 	}
 
+	@Test
+	public void testGetWithSystemObjectFields() throws Exception {
+		ObjectField systemObjectFieldCreator =
+			_objectFieldLocalService.getObjectField(
+				_objectDefinition1.getObjectDefinitionId(), "creator");
+
+		ObjectField systemObjectFieldId =
+			_objectFieldLocalService.getObjectField(
+				_objectDefinition1.getObjectDefinitionId(), "id");
+
+		_addAPIApplication(
+			_API_APPLICATION_ERC_1, _API_ENDPOINT_ERC_1, _BASE_URL_1,
+			_objectDefinition1.getExternalReferenceCode(),
+			_API_APPLICATION_PATH_1, null,
+			APIApplication.Endpoint.RetrieveType.COLLECTION.getValue(),
+			APIApplication.Endpoint.Scope.COMPANY,
+			systemObjectFieldCreator.getExternalReferenceCode(),
+			systemObjectFieldId.getExternalReferenceCode());
+
+		_publishAPIApplication(_API_APPLICATION_ERC_1);
+
+		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(
+			_objectDefinition1, "externalReferenceCode",
+			RandomTestUtil.randomString());
+
+		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+			null, "c/" + _BASE_URL_1 + _API_APPLICATION_PATH_1,
+			Http.Method.GET);
+
+		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
+
+		jsonObject = itemsJSONArray.getJSONObject(0);
+
+		Assert.assertEquals(
+			objectEntry.getObjectEntryId(), jsonObject.getInt("id"));
+
+		JSONObject creatorJSONObject = jsonObject.getJSONObject("creator");
+
+		Assert.assertEquals(
+			objectEntry.getUserName(), creatorJSONObject.getString("name"));
+	}
+
 	private void _addAggregationObjectField(
 			ObjectDefinition objectDefinition, String relationshipName)
 		throws Exception {
@@ -1607,6 +1649,71 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 								"objectRelationshipNames",
 								objectRelationshipName1 + "," +
 									objectRelationshipName2
+							))
+					).put(
+						"description", "description"
+					).put(
+						"externalReferenceCode", apiSchemaExternalReferenceCode
+					).put(
+						"mainObjectDefinitionERC",
+						objectDefinitionExternalReferenceCode
+					).put(
+						"name", "name"
+					))
+			).put(
+				"applicationStatus", "unpublished"
+			).put(
+				"baseURL", baseURL
+			).put(
+				"externalReferenceCode", apiApplicationExternalReferenceCode
+			).put(
+				"title", RandomTestUtil.randomString()
+			).toString(),
+			"headless-builder/applications", Http.Method.POST);
+
+		_relateAPIEndpointWithAPISchemas(
+			apiEndpointExternalReferenceCode, apiSchemaExternalReferenceCode);
+	}
+
+	private void _addAPIApplication(
+			String apiApplicationExternalReferenceCode,
+			String apiEndpointExternalReferenceCode, String baseURL,
+			String objectDefinitionExternalReferenceCode, String path,
+			String pathParameter, String retrieveType,
+			APIApplication.Endpoint.Scope scope,
+			String systemObjectFieldCreatorExternalReferenceCode,
+			String systemObjectFieldIdExternalReferenceCode)
+		throws Exception {
+
+		String apiSchemaExternalReferenceCode = RandomTestUtil.randomString();
+
+		assertSuccessfulHttpCode(
+			JSONUtil.put(
+				"apiApplicationToAPIEndpoints",
+				_createAPIEndpoint(
+					apiEndpointExternalReferenceCode, path, pathParameter,
+					retrieveType, scope)
+			).put(
+				"apiApplicationToAPISchemas",
+				JSONUtil.put(
+					JSONUtil.put(
+						"apiSchemaToAPIProperties",
+						JSONUtil.putAll(
+							JSONUtil.put(
+								"description", "description"
+							).put(
+								"name", "id"
+							).put(
+								"objectFieldERC",
+								systemObjectFieldIdExternalReferenceCode
+							),
+							JSONUtil.put(
+								"description", "description"
+							).put(
+								"name", "creator"
+							).put(
+								"objectFieldERC",
+								systemObjectFieldCreatorExternalReferenceCode
 							))
 					).put(
 						"description", "description"


### PR DESCRIPTION
## Motivation
The idea of this PR is to allow to retrieve those missing System Object Fields assign as API Properties: like `id` or `Author`.

**What is new?**
- Allow to set `creator` and `id` in ObjectEntry's DTO.
- Create some test cases.

**How to test it?**
1. Deploy `headless-builder-api` and `headless-builder-impl`
2. Create a Custom Object Definition (Student) with a Custom Object Field (nameStudent). Publish it. 
3. Create some students with different nameStudent
4. Go to Objects > API Builder. Create an API Application called API TEST.
5. Go inside API TEST and go to Schemas tab. Create a new Schema called Student Schema selecting the Student Custom Object Definition.
6. Go inside Student Schema and add some properties like Author, ID and Student Name.
7. Create a new API Endpoint with a path of /students of Collection type and scoped by Company.
8. Publish API TEST application.
9. Go to API Explorer and select /c/api-test/ application.
10. Execute /students


**JIRA Related Ticket**
https://liferay.atlassian.net/browse/LPS-201030