### PR TITLE
LPS-202115 Fixing and improving responses generated by POST API Endpoints

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/application/publisher/APIApplicationPublisherImpl.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/application/publisher/APIApplicationPublisherImpl.java
@@ -188,6 +188,8 @@ public class APIApplicationPublisherImpl
 		).put(
 			"liferay.jackson", false
 		).put(
+			"liferay.objects.exception.mapper", true
+		).put(
 			"osgi.jaxrs.application.base",
 			HeadlessBuilderConstants.BASE_PATH_SUFFIX + baseURL
 		).put(

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/helper/EndpointHelper.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/helper/EndpointHelper.java
@@ -222,6 +222,10 @@ public class EndpointHelper {
 			ObjectEntry objectEntry, APIApplication.Schema schema)
 		throws Exception {
 
+		if (schema == null) {
+			return null;
+		}
+
 		Map<String, Object> responseEntityMap = new HashMap<>();
 
 		Map<String, Object> objectEntryProperties = _getObjectEntryProperties(

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/helper/EndpointHelper.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/helper/EndpointHelper.java
@@ -219,8 +219,7 @@ public class EndpointHelper {
 	}
 
 	private Map<String, Object> _getResponseEntityMap(
-			ObjectEntry objectEntry, APIApplication.Schema schema)
-		throws Exception {
+		ObjectEntry objectEntry, APIApplication.Schema schema) {
 
 		if (schema == null) {
 			return null;

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/resource/HeadlessBuilderResourceImpl.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/resource/HeadlessBuilderResourceImpl.java
@@ -204,8 +204,15 @@ public class HeadlessBuilderResourceImpl {
 			).build();
 		}
 
+		Object object = successUnsafeFunction.apply(endpoint);
+
+		if (object == null) {
+			return Response.noContent(
+			).build();
+		}
+
 		return Response.ok(
-			successUnsafeFunction.apply(endpoint)
+			object
 		).build();
 	}
 

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
@@ -1118,13 +1118,8 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 
 	@Test
 	public void testGetWithPostEndpoint() throws Exception {
-		int index = 10;
-
-		ObjectDefinition objectDefinition = _addObjectDefinition(
-			index, true, ObjectDefinitionConstants.SCOPE_COMPANY);
-
 		_addAPIApplicationWithGetAndPostEndpoint(
-			objectDefinition.getExternalReferenceCode(), index);
+			_objectDefinition1.getExternalReferenceCode(), 1);
 
 		_publishAPIApplication(_API_APPLICATION_ERC_1);
 

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
@@ -1728,7 +1728,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 			7, true, ObjectDefinitionConstants.SCOPE_COMPANY);
 
 		_addAPIApplicationWithPostEndpoint(
-			_API_APPLICATION_ERC_1, _API_ENDPOINT_ERC_1, _BASE_URL_1, true, 7,
+			true, _API_APPLICATION_ERC_1, _API_ENDPOINT_ERC_1, _BASE_URL_1, 7,
 			objectDefinition.getExternalReferenceCode(), "/test",
 			APIApplication.Endpoint.Scope.COMPANY);
 
@@ -1856,7 +1856,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 			8, true, ObjectDefinitionConstants.SCOPE_COMPANY);
 
 		_addAPIApplicationWithPostEndpoint(
-			_API_APPLICATION_ERC_1, _API_ENDPOINT_ERC_1, _BASE_URL_1, true, 8,
+			true, _API_APPLICATION_ERC_1, _API_ENDPOINT_ERC_1, _BASE_URL_1, 8,
 			objectDefinition.getExternalReferenceCode(), "/test",
 			APIApplication.Endpoint.Scope.COMPANY);
 
@@ -1886,7 +1886,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 			9, false, ObjectDefinitionConstants.SCOPE_COMPANY);
 
 		_addAPIApplicationWithPostEndpoint(
-			_API_APPLICATION_ERC_1, _API_ENDPOINT_ERC_1, _BASE_URL_1, false, 9,
+			false, _API_APPLICATION_ERC_1, _API_ENDPOINT_ERC_1, _BASE_URL_1, 9,
 			objectDefinition.getExternalReferenceCode(), "/test",
 			APIApplication.Endpoint.Scope.COMPANY);
 
@@ -2235,7 +2235,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 
 		String apiSchemaExternalReferenceCode = RandomTestUtil.randomString();
 
-		assertSuccessfulHttpCode(
+		assertSuccessfulJSONObject(
 			JSONUtil.put(
 				"apiApplicationToAPIEndpoints",
 				JSONUtil.putAll(
@@ -2392,7 +2392,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 			).toString(),
 			"headless-builder/applications", Http.Method.POST);
 
-		assertSuccessfulHttpCode(
+		assertSuccessfulJSONObject(
 			null,
 			StringBundler.concat(
 				"headless-builder/schemas/by-external-reference-code/",
@@ -2401,7 +2401,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 				getAPIEndpointExternalReferenceCode),
 			Http.Method.PUT);
 
-		assertSuccessfulHttpCode(
+		assertSuccessfulJSONObject(
 			null,
 			StringBundler.concat(
 				"headless-builder/schemas/by-external-reference-code/",
@@ -2410,7 +2410,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 				postAPIEndpointExternalReferenceCode),
 			Http.Method.PUT);
 
-		assertSuccessfulHttpCode(
+		assertSuccessfulJSONObject(
 			null,
 			StringBundler.concat(
 				"headless-builder/schemas/by-external-reference-code/",
@@ -2421,9 +2421,9 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 	}
 
 	private void _addAPIApplicationWithPostEndpoint(
+			boolean addResponseSchema,
 			String apiApplicationExternalReferenceCode,
-			String apiEndpointExternalReferenceCode, String baseURL,
-			boolean hasResponseSchema, int index,
+			String apiEndpointExternalReferenceCode, String baseURL, int index,
 			String objectDefinitionExternalReferenceCode, String path,
 			APIApplication.Endpoint.Scope scope)
 		throws Exception {
@@ -2589,7 +2589,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 				apiEndpointExternalReferenceCode),
 			Http.Method.PUT);
 
-		if (hasResponseSchema) {
+		if (addResponseSchema) {
 			assertSuccessfulJSONObject(
 				null,
 				StringBundler.concat(

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
@@ -143,11 +143,11 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 				false, listTypeEntries);
 
 		_objectDefinition1 = _addObjectDefinition(
-			1, false, ObjectDefinitionConstants.SCOPE_COMPANY);
+			1, ObjectDefinitionConstants.SCOPE_COMPANY);
 		_objectDefinition2 = _addObjectDefinition(
-			2, false, ObjectDefinitionConstants.SCOPE_COMPANY);
+			2, ObjectDefinitionConstants.SCOPE_COMPANY);
 		_objectDefinition3 = _addObjectDefinition(
-			3, false, ObjectDefinitionConstants.SCOPE_COMPANY);
+			3, ObjectDefinitionConstants.SCOPE_COMPANY);
 
 		_objectRelationship1 = _addObjectRelationship(
 			_objectDefinition1, _objectDefinition2,
@@ -162,11 +162,11 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 			_objectDefinition2, _objectRelationship2.getName());
 
 		_siteScopedObjectDefinition1 = _addObjectDefinition(
-			1, false, ObjectDefinitionConstants.SCOPE_SITE);
+			1, ObjectDefinitionConstants.SCOPE_SITE);
 		_siteScopedObjectDefinition2 = _addObjectDefinition(
-			2, false, ObjectDefinitionConstants.SCOPE_SITE);
+			2, ObjectDefinitionConstants.SCOPE_SITE);
 		_siteScopedObjectDefinition3 = _addObjectDefinition(
-			3, false, ObjectDefinitionConstants.SCOPE_SITE);
+			3, ObjectDefinitionConstants.SCOPE_SITE);
 
 		_siteScopedObjectRelationship1 = _addObjectRelationship(
 			_siteScopedObjectDefinition1, _siteScopedObjectDefinition2,
@@ -1035,11 +1035,11 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 	@Test
 	public void testGetWithIndirectlyUnrelatedObjectEntries() throws Exception {
 		ObjectDefinition objectDefinition1 = _addObjectDefinition(
-			4, false, ObjectDefinitionConstants.SCOPE_COMPANY);
+			4, ObjectDefinitionConstants.SCOPE_COMPANY);
 		ObjectDefinition objectDefinition2 = _addObjectDefinition(
-			5, false, ObjectDefinitionConstants.SCOPE_COMPANY);
+			5, ObjectDefinitionConstants.SCOPE_COMPANY);
 		ObjectDefinition objectDefinition3 = _addObjectDefinition(
-			6, false, ObjectDefinitionConstants.SCOPE_COMPANY);
+			6, ObjectDefinitionConstants.SCOPE_COMPANY);
 
 		ObjectRelationship objectRelationship1 = _addObjectRelationship(
 			objectDefinition2, objectDefinition1,
@@ -2140,11 +2140,89 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 
 	@Test
 	public void testPostWithMissingRequiredField() throws Exception {
-		ObjectDefinition objectDefinition = _addObjectDefinition(
-			8, true, ObjectDefinitionConstants.SCOPE_COMPANY);
+		String objectFieldExternalReferenceCode = RandomTestUtil.randomString();
 
-		_addAPIApplicationWithPostEndpoint(
-			true, 8, objectDefinition.getExternalReferenceCode());
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				Collections.singletonList(
+					new IntegerObjectFieldBuilder(
+					).externalReferenceCode(
+						objectFieldExternalReferenceCode
+					).labelMap(
+						LocalizedMapUtil.getLocalizedMap(
+							RandomTestUtil.randomString())
+					).name(
+						"integerField"
+					).required(
+						true
+					).build()),
+				ObjectDefinitionConstants.SCOPE_COMPANY);
+
+		String apiSchemaExternalReferenceCode = RandomTestUtil.randomString();
+
+		assertSuccessfulJSONObject(
+			JSONUtil.put(
+				"apiApplicationToAPIEndpoints",
+				JSONUtil.putAll(
+					_createAPIEndpoint(
+						HeadlessBuilderResourceTest._API_ENDPOINT_ERC_1,
+						Http.Method.POST, "/test", null,
+						APIApplication.Endpoint.RetrieveType.SINGLE_ELEMENT.
+							getValue(),
+						APIApplication.Endpoint.Scope.COMPANY))
+			).put(
+				"apiApplicationToAPISchemas",
+				JSONUtil.put(
+					JSONUtil.put(
+						"apiSchemaToAPIProperties",
+						JSONUtil.putAll(
+							JSONUtil.put(
+								"description", "description"
+							).put(
+								"name", "integerProperty"
+							).put(
+								"objectFieldERC",
+								objectFieldExternalReferenceCode
+							))
+					).put(
+						"description", "description"
+					).put(
+						"externalReferenceCode", apiSchemaExternalReferenceCode
+					).put(
+						"mainObjectDefinitionERC",
+						objectDefinition.getExternalReferenceCode()
+					).put(
+						"name", "name"
+					))
+			).put(
+				"applicationStatus", "unpublished"
+			).put(
+				"baseURL", HeadlessBuilderResourceTest._BASE_URL_1
+			).put(
+				"externalReferenceCode",
+				HeadlessBuilderResourceTest._API_APPLICATION_ERC_1
+			).put(
+				"title", RandomTestUtil.randomString()
+			).toString(),
+			"headless-builder/applications", Http.Method.POST);
+
+		assertSuccessfulJSONObject(
+			null,
+			StringBundler.concat(
+				"headless-builder/schemas/by-external-reference-code/",
+				apiSchemaExternalReferenceCode,
+				"/requestAPISchemaToAPIEndpoints/",
+				HeadlessBuilderResourceTest._API_ENDPOINT_ERC_1),
+			Http.Method.PUT);
+
+		assertSuccessfulJSONObject(
+			null,
+			StringBundler.concat(
+				"headless-builder/schemas/by-external-reference-code/",
+				apiSchemaExternalReferenceCode,
+				"/responseAPISchemaToAPIEndpoints/",
+				HeadlessBuilderResourceTest._API_ENDPOINT_ERC_1),
+			Http.Method.PUT);
 
 		_publishAPIApplication(_API_APPLICATION_ERC_1);
 
@@ -2154,7 +2232,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 			).put(
 				"title",
 				"No value was provided for required object field " +
-					"\"richTextField\""
+					"\"integerField\""
 			).toString(),
 			HTTPTestUtil.invokeToJSONObject(
 				JSONUtil.put(
@@ -2622,8 +2700,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 			).build());
 	}
 
-	private ObjectDefinition _addObjectDefinition(
-			int index, boolean required, String scope)
+	private ObjectDefinition _addObjectDefinition(int index, String scope)
 		throws Exception {
 
 		return ObjectDefinitionTestUtil.publishObjectDefinition(
@@ -2661,8 +2738,6 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 						RandomTestUtil.randomString())
 				).name(
 					"dateField"
-				).required(
-					required
 				).build(),
 				new DateTimeObjectFieldBuilder(
 				).externalReferenceCode(
@@ -2677,8 +2752,6 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 						_createObjectFieldSetting(
 							ObjectFieldSettingConstants.NAME_TIME_STORAGE,
 							ObjectFieldSettingConstants.VALUE_CONVERT_TO_UTC))
-				).required(
-					required
 				).build(),
 				new DecimalObjectFieldBuilder(
 				).externalReferenceCode(
@@ -2688,8 +2761,6 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 						RandomTestUtil.randomString())
 				).name(
 					"decimalField"
-				).required(
-					required
 				).build(),
 				new IntegerObjectFieldBuilder(
 				).externalReferenceCode(
@@ -2699,8 +2770,6 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 						RandomTestUtil.randomString())
 				).name(
 					"integerField"
-				).required(
-					required
 				).build(),
 				new LongIntegerObjectFieldBuilder(
 				).externalReferenceCode(
@@ -2710,8 +2779,6 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 						RandomTestUtil.randomString())
 				).name(
 					"longIntegerField"
-				).required(
-					required
 				).build(),
 				new LongTextObjectFieldBuilder(
 				).externalReferenceCode(
@@ -2721,8 +2788,6 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 						RandomTestUtil.randomString())
 				).name(
 					"longTextField"
-				).required(
-					required
 				).build(),
 				new MultiselectPicklistObjectFieldBuilder(
 				).externalReferenceCode(
@@ -2734,8 +2799,6 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 					_listTypeDefinition.getListTypeDefinitionId()
 				).name(
 					"multiselectPicklistField"
-				).required(
-					required
 				).build(),
 				new PicklistObjectFieldBuilder(
 				).externalReferenceCode(
@@ -2747,8 +2810,6 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 					"picklistField"
 				).listTypeDefinitionId(
 					_listTypeDefinition.getListTypeDefinitionId()
-				).required(
-					required
 				).build(),
 				new PrecisionDecimalObjectFieldBuilder(
 				).externalReferenceCode(
@@ -2758,8 +2819,6 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 						RandomTestUtil.randomString())
 				).name(
 					"precisionDecimalField"
-				).required(
-					required
 				).build(),
 				new RichTextObjectFieldBuilder(
 				).externalReferenceCode(
@@ -2769,8 +2828,6 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 						RandomTestUtil.randomString())
 				).name(
 					"richTextField"
-				).required(
-					required
 				).build(),
 				new TextObjectFieldBuilder(
 				).externalReferenceCode(
@@ -2780,8 +2837,6 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 						RandomTestUtil.randomString())
 				).name(
 					"textField"
-				).required(
-					required
 				).build(),
 				new TextObjectFieldBuilder(
 				).externalReferenceCode(
@@ -2796,8 +2851,6 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 						_createObjectFieldSetting(
 							ObjectFieldSettingConstants.NAME_UNIQUE_VALUES,
 							Boolean.TRUE.toString()))
-				).required(
-					required
 				).build()),
 			scope);
 	}

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
@@ -2017,11 +2017,8 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 
 	@Test
 	public void testPostWithAllFields() throws Exception {
-		ObjectDefinition objectDefinition = _addObjectDefinition(
-			7, true, ObjectDefinitionConstants.SCOPE_COMPANY);
-
 		_addAPIApplicationWithPostEndpoint(
-			true, 7, objectDefinition.getExternalReferenceCode());
+			true, 1, _objectDefinition1.getExternalReferenceCode());
 
 		_publishAPIApplication(_API_APPLICATION_ERC_1);
 
