### PR TITLE
LPS-202545: Check if objectFieldSetting is null or empty to set unique property for ObjectFields

### DIFF
--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/field/setting/util/ObjectFieldSettingUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/field/setting/util/ObjectFieldSettingUtil.java
@@ -115,6 +115,10 @@ public class ObjectFieldSettingUtil {
 	public static boolean isUnique(
 		List<ObjectFieldSetting> objectFieldSetting) {
 
+		if (ListUtil.isNull(objectFieldSetting)) {
+			return false;
+		}
+
 		return GetterUtil.getBoolean(
 			getValue(
 				ObjectFieldSettingConstants.NAME_UNIQUE_VALUES,


### PR DESCRIPTION
## Motivation
This PR checks if the objectFieldSettings is null or empty. If it is not, it will retrieve the objectFieldSetting value given its key.

**JIRA Related Ticket**
https://liferay.atlassian.net/browse/LPS-202545