### PR TITLE
LPS-155562 Use Search Index over Database to prevent full table scan

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardMessageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardMessageResourceImpl.java
@@ -165,9 +165,7 @@ public class MessageBoardMessageResourceImpl
 					mbMessage.getGroupId())
 			).build();
 
-		if ((search == null) && (filter == null)) {
-			flatten = GetterUtil.getBoolean(flatten);
-
+		if ((search == null) && (filter == null) && !flatten) {
 			int status = WorkflowConstants.STATUS_APPROVED;
 
 			PermissionChecker permissionChecker =


### PR DESCRIPTION
While using Glowroot to diagnose a performance issue with Liferay Ask, I discovered that the problem stems from the flatten parameter performing full table scans in the database. This is because the flatten parameter utilizes the treePath field, which is a long text field and not indexable.

Considering that the MBMessage table on Liferay.dev contains over 350,000 records, the full table scan proves to be quite expensive, leading to some posts in Liferay Ask taking up to 20 seconds to render.

With this modification, whenever flatten is used, it now defaults to the search index instead of the database to avoid the full table scan. After implementing this change locally, Liferay Ask now has sub-second response times for every post and no longer registers as a slow transaction in Glowroot.

On Production Liferay.dev, this issue has occurred over 3000 times within a 24-hour time span:

![glowroot-lrdev-ask](https://github.com/brianchandotcom/liferay-portal/assets/4322161/e2fcac83-8d22-4b6d-b133-bdf6d1b31397)