@@ -2135,8 +2132,8 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 
 		List<ObjectEntry> objectEntries =
 			_objectEntryLocalService.getObjectEntries(
-				0, objectDefinition.getObjectDefinitionId(), QueryUtil.ALL_POS,
-				QueryUtil.ALL_POS);
+				0, _objectDefinition1.getObjectDefinitionId(),
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 
 		Assert.assertEquals(objectEntries.toString(), 1, objectEntries.size());
 	}
@@ -2171,11 +2168,8 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 
 	@Test
 	public void testPostWithoutResponseSchema() throws Exception {
-		ObjectDefinition objectDefinition = _addObjectDefinition(
-			9, false, ObjectDefinitionConstants.SCOPE_COMPANY);
-
 		_addAPIApplicationWithPostEndpoint(
-			false, 9, objectDefinition.getExternalReferenceCode());
+			false, 1, _objectDefinition1.getExternalReferenceCode());
 
 		_publishAPIApplication(_API_APPLICATION_ERC_1);
 
@@ -2194,8 +2188,8 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 
 		List<ObjectEntry> objectEntries =
 			_objectEntryLocalService.getObjectEntries(
-				0, objectDefinition.getObjectDefinitionId(), QueryUtil.ALL_POS,
-				QueryUtil.ALL_POS);
+				0, _objectDefinition1.getObjectDefinitionId(),
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 
 		ObjectEntry objectEntry = objectEntries.get(objectEntries.size() - 1);
 

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
@@ -1118,8 +1118,188 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 
 	@Test
 	public void testGetWithPostEndpoint() throws Exception {
-		_addAPIApplicationWithGetAndPostEndpoint(
-			_objectDefinition1.getExternalReferenceCode(), 1);
+		String apiSchemaExternalReferenceCode = RandomTestUtil.randomString();
+
+		assertSuccessfulJSONObject(
+			JSONUtil.put(
+				"apiApplicationToAPIEndpoints",
+				JSONUtil.putAll(
+					// Order is relevant to reproduce the issue
+					_createAPIEndpoint(
+						_API_ENDPOINT_ERC_2, Http.Method.POST,
+						"/testpost", null,
+						APIApplication.Endpoint.RetrieveType.SINGLE_ELEMENT.
+							getValue(),
+						APIApplication.Endpoint.Scope.COMPANY),
+					_createAPIEndpoint(
+						_API_ENDPOINT_ERC_1, Http.Method.GET,
+						"/testget", null,
+						APIApplication.Endpoint.RetrieveType.COLLECTION.
+							getValue(),
+						APIApplication.Endpoint.Scope.COMPANY))
+			).put(
+				"apiApplicationToAPISchemas",
+				JSONUtil.put(
+					JSONUtil.put(
+						"apiSchemaToAPIProperties",
+						JSONUtil.putAll(
+							JSONUtil.put(
+								"description", "description"
+							).put(
+								"name", "attachmentProperty"
+							).put(
+								"objectFieldERC",
+								_API_SCHEMA_ATTACHMENT_FIELD_ERC + 1
+							),
+							JSONUtil.put(
+								"description", "description"
+							).put(
+								"name", "booleanProperty"
+							).put(
+								"objectFieldERC",
+								_API_SCHEMA_BOOLEAN_FIELD_ERC + 1
+							),
+							JSONUtil.put(
+								"description", "description"
+							).put(
+								"name", "dateProperty"
+							).put(
+								"objectFieldERC",
+								_API_SCHEMA_DATE_FIELD_ERC + 1
+							),
+							JSONUtil.put(
+								"description", "description"
+							).put(
+								"name", "dateTimeProperty"
+							).put(
+								"objectFieldERC",
+								_API_SCHEMA_DATE_TIME_FIELD_ERC + 1
+							),
+							JSONUtil.put(
+								"description", "description"
+							).put(
+								"name", "decimalProperty"
+							).put(
+								"objectFieldERC",
+								_API_SCHEMA_DECIMAL_FIELD_ERC + 1
+							),
+							JSONUtil.put(
+								"description", "description"
+							).put(
+								"name", "integerProperty"
+							).put(
+								"objectFieldERC",
+								_API_SCHEMA_INTEGER_FIELD_ERC + 1
+							),
+							JSONUtil.put(
+								"description", "description"
+							).put(
+								"name", "longIntegerProperty"
+							).put(
+								"objectFieldERC",
+								_API_SCHEMA_LONG_INTEGER_FIELD_ERC + 1
+							),
+							JSONUtil.put(
+								"description", "description"
+							).put(
+								"name", "longTextProperty"
+							).put(
+								"objectFieldERC",
+								_API_SCHEMA_LONG_TEXT_FIELD_ERC + 1
+							),
+							JSONUtil.put(
+								"description", "description"
+							).put(
+								"name", "multiselectPicklistProperty"
+							).put(
+								"objectFieldERC",
+								_API_SCHEMA_MULTISELECT_PICKLIST_FIELD_ERC + 1
+							),
+							JSONUtil.put(
+								"description", "description"
+							).put(
+								"name", "picklistProperty"
+							).put(
+								"objectFieldERC",
+								_API_SCHEMA_PICKLIST_FIELD_ERC + 1
+							),
+							JSONUtil.put(
+								"description", "description"
+							).put(
+								"name", "precisionDecimalProperty"
+							).put(
+								"objectFieldERC",
+								_API_SCHEMA_PRECISION_DECIMAL_FIELD_ERC + 1
+							),
+							JSONUtil.put(
+								"description", "description"
+							).put(
+								"name", "richTextProperty"
+							).put(
+								"objectFieldERC",
+								_API_SCHEMA_RICH_TEXT_FIELD_ERC + 1
+							),
+							JSONUtil.put(
+								"description", "description"
+							).put(
+								"name", "textProperty"
+							).put(
+								"objectFieldERC",
+								_API_SCHEMA_TEXT_FIELD_ERC + 1
+							),
+							JSONUtil.put(
+								"description", "description"
+							).put(
+								"name", "textUniqueProperty"
+							).put(
+								"objectFieldERC",
+								_API_SCHEMA_UNIQUE_TEXT_FIELD_ERC + 1
+							))
+					).put(
+						"description", "description"
+					).put(
+						"externalReferenceCode", apiSchemaExternalReferenceCode
+					).put(
+						"mainObjectDefinitionERC",
+						_objectDefinition1.getExternalReferenceCode()
+					).put(
+						"name", "name"
+					))
+			).put(
+				"applicationStatus", "unpublished"
+			).put(
+				"baseURL", _BASE_URL_1
+			).put(
+				"externalReferenceCode",
+				_API_APPLICATION_ERC_1
+			).put(
+				"title", RandomTestUtil.randomString()
+			).toString(),
+			"headless-builder/applications", Http.Method.POST);
+
+		assertSuccessfulJSONObject(
+			null,
+			StringBundler.concat(
+				"headless-builder/schemas/by-external-reference-code/",
+				apiSchemaExternalReferenceCode,
+				"/responseAPISchemaToAPIEndpoints/", _API_ENDPOINT_ERC_1),
+			Http.Method.PUT);
+
+		assertSuccessfulJSONObject(
+			null,
+			StringBundler.concat(
+				"headless-builder/schemas/by-external-reference-code/",
+				apiSchemaExternalReferenceCode,
+				"/requestAPISchemaToAPIEndpoints/", _API_ENDPOINT_ERC_2),
+			Http.Method.PUT);
+
+		assertSuccessfulJSONObject(
+			null,
+			StringBundler.concat(
+				"headless-builder/schemas/by-external-reference-code/",
+				apiSchemaExternalReferenceCode,
+				"/responseAPISchemaToAPIEndpoints/", _API_ENDPOINT_ERC_2),
+			Http.Method.PUT);
 
 		_publishAPIApplication(_API_APPLICATION_ERC_1);
 
@@ -2217,194 +2397,6 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 
 		_relateAPIEndpointWithAPISchemas(
 			apiEndpointExternalReferenceCode, apiSchemaExternalReferenceCode);
-	}
-
-	private void _addAPIApplicationWithGetAndPostEndpoint(
-			String objectDefinitionExternalReferenceCode, int index)
-		throws Exception {
-
-		String apiSchemaExternalReferenceCode = RandomTestUtil.randomString();
-
-		assertSuccessfulJSONObject(
-			JSONUtil.put(
-				"apiApplicationToAPIEndpoints",
-				JSONUtil.putAll(
-					// Order is relevant to reproduce the issue
-					_createAPIEndpoint(
-						_API_ENDPOINT_ERC_2, Http.Method.POST,
-						"/testpost", null,
-						APIApplication.Endpoint.RetrieveType.SINGLE_ELEMENT.
-							getValue(),
-						APIApplication.Endpoint.Scope.COMPANY),
-					_createAPIEndpoint(
-						_API_ENDPOINT_ERC_1, Http.Method.GET,
-						"/testget", null,
-						APIApplication.Endpoint.RetrieveType.COLLECTION.
-							getValue(),
-						APIApplication.Endpoint.Scope.COMPANY))
-			).put(
-				"apiApplicationToAPISchemas",
-				JSONUtil.put(
-					JSONUtil.put(
-						"apiSchemaToAPIProperties",
-						JSONUtil.putAll(
-							JSONUtil.put(
-								"description", "description"
-							).put(
-								"name", "attachmentProperty"
-							).put(
-								"objectFieldERC",
-								_API_SCHEMA_ATTACHMENT_FIELD_ERC + index
-							),
-							JSONUtil.put(
-								"description", "description"
-							).put(
-								"name", "booleanProperty"
-							).put(
-								"objectFieldERC",
-								_API_SCHEMA_BOOLEAN_FIELD_ERC + index
-							),
-							JSONUtil.put(
-								"description", "description"
-							).put(
-								"name", "dateProperty"
-							).put(
-								"objectFieldERC",
-								_API_SCHEMA_DATE_FIELD_ERC + index
-							),
-							JSONUtil.put(
-								"description", "description"
-							).put(
-								"name", "dateTimeProperty"
-							).put(
-								"objectFieldERC",
-								_API_SCHEMA_DATE_TIME_FIELD_ERC + index
-							),
-							JSONUtil.put(
-								"description", "description"
-							).put(
-								"name", "decimalProperty"
-							).put(
-								"objectFieldERC",
-								_API_SCHEMA_DECIMAL_FIELD_ERC + index
-							),
-							JSONUtil.put(
-								"description", "description"
-							).put(
-								"name", "integerProperty"
-							).put(
-								"objectFieldERC",
-								_API_SCHEMA_INTEGER_FIELD_ERC + index
-							),
-							JSONUtil.put(
-								"description", "description"
-							).put(
-								"name", "longIntegerProperty"
-							).put(
-								"objectFieldERC",
-								_API_SCHEMA_LONG_INTEGER_FIELD_ERC + index
-							),
-							JSONUtil.put(
-								"description", "description"
-							).put(
-								"name", "longTextProperty"
-							).put(
-								"objectFieldERC",
-								_API_SCHEMA_LONG_TEXT_FIELD_ERC + index
-							),
-							JSONUtil.put(
-								"description", "description"
-							).put(
-								"name", "multiselectPicklistProperty"
-							).put(
-								"objectFieldERC",
-								_API_SCHEMA_MULTISELECT_PICKLIST_FIELD_ERC + index
-							),
-							JSONUtil.put(
-								"description", "description"
-							).put(
-								"name", "picklistProperty"
-							).put(
-								"objectFieldERC",
-								_API_SCHEMA_PICKLIST_FIELD_ERC + index
-							),
-							JSONUtil.put(
-								"description", "description"
-							).put(
-								"name", "precisionDecimalProperty"
-							).put(
-								"objectFieldERC",
-								_API_SCHEMA_PRECISION_DECIMAL_FIELD_ERC + index
-							),
-							JSONUtil.put(
-								"description", "description"
-							).put(
-								"name", "richTextProperty"
-							).put(
-								"objectFieldERC",
-								_API_SCHEMA_RICH_TEXT_FIELD_ERC + index
-							),
-							JSONUtil.put(
-								"description", "description"
-							).put(
-								"name", "textProperty"
-							).put(
-								"objectFieldERC",
-								_API_SCHEMA_TEXT_FIELD_ERC + index
-							),
-							JSONUtil.put(
-								"description", "description"
-							).put(
-								"name", "textUniqueProperty"
-							).put(
-								"objectFieldERC",
-								_API_SCHEMA_UNIQUE_TEXT_FIELD_ERC + index
-							))
-					).put(
-						"description", "description"
-					).put(
-						"externalReferenceCode", apiSchemaExternalReferenceCode
-					).put(
-						"mainObjectDefinitionERC",
-						objectDefinitionExternalReferenceCode
-					).put(
-						"name", "name"
-					))
-			).put(
-				"applicationStatus", "unpublished"
-			).put(
-				"baseURL", _BASE_URL_1
-			).put(
-				"externalReferenceCode",
-				_API_APPLICATION_ERC_1
-			).put(
-				"title", RandomTestUtil.randomString()
-			).toString(),
-			"headless-builder/applications", Http.Method.POST);
-
-		assertSuccessfulJSONObject(
-			null,
-			StringBundler.concat(
-				"headless-builder/schemas/by-external-reference-code/",
-				apiSchemaExternalReferenceCode,
-				"/responseAPISchemaToAPIEndpoints/", _API_ENDPOINT_ERC_1),
-			Http.Method.PUT);
-
-		assertSuccessfulJSONObject(
-			null,
-			StringBundler.concat(
-				"headless-builder/schemas/by-external-reference-code/",
-				apiSchemaExternalReferenceCode,
-				"/requestAPISchemaToAPIEndpoints/", _API_ENDPOINT_ERC_2),
-			Http.Method.PUT);
-
-		assertSuccessfulJSONObject(
-			null,
-			StringBundler.concat(
-				"headless-builder/schemas/by-external-reference-code/",
-				apiSchemaExternalReferenceCode,
-				"/responseAPISchemaToAPIEndpoints/", _API_ENDPOINT_ERC_2),
-			Http.Method.PUT);
 	}
 
 	private void _addAPIApplicationWithPostEndpoint(

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
@@ -2018,7 +2018,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 	@Test
 	public void testPostWithAllFields() throws Exception {
 		_addAPIApplicationWithPostEndpoint(
-			true, 1, _objectDefinition1.getExternalReferenceCode());
+			true, _objectDefinition1.getExternalReferenceCode());
 
 		_publishAPIApplication(_API_APPLICATION_ERC_1);
 
@@ -2247,7 +2247,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 	@Test
 	public void testPostWithoutResponseSchema() throws Exception {
 		_addAPIApplicationWithPostEndpoint(
-			false, 1, _objectDefinition1.getExternalReferenceCode());
+			false, _objectDefinition1.getExternalReferenceCode());
 
 		_publishAPIApplication(_API_APPLICATION_ERC_1);
 
@@ -2448,7 +2448,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 	}
 
 	private void _addAPIApplicationWithPostEndpoint(
-			boolean addResponseSchema, int index,
+			boolean addResponseSchema,
 			String objectDefinitionExternalReferenceCode)
 		throws Exception {
 
@@ -2476,7 +2476,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 								"name", "attachmentProperty"
 							).put(
 								"objectFieldERC",
-								_API_SCHEMA_ATTACHMENT_FIELD_ERC + index
+								_API_SCHEMA_ATTACHMENT_FIELD_ERC + 1
 							),
 							JSONUtil.put(
 								"description", "description"
@@ -2484,15 +2484,14 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 								"name", "booleanProperty"
 							).put(
 								"objectFieldERC",
-								_API_SCHEMA_BOOLEAN_FIELD_ERC + index
+								_API_SCHEMA_BOOLEAN_FIELD_ERC + 1
 							),
 							JSONUtil.put(
 								"description", "description"
 							).put(
 								"name", "dateProperty"
 							).put(
-								"objectFieldERC",
-								_API_SCHEMA_DATE_FIELD_ERC + index
+								"objectFieldERC", _API_SCHEMA_DATE_FIELD_ERC + 1
 							),
 							JSONUtil.put(
 								"description", "description"
@@ -2500,7 +2499,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 								"name", "dateTimeProperty"
 							).put(
 								"objectFieldERC",
-								_API_SCHEMA_DATE_TIME_FIELD_ERC + index
+								_API_SCHEMA_DATE_TIME_FIELD_ERC + 1
 							),
 							JSONUtil.put(
 								"description", "description"
@@ -2508,7 +2507,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 								"name", "decimalProperty"
 							).put(
 								"objectFieldERC",
-								_API_SCHEMA_DECIMAL_FIELD_ERC + index
+								_API_SCHEMA_DECIMAL_FIELD_ERC + 1
 							),
 							JSONUtil.put(
 								"description", "description"
@@ -2516,7 +2515,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 								"name", "integerProperty"
 							).put(
 								"objectFieldERC",
-								_API_SCHEMA_INTEGER_FIELD_ERC + index
+								_API_SCHEMA_INTEGER_FIELD_ERC + 1
 							),
 							JSONUtil.put(
 								"description", "description"
@@ -2524,7 +2523,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 								"name", "longIntegerProperty"
 							).put(
 								"objectFieldERC",
-								_API_SCHEMA_LONG_INTEGER_FIELD_ERC + index
+								_API_SCHEMA_LONG_INTEGER_FIELD_ERC + 1
 							),
 							JSONUtil.put(
 								"description", "description"
@@ -2532,7 +2531,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 								"name", "longTextProperty"
 							).put(
 								"objectFieldERC",
-								_API_SCHEMA_LONG_TEXT_FIELD_ERC + index
+								_API_SCHEMA_LONG_TEXT_FIELD_ERC + 1
 							),
 							JSONUtil.put(
 								"description", "description"
@@ -2540,8 +2539,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 								"name", "multiselectPicklistProperty"
 							).put(
 								"objectFieldERC",
-								_API_SCHEMA_MULTISELECT_PICKLIST_FIELD_ERC +
-									index
+								_API_SCHEMA_MULTISELECT_PICKLIST_FIELD_ERC + 1
 							),
 							JSONUtil.put(
 								"description", "description"
@@ -2549,7 +2547,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 								"name", "picklistProperty"
 							).put(
 								"objectFieldERC",
-								_API_SCHEMA_PICKLIST_FIELD_ERC + index
+								_API_SCHEMA_PICKLIST_FIELD_ERC + 1
 							),
 							JSONUtil.put(
 								"description", "description"
@@ -2557,7 +2555,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 								"name", "precisionDecimalProperty"
 							).put(
 								"objectFieldERC",
-								_API_SCHEMA_PRECISION_DECIMAL_FIELD_ERC + index
+								_API_SCHEMA_PRECISION_DECIMAL_FIELD_ERC + 1
 							),
 							JSONUtil.put(
 								"description", "description"
@@ -2565,15 +2563,14 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 								"name", "richTextProperty"
 							).put(
 								"objectFieldERC",
-								_API_SCHEMA_RICH_TEXT_FIELD_ERC + index
+								_API_SCHEMA_RICH_TEXT_FIELD_ERC + 1
 							),
 							JSONUtil.put(
 								"description", "description"
 							).put(
 								"name", "textProperty"
 							).put(
-								"objectFieldERC",
-								_API_SCHEMA_TEXT_FIELD_ERC + index
+								"objectFieldERC", _API_SCHEMA_TEXT_FIELD_ERC + 1
 							),
 							JSONUtil.put(
 								"description", "description"
@@ -2581,7 +2578,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 								"name", "textUniqueProperty"
 							).put(
 								"objectFieldERC",
-								_API_SCHEMA_UNIQUE_TEXT_FIELD_ERC + index
+								_API_SCHEMA_UNIQUE_TEXT_FIELD_ERC + 1
 							))
 					).put(
 						"description", "description"

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
@@ -385,9 +385,14 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 			APIApplication.Endpoint.RetrieveType.COLLECTION.getValue(),
 			APIApplication.Endpoint.Scope.COMPANY);
 
