### PR TITLE
LPS-196240 Only clear the ThreadLocal's ObjectEntryIdsMap when current service call is not itself product of an action. Also, clear before since the update action is done asynchronously

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/action/executor/UpdateObjectEntryObjectActionExecutorImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/action/executor/UpdateObjectEntryObjectActionExecutorImpl.java
@@ -10,6 +10,7 @@ import com.liferay.object.action.executor.ObjectActionExecutor;
 import com.liferay.object.constants.ObjectActionConstants;
 import com.liferay.object.constants.ObjectActionExecutorConstants;
 import com.liferay.object.entry.util.ObjectEntryThreadLocal;
+import com.liferay.object.internal.action.util.ObjectActionThreadLocal;
 import com.liferay.object.internal.action.util.ObjectEntryVariablesUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectField;
@@ -102,6 +103,7 @@ public class UpdateObjectEntryObjectActionExecutorImpl
 			ObjectEntryThreadLocal.isSkipObjectEntryResourcePermission();
 
 		try {
+			ObjectActionThreadLocal.setClearObjectEntryIdsMap(false);
 			ObjectEntryThreadLocal.setSkipObjectEntryResourcePermission(true);
 			ObjectEntryThreadLocal.setSkipReadOnlyObjectFieldsValidation(true);
 
@@ -144,6 +146,7 @@ public class UpdateObjectEntryObjectActionExecutorImpl
 			throw exception;
 		}
 		finally {
+			ObjectActionThreadLocal.setClearObjectEntryIdsMap(true);
 			ObjectEntryThreadLocal.setSkipObjectEntryResourcePermission(
 				skipObjectEntryResourcePermission);
 			ObjectEntryThreadLocal.setSkipReadOnlyObjectFieldsValidation(false);

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/action/util/ObjectActionThreadLocal.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/action/util/ObjectActionThreadLocal.java
@@ -5,6 +5,7 @@
 
 package com.liferay.object.internal.action.util;
 
+import com.liferay.object.entry.util.ObjectEntryThreadLocal;
 import com.liferay.petra.lang.CentralizedThreadLocal;
 
 import java.util.HashMap;
@@ -43,6 +44,21 @@ public class ObjectActionThreadLocal {
 		return _objectEntryIdsMapThreadLocal.get();
 	}
 
+	public static boolean isClearObjectEntryIdsMap() {
+		return _clearObjectEntryIdsMapThreadLocal.get();
+	}
+
+	public static void setClearObjectEntryIdsMap(
+		boolean clearObjectEntryIdsMap) {
+
+		_clearObjectEntryIdsMapThreadLocal.set(clearObjectEntryIdsMap);
+	}
+
+	private static final ThreadLocal<Boolean>
+		_clearObjectEntryIdsMapThreadLocal = new CentralizedThreadLocal<>(
+			ObjectEntryThreadLocal.class +
+				"._clearObjectEntryIdsMapThreadLocal",
+			() -> true);
 	private static final ThreadLocal<Map<Long, Set<Long>>>
 		_objectEntryIdsMapThreadLocal = new CentralizedThreadLocal<>(
 			ObjectActionThreadLocal.class.getName() +

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -294,7 +294,16 @@ public class ObjectEntryLocalServiceImpl
 			objectEntry.getUserId(), objectDefinition.getClassName(),
 			objectEntry.getPrimaryKey(), false, false, false);
 
+		boolean clearObjectEntryIdsMap =
+			ObjectActionThreadLocal.isClearObjectEntryIdsMap();
+
 		try {
+			if (clearObjectEntryIdsMap) {
+				ObjectActionThreadLocal.clearObjectEntryIdsMap();
+			}
+
+			ObjectActionThreadLocal.setClearObjectEntryIdsMap(false);
+
 			if (workflowAction == WorkflowConstants.ACTION_SAVE_DRAFT) {
 				ObjectEntryThreadLocal.setSkipObjectValidationRules(true);
 			}
@@ -302,6 +311,9 @@ public class ObjectEntryLocalServiceImpl
 			objectEntry = objectEntryPersistence.update(objectEntry);
 		}
 		finally {
+			ObjectActionThreadLocal.setClearObjectEntryIdsMap(
+				clearObjectEntryIdsMap);
+
 			ObjectEntryThreadLocal.setSkipObjectValidationRules(false);
 		}
 
@@ -315,8 +327,6 @@ public class ObjectEntryLocalServiceImpl
 		_startWorkflowInstance(userId, objectEntry, serviceContext);
 
 		_reindex(objectEntry);
-
-		ObjectActionThreadLocal.clearObjectEntryIdsMap();
 
 		return objectEntry;
 	}