-		_addAPIFilter(
-			_API_ENDPOINT_ERC_1,
-			"textField eq 'value5' or textField eq 'value7'");
+		assertSuccessfulJSONObject(
+			JSONUtil.put(
+				"oDataFilter", "textField eq 'value5' or textField eq 'value7'"
+			).put(
+				"r_apiEndpointToAPIFilters_c_apiEndpointERC",
+				HeadlessBuilderResourceTest._API_ENDPOINT_ERC_1
+			).toString(),
+			"headless-builder/filters", Http.Method.POST);
 
 		_publishAPIApplication(_API_APPLICATION_ERC_1);
 
@@ -452,7 +457,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 			APIApplication.Endpoint.RetrieveType.COLLECTION.getValue(),
 			APIApplication.Endpoint.Scope.COMPANY);
 
-		_addAPISort(_API_ENDPOINT_ERC_1, "textField:asc");
+		_addAPISort("textField:asc");
 
 		_publishAPIApplication(_API_APPLICATION_ERC_1);
 
@@ -637,7 +642,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 			APIApplication.Endpoint.RetrieveType.COLLECTION.getValue(),
 			APIApplication.Endpoint.Scope.COMPANY);
 
-		_addAPISort(_API_ENDPOINT_ERC_1, "textField:desc");
+		_addAPISort("textField:desc");
 
 		_publishAPIApplication(_API_APPLICATION_ERC_1);
 
@@ -1043,11 +1048,70 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 			objectDefinition2, objectDefinition3,
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
-		_addAPIApplication(
-			_API_APPLICATION_ERC_1, _API_ENDPOINT_ERC_1, _BASE_URL_1,
-			objectDefinition1.getExternalReferenceCode(),
-			objectRelationship1.getName(), objectRelationship2.getName(),
-			_API_APPLICATION_PATH_1);
+		String apiSchemaExternalReferenceCode = RandomTestUtil.randomString();
+
+		assertSuccessfulJSONObject(
+			JSONUtil.put(
+				"apiApplicationToAPIEndpoints",
+				JSONUtil.putAll(
+					_createAPIEndpoint(
+						HeadlessBuilderResourceTest._API_ENDPOINT_ERC_1,
+						Http.Method.GET,
+						HeadlessBuilderResourceTest._API_APPLICATION_PATH_1,
+						null,
+						APIApplication.Endpoint.RetrieveType.COLLECTION.
+							getValue(),
+						APIApplication.Endpoint.Scope.COMPANY))
+			).put(
+				"apiApplicationToAPISchemas",
+				JSONUtil.put(
+					JSONUtil.put(
+						"apiSchemaToAPIProperties",
+						JSONUtil.putAll(
+							JSONUtil.put(
+								"description", "description"
+							).put(
+								"name", "integerProperty4"
+							).put(
+								"objectFieldERC",
+								_API_SCHEMA_INTEGER_FIELD_ERC + 4
+							),
+							JSONUtil.put(
+								"description", "description"
+							).put(
+								"name", "relatedTextProperty6"
+							).put(
+								"objectFieldERC", _API_SCHEMA_TEXT_FIELD_ERC + 6
+							).put(
+								"objectRelationshipNames",
+								objectRelationship1.getName() + "," +
+									objectRelationship2.getName()
+							))
+					).put(
+						"description", "description"
+					).put(
+						"externalReferenceCode", apiSchemaExternalReferenceCode
+					).put(
+						"mainObjectDefinitionERC",
+						objectDefinition1.getExternalReferenceCode()
+					).put(
+						"name", "name"
+					))
+			).put(
+				"applicationStatus", "unpublished"
+			).put(
+				"baseURL", HeadlessBuilderResourceTest._BASE_URL_1
+			).put(
+				"externalReferenceCode",
+				HeadlessBuilderResourceTest._API_APPLICATION_ERC_1
+			).put(
+				"title", RandomTestUtil.randomString()
+			).toString(),
+			"headless-builder/applications", Http.Method.POST);
+
+		_relateAPIEndpointWithAPISchemas(
+			HeadlessBuilderResourceTest._API_ENDPOINT_ERC_1,
+			apiSchemaExternalReferenceCode);
 
 		_publishAPIApplication(_API_APPLICATION_ERC_1);
 
@@ -1865,14 +1929,68 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 			_objectFieldLocalService.getObjectField(
 				_objectDefinition1.getObjectDefinitionId(), "id");
 
-		_addAPIApplication(
-			_API_APPLICATION_ERC_1, _API_ENDPOINT_ERC_1, _BASE_URL_1,
-			_objectDefinition1.getExternalReferenceCode(),
-			_API_APPLICATION_PATH_1, null,
-			APIApplication.Endpoint.RetrieveType.COLLECTION.getValue(),
-			APIApplication.Endpoint.Scope.COMPANY,
-			systemObjectFieldCreator.getExternalReferenceCode(),
-			systemObjectFieldId.getExternalReferenceCode());
+		String apiSchemaExternalReferenceCode = RandomTestUtil.randomString();
+
+		assertSuccessfulJSONObject(
+			JSONUtil.put(
+				"apiApplicationToAPIEndpoints",
+				JSONUtil.putAll(
+					_createAPIEndpoint(
+						HeadlessBuilderResourceTest._API_ENDPOINT_ERC_1,
+						Http.Method.GET,
+						HeadlessBuilderResourceTest._API_APPLICATION_PATH_1,
+						null,
+						APIApplication.Endpoint.RetrieveType.COLLECTION.
+							getValue(),
+						APIApplication.Endpoint.Scope.COMPANY))
+			).put(
+				"apiApplicationToAPISchemas",
+				JSONUtil.put(
+					JSONUtil.put(
+						"apiSchemaToAPIProperties",
+						JSONUtil.putAll(
+							JSONUtil.put(
+								"description", "description"
+							).put(
+								"name", "id"
+							).put(
+								"objectFieldERC",
+								systemObjectFieldId.getExternalReferenceCode()
+							),
+							JSONUtil.put(
+								"description", "description"
+							).put(
+								"name", "creator"
+							).put(
+								"objectFieldERC",
+								systemObjectFieldCreator.
+									getExternalReferenceCode()
+							))
+					).put(
+						"description", "description"
+					).put(
+						"externalReferenceCode", apiSchemaExternalReferenceCode
+					).put(
+						"mainObjectDefinitionERC",
+						_objectDefinition1.getExternalReferenceCode()
+					).put(
+						"name", "name"
+					))
+			).put(
+				"applicationStatus", "unpublished"
+			).put(
+				"baseURL", HeadlessBuilderResourceTest._BASE_URL_1
+			).put(
+				"externalReferenceCode",
+				HeadlessBuilderResourceTest._API_APPLICATION_ERC_1
+			).put(
+				"title", RandomTestUtil.randomString()
+			).toString(),
+			"headless-builder/applications", Http.Method.POST);
+
+		_relateAPIEndpointWithAPISchemas(
+			HeadlessBuilderResourceTest._API_ENDPOINT_ERC_1,
+			apiSchemaExternalReferenceCode);
 
 		_publishAPIApplication(_API_APPLICATION_ERC_1);
 
@@ -1903,9 +2021,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 			7, true, ObjectDefinitionConstants.SCOPE_COMPANY);
 
 		_addAPIApplicationWithPostEndpoint(
-			true, _API_APPLICATION_ERC_1, _API_ENDPOINT_ERC_1, _BASE_URL_1, 7,
-			objectDefinition.getExternalReferenceCode(), "/test",
-			APIApplication.Endpoint.Scope.COMPANY);
+			true, 7, objectDefinition.getExternalReferenceCode());
 
 		_publishAPIApplication(_API_APPLICATION_ERC_1);
 
@@ -2031,9 +2147,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 			8, true, ObjectDefinitionConstants.SCOPE_COMPANY);
 
 		_addAPIApplicationWithPostEndpoint(
-			true, _API_APPLICATION_ERC_1, _API_ENDPOINT_ERC_1, _BASE_URL_1, 8,
-			objectDefinition.getExternalReferenceCode(), "/test",
-			APIApplication.Endpoint.Scope.COMPANY);
+			true, 8, objectDefinition.getExternalReferenceCode());
 
 		_publishAPIApplication(_API_APPLICATION_ERC_1);
 
@@ -2061,9 +2175,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 			9, false, ObjectDefinitionConstants.SCOPE_COMPANY);
 
 		_addAPIApplicationWithPostEndpoint(
-			false, _API_APPLICATION_ERC_1, _API_ENDPOINT_ERC_1, _BASE_URL_1, 9,
-			objectDefinition.getExternalReferenceCode(), "/test",
-			APIApplication.Endpoint.Scope.COMPANY);
+			false, 9, objectDefinition.getExternalReferenceCode());
 
 		_publishAPIApplication(_API_APPLICATION_ERC_1);
 
@@ -2114,142 +2226,6 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 
 		ObjectFieldTestUtil.addCustomObjectField(
 			TestPropsValues.getUserId(), aggregationObjectField);
-	}
-
-	private void _addAPIApplication(
-			String apiApplicationExternalReferenceCode,
-			String apiEndpointExternalReferenceCode, String baseURL,
-			String objectDefinitionExternalReferenceCode,
-			String objectRelationshipName1, String objectRelationshipName2,
-			String path)
-		throws Exception {
-
-		String apiSchemaExternalReferenceCode = RandomTestUtil.randomString();
-
-		assertSuccessfulJSONObject(
-			JSONUtil.put(
-				"apiApplicationToAPIEndpoints",
-				JSONUtil.putAll(
-					_createAPIEndpoint(
-						apiEndpointExternalReferenceCode, Http.Method.GET, path,
-						null,
-						APIApplication.Endpoint.RetrieveType.COLLECTION.
-							getValue(),
-						APIApplication.Endpoint.Scope.COMPANY))
-			).put(
-				"apiApplicationToAPISchemas",
-				JSONUtil.put(
-					JSONUtil.put(
-						"apiSchemaToAPIProperties",
-						JSONUtil.putAll(
-							JSONUtil.put(
-								"description", "description"
-							).put(
-								"name", "integerProperty4"
-							).put(
-								"objectFieldERC",
-								_API_SCHEMA_INTEGER_FIELD_ERC + 4
-							),
-							JSONUtil.put(
-								"description", "description"
-							).put(
-								"name", "relatedTextProperty6"
-							).put(
-								"objectFieldERC", _API_SCHEMA_TEXT_FIELD_ERC + 6
-							).put(
-								"objectRelationshipNames",
-								objectRelationshipName1 + "," +
-									objectRelationshipName2
-							))
-					).put(
-						"description", "description"
-					).put(
-						"externalReferenceCode", apiSchemaExternalReferenceCode
-					).put(
-						"mainObjectDefinitionERC",
-						objectDefinitionExternalReferenceCode
-					).put(
-						"name", "name"
-					))
-			).put(
-				"applicationStatus", "unpublished"
-			).put(
-				"baseURL", baseURL
-			).put(
-				"externalReferenceCode", apiApplicationExternalReferenceCode
-			).put(
-				"title", RandomTestUtil.randomString()
-			).toString(),
-			"headless-builder/applications", Http.Method.POST);
-
-		_relateAPIEndpointWithAPISchemas(
-			apiEndpointExternalReferenceCode, apiSchemaExternalReferenceCode);
-	}
-
-	private void _addAPIApplication(
-			String apiApplicationExternalReferenceCode,
-			String apiEndpointExternalReferenceCode, String baseURL,
-			String objectDefinitionExternalReferenceCode, String path,
-			String pathParameter, String retrieveType,
-			APIApplication.Endpoint.Scope scope,
-			String systemObjectFieldCreatorExternalReferenceCode,
-			String systemObjectFieldIdExternalReferenceCode)
-		throws Exception {
-
-		String apiSchemaExternalReferenceCode = RandomTestUtil.randomString();
-
-		assertSuccessfulJSONObject(
-			JSONUtil.put(
-				"apiApplicationToAPIEndpoints",
-				JSONUtil.putAll(
-					_createAPIEndpoint(
-						apiEndpointExternalReferenceCode, Http.Method.GET, path,
-						pathParameter, retrieveType, scope))
-			).put(
-				"apiApplicationToAPISchemas",
-				JSONUtil.put(
-					JSONUtil.put(
-						"apiSchemaToAPIProperties",
-						JSONUtil.putAll(
-							JSONUtil.put(
-								"description", "description"
-							).put(
-								"name", "id"
-							).put(
-								"objectFieldERC",
-								systemObjectFieldIdExternalReferenceCode
-							),
-							JSONUtil.put(
-								"description", "description"
-							).put(
-								"name", "creator"
-							).put(
-								"objectFieldERC",
-								systemObjectFieldCreatorExternalReferenceCode
-							))
-					).put(
-						"description", "description"
-					).put(
-						"externalReferenceCode", apiSchemaExternalReferenceCode
-					).put(
-						"mainObjectDefinitionERC",
-						objectDefinitionExternalReferenceCode
-					).put(
-						"name", "name"
-					))
-			).put(
-				"applicationStatus", "unpublished"
-			).put(
-				"baseURL", baseURL
-			).put(
-				"externalReferenceCode", apiApplicationExternalReferenceCode
-			).put(
-				"title", RandomTestUtil.randomString()
-			).toString(),
-			"headless-builder/applications", Http.Method.POST);
-
-		_relateAPIEndpointWithAPISchemas(
-			apiEndpointExternalReferenceCode, apiSchemaExternalReferenceCode);
 	}
 
 	private void _addAPIApplication(
@@ -2400,11 +2376,8 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 	}
 
 	private void _addAPIApplicationWithPostEndpoint(
-			boolean addResponseSchema,
-			String apiApplicationExternalReferenceCode,
-			String apiEndpointExternalReferenceCode, String baseURL, int index,
-			String objectDefinitionExternalReferenceCode, String path,
-			APIApplication.Endpoint.Scope scope)
+			boolean addResponseSchema, int index,
+			String objectDefinitionExternalReferenceCode)
 		throws Exception {
 
 		String apiSchemaExternalReferenceCode = RandomTestUtil.randomString();
@@ -2414,11 +2387,11 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 				"apiApplicationToAPIEndpoints",
 				JSONUtil.putAll(
 					_createAPIEndpoint(
-						apiEndpointExternalReferenceCode, Http.Method.POST,
-						path, null,
+						HeadlessBuilderResourceTest._API_ENDPOINT_ERC_1,
+						Http.Method.POST, "/test", null,
 						APIApplication.Endpoint.RetrieveType.SINGLE_ELEMENT.
 							getValue(),
-						scope))
+						APIApplication.Endpoint.Scope.COMPANY))
 			).put(
 				"apiApplicationToAPISchemas",
 				JSONUtil.put(
@@ -2551,9 +2524,10 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 			).put(
 				"applicationStatus", "unpublished"
 			).put(
-				"baseURL", baseURL
+				"baseURL", HeadlessBuilderResourceTest._BASE_URL_1
 			).put(
-				"externalReferenceCode", apiApplicationExternalReferenceCode
+				"externalReferenceCode",
+				HeadlessBuilderResourceTest._API_APPLICATION_ERC_1
 			).put(
 				"title", RandomTestUtil.randomString()
 			).toString(),
@@ -2565,7 +2539,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 				"headless-builder/schemas/by-external-reference-code/",
 				apiSchemaExternalReferenceCode,
 				"/requestAPISchemaToAPIEndpoints/",
-				apiEndpointExternalReferenceCode),
+				HeadlessBuilderResourceTest._API_ENDPOINT_ERC_1),
 			Http.Method.PUT);
 
 		if (addResponseSchema) {
@@ -2575,35 +2549,18 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 					"headless-builder/schemas/by-external-reference-code/",
 					apiSchemaExternalReferenceCode,
 					"/responseAPISchemaToAPIEndpoints/",
-					apiEndpointExternalReferenceCode),
+					HeadlessBuilderResourceTest._API_ENDPOINT_ERC_1),
 				Http.Method.PUT);
 		}
 	}
 
-	private void _addAPIFilter(
-			String apiEndpointExternalReferenceCode, String filterString)
-		throws Exception {
-
-		assertSuccessfulJSONObject(
-			JSONUtil.put(
-				"oDataFilter", filterString
-			).put(
-				"r_apiEndpointToAPIFilters_c_apiEndpointERC",
-				apiEndpointExternalReferenceCode
-			).toString(),
-			"headless-builder/filters", Http.Method.POST);
-	}
-
-	private void _addAPISort(
-			String apiEndpointExternalReferenceCode, String sortString)
-		throws Exception {
-
+	private void _addAPISort(String sortString) throws Exception {
 		assertSuccessfulJSONObject(
 			JSONUtil.put(
 				"oDataSort", sortString
 			).put(
 				"r_apiEndpointToAPISorts_c_apiEndpointERC",
-				apiEndpointExternalReferenceCode
+				HeadlessBuilderResourceTest._API_ENDPOINT_ERC_1
 			).toString(),
 			"headless-builder/sorts", Http.Method.POST);
 	}

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
@@ -1717,6 +1717,36 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 		Assert.assertEquals(objectEntries.toString(), 1, objectEntries.size());
 	}
 
+	@Test
+	public void testPostWithObjectException() throws Exception {
+		ObjectDefinition objectDefinition = _addObjectDefinition(
+			8, true, ObjectDefinitionConstants.SCOPE_COMPANY);
+
+		_addAPIApplicationWithPostEndpoint(
+			_API_APPLICATION_ERC_1, _API_ENDPOINT_ERC_1, _BASE_URL_1, 8,
+			objectDefinition.getExternalReferenceCode(), "/test",
+			APIApplication.Endpoint.Scope.COMPANY);
+
+		_publishAPIApplication(_API_APPLICATION_ERC_1);
+
+		JSONAssert.assertEquals(
+			JSONUtil.put(
+				"status", "BAD_REQUEST"
+			).put(
+				"title",
+				"No value was provided for required object field " +
+					"\"richTextField\""
+			).toString(),
+			HTTPTestUtil.invokeToJSONObject(
+				JSONUtil.put(
+					"booleanProperty", RandomTestUtil.randomBoolean()
+				).toString(),
+				StringBundler.concat("c/", _BASE_URL_1, "/test"),
+				Http.Method.POST
+			).toString(),
+			JSONCompareMode.STRICT);
+	}
+
 	private void _addAggregationObjectField(
 			ObjectDefinition objectDefinition, String relationshipName)
 		throws Exception {

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
@@ -1122,9 +1122,10 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 			10, true, ObjectDefinitionConstants.SCOPE_COMPANY);
 
 		_addAPIApplicationWithGetAndPostEndpoint(
-			_API_APPLICATION_ERC_1, _API_ENDPOINT_ERC_1, _API_ENDPOINT_ERC_2,
-			_BASE_URL_1, 10, objectDefinition.getExternalReferenceCode(),
-			"/testget", "/testpost", APIApplication.Endpoint.Scope.COMPANY);
+			_API_APPLICATION_ERC_1, _BASE_URL_1, _API_ENDPOINT_ERC_1, 10,
+			objectDefinition.getExternalReferenceCode(), "/testget",
+			"/testpost", _API_ENDPOINT_ERC_2,
+			APIApplication.Endpoint.Scope.COMPANY);
 
 		_publishAPIApplication(_API_APPLICATION_ERC_1);
 
@@ -2225,11 +2226,10 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 	}
 
 	private void _addAPIApplicationWithGetAndPostEndpoint(
-			String apiApplicationExternalReferenceCode,
-			String getAPIEndpointExternalReferenceCode,
-			String postAPIEndpointExternalReferenceCode, String baseURL,
-			int index, String objectDefinitionExternalReferenceCode,
-			String pathGet, String pathPost,
+			String apiApplicationExternalReferenceCode, String baseURL,
+			String getAPIEndpointExternalReferenceCode, int index,
+			String objectDefinitionExternalReferenceCode, String pathGet,
+			String pathPost, String postAPIEndpointExternalReferenceCode,
 			APIApplication.Endpoint.Scope scope)
 		throws Exception {
 

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
@@ -1117,7 +1117,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 	}
 
 	@Test