@@ -456,6 +466,8 @@ public class ObjectEntryLocalServiceImpl
 
 		Map<String, Serializable> values = objectEntry.getValues();
 
+		ObjectActionThreadLocal.clearObjectEntryIdsMap();
+
 		objectEntry = objectEntryPersistence.remove(objectEntry);
 
 		ObjectDefinition objectDefinition =
@@ -503,8 +515,6 @@ public class ObjectEntryLocalServiceImpl
 
 			indexer.delete(objectEntry);
 		}
-
-		ObjectActionThreadLocal.clearObjectEntryIdsMap();
 
 		return objectEntry;
 	}

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectActionLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectActionLocalServiceTest.java
@@ -828,6 +828,97 @@ public class ObjectActionLocalServiceTest {
 	}
 
 	@Test
+	public void testAddObjectActionWithInfiniteLoop() throws Exception {
+
+		// Create related object actions to test infinite loop handling
+
+		_publishCustomObjectDefinition();
+
+		UnicodeProperties unicodeProperties = UnicodePropertiesBuilder.put(
+			"objectDefinitionId", _objectDefinition.getObjectDefinitionId()
+		).put(
+			"predefinedValues",
+			JSONUtil.putAll(
+				JSONUtil.put(
+					"inputAsValue", true
+				).put(
+					"name", "firstName"
+				).put(
+					"value", "Peter"
+				),
+				JSONUtil.put(
+					"inputAsValue", true
+				).put(
+					"name", "lastName"
+				).put(
+					"value", "White"
+				),
+				JSONUtil.put(
+					"inputAsValue", true
+				).put(
+					"name", "time"
+				).put(
+					"value", "2023-06-01 06:42:08.0"
+				)
+			).toString()
+		).build();
+
+		ObjectAction objectAction6 = _addObjectAction(
+			RandomTestUtil.randomString(),
+			ObjectActionExecutorConstants.KEY_UPDATE_OBJECT_ENTRY,
+			ObjectActionTriggerConstants.KEY_ON_AFTER_ADD, unicodeProperties,
+			false);
+		ObjectAction objectAction7 = _addObjectAction(
+			RandomTestUtil.randomString(),
+			ObjectActionExecutorConstants.KEY_ADD_OBJECT_ENTRY,
+			ObjectActionTriggerConstants.KEY_ON_AFTER_UPDATE, unicodeProperties,
+			false);
+
+		// Add object entry
+
+		PermissionChecker originalPermissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+		String originalName = PrincipalThreadLocal.getName();
+
+		try {
+			PermissionThreadLocal.setPermissionChecker(
+				PermissionCheckerFactoryUtil.create(_user));
+			PrincipalThreadLocal.setName(_user.getUserId());
+
+			_objectEntryLocalService.addObjectEntry(
+				TestPropsValues.getUserId(), 0,
+				_objectDefinition.getObjectDefinitionId(),
+				HashMapBuilder.<String, Serializable>put(
+					"firstName", "John"
+				).put(
+					"lastName", "Smith"
+				).build(),
+				ServiceContextTestUtil.getServiceContext());
+		}
+		finally {
+			PermissionThreadLocal.setPermissionChecker(
+				originalPermissionChecker);
+			PrincipalThreadLocal.setName(originalName);
+		}
+
+		// Related object actions must be executed correctly
+		// to avoid infinite loop
+
+		objectAction6 = _objectActionLocalService.getObjectAction(
+			objectAction6.getObjectActionId());
+		objectAction7 = _objectActionLocalService.getObjectAction(
+			objectAction7.getObjectActionId());
+
+		Assert.assertEquals(
+			objectAction6.getStatus(), ObjectActionConstants.STATUS_SUCCESS);
+		Assert.assertEquals(
+			objectAction7.getStatus(), ObjectActionConstants.STATUS_SUCCESS);
+
+		_objectActionLocalService.deleteObjectAction(objectAction6);
+		_objectActionLocalService.deleteObjectAction(objectAction7);
+	}
+
+	@Test
 	public void testAddObjectActionWithMoreThanOneObjectEntry()
 		throws Exception {
 


### PR DESCRIPTION
Follow up on: https://github.com/brianchandotcom/liferay-portal/pull/144272