-	public void testGetWithPostEndpointPresent() throws Exception {
+	public void testGetWithPostEndpoint() throws Exception {
 		ObjectDefinition objectDefinition = _addObjectDefinition(
 			10, true, ObjectDefinitionConstants.SCOPE_COMPANY);
 

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
@@ -1117,6 +1117,138 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 	}
 
 	@Test
+	public void testGetWithPostEndpointPresent() throws Exception {
+		ObjectDefinition objectDefinition = _addObjectDefinition(
+			10, true, ObjectDefinitionConstants.SCOPE_COMPANY);
+
+		_addAPIApplicationWithGetAndPostEndpoint(
+			_API_APPLICATION_ERC_1, _API_ENDPOINT_ERC_1, _API_ENDPOINT_ERC_2,
+			_BASE_URL_1, 10, objectDefinition.getExternalReferenceCode(),
+			"/testget", "/testpost", APIApplication.Endpoint.Scope.COMPANY);
+
+		_publishAPIApplication(_API_APPLICATION_ERC_1);
+
+		Document document = _addRandomDocument();
+
+		long attachmentPropertyIdValue = document.getId();
+
+		boolean booleanPropertyValue = RandomTestUtil.randomBoolean();
+		String datePropertyValue = _dateFormat.format(
+			RandomTestUtil.nextDate());
+		String dateTimePropertyValue = _dateTimeFormat.format(
+			RandomTestUtil.nextDate());
+		double decimalPropertyValue = RandomTestUtil.randomDouble();
+		int integerPropertyValue = RandomTestUtil.randomInt();
+		long longIntegerPropertyValue = RandomTestUtil.randomLong(
+			ObjectFieldValidationConstants.BUSINESS_TYPE_LONG_VALUE_MIN,
+			ObjectFieldValidationConstants.BUSINESS_TYPE_LONG_VALUE_MAX);
+		String longTextPropertyValue = RandomTestUtil.randomString();
+		Serializable multiselectPicklistPropertyValue =
+			(Serializable)TransformUtil.transform(
+				Arrays.asList(ListTypeValue.VALUE1, ListTypeValue.VALUE3),
+				ListTypeValue::name);
+		String picklistPropertyValue = ListTypeValue.VALUE1.name();
+		double precisionDecimalPropertyValue = 1.1;
+		String richTextPropertyValue = RandomTestUtil.randomString();
+		String textPropertyValue = RandomTestUtil.randomString();
+		String textUniquePropertyValue = "Unique field value";
+
+		JSONObject expectedJSONObject = JSONUtil.put(
+			"attachmentProperty", JSONUtil.put("id", attachmentPropertyIdValue)
+		).put(
+			"booleanProperty", booleanPropertyValue
+		).put(
+			"dateProperty", datePropertyValue
+		).put(
+			"dateTimeProperty", dateTimePropertyValue
+		).put(
+			"decimalProperty", decimalPropertyValue
+		).put(
+			"integerProperty", integerPropertyValue
+		).put(
+			"longIntegerProperty", (Long)longIntegerPropertyValue
+		).put(
+			"longTextProperty", longTextPropertyValue
+		).put(
+			"multiselectPicklistProperty",
+			JSONUtil.putAll(
+				JSONUtil.put(
+					"key", ListTypeValue.VALUE1
+				).put(
+					"name", ListTypeValue.VALUE1
+				),
+				JSONUtil.put(
+					"key", ListTypeValue.VALUE3
+				).put(
+					"name", ListTypeValue.VALUE3
+				))
+		).put(
+			"picklistProperty",
+			JSONUtil.put(
+				"key", ListTypeValue.VALUE1
+			).put(
+				"name", ListTypeValue.VALUE1
+			)
+		).put(
+			"precisionDecimalProperty", precisionDecimalPropertyValue
+		).put(
+			"richTextProperty", richTextPropertyValue
+		).put(
+			"textProperty", textPropertyValue
+		).put(
+			"textUniqueProperty", textUniquePropertyValue
+		);
+
+		JSONAssert.assertEquals(
+			expectedJSONObject.toString(),
+			HTTPTestUtil.invokeToJSONObject(
+				JSONUtil.put(
+					"attachmentProperty", attachmentPropertyIdValue
+				).put(
+					"booleanProperty", booleanPropertyValue
+				).put(
+					"dateProperty", datePropertyValue
+				).put(
+					"dateTimeProperty", dateTimePropertyValue
+				).put(
+					"decimalProperty", decimalPropertyValue
+				).put(
+					"integerProperty", integerPropertyValue
+				).put(
+					"longIntegerProperty", longIntegerPropertyValue
+				).put(
+					"longTextProperty", longTextPropertyValue
+				).put(
+					"multiselectPicklistProperty",
+					multiselectPicklistPropertyValue
+				).put(
+					"picklistProperty", picklistPropertyValue
+				).put(
+					"precisionDecimalProperty", precisionDecimalPropertyValue
+				).put(
+					"richTextProperty", richTextPropertyValue
+				).put(
+					"textProperty", textPropertyValue
+				).put(
+					"textUniqueProperty", textUniquePropertyValue
+				).toString(),
+				StringBundler.concat("c/", _BASE_URL_1, "/testpost"),
+				Http.Method.POST
+			).toString(),
+			JSONCompareMode.LENIENT);
+
+		JSONAssert.assertEquals(
+			JSONUtil.put(
+				"items", JSONUtil.putAll(expectedJSONObject)
+			).toString(),
+			HTTPTestUtil.invokeToJSONObject(
+				null, StringBundler.concat("c/", _BASE_URL_1, "/testget"),
+				Http.Method.GET
+			).toString(),
+			JSONCompareMode.LENIENT);
+	}
+
+	@Test
 	public void testGetWithRelatedModel() throws Exception {
 		JSONObject apiApplicationJSONObject = HTTPTestUtil.invokeToJSONObject(
 			JSONUtil.put(
@@ -1822,11 +1954,13 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 		assertSuccessfulJSONObject(
 			JSONUtil.put(
 				"apiApplicationToAPIEndpoints",
-				_createAPIEndpoint(
-					apiEndpointExternalReferenceCode, Http.Method.GET, path,
-					null,
-					APIApplication.Endpoint.RetrieveType.COLLECTION.getValue(),
-					APIApplication.Endpoint.Scope.COMPANY)
+				JSONUtil.putAll(
+					_createAPIEndpoint(
+						apiEndpointExternalReferenceCode, Http.Method.GET, path,
+						null,
+						APIApplication.Endpoint.RetrieveType.COLLECTION.
+							getValue(),
+						APIApplication.Endpoint.Scope.COMPANY))
 			).put(
 				"apiApplicationToAPISchemas",
 				JSONUtil.put(
@@ -1892,9 +2026,10 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 		assertSuccessfulJSONObject(
 			JSONUtil.put(
 				"apiApplicationToAPIEndpoints",
-				_createAPIEndpoint(
-					apiEndpointExternalReferenceCode, Http.Method.GET, path,
-					pathParameter, retrieveType, scope)
+				JSONUtil.putAll(
+					_createAPIEndpoint(
+						apiEndpointExternalReferenceCode, Http.Method.GET, path,
+						pathParameter, retrieveType, scope))
 			).put(
 				"apiApplicationToAPISchemas",
 				JSONUtil.put(
@@ -1956,9 +2091,10 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 		assertSuccessfulJSONObject(
 			JSONUtil.put(
 				"apiApplicationToAPIEndpoints",
-				_createAPIEndpoint(
-					apiEndpointExternalReferenceCode, Http.Method.GET, path,
-					pathParameter, retrieveType, scope)
+				JSONUtil.putAll(
+					_createAPIEndpoint(
+						apiEndpointExternalReferenceCode, Http.Method.GET, path,
+						pathParameter, retrieveType, scope))
 			).put(
 				"apiApplicationToAPISchemas",
 				JSONUtil.put(
@@ -2088,6 +2224,202 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 			apiEndpointExternalReferenceCode, apiSchemaExternalReferenceCode);
 	}
 
+	private void _addAPIApplicationWithGetAndPostEndpoint(
+			String apiApplicationExternalReferenceCode,
+			String getAPIEndpointExternalReferenceCode,
+			String postAPIEndpointExternalReferenceCode, String baseURL,
+			int index, String objectDefinitionExternalReferenceCode,
+			String pathGet, String pathPost,
+			APIApplication.Endpoint.Scope scope)
+		throws Exception {
+
+		String apiSchemaExternalReferenceCode = RandomTestUtil.randomString();
+
+		assertSuccessfulHttpCode(
+			JSONUtil.put(
+				"apiApplicationToAPIEndpoints",
+				JSONUtil.putAll(
+					// Order is relevant to reproduce the issue
+					_createAPIEndpoint(
+						postAPIEndpointExternalReferenceCode, Http.Method.POST,
+						pathPost, null,
+						APIApplication.Endpoint.RetrieveType.SINGLE_ELEMENT.
+							getValue(),
+						scope),
+					_createAPIEndpoint(
+						getAPIEndpointExternalReferenceCode, Http.Method.GET,
+						pathGet, null,
+						APIApplication.Endpoint.RetrieveType.COLLECTION.
+							getValue(),
+						scope))
+			).put(
+				"apiApplicationToAPISchemas",
+				JSONUtil.put(
+					JSONUtil.put(
+						"apiSchemaToAPIProperties",
+						JSONUtil.putAll(
+							JSONUtil.put(
+								"description", "description"
+							).put(
+								"name", "attachmentProperty"
+							).put(
+								"objectFieldERC",
+								_API_SCHEMA_ATTACHMENT_FIELD_ERC + index
+							),
+							JSONUtil.put(
+								"description", "description"
+							).put(
+								"name", "booleanProperty"
+							).put(
+								"objectFieldERC",
+								_API_SCHEMA_BOOLEAN_FIELD_ERC + index
+							),
+							JSONUtil.put(
+								"description", "description"
+							).put(
+								"name", "dateProperty"
+							).put(
+								"objectFieldERC",
+								_API_SCHEMA_DATE_FIELD_ERC + index
+							),
+							JSONUtil.put(
+								"description", "description"
+							).put(
+								"name", "dateTimeProperty"
+							).put(
+								"objectFieldERC",
+								_API_SCHEMA_DATE_TIME_FIELD_ERC + index
+							),
+							JSONUtil.put(
+								"description", "description"
+							).put(
+								"name", "decimalProperty"
+							).put(
+								"objectFieldERC",
+								_API_SCHEMA_DECIMAL_FIELD_ERC + index
+							),
+							JSONUtil.put(
+								"description", "description"
+							).put(
+								"name", "integerProperty"
+							).put(
+								"objectFieldERC",
+								_API_SCHEMA_INTEGER_FIELD_ERC + index
+							),
+							JSONUtil.put(
+								"description", "description"
+							).put(
+								"name", "longIntegerProperty"
+							).put(
+								"objectFieldERC",
+								_API_SCHEMA_LONG_INTEGER_FIELD_ERC + index
+							),
+							JSONUtil.put(
+								"description", "description"
+							).put(
+								"name", "longTextProperty"
+							).put(
+								"objectFieldERC",
+								_API_SCHEMA_LONG_TEXT_FIELD_ERC + index
+							),
+							JSONUtil.put(
+								"description", "description"
+							).put(
+								"name", "multiselectPicklistProperty"
+							).put(
+								"objectFieldERC",
+								_API_SCHEMA_MULTISELECT_PICKLIST_FIELD_ERC +
+									index
+							),
+							JSONUtil.put(
+								"description", "description"
+							).put(
+								"name", "picklistProperty"
+							).put(
+								"objectFieldERC",
+								_API_SCHEMA_PICKLIST_FIELD_ERC + index
+							),
+							JSONUtil.put(
+								"description", "description"
+							).put(
+								"name", "precisionDecimalProperty"
+							).put(
+								"objectFieldERC",
+								_API_SCHEMA_PRECISION_DECIMAL_FIELD_ERC + index
+							),
+							JSONUtil.put(
+								"description", "description"
+							).put(
+								"name", "richTextProperty"
+							).put(
+								"objectFieldERC",
+								_API_SCHEMA_RICH_TEXT_FIELD_ERC + index
+							),
+							JSONUtil.put(
+								"description", "description"
+							).put(
+								"name", "textProperty"
+							).put(
+								"objectFieldERC",
+								_API_SCHEMA_TEXT_FIELD_ERC + index
+							),
+							JSONUtil.put(
+								"description", "description"
+							).put(
+								"name", "textUniqueProperty"
+							).put(
+								"objectFieldERC",
+								_API_SCHEMA_UNIQUE_TEXT_FIELD_ERC + index
+							))
+					).put(
+						"description", "description"
+					).put(
+						"externalReferenceCode", apiSchemaExternalReferenceCode
+					).put(
+						"mainObjectDefinitionERC",
+						objectDefinitionExternalReferenceCode
+					).put(
+						"name", "name"
+					))
+			).put(
+				"applicationStatus", "unpublished"
+			).put(
+				"baseURL", baseURL
+			).put(
+				"externalReferenceCode", apiApplicationExternalReferenceCode
+			).put(
+				"title", RandomTestUtil.randomString()
+			).toString(),
+			"headless-builder/applications", Http.Method.POST);
+
+		assertSuccessfulHttpCode(
+			null,
+			StringBundler.concat(
+				"headless-builder/schemas/by-external-reference-code/",
+				apiSchemaExternalReferenceCode,
+				"/responseAPISchemaToAPIEndpoints/",
+				getAPIEndpointExternalReferenceCode),
+			Http.Method.PUT);
+
+		assertSuccessfulHttpCode(
+			null,
+			StringBundler.concat(
+				"headless-builder/schemas/by-external-reference-code/",
+				apiSchemaExternalReferenceCode,
+				"/requestAPISchemaToAPIEndpoints/",
+				postAPIEndpointExternalReferenceCode),
+			Http.Method.PUT);
+
+		assertSuccessfulHttpCode(
+			null,
+			StringBundler.concat(
+				"headless-builder/schemas/by-external-reference-code/",
+				apiSchemaExternalReferenceCode,
+				"/responseAPISchemaToAPIEndpoints/",
+				postAPIEndpointExternalReferenceCode),
+			Http.Method.PUT);
+	}
+
 	private void _addAPIApplicationWithPostEndpoint(
 			String apiApplicationExternalReferenceCode,
 			String apiEndpointExternalReferenceCode, String baseURL,
@@ -2101,12 +2433,13 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 		assertSuccessfulJSONObject(
 			JSONUtil.put(
 				"apiApplicationToAPIEndpoints",
-				_createAPIEndpoint(
-					apiEndpointExternalReferenceCode, Http.Method.POST, path,
-					null,
-					APIApplication.Endpoint.RetrieveType.SINGLE_ELEMENT.
-						getValue(),
-					scope)
+				JSONUtil.putAll(
+					_createAPIEndpoint(
+						apiEndpointExternalReferenceCode, Http.Method.POST,
+						path, null,
+						APIApplication.Endpoint.RetrieveType.SINGLE_ELEMENT.
+							getValue(),
+						scope))
 			).put(
 				"apiApplicationToAPISchemas",
 				JSONUtil.put(
@@ -2589,7 +2922,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 			String.valueOf(itemJSONObject.get(expectedObjectFieldName)));
 	}
 
-	private JSONArray _createAPIEndpoint(
+	private JSONObject _createAPIEndpoint(
 		String apiEndpointExternalReferenceCode, Http.Method method,
 		String path, String pathParameter, String retrieveType,
 		APIApplication.Endpoint.Scope scope) {
@@ -2601,27 +2934,6 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 			(pathParameter != null)) {
 
 			return JSONUtil.put(
-				JSONUtil.put(
-					"description", "description"
-				).put(
-					"externalReferenceCode", apiEndpointExternalReferenceCode
-				).put(
-					"httpMethod", StringUtil.toLowerCase(method.name())
-				).put(
-					"name", "name"
-				).put(
-					"path", path + "/{pathId}"
-				).put(
-					"pathParameter", pathParameter
-				).put(
-					"retrieveType", retrieveType
-				).put(
-					"scope", StringUtil.toLowerCase(scope.name())
-				));
-		}
-
-		return JSONUtil.put(
-			JSONUtil.put(
 				"description", "description"
 			).put(
 				"externalReferenceCode", apiEndpointExternalReferenceCode
@@ -2630,12 +2942,31 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 			).put(
 				"name", "name"
 			).put(
-				"path", path
+				"path", path + "/{pathId}"
+			).put(
+				"pathParameter", pathParameter
 			).put(
 				"retrieveType", retrieveType
 			).put(
 				"scope", StringUtil.toLowerCase(scope.name())
-			));
+			);
+		}
+
+		return JSONUtil.put(
+			"description", "description"
+		).put(
+			"externalReferenceCode", apiEndpointExternalReferenceCode
+		).put(
+			"httpMethod", StringUtil.toLowerCase(method.name())
+		).put(
+			"name", "name"
+		).put(
+			"path", path
+		).put(
+			"retrieveType", retrieveType
+		).put(
+			"scope", StringUtil.toLowerCase(scope.name())
+		);
 	}
 
 	private ObjectFieldSetting _createObjectFieldSetting(

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
@@ -1118,14 +1118,13 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 
 	@Test
 	public void testGetWithPostEndpoint() throws Exception {
+		int index = 10;
+
 		ObjectDefinition objectDefinition = _addObjectDefinition(
-			10, true, ObjectDefinitionConstants.SCOPE_COMPANY);
+			index, true, ObjectDefinitionConstants.SCOPE_COMPANY);
 
 		_addAPIApplicationWithGetAndPostEndpoint(
-			_API_APPLICATION_ERC_1, _BASE_URL_1, _API_ENDPOINT_ERC_1, 10,
-			objectDefinition.getExternalReferenceCode(), "/testget",
-			"/testpost", _API_ENDPOINT_ERC_2,
-			APIApplication.Endpoint.Scope.COMPANY);
+			objectDefinition.getExternalReferenceCode(), index);
 
 		_publishAPIApplication(_API_APPLICATION_ERC_1);
 
@@ -2226,11 +2225,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 	}
 
 	private void _addAPIApplicationWithGetAndPostEndpoint(
-			String apiApplicationExternalReferenceCode, String baseURL,
-			String getAPIEndpointExternalReferenceCode, int index,
-			String objectDefinitionExternalReferenceCode, String pathGet,
-			String pathPost, String postAPIEndpointExternalReferenceCode,
-			APIApplication.Endpoint.Scope scope)
+			String objectDefinitionExternalReferenceCode, int index)
 		throws Exception {
 
 		String apiSchemaExternalReferenceCode = RandomTestUtil.randomString();
@@ -2241,17 +2236,17 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 				JSONUtil.putAll(
 					// Order is relevant to reproduce the issue
 					_createAPIEndpoint(
-						postAPIEndpointExternalReferenceCode, Http.Method.POST,
-						pathPost, null,
+						_API_ENDPOINT_ERC_2, Http.Method.POST,
+						"/testpost", null,
 						APIApplication.Endpoint.RetrieveType.SINGLE_ELEMENT.
 							getValue(),
-						scope),
+						APIApplication.Endpoint.Scope.COMPANY),
 					_createAPIEndpoint(
-						getAPIEndpointExternalReferenceCode, Http.Method.GET,
-						pathGet, null,
+						_API_ENDPOINT_ERC_1, Http.Method.GET,
+						"/testget", null,
 						APIApplication.Endpoint.RetrieveType.COLLECTION.
 							getValue(),
-						scope))
+						APIApplication.Endpoint.Scope.COMPANY))
 			).put(
 				"apiApplicationToAPISchemas",
 				JSONUtil.put(
@@ -2328,8 +2323,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 								"name", "multiselectPicklistProperty"
 							).put(
 								"objectFieldERC",
-								_API_SCHEMA_MULTISELECT_PICKLIST_FIELD_ERC +
-									index
+								_API_SCHEMA_MULTISELECT_PICKLIST_FIELD_ERC + index
 							),
 							JSONUtil.put(
 								"description", "description"
@@ -2384,9 +2378,10 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 			).put(
 				"applicationStatus", "unpublished"
 			).put(
-				"baseURL", baseURL
+				"baseURL", _BASE_URL_1
 			).put(
-				"externalReferenceCode", apiApplicationExternalReferenceCode
+				"externalReferenceCode",
+				_API_APPLICATION_ERC_1
 			).put(
 				"title", RandomTestUtil.randomString()
 			).toString(),
@@ -2397,8 +2392,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 			StringBundler.concat(
 				"headless-builder/schemas/by-external-reference-code/",
 				apiSchemaExternalReferenceCode,
-				"/responseAPISchemaToAPIEndpoints/",
-				getAPIEndpointExternalReferenceCode),
+				"/responseAPISchemaToAPIEndpoints/", _API_ENDPOINT_ERC_1),
 			Http.Method.PUT);
 
 		assertSuccessfulJSONObject(
@@ -2406,8 +2400,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 			StringBundler.concat(
 				"headless-builder/schemas/by-external-reference-code/",
 				apiSchemaExternalReferenceCode,
-				"/requestAPISchemaToAPIEndpoints/",
-				postAPIEndpointExternalReferenceCode),
+				"/requestAPISchemaToAPIEndpoints/", _API_ENDPOINT_ERC_2),
 			Http.Method.PUT);
 
 		assertSuccessfulJSONObject(
@@ -2415,8 +2408,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 			StringBundler.concat(
 				"headless-builder/schemas/by-external-reference-code/",
 				apiSchemaExternalReferenceCode,
-				"/responseAPISchemaToAPIEndpoints/",
-				postAPIEndpointExternalReferenceCode),
+				"/responseAPISchemaToAPIEndpoints/", _API_ENDPOINT_ERC_2),
 			Http.Method.PUT);
 	}
 

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
@@ -82,6 +82,7 @@ import java.text.DateFormat;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import org.junit.Assert;
@@ -1595,7 +1596,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 			7, true, ObjectDefinitionConstants.SCOPE_COMPANY);
 
 		_addAPIApplicationWithPostEndpoint(
-			_API_APPLICATION_ERC_1, _API_ENDPOINT_ERC_1, _BASE_URL_1, 7,
+			_API_APPLICATION_ERC_1, _API_ENDPOINT_ERC_1, _BASE_URL_1, true, 7,
 			objectDefinition.getExternalReferenceCode(), "/test",
 			APIApplication.Endpoint.Scope.COMPANY);
 
@@ -1723,7 +1724,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 			8, true, ObjectDefinitionConstants.SCOPE_COMPANY);
 
 		_addAPIApplicationWithPostEndpoint(
-			_API_APPLICATION_ERC_1, _API_ENDPOINT_ERC_1, _BASE_URL_1, 8,
+			_API_APPLICATION_ERC_1, _API_ENDPOINT_ERC_1, _BASE_URL_1, true, 8,
 			objectDefinition.getExternalReferenceCode(), "/test",
 			APIApplication.Endpoint.Scope.COMPANY);
 
@@ -1745,6 +1746,43 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 				Http.Method.POST
 			).toString(),
 			JSONCompareMode.STRICT);
+	}
+
+	@Test
+	public void testPostWithoutResponseSchema() throws Exception {
+		ObjectDefinition objectDefinition = _addObjectDefinition(
+			9, false, ObjectDefinitionConstants.SCOPE_COMPANY);
+
+		_addAPIApplicationWithPostEndpoint(
+			_API_APPLICATION_ERC_1, _API_ENDPOINT_ERC_1, _BASE_URL_1, false, 9,
+			objectDefinition.getExternalReferenceCode(), "/test",
+			APIApplication.Endpoint.Scope.COMPANY);
+
+		_publishAPIApplication(_API_APPLICATION_ERC_1);
+
+		String textPropertyValue = RandomTestUtil.randomString();
+
+		JSONAssert.assertEquals(
+			"{}",
+			HTTPTestUtil.invokeToJSONObject(
+				JSONUtil.put(
+					"textProperty", textPropertyValue
+				).toString(),
+				StringBundler.concat("c/", _BASE_URL_1, "/test"),
+				Http.Method.POST
+			).toString(),
+			JSONCompareMode.STRICT);
+
+		List<ObjectEntry> objectEntries =
+			_objectEntryLocalService.getObjectEntries(
+				0, objectDefinition.getObjectDefinitionId(), QueryUtil.ALL_POS,
+				QueryUtil.ALL_POS);
+
+		ObjectEntry objectEntry = objectEntries.get(objectEntries.size() - 1);
+
+		Map<String, Serializable> values = objectEntry.getValues();
+
+		Assert.assertEquals(textPropertyValue, values.get("textField"));
 	}
 
 	private void _addAggregationObjectField(
@@ -2052,7 +2090,8 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 
 	private void _addAPIApplicationWithPostEndpoint(
 			String apiApplicationExternalReferenceCode,
-			String apiEndpointExternalReferenceCode, String baseURL, int index,
+			String apiEndpointExternalReferenceCode, String baseURL,
+			boolean hasResponseSchema, int index,
 			String objectDefinitionExternalReferenceCode, String path,
 			APIApplication.Endpoint.Scope scope)
 		throws Exception {
@@ -2216,14 +2255,17 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 				"/requestAPISchemaToAPIEndpoints/",
 				apiEndpointExternalReferenceCode),
 			Http.Method.PUT);
-		assertSuccessfulJSONObject(
-			null,
-			StringBundler.concat(
-				"headless-builder/schemas/by-external-reference-code/",
-				apiSchemaExternalReferenceCode,
-				"/responseAPISchemaToAPIEndpoints/",
-				apiEndpointExternalReferenceCode),
-			Http.Method.PUT);
+
+		if (hasResponseSchema) {
+			assertSuccessfulJSONObject(
+				null,
+				StringBundler.concat(
+					"headless-builder/schemas/by-external-reference-code/",
+					apiSchemaExternalReferenceCode,
+					"/responseAPISchemaToAPIEndpoints/",
+					apiEndpointExternalReferenceCode),
+				Http.Method.PUT);
+		}
 	}
 
 	private void _addAPIFilter(

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
@@ -1898,7 +1898,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 	}
 
 	@Test
-	public void testPostObjectEntry() throws Exception {
+	public void testPostWithAllFields() throws Exception {
 		ObjectDefinition objectDefinition = _addObjectDefinition(
 			7, true, ObjectDefinitionConstants.SCOPE_COMPANY);
 
@@ -2026,7 +2026,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 	}
 
 	@Test
-	public void testPostWithObjectException() throws Exception {
+	public void testPostWithMissingRequiredField() throws Exception {
 		ObjectDefinition objectDefinition = _addObjectDefinition(
 			8, true, ObjectDefinitionConstants.SCOPE_COMPANY);
 

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
@@ -390,7 +390,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 				"oDataFilter", "textField eq 'value5' or textField eq 'value7'"
 			).put(
 				"r_apiEndpointToAPIFilters_c_apiEndpointERC",
-				HeadlessBuilderResourceTest._API_ENDPOINT_ERC_1
+				_API_ENDPOINT_ERC_1
 			).toString(),
 			"headless-builder/filters", Http.Method.POST);
 
@@ -1055,10 +1055,8 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 				"apiApplicationToAPIEndpoints",
 				JSONUtil.putAll(
 					_createAPIEndpoint(
-						HeadlessBuilderResourceTest._API_ENDPOINT_ERC_1,
-						Http.Method.GET,
-						HeadlessBuilderResourceTest._API_APPLICATION_PATH_1,
-						null,
+						_API_ENDPOINT_ERC_1, Http.Method.GET,
+						_API_APPLICATION_PATH_1, null,
 						APIApplication.Endpoint.RetrieveType.COLLECTION.
 							getValue(),
 						APIApplication.Endpoint.Scope.COMPANY))
@@ -1100,18 +1098,16 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 			).put(
 				"applicationStatus", "unpublished"
 			).put(
-				"baseURL", HeadlessBuilderResourceTest._BASE_URL_1
+				"baseURL", _BASE_URL_1
 			).put(
-				"externalReferenceCode",
-				HeadlessBuilderResourceTest._API_APPLICATION_ERC_1
+				"externalReferenceCode", _API_APPLICATION_ERC_1
 			).put(
 				"title", RandomTestUtil.randomString()
 			).toString(),
 			"headless-builder/applications", Http.Method.POST);
 
 		_relateAPIEndpointWithAPISchemas(
-			HeadlessBuilderResourceTest._API_ENDPOINT_ERC_1,
-			apiSchemaExternalReferenceCode);
+			_API_ENDPOINT_ERC_1, apiSchemaExternalReferenceCode);
 
 		_publishAPIApplication(_API_APPLICATION_ERC_1);
 
@@ -1936,10 +1932,8 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 				"apiApplicationToAPIEndpoints",
 				JSONUtil.putAll(
 					_createAPIEndpoint(
-						HeadlessBuilderResourceTest._API_ENDPOINT_ERC_1,
-						Http.Method.GET,
-						HeadlessBuilderResourceTest._API_APPLICATION_PATH_1,
-						null,
+						_API_ENDPOINT_ERC_1, Http.Method.GET,
+						_API_APPLICATION_PATH_1, null,
 						APIApplication.Endpoint.RetrieveType.COLLECTION.
 							getValue(),
 						APIApplication.Endpoint.Scope.COMPANY))
@@ -1979,18 +1973,16 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 			).put(
 				"applicationStatus", "unpublished"
 			).put(
-				"baseURL", HeadlessBuilderResourceTest._BASE_URL_1
+				"baseURL", _BASE_URL_1
 			).put(
-				"externalReferenceCode",
-				HeadlessBuilderResourceTest._API_APPLICATION_ERC_1
+				"externalReferenceCode", _API_APPLICATION_ERC_1
 			).put(
 				"title", RandomTestUtil.randomString()
 			).toString(),
 			"headless-builder/applications", Http.Method.POST);
 
 		_relateAPIEndpointWithAPISchemas(
-			HeadlessBuilderResourceTest._API_ENDPOINT_ERC_1,
-			apiSchemaExternalReferenceCode);
+			_API_ENDPOINT_ERC_1, apiSchemaExternalReferenceCode);
 
 		_publishAPIApplication(_API_APPLICATION_ERC_1);
 
@@ -2165,8 +2157,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 				"apiApplicationToAPIEndpoints",
 				JSONUtil.putAll(
 					_createAPIEndpoint(
-						HeadlessBuilderResourceTest._API_ENDPOINT_ERC_1,
-						Http.Method.POST, "/test", null,
+						_API_ENDPOINT_ERC_1, Http.Method.POST, "/test", null,
 						APIApplication.Endpoint.RetrieveType.SINGLE_ELEMENT.
 							getValue(),
 						APIApplication.Endpoint.Scope.COMPANY))
@@ -2197,10 +2188,9 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 			).put(
 				"applicationStatus", "unpublished"
 			).put(
-				"baseURL", HeadlessBuilderResourceTest._BASE_URL_1
+				"baseURL", _BASE_URL_1
 			).put(
-				"externalReferenceCode",
-				HeadlessBuilderResourceTest._API_APPLICATION_ERC_1
+				"externalReferenceCode", _API_APPLICATION_ERC_1
 			).put(
 				"title", RandomTestUtil.randomString()
 			).toString(),
@@ -2211,8 +2201,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 			StringBundler.concat(
 				"headless-builder/schemas/by-external-reference-code/",
 				apiSchemaExternalReferenceCode,
-				"/requestAPISchemaToAPIEndpoints/",
-				HeadlessBuilderResourceTest._API_ENDPOINT_ERC_1),
+				"/requestAPISchemaToAPIEndpoints/", _API_ENDPOINT_ERC_1),
 			Http.Method.PUT);
 
 		assertSuccessfulJSONObject(
@@ -2220,8 +2209,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 			StringBundler.concat(
 				"headless-builder/schemas/by-external-reference-code/",
 				apiSchemaExternalReferenceCode,
-				"/responseAPISchemaToAPIEndpoints/",
-				HeadlessBuilderResourceTest._API_ENDPOINT_ERC_1),
+				"/responseAPISchemaToAPIEndpoints/", _API_ENDPOINT_ERC_1),
 			Http.Method.PUT);
 
 		_publishAPIApplication(_API_APPLICATION_ERC_1);
@@ -2459,8 +2447,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 				"apiApplicationToAPIEndpoints",
 				JSONUtil.putAll(
 					_createAPIEndpoint(
-						HeadlessBuilderResourceTest._API_ENDPOINT_ERC_1,
-						Http.Method.POST, "/test", null,
+						_API_ENDPOINT_ERC_1, Http.Method.POST, "/test", null,
 						APIApplication.Endpoint.RetrieveType.SINGLE_ELEMENT.
 							getValue(),
 						APIApplication.Endpoint.Scope.COMPANY))
@@ -2593,10 +2580,9 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 			).put(
 				"applicationStatus", "unpublished"
 			).put(
-				"baseURL", HeadlessBuilderResourceTest._BASE_URL_1
+				"baseURL", _BASE_URL_1
 			).put(
-				"externalReferenceCode",
-				HeadlessBuilderResourceTest._API_APPLICATION_ERC_1
+				"externalReferenceCode", _API_APPLICATION_ERC_1
 			).put(
 				"title", RandomTestUtil.randomString()
 			).toString(),
@@ -2607,8 +2593,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 			StringBundler.concat(
 				"headless-builder/schemas/by-external-reference-code/",
 				apiSchemaExternalReferenceCode,
-				"/requestAPISchemaToAPIEndpoints/",
-				HeadlessBuilderResourceTest._API_ENDPOINT_ERC_1),
+				"/requestAPISchemaToAPIEndpoints/", _API_ENDPOINT_ERC_1),
 			Http.Method.PUT);
 
 		if (addResponseSchema) {
@@ -2617,8 +2602,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 				StringBundler.concat(
 					"headless-builder/schemas/by-external-reference-code/",
 					apiSchemaExternalReferenceCode,
-					"/responseAPISchemaToAPIEndpoints/",
-					HeadlessBuilderResourceTest._API_ENDPOINT_ERC_1),
+					"/responseAPISchemaToAPIEndpoints/", _API_ENDPOINT_ERC_1),
 				Http.Method.PUT);
 		}
 	}
@@ -2628,8 +2612,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 			JSONUtil.put(
 				"oDataSort", sortString
 			).put(
-				"r_apiEndpointToAPISorts_c_apiEndpointERC",
-				HeadlessBuilderResourceTest._API_ENDPOINT_ERC_1
+				"r_apiEndpointToAPISorts_c_apiEndpointERC", _API_ENDPOINT_ERC_1
 			).toString(),
 			"headless-builder/sorts", Http.Method.POST);
 	}

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -585,7 +585,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 	private List<ServiceRegistration<?>> _registerExceptionMappers(
 		String jaxRsApplicationName, ObjectDefinition objectDefinition) {
 
-		String selectCondition = StringBundler.concat(
+		String applicationSelectFilterString = StringBundler.concat(
 			"(|(liferay.objects.exception.mapper = true)(osgi.jaxrs.name= ",
 			jaxRsApplicationName, "))");
 
@@ -593,7 +593,8 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 			_bundleContext.registerService(
 				ExceptionMapper.class, new ObjectAssetCategoryExceptionMapper(),
 				HashMapDictionaryBuilder.<String, Object>put(
-					"osgi.jaxrs.application.select", selectCondition
+					"osgi.jaxrs.application.select",
+					applicationSelectFilterString
 				).put(
 					"osgi.jaxrs.extension", "true"
 				).put(
@@ -605,7 +606,8 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 				ExceptionMapper.class,
 				new ObjectEntryManagerHttpExceptionMapper(),
 				HashMapDictionaryBuilder.<String, Object>put(
-					"osgi.jaxrs.application.select", selectCondition
+					"osgi.jaxrs.application.select",
+					applicationSelectFilterString
 				).put(
 					"osgi.jaxrs.extension", "true"
 				).put(
@@ -617,7 +619,8 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 				ExceptionMapper.class,
 				new ObjectEntryStatusExceptionMapper(_language),
 				HashMapDictionaryBuilder.<String, Object>put(
-					"osgi.jaxrs.application.select", selectCondition
+					"osgi.jaxrs.application.select",
+					applicationSelectFilterString
 				).put(
 					"osgi.jaxrs.extension", "true"
 				).put(
@@ -629,7 +632,8 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 				ExceptionMapper.class,
 				new ObjectEntryValuesExceptionMapper(_language),
 				HashMapDictionaryBuilder.<String, Object>put(
-					"osgi.jaxrs.application.select", selectCondition
+					"osgi.jaxrs.application.select",
+					applicationSelectFilterString
 				).put(
 					"osgi.jaxrs.extension", "true"
 				).put(
@@ -641,7 +645,8 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 				ExceptionMapper.class,
 				new ObjectRelationshipDeletionTypeExceptionMapper(_language),
 				HashMapDictionaryBuilder.<String, Object>put(
-					"osgi.jaxrs.application.select", selectCondition
+					"osgi.jaxrs.application.select",
+					applicationSelectFilterString
 				).put(
 					"osgi.jaxrs.extension", "true"
 				).put(
@@ -654,7 +659,8 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 				new ObjectValidationRuleEngineExceptionMapper(
 					_jsonFactory, _language),
 				HashMapDictionaryBuilder.<String, Object>put(
-					"osgi.jaxrs.application.select", selectCondition
+					"osgi.jaxrs.application.select",
+					applicationSelectFilterString
 				).put(
 					"osgi.jaxrs.extension", "true"
 				).put(
@@ -666,7 +672,8 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 				ExceptionMapper.class,
 				new RequiredObjectRelationshipExceptionMapper(_language),
 				HashMapDictionaryBuilder.<String, Object>put(
-					"osgi.jaxrs.application.select", selectCondition
+					"osgi.jaxrs.application.select",
+					applicationSelectFilterString
 				).put(
 					"osgi.jaxrs.extension", "true"
 				).put(
@@ -678,7 +685,8 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 				ExceptionMapper.class,
 				new UnsupportedOperationExceptionMapper(),
 				HashMapDictionaryBuilder.<String, Object>put(
-					"osgi.jaxrs.application.select", selectCondition
+					"osgi.jaxrs.application.select",
+					applicationSelectFilterString
 				).put(
 					"osgi.jaxrs.extension", "true"
 				).put(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -599,7 +599,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 				new UnsupportedOperationExceptionMapper()),
 			exceptionMapper -> {
 				Class<? extends ExceptionMapper> clazz =
-					((ExceptionMapper<?>)exceptionMapper).getClass();
+					exceptionMapper.getClass();
 
 				return _bundleContext.registerService(
 					(Class<ExceptionMapper<?>>)(Class<?>)ExceptionMapper.class,

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -73,6 +73,7 @@ import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
 import com.liferay.portal.vulcan.extension.ExtensionProviderRegistry;
 import com.liferay.portal.vulcan.graphql.dto.GraphQLDTOContributor;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.BaseExceptionMapper;
 import com.liferay.portal.vulcan.resource.OpenAPIResource;
 
 import java.lang.reflect.Method;
@@ -607,32 +608,27 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 	private List<ServiceRegistration<?>> _registerExceptionMappers(
 		String jaxRsApplicationName, ObjectDefinition objectDefinition) {
 
-		return Arrays.asList(
-			_registerExceptionMapper(
-				new ObjectAssetCategoryExceptionMapper(), jaxRsApplicationName,
-				objectDefinition),
-			_registerExceptionMapper(
-				new ObjectEntryManagerHttpExceptionMapper(),
-				jaxRsApplicationName, objectDefinition),
-			_registerExceptionMapper(
-				new ObjectEntryStatusExceptionMapper(_language),
-				jaxRsApplicationName, objectDefinition),
-			_registerExceptionMapper(
-				new ObjectEntryValuesExceptionMapper(_language),
-				jaxRsApplicationName, objectDefinition),
-			_registerExceptionMapper(
-				new ObjectRelationshipDeletionTypeExceptionMapper(_language),
-				jaxRsApplicationName, objectDefinition),
-			_registerExceptionMapper(
-				new ObjectValidationRuleEngineExceptionMapper(
-					_jsonFactory, _language),
-				jaxRsApplicationName, objectDefinition),
-			_registerExceptionMapper(
-				new RequiredObjectRelationshipExceptionMapper(_language),
-				jaxRsApplicationName, objectDefinition),
-			_registerExceptionMapper(
-				new UnsupportedOperationExceptionMapper(), jaxRsApplicationName,
-				objectDefinition));
+		List<ServiceRegistration<?>> serviceRegistrations = new ArrayList<>();
+
+		for (BaseExceptionMapper<? extends Exception> exceptionMapper :
+				Arrays.asList(
+					new ObjectAssetCategoryExceptionMapper(),
+					new ObjectEntryManagerHttpExceptionMapper(),
+					new ObjectEntryStatusExceptionMapper(_language),
+					new ObjectEntryValuesExceptionMapper(_language),
+					new ObjectRelationshipDeletionTypeExceptionMapper(
+						_language),
+					new ObjectValidationRuleEngineExceptionMapper(
+						_jsonFactory, _language),
+					new RequiredObjectRelationshipExceptionMapper(_language),
+					new UnsupportedOperationExceptionMapper())) {
+
+			serviceRegistrations.add(
+				_registerExceptionMapper(
+					exceptionMapper, jaxRsApplicationName, objectDefinition));
+		}
+
+		return serviceRegistrations;
 	}
 
 	private boolean _shouldUnregisterApplication(String restContextPath) {

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -47,6 +47,7 @@ import com.liferay.object.service.ObjectRelationshipService;
 import com.liferay.object.system.JaxRsApplicationDescriptor;
 import com.liferay.object.system.SystemObjectDefinitionManager;
 import com.liferay.object.system.SystemObjectDefinitionManagerRegistry;
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
@@ -73,7 +74,6 @@ import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
 import com.liferay.portal.vulcan.extension.ExtensionProviderRegistry;
 import com.liferay.portal.vulcan.graphql.dto.GraphQLDTOContributor;
-import com.liferay.portal.vulcan.jaxrs.exception.mapper.BaseExceptionMapper;
 import com.liferay.portal.vulcan.resource.OpenAPIResource;
 
 import java.lang.reflect.Method;
@@ -608,27 +608,19 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 	private List<ServiceRegistration<?>> _registerExceptionMappers(
 		String jaxRsApplicationName, ObjectDefinition objectDefinition) {
 
-		List<ServiceRegistration<?>> serviceRegistrations = new ArrayList<>();
-
-		for (BaseExceptionMapper<? extends Exception> exceptionMapper :
-				Arrays.asList(
-					new ObjectAssetCategoryExceptionMapper(),
-					new ObjectEntryManagerHttpExceptionMapper(),
-					new ObjectEntryStatusExceptionMapper(_language),
-					new ObjectEntryValuesExceptionMapper(_language),
-					new ObjectRelationshipDeletionTypeExceptionMapper(
-						_language),
-					new ObjectValidationRuleEngineExceptionMapper(
-						_jsonFactory, _language),
-					new RequiredObjectRelationshipExceptionMapper(_language),
-					new UnsupportedOperationExceptionMapper())) {
-
-			serviceRegistrations.add(
-				_registerExceptionMapper(
-					exceptionMapper, jaxRsApplicationName, objectDefinition));
-		}
-
-		return serviceRegistrations;
+		return TransformUtil.transform(
+			Arrays.asList(
+				new ObjectAssetCategoryExceptionMapper(),
+				new ObjectEntryManagerHttpExceptionMapper(),
+				new ObjectEntryStatusExceptionMapper(_language),
+				new ObjectEntryValuesExceptionMapper(_language),
+				new ObjectRelationshipDeletionTypeExceptionMapper(_language),
+				new ObjectValidationRuleEngineExceptionMapper(
+					_jsonFactory, _language),
+				new RequiredObjectRelationshipExceptionMapper(_language),
+				new UnsupportedOperationExceptionMapper()),
+			exceptionMapper -> _registerExceptionMapper(
+				exceptionMapper, jaxRsApplicationName, objectDefinition));
 	}
 
 	private boolean _shouldUnregisterApplication(String restContextPath) {

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -595,7 +595,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 			HashMapDictionaryBuilder.<String, Object>put(
 				"osgi.jaxrs.application.select",
 				StringBundler.concat(
-					"(|(liferay.objects.exception.mapper = true)",
+					"(|(liferay.objects.exception.mapper=true)",
 					"(osgi.jaxrs.name= ", jaxRsApplicationName, "))")
 			).put(
 				"osgi.jaxrs.extension", "true"

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -582,118 +582,57 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 				objectDefinition));
 	}
 
+	private ServiceRegistration<ExceptionMapper<?>> _registerExceptionMapper(
+		ExceptionMapper<?> exceptionMapper, String jaxRsApplicationName,
+		ObjectDefinition objectDefinition) {
+
+		Class<? extends ExceptionMapper> clazz = exceptionMapper.getClass();
+
+		return _bundleContext.registerService(
+			(Class<ExceptionMapper<?>>)(Class<?>)ExceptionMapper.class,
+			exceptionMapper,
+			HashMapDictionaryBuilder.<String, Object>put(
+				"osgi.jaxrs.application.select",
+				StringBundler.concat(
+					"(|(liferay.objects.exception.mapper = true)",
+					"(osgi.jaxrs.name= ", jaxRsApplicationName, "))")
+			).put(
+				"osgi.jaxrs.extension", "true"
+			).put(
+				"osgi.jaxrs.name",
+				objectDefinition.getOSGiJaxRsName(clazz.getSimpleName())
+			).build());
+	}
+
 	private List<ServiceRegistration<?>> _registerExceptionMappers(
 		String jaxRsApplicationName, ObjectDefinition objectDefinition) {
 
-		String applicationSelectFilterString = StringBundler.concat(
-			"(|(liferay.objects.exception.mapper = true)(osgi.jaxrs.name= ",
-			jaxRsApplicationName, "))");
-
 		return Arrays.asList(
-			_bundleContext.registerService(
-				ExceptionMapper.class, new ObjectAssetCategoryExceptionMapper(),
-				HashMapDictionaryBuilder.<String, Object>put(
-					"osgi.jaxrs.application.select",
-					applicationSelectFilterString
-				).put(
-					"osgi.jaxrs.extension", "true"
-				).put(
-					"osgi.jaxrs.name",
-					objectDefinition.getOSGiJaxRsName(
-						"ObjectAssetCategoryExceptionMapper")
-				).build()),
-			_bundleContext.registerService(
-				ExceptionMapper.class,
+			_registerExceptionMapper(
+				new ObjectAssetCategoryExceptionMapper(), jaxRsApplicationName,
+				objectDefinition),
+			_registerExceptionMapper(
 				new ObjectEntryManagerHttpExceptionMapper(),
-				HashMapDictionaryBuilder.<String, Object>put(
-					"osgi.jaxrs.application.select",
-					applicationSelectFilterString
-				).put(
-					"osgi.jaxrs.extension", "true"
-				).put(
-					"osgi.jaxrs.name",
-					objectDefinition.getOSGiJaxRsName(
-						"ObjectEntryManagerHttpExceptionMapper")
-				).build()),
-			_bundleContext.registerService(
-				ExceptionMapper.class,
+				jaxRsApplicationName, objectDefinition),
+			_registerExceptionMapper(
 				new ObjectEntryStatusExceptionMapper(_language),
-				HashMapDictionaryBuilder.<String, Object>put(
-					"osgi.jaxrs.application.select",
-					applicationSelectFilterString
-				).put(
-					"osgi.jaxrs.extension", "true"
-				).put(
-					"osgi.jaxrs.name",
-					objectDefinition.getOSGiJaxRsName(
-						"ObjectEntryStatusExceptionMapper")
-				).build()),
-			_bundleContext.registerService(
-				ExceptionMapper.class,
+				jaxRsApplicationName, objectDefinition),
+			_registerExceptionMapper(
 				new ObjectEntryValuesExceptionMapper(_language),
-				HashMapDictionaryBuilder.<String, Object>put(
-					"osgi.jaxrs.application.select",
-					applicationSelectFilterString
-				).put(
-					"osgi.jaxrs.extension", "true"
-				).put(
-					"osgi.jaxrs.name",
-					objectDefinition.getOSGiJaxRsName(
-						"ObjectEntryValuesExceptionMapper")
-				).build()),
-			_bundleContext.registerService(
-				ExceptionMapper.class,
+				jaxRsApplicationName, objectDefinition),
+			_registerExceptionMapper(
 				new ObjectRelationshipDeletionTypeExceptionMapper(_language),
-				HashMapDictionaryBuilder.<String, Object>put(
-					"osgi.jaxrs.application.select",
-					applicationSelectFilterString
-				).put(
-					"osgi.jaxrs.extension", "true"
-				).put(
-					"osgi.jaxrs.name",
-					objectDefinition.getOSGiJaxRsName(
-						"ObjectRelationshipDeletionTypeExceptionMapper")
-				).build()),
-			_bundleContext.registerService(
-				ExceptionMapper.class,
+				jaxRsApplicationName, objectDefinition),
+			_registerExceptionMapper(
 				new ObjectValidationRuleEngineExceptionMapper(
 					_jsonFactory, _language),
-				HashMapDictionaryBuilder.<String, Object>put(
-					"osgi.jaxrs.application.select",
-					applicationSelectFilterString
-				).put(
-					"osgi.jaxrs.extension", "true"
-				).put(
-					"osgi.jaxrs.name",
-					objectDefinition.getOSGiJaxRsName(
-						"ObjectValidationRuleEngineExceptionMapper")
-				).build()),
-			_bundleContext.registerService(
-				ExceptionMapper.class,
+				jaxRsApplicationName, objectDefinition),
+			_registerExceptionMapper(
 				new RequiredObjectRelationshipExceptionMapper(_language),
-				HashMapDictionaryBuilder.<String, Object>put(
-					"osgi.jaxrs.application.select",
-					applicationSelectFilterString
-				).put(
-					"osgi.jaxrs.extension", "true"
-				).put(
-					"osgi.jaxrs.name",
-					objectDefinition.getOSGiJaxRsName(
-						"RequiredObjectRelationshipExceptionMapper")
-				).build()),
-			_bundleContext.registerService(
-				ExceptionMapper.class,
-				new UnsupportedOperationExceptionMapper(),
-				HashMapDictionaryBuilder.<String, Object>put(
-					"osgi.jaxrs.application.select",
-					applicationSelectFilterString
-				).put(
-					"osgi.jaxrs.extension", "true"
-				).put(
-					"osgi.jaxrs.name",
-					objectDefinition.getOSGiJaxRsName(
-						"UnsupportedOperationExceptionMapper")
-				).build()));
+				jaxRsApplicationName, objectDefinition),
+			_registerExceptionMapper(
+				new UnsupportedOperationExceptionMapper(), jaxRsApplicationName,
+				objectDefinition));
 	}
 
 	private boolean _shouldUnregisterApplication(String restContextPath) {

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -583,28 +583,6 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 				objectDefinition));
 	}
 
-	private ServiceRegistration<ExceptionMapper<?>> _registerExceptionMapper(
-		ExceptionMapper<?> exceptionMapper, String jaxRsApplicationName,
-		ObjectDefinition objectDefinition) {
-
-		Class<? extends ExceptionMapper> clazz = exceptionMapper.getClass();
-
-		return _bundleContext.registerService(
-			(Class<ExceptionMapper<?>>)(Class<?>)ExceptionMapper.class,
-			exceptionMapper,
-			HashMapDictionaryBuilder.<String, Object>put(
-				"osgi.jaxrs.application.select",
-				StringBundler.concat(
-					"(|(liferay.objects.exception.mapper=true)",
-					"(osgi.jaxrs.name= ", jaxRsApplicationName, "))")
-			).put(
-				"osgi.jaxrs.extension", "true"
-			).put(
-				"osgi.jaxrs.name",
-				objectDefinition.getOSGiJaxRsName(clazz.getSimpleName())
-			).build());
-	}
-
 	private List<ServiceRegistration<?>> _registerExceptionMappers(
 		String jaxRsApplicationName, ObjectDefinition objectDefinition) {
 
@@ -619,8 +597,25 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 					_jsonFactory, _language),
 				new RequiredObjectRelationshipExceptionMapper(_language),
 				new UnsupportedOperationExceptionMapper()),
-			exceptionMapper -> _registerExceptionMapper(
-				exceptionMapper, jaxRsApplicationName, objectDefinition));
+			exceptionMapper -> {
+				Class<? extends ExceptionMapper> clazz =
+					((ExceptionMapper<?>)exceptionMapper).getClass();
+
+				return _bundleContext.registerService(
+					(Class<ExceptionMapper<?>>)(Class<?>)ExceptionMapper.class,
+					exceptionMapper,
+					HashMapDictionaryBuilder.<String, Object>put(
+						"osgi.jaxrs.application.select",
+						StringBundler.concat(
+							"(|(liferay.objects.exception.mapper=true)",
+							"(osgi.jaxrs.name= ", jaxRsApplicationName, "))")
+					).put(
+						"osgi.jaxrs.extension", "true"
+					).put(
+						"osgi.jaxrs.name",
+						objectDefinition.getOSGiJaxRsName(clazz.getSimpleName())
+					).build());
+			});
 	}
 
 	private boolean _shouldUnregisterApplication(String restContextPath) {

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -47,6 +47,7 @@ import com.liferay.object.service.ObjectRelationshipService;
 import com.liferay.object.system.JaxRsApplicationDescriptor;
 import com.liferay.object.system.SystemObjectDefinitionManager;
 import com.liferay.object.system.SystemObjectDefinitionManagerRegistry;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
 import com.liferay.portal.kernel.json.JSONFactory;
@@ -584,12 +585,15 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 	private List<ServiceRegistration<?>> _registerExceptionMappers(
 		String jaxRsApplicationName, ObjectDefinition objectDefinition) {
 
+		String selectCondition = StringBundler.concat(
+			"(|(liferay.objects.exception.mapper = true)(osgi.jaxrs.name= ",
+			jaxRsApplicationName, "))");
+
 		return Arrays.asList(
 			_bundleContext.registerService(
 				ExceptionMapper.class, new ObjectAssetCategoryExceptionMapper(),
 				HashMapDictionaryBuilder.<String, Object>put(
-					"osgi.jaxrs.application.select",
-					"(osgi.jaxrs.name=" + jaxRsApplicationName + ")"
+					"osgi.jaxrs.application.select", selectCondition
 				).put(
 					"osgi.jaxrs.extension", "true"
 				).put(
@@ -601,8 +605,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 				ExceptionMapper.class,
 				new ObjectEntryManagerHttpExceptionMapper(),
 				HashMapDictionaryBuilder.<String, Object>put(
-					"osgi.jaxrs.application.select",
-					"(osgi.jaxrs.name=" + jaxRsApplicationName + ")"
+					"osgi.jaxrs.application.select", selectCondition
 				).put(
 					"osgi.jaxrs.extension", "true"
 				).put(
@@ -614,8 +617,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 				ExceptionMapper.class,
 				new ObjectEntryStatusExceptionMapper(_language),
 				HashMapDictionaryBuilder.<String, Object>put(
-					"osgi.jaxrs.application.select",
-					"(osgi.jaxrs.name=" + jaxRsApplicationName + ")"
+					"osgi.jaxrs.application.select", selectCondition
 				).put(
 					"osgi.jaxrs.extension", "true"
 				).put(
@@ -627,8 +629,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 				ExceptionMapper.class,
 				new ObjectEntryValuesExceptionMapper(_language),
 				HashMapDictionaryBuilder.<String, Object>put(
-					"osgi.jaxrs.application.select",
-					"(osgi.jaxrs.name=" + jaxRsApplicationName + ")"
+					"osgi.jaxrs.application.select", selectCondition
 				).put(
 					"osgi.jaxrs.extension", "true"
 				).put(
@@ -640,8 +641,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 				ExceptionMapper.class,
 				new ObjectRelationshipDeletionTypeExceptionMapper(_language),
 				HashMapDictionaryBuilder.<String, Object>put(
-					"osgi.jaxrs.application.select",
-					"(osgi.jaxrs.name=" + jaxRsApplicationName + ")"
+					"osgi.jaxrs.application.select", selectCondition
 				).put(
 					"osgi.jaxrs.extension", "true"
 				).put(
@@ -654,8 +654,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 				new ObjectValidationRuleEngineExceptionMapper(
 					_jsonFactory, _language),
 				HashMapDictionaryBuilder.<String, Object>put(
-					"osgi.jaxrs.application.select",
-					"(osgi.jaxrs.name=" + jaxRsApplicationName + ")"
+					"osgi.jaxrs.application.select", selectCondition
 				).put(
 					"osgi.jaxrs.extension", "true"
 				).put(
@@ -667,8 +666,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 				ExceptionMapper.class,
 				new RequiredObjectRelationshipExceptionMapper(_language),
 				HashMapDictionaryBuilder.<String, Object>put(
-					"osgi.jaxrs.application.select",
-					"(osgi.jaxrs.name=" + jaxRsApplicationName + ")"
+					"osgi.jaxrs.application.select", selectCondition
 				).put(
 					"osgi.jaxrs.extension", "true"
 				).put(
@@ -680,8 +678,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 				ExceptionMapper.class,
 				new UnsupportedOperationExceptionMapper(),
 				HashMapDictionaryBuilder.<String, Object>put(
-					"osgi.jaxrs.application.select",
-					"(osgi.jaxrs.name=" + jaxRsApplicationName + ")"
+					"osgi.jaxrs.application.select", selectCondition
 				).put(
 					"osgi.jaxrs.extension", "true"
 				).put(


### PR DESCRIPTION
**Purpose of this PR:**
This PR improves the messages of the responses given by POST API Endpoints created through API Builder.

**This is done through:**
- Generating Object exception mappers services for the API Builder execution enviroment.
- Adapting the way we treat the responses when a response schema is null.
- Creating tests for the aforementioned + a test for another already solved bug.

See the following **Jira Ticket**: [LPS-202115](https://liferay.atlassian.net/browse/LPS-202115)

<summary> 
Steps to test:
</summary>

<details>

- Create an API Application, API Schema with API Properties through UI or through API calls. Here's a code-snippet to create such a structure:

```bash
curl -X 'POST' \
  'http://localhost:8080/o/object-admin/v1.0/object-definitions' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -u 'test@liferay.com:test' \
  -d '{"enableComments":false,"objectRelationships":[],"enableCategorization":true,"accountEntryRestrictedObjectFieldName":"","objectActions":[],"accountEntryRestricted":false,"externalReferenceCode":"boss-object-erc","objectFields":[{"indexed":false,"objectFieldSettings":[],"readOnly":"true","DBType":"String","label":{"en_US":"Author"},"type":"String","required":false,"externalReferenceCode":"c130234e-14a4-e181-840e-9894ad6d81de","indexedAsKeyword":false,"system":true,"indexedLanguageId":"","name":"creator","state":false,"businessType":"Text","readOnlyConditionExpression":""},{"indexed":false,"objectFieldSettings":[],"readOnly":"true","DBType":"Date","label":{"en_US":"Create Date"},"type":"Date","required":false,"externalReferenceCode":"41c453fa-77c3-241f-65fc-4381c74ad603","indexedAsKeyword":false,"system":true,"indexedLanguageId":"","name":"createDate","state":false,"businessType":"Date","readOnlyConditionExpression":""},{"indexed":false,"objectFieldSettings":[],"readOnly":"false","DBType":"String","label":{"en_US":"External Reference Code"},"type":"String","required":false,"externalReferenceCode":"fcab3cce-d9cb-96e2-8c8c-d6f6e79e87ad","indexedAsKeyword":false,"system":true,"indexedLanguageId":"","name":"externalReferenceCode","state":false,"businessType":"Text","readOnlyConditionExpression":""},{"indexed":true,"objectFieldSettings":[],"readOnly":"true","DBType":"Long","label":{"en_US":"ID"},"type":"Long","required":false,"externalReferenceCode":"6db8c8ea-4009-a83b-2b3b-be03ba7148b2","indexedAsKeyword":true,"system":true,"indexedLanguageId":"","name":"id","state":false,"businessType":"LongInteger","readOnlyConditionExpression":""},{"indexed":false,"objectFieldSettings":[],"readOnly":"true","DBType":"Date","label":{"en_US":"Modified Date"},"type":"Date","required":false,"externalReferenceCode":"88cd1e66-639c-f402-c416-83796df67037","indexedAsKeyword":false,"system":true,"indexedLanguageId":"","name":"modifiedDate","state":false,"businessType":"Date","readOnlyConditionExpression":""},{"indexed":false,"objectFieldSettings":[],"readOnly":"true","DBType":"String","label":{"en_US":"Status"},"type":"String","required":false,"externalReferenceCode":"5e2a7c7d-b92b-70b1-c289-eaed0bb720fa","indexedAsKeyword":false,"system":true,"indexedLanguageId":"","name":"status","state":false,"businessType":"Text","readOnlyConditionExpression":""},{"indexed":true,"objectFieldSettings":[],"readOnly":"false","DBType":"String","label":{"en_US":"Boss name"},"type":"String","required":true,"externalReferenceCode":"1e9b697c-2f66-2298-cf68-2dac6a8e6b0f","indexedAsKeyword":false,"system":false,"indexedLanguageId":"en_US","name":"bossName","state":false,"businessType":"Text","readOnlyConditionExpression":""}],"restContextPath":"/o/c/bosses","scope":"company","portlet":true,"modifiable":true,"parameterRequired":false,"enableObjectEntryHistory":false,"titleObjectFieldName":"id","objectValidationRules":[],"active":true,"defaultLanguageId":"en_US","label":{"en_US":"Boss"},"panelCategoryKey":"","pluralLabel":{"en_US":"Bosses"},"objectLayouts":[],"system":false,"objectViews":[],"name":"Boss","actions":{"permissions":{},"get":{},"update":{},"delete":{}},"status":{"label_i18n":"Approved","code":0,"label":"approved"}}'
  
  curl -X 'POST' \
  'http://localhost:8080/o/object-admin/v1.0/object-definitions' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -u 'test@liferay.com:test' \
  -d '{"enableComments":false,"objectRelationships":[],"enableCategorization":true,"accountEntryRestrictedObjectFieldName":"","objectActions":[],"accountEntryRestricted":false,"externalReferenceCode":"employee-object-erc","objectFields":[{"indexed":false,"objectFieldSettings":[],"readOnly":"true","DBType":"String","label":{"en_US":"Author"},"type":"String","required":false,"externalReferenceCode":"f9943aa1-7acf-d968-7b99-b469b1f575ab","indexedAsKeyword":false,"system":true,"indexedLanguageId":"","name":"creator","state":false,"businessType":"Text","readOnlyConditionExpression":""},{"indexed":false,"objectFieldSettings":[],"readOnly":"true","DBType":"Date","label":{"en_US":"Create Date"},"type":"Date","required":false,"externalReferenceCode":"60a273b0-ccab-1933-4a32-cb05e36d2a05","indexedAsKeyword":false,"system":true,"indexedLanguageId":"","name":"createDate","state":false,"businessType":"Date","readOnlyConditionExpression":""},{"indexed":false,"objectFieldSettings":[],"readOnly":"false","DBType":"String","label":{"en_US":"External Reference Code"},"type":"String","required":false,"externalReferenceCode":"1841633b-6398-7958-5ba3-bfc12f70191d","indexedAsKeyword":false,"system":true,"indexedLanguageId":"","name":"externalReferenceCode","state":false,"businessType":"Text","readOnlyConditionExpression":""},{"indexed":true,"objectFieldSettings":[],"readOnly":"true","DBType":"Long","label":{"en_US":"ID"},"type":"Long","required":false,"externalReferenceCode":"d60809bd-66fa-3bca-d907-252dbc3fb52a","indexedAsKeyword":true,"system":true,"indexedLanguageId":"","name":"id","state":false,"businessType":"LongInteger","readOnlyConditionExpression":""},{"indexed":false,"objectFieldSettings":[],"readOnly":"true","DBType":"Date","label":{"en_US":"Modified Date"},"type":"Date","required":false,"externalReferenceCode":"7645fa33-8eaa-70ec-d376-89010c32330f","indexedAsKeyword":false,"system":true,"indexedLanguageId":"","name":"modifiedDate","state":false,"businessType":"Date","readOnlyConditionExpression":""},{"indexed":false,"objectFieldSettings":[],"readOnly":"true","DBType":"String","label":{"en_US":"Status"},"type":"String","required":false,"externalReferenceCode":"1620c918-d7f8-be9c-1553-9848da72fd72","indexedAsKeyword":false,"system":true,"indexedLanguageId":"","name":"status","state":false,"businessType":"Text","readOnlyConditionExpression":""},{"indexed":true,"objectFieldSettings":[],"readOnly":"false","DBType":"String","label":{"en_US":"employeeName"},"type":"String","required":true,"externalReferenceCode":"122b6735-1664-915d-aa00-46ab0368d958","indexedAsKeyword":false,"system":false,"indexedLanguageId":"en_US","name":"employeeName","state":false,"businessType":"Text","readOnlyConditionExpression":""}],"restContextPath":"/o/c/employees","scope":"company","portlet":true,"modifiable":true,"parameterRequired":false,"enableObjectEntryHistory":false,"titleObjectFieldName":"id","objectValidationRules":[],"active":true,"defaultLanguageId":"en_US","label":{"en_US":"Employee"},"panelCategoryKey":"","pluralLabel":{"en_US":"Employees"},"objectLayouts":[],"system":false,"objectViews":[],"name":"Employee","actions":{"permissions":{},"get":{},"update":{},"delete":{}},"status":{"label_i18n":"Approved","code":0,"label":"approved"}}'
  
  curl -X 'POST' \
  'http://localhost:8080/o/object-admin/v1.0/object-definitions' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -u 'test@liferay.com:test' \
  -d '{"enableComments":false,"objectRelationships":[{"objectDefinitionSystem2":false,"parameterObjectFieldName":"","parameterObjectFieldId":0,"label":{"en_US":"companyBosses"},"reverse":false,"type":"oneToMany","objectDefinitionModifiable2":true,"name":"companyBosses","deletionType":"prevent","objectDefinitionExternalReferenceCode1":"company-object-erc","objectDefinitionExternalReferenceCode2":"boss-object-erc","objectDefinitionName2":"Boss"},{"objectDefinitionSystem2":false,"parameterObjectFieldName":"","parameterObjectFieldId":0,"label":{"en_US":"companyEmployees"},"reverse":false,"type":"oneToMany","objectDefinitionModifiable2":true,"name":"companyEmployees","deletionType":"prevent","objectDefinitionExternalReferenceCode1":"company-object-erc","objectDefinitionExternalReferenceCode2":"employee-object-erc","objectDefinitionName2":"Employee"}],"enableCategorization":true,"accountEntryRestrictedObjectFieldName":"","objectActions":[],"accountEntryRestricted":false,"externalReferenceCode":"company-object-erc","objectFields":[{"indexed":false,"objectFieldSettings":[],"readOnly":"true","DBType":"String","label":{"en_US":"Author"},"type":"String","required":false,"externalReferenceCode":"dc58e5db-c00a-2d4c-b09b-8534091d4417","indexedAsKeyword":false,"system":true,"indexedLanguageId":"","name":"creator","state":false,"businessType":"Text","readOnlyConditionExpression":""},{"indexed":false,"objectFieldSettings":[],"readOnly":"true","DBType":"Date","label":{"en_US":"Create Date"},"type":"Date","required":false,"externalReferenceCode":"cd18c9b1-aa57-7f56-0dd9-643b4336e005","indexedAsKeyword":false,"system":true,"indexedLanguageId":"","name":"createDate","state":false,"businessType":"Date","readOnlyConditionExpression":""},{"indexed":false,"objectFieldSettings":[],"readOnly":"false","DBType":"String","label":{"en_US":"External Reference Code"},"type":"String","required":false,"externalReferenceCode":"232f7ef6-dc4d-7796-6e21-a95b010b3382","indexedAsKeyword":false,"system":true,"indexedLanguageId":"","name":"externalReferenceCode","state":false,"businessType":"Text","readOnlyConditionExpression":""},{"indexed":true,"objectFieldSettings":[],"readOnly":"true","DBType":"Long","label":{"en_US":"ID"},"type":"Long","required":false,"externalReferenceCode":"1443c4e0-e5d0-2b18-cdca-1642dc7e58c3","indexedAsKeyword":true,"system":true,"indexedLanguageId":"","name":"id","state":false,"businessType":"LongInteger","readOnlyConditionExpression":""},{"indexed":false,"objectFieldSettings":[],"readOnly":"true","DBType":"Date","label":{"en_US":"Modified Date"},"type":"Date","required":false,"externalReferenceCode":"c39b7bc9-a38b-388a-cfb9-438834cca715","indexedAsKeyword":false,"system":true,"indexedLanguageId":"","name":"modifiedDate","state":false,"businessType":"Date","readOnlyConditionExpression":""},{"indexed":false,"objectFieldSettings":[],"readOnly":"true","DBType":"String","label":{"en_US":"Status"},"type":"String","required":false,"externalReferenceCode":"d53001b3-baa2-96a2-b729-71b2f339e21f","indexedAsKeyword":false,"system":true,"indexedLanguageId":"","name":"status","state":false,"businessType":"Text","readOnlyConditionExpression":""},{"indexed":true,"objectFieldSettings":[],"readOnly":"false","DBType":"String","label":{"en_US":"Company name"},"type":"String","required":true,"externalReferenceCode":"d32476e9-3978-c559-29f2-b611aef28115","indexedAsKeyword":false,"system":false,"indexedLanguageId":"en_US","name":"companyName","state":false,"businessType":"Text","readOnlyConditionExpression":""}],"restContextPath":"/o/c/companies","scope":"company","portlet":true,"modifiable":true,"parameterRequired":false,"enableObjectEntryHistory":false,"titleObjectFieldName":"id","objectValidationRules":[],"active":true,"defaultLanguageId":"en_US","label":{"en_US":"Company"},"panelCategoryKey":"","pluralLabel":{"en_US":"Companies"},"objectLayouts":[],"system":false,"objectViews":[],"name":"Company","actions":{"permissions":{},"get":{},"update":{},"delete":{}},"status":{"label_i18n":"Approved","code":0,"label":"approved"}}'
  
curl -X 'POST' \
  'http://localhost:8080/o/c/companies/' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -u 'test@liferay.com:test' \
  -d '{
  "externalReferenceCode": "google-erc",
  "companyName": "Google",
  "companyBosses": [
    {
      "externalReferenceCode": "john-erc",
      "bossName": "John"
    },
    {
      "externalReferenceCode": "enmma-erc",
      "bossName": "Enmma"
    }
  ],
  "companyEmployees": [
    {
      "externalReferenceCode": "albert-erc",
      "employeeName": "Albert"
    },
    {
      "externalReferenceCode": "emily-erc",
      "employeeName": "Emily"
    },
    {
      "externalReferenceCode": "jacob-erc",
      "employeeName": "Jacob"
    }
  ]
}'

curl -X 'POST' \
  'http://localhost:8080/o/c/companies/' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -u 'test@liferay.com:test' \
  -d '{
  "externalReferenceCode": "liferay-erc",
  "companyName": "Liferay",
  "companyBosses": [
    {
      "externalReferenceCode": "brian-erc",
      "bossName": "Brian"
    },
    {
      "externalReferenceCode": "marco-erc",
      "bossName": "Marco"
    }
  ],
  "companyEmployees": [
    {
      "externalReferenceCode": "alex-erc",
      "employeeName": "Alex"
    },
    {
      "externalReferenceCode": "sergio-erc",
      "employeeName": "Sergio"
    },
    {
      "externalReferenceCode": "bruno-erc",
      "employeeName": "Bruno"
    }
  ]
}'

curl -X 'POST' \
  'http://localhost:8080/o/c/companies/' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -u 'test@liferay.com:test' \
  -d '{
  "externalReferenceCode": "oracle-erc",
  "companyName": "Oracle",
  "companyBosses": [
    {
      "externalReferenceCode": "keanu-erc",
      "bossName": "Keanu"
    }
  ],
  "companyEmployees": [
    {
      "externalReferenceCode": "stewart-erc",
      "employeeName": "Stewart"
    },
    {
      "externalReferenceCode": "james-erc",
      "employeeName": "James"
    }
  ]
}'

curl -X 'POST' \
  'http://localhost:8080/o/headless-builder/applications/' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -u 'test@liferay.com:test' \
  -d '{
  "externalReferenceCode": "companies-manager-erc",
  "applicationStatus": "published",
  "baseURL": "companymanager",
  "description": "Retrive the data from the different companies, bosses and employees.",
  "title": "Companies manager"
}'

curl -X 'POST' \
  'http://localhost:8080/o/headless-builder/endpoints/' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -u 'test@liferay.com:test' \
  -d '{
  "externalReferenceCode": "get-all-boss-employees-erc",
  "description": "This endpoint returns the names of all the existing bosses and their employees",
  "httpMethod": "get",
  "name": "getBossEmployee",
  "path": "/getbossemployee",
  "r_apiApplicationToAPIEndpoints_c_apiApplicationERC": "companies-manager-erc",
  "responseAPISchemaToAPIEndpoints": {
    "externalReferenceCode": "boss-schema-erc",
    "description": "The boss schema",
    "mainObjectDefinitionERC": "boss-object-erc",
    "name": "Boss",
    "r_apiApplicationToAPISchemas_c_apiApplicationERC": "companies-manager-erc",
    "apiSchemaToAPIProperties": [
      {
        "externalReferenceCode": "boss-name-property-erc",
        "description": "The name of the desired boss",
        "name": "bossName",
        "objectFieldERC": "1e9b697c-2f66-2298-cf68-2dac6a8e6b0f"
      },
      {
        "externalReferenceCode": "employee-name-property-erc",
        "description": "The name of the desired employee",
        "name": "employeeName",
        "objectFieldERC": "122b6735-1664-915d-aa00-46ab0368d958",
        "objectRelationshipNames": "companyBosses,companyEmployees"
      }
    ]
  },
  "retrieveType": "collection",
  "scope": "company"
}'
```

- Create a POST API Endpoint considering that this type of endpoints doesn't support path parameters and they can only have a `singleElement` retrieve-type. Here's a code-snippet to create such a structure:

```bash
curl -X 'POST' \
  'http://localhost:8080/o/headless-builder/endpoints/' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -u 'test@liferay.com:test' \
  -d '{
  "externalReferenceCode": "post-boss-endpoint-erc",
  "description": "This is a post boss endpoint",
  "httpMethod": "post",
  "name": "Post boss",
  "path": "/boss",
  "r_apiApplicationToAPIEndpoints_c_apiApplicationERC": "companies-manager-erc",
  "r_requestAPISchemaToAPIEndpoints_c_apiSchemaERC": "boss-schema-erc",
  "r_responseAPISchemaToAPIEndpoints_c_apiSchemaERC": "boss-schema-erc",
  "retrieveType": "singleElement",
  "scope": "company"
}'
```

- Execute the recently created API Endpoint but forcing an error from the Object infrastructure. Here's a CURL example in which a required field is not stablished:
```bash
curl -X 'POST' \
  'http://localhost:8080/o/c/companymanager/boss' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -u 'test@liferay.com:test' \
  -d '{}'
```
</details>