### PR TITLE
LPS-196453: Aggregation and facet translators with dependent translators ( Part 3 of LPS-196453)

### DIFF
--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/aggregation/AggregationResultTranslatorFactory.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/aggregation/AggregationResultTranslatorFactory.java
@@ -1,0 +1,21 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.opensearch2.internal.aggregation;
+
+import com.liferay.portal.search.aggregation.AggregationResultTranslator;
+
+import org.opensearch.client.opensearch._types.aggregations.Aggregate;
+
+/**
+ * @author André de Oliveira
+ * @author Petteri Karttunen
+ */
+public interface AggregationResultTranslatorFactory {
+
+	public AggregationResultTranslator createAggregationResultTranslator(
+		Aggregate aggregate);
+
+}

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/aggregation/OpenSearchAggregationResultTranslator.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/aggregation/OpenSearchAggregationResultTranslator.java
@@ -1,0 +1,885 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.opensearch2.internal.aggregation;
+
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.search.aggregation.Aggregation;
+import com.liferay.portal.search.aggregation.AggregationResult;
+import com.liferay.portal.search.aggregation.AggregationResultTranslator;
+import com.liferay.portal.search.aggregation.AggregationResults;
+import com.liferay.portal.search.aggregation.bucket.Bucket;
+import com.liferay.portal.search.aggregation.bucket.BucketAggregationResult;
+import com.liferay.portal.search.aggregation.bucket.ChildrenAggregation;
+import com.liferay.portal.search.aggregation.bucket.ChildrenAggregationResult;
+import com.liferay.portal.search.aggregation.bucket.DateHistogramAggregation;
+import com.liferay.portal.search.aggregation.bucket.DateHistogramAggregationResult;
+import com.liferay.portal.search.aggregation.bucket.DateRangeAggregation;
+import com.liferay.portal.search.aggregation.bucket.DiversifiedSamplerAggregation;
+import com.liferay.portal.search.aggregation.bucket.DiversifiedSamplerAggregationResult;
+import com.liferay.portal.search.aggregation.bucket.FilterAggregation;
+import com.liferay.portal.search.aggregation.bucket.FilterAggregationResult;
+import com.liferay.portal.search.aggregation.bucket.FiltersAggregation;
+import com.liferay.portal.search.aggregation.bucket.FiltersAggregationResult;
+import com.liferay.portal.search.aggregation.bucket.GeoDistanceAggregation;
+import com.liferay.portal.search.aggregation.bucket.GeoDistanceAggregationResult;
+import com.liferay.portal.search.aggregation.bucket.GeoHashGridAggregation;
+import com.liferay.portal.search.aggregation.bucket.GeoHashGridAggregationResult;
+import com.liferay.portal.search.aggregation.bucket.GlobalAggregation;
+import com.liferay.portal.search.aggregation.bucket.GlobalAggregationResult;
+import com.liferay.portal.search.aggregation.bucket.HistogramAggregation;
+import com.liferay.portal.search.aggregation.bucket.HistogramAggregationResult;
+import com.liferay.portal.search.aggregation.bucket.MissingAggregation;
+import com.liferay.portal.search.aggregation.bucket.MissingAggregationResult;
+import com.liferay.portal.search.aggregation.bucket.NestedAggregation;
+import com.liferay.portal.search.aggregation.bucket.NestedAggregationResult;
+import com.liferay.portal.search.aggregation.bucket.RangeAggregation;
+import com.liferay.portal.search.aggregation.bucket.RangeAggregationResult;
+import com.liferay.portal.search.aggregation.bucket.ReverseNestedAggregation;
+import com.liferay.portal.search.aggregation.bucket.ReverseNestedAggregationResult;
+import com.liferay.portal.search.aggregation.bucket.SamplerAggregation;
+import com.liferay.portal.search.aggregation.bucket.SamplerAggregationResult;
+import com.liferay.portal.search.aggregation.bucket.SignificantTermsAggregation;
+import com.liferay.portal.search.aggregation.bucket.SignificantTermsAggregationResult;
+import com.liferay.portal.search.aggregation.bucket.SignificantTextAggregation;
+import com.liferay.portal.search.aggregation.bucket.SignificantTextAggregationResult;
+import com.liferay.portal.search.aggregation.bucket.TermsAggregation;
+import com.liferay.portal.search.aggregation.bucket.TermsAggregationResult;
+import com.liferay.portal.search.aggregation.metrics.AvgAggregation;
+import com.liferay.portal.search.aggregation.metrics.AvgAggregationResult;
+import com.liferay.portal.search.aggregation.metrics.CardinalityAggregation;
+import com.liferay.portal.search.aggregation.metrics.CardinalityAggregationResult;
+import com.liferay.portal.search.aggregation.metrics.ExtendedStatsAggregation;
+import com.liferay.portal.search.aggregation.metrics.ExtendedStatsAggregationResult;
+import com.liferay.portal.search.aggregation.metrics.GeoBoundsAggregation;
+import com.liferay.portal.search.aggregation.metrics.GeoBoundsAggregationResult;
+import com.liferay.portal.search.aggregation.metrics.GeoCentroidAggregation;
+import com.liferay.portal.search.aggregation.metrics.GeoCentroidAggregationResult;
+import com.liferay.portal.search.aggregation.metrics.MaxAggregation;
+import com.liferay.portal.search.aggregation.metrics.MaxAggregationResult;
+import com.liferay.portal.search.aggregation.metrics.MinAggregation;
+import com.liferay.portal.search.aggregation.metrics.MinAggregationResult;
+import com.liferay.portal.search.aggregation.metrics.PercentileRanksAggregation;
+import com.liferay.portal.search.aggregation.metrics.PercentileRanksAggregationResult;
+import com.liferay.portal.search.aggregation.metrics.PercentilesAggregation;
+import com.liferay.portal.search.aggregation.metrics.PercentilesAggregationResult;
+import com.liferay.portal.search.aggregation.metrics.ScriptedMetricAggregation;
+import com.liferay.portal.search.aggregation.metrics.ScriptedMetricAggregationResult;
+import com.liferay.portal.search.aggregation.metrics.StatsAggregation;
+import com.liferay.portal.search.aggregation.metrics.StatsAggregationResult;
+import com.liferay.portal.search.aggregation.metrics.SumAggregation;
+import com.liferay.portal.search.aggregation.metrics.SumAggregationResult;
+import com.liferay.portal.search.aggregation.metrics.TopHitsAggregation;
+import com.liferay.portal.search.aggregation.metrics.TopHitsAggregationResult;
+import com.liferay.portal.search.aggregation.metrics.ValueCountAggregation;
+import com.liferay.portal.search.aggregation.metrics.ValueCountAggregationResult;
+import com.liferay.portal.search.aggregation.metrics.WeightedAvgAggregation;
+import com.liferay.portal.search.aggregation.metrics.WeightedAvgAggregationResult;
+import com.liferay.portal.search.aggregation.pipeline.PipelineAggregationResultTranslator;
+import com.liferay.portal.search.geolocation.GeoBuilders;
+import com.liferay.portal.search.geolocation.GeoLocationPoint;
+import com.liferay.portal.search.opensearch2.internal.hits.HitsMetadataTranslator;
+
+import java.util.List;
+import java.util.Map;
+
+import org.opensearch.client.opensearch._types.GeoBounds;
+import org.opensearch.client.opensearch._types.GeoLocation;
+import org.opensearch.client.opensearch._types.LatLonGeoLocation;
+import org.opensearch.client.opensearch._types.TopLeftBottomRightGeoBounds;
+import org.opensearch.client.opensearch._types.aggregations.Aggregate;
+import org.opensearch.client.opensearch._types.aggregations.AvgAggregate;
+import org.opensearch.client.opensearch._types.aggregations.Buckets;
+import org.opensearch.client.opensearch._types.aggregations.CardinalityAggregate;
+import org.opensearch.client.opensearch._types.aggregations.ChildrenAggregate;
+import org.opensearch.client.opensearch._types.aggregations.DateHistogramAggregate;
+import org.opensearch.client.opensearch._types.aggregations.DateHistogramBucket;
+import org.opensearch.client.opensearch._types.aggregations.DateRangeAggregate;
+import org.opensearch.client.opensearch._types.aggregations.ExtendedStatsAggregate;
+import org.opensearch.client.opensearch._types.aggregations.FilterAggregate;
+import org.opensearch.client.opensearch._types.aggregations.FiltersAggregate;
+import org.opensearch.client.opensearch._types.aggregations.FiltersBucket;
+import org.opensearch.client.opensearch._types.aggregations.GeoBoundsAggregate;
+import org.opensearch.client.opensearch._types.aggregations.GeoCentroidAggregate;
+import org.opensearch.client.opensearch._types.aggregations.GeoDistanceAggregate;
+import org.opensearch.client.opensearch._types.aggregations.GeoHashGridAggregate;
+import org.opensearch.client.opensearch._types.aggregations.GeoHashGridBucket;
+import org.opensearch.client.opensearch._types.aggregations.GlobalAggregate;
+import org.opensearch.client.opensearch._types.aggregations.HdrPercentileRanksAggregate;
+import org.opensearch.client.opensearch._types.aggregations.HdrPercentilesAggregate;
+import org.opensearch.client.opensearch._types.aggregations.HistogramAggregate;
+import org.opensearch.client.opensearch._types.aggregations.HistogramBucket;
+import org.opensearch.client.opensearch._types.aggregations.LongTermsAggregate;
+import org.opensearch.client.opensearch._types.aggregations.LongTermsBucket;
+import org.opensearch.client.opensearch._types.aggregations.MaxAggregate;
+import org.opensearch.client.opensearch._types.aggregations.MinAggregate;
+import org.opensearch.client.opensearch._types.aggregations.MissingAggregate;
+import org.opensearch.client.opensearch._types.aggregations.NestedAggregate;
+import org.opensearch.client.opensearch._types.aggregations.Percentiles;
+import org.opensearch.client.opensearch._types.aggregations.RangeAggregate;
+import org.opensearch.client.opensearch._types.aggregations.RangeBucket;
+import org.opensearch.client.opensearch._types.aggregations.ReverseNestedAggregate;
+import org.opensearch.client.opensearch._types.aggregations.SamplerAggregate;
+import org.opensearch.client.opensearch._types.aggregations.ScriptedMetricAggregate;
+import org.opensearch.client.opensearch._types.aggregations.StatsAggregate;
+import org.opensearch.client.opensearch._types.aggregations.StringTermsAggregate;
+import org.opensearch.client.opensearch._types.aggregations.StringTermsBucket;
+import org.opensearch.client.opensearch._types.aggregations.SumAggregate;
+import org.opensearch.client.opensearch._types.aggregations.TDigestPercentileRanksAggregate;
+import org.opensearch.client.opensearch._types.aggregations.TDigestPercentilesAggregate;
+import org.opensearch.client.opensearch._types.aggregations.TopHitsAggregate;
+import org.opensearch.client.opensearch._types.aggregations.ValueCountAggregate;
+import org.opensearch.client.opensearch._types.aggregations.WeightedAvgAggregate;
+
+/**
+ * @author Michael C. Han
+ * @author Petteri Karttunen
+ */
+public class OpenSearchAggregationResultTranslator
+	implements AggregationResultTranslator, AggregationResultTranslatorFactory,
+			   PipelineAggregationResultTranslatorFactory {
+
+	public OpenSearchAggregationResultTranslator(
+		Aggregate aggregate, AggregationResults aggregationResults,
+		GeoBuilders geoBuilders,
+		HitsMetadataTranslator hitsMetadataTranslator) {
+
+		_aggregate = aggregate;
+		_aggregationResults = aggregationResults;
+		_geoBuilders = geoBuilders;
+		_hitsMetadataTranslator = hitsMetadataTranslator;
+	}
+
+	@Override
+	public AggregationResultTranslator createAggregationResultTranslator(
+		Aggregate aggregate) {
+
+		return new OpenSearchAggregationResultTranslator(
+			aggregate, _aggregationResults, _geoBuilders,
+			_hitsMetadataTranslator);
+	}
+
+	@Override
+	public PipelineAggregationResultTranslator
+		createPipelineAggregationResultTranslator(Aggregate aggregate) {
+
+		return new OpenSearchPipelineAggregationResultTranslator(
+			aggregate, _aggregationResults);
+	}
+
+	@Override
+	public AvgAggregationResult visit(AvgAggregation avgAggregation) {
+		AvgAggregate avgAggregate = _aggregate.avg();
+
+		return _aggregationResults.avg(
+			avgAggregation.getName(), avgAggregate.value());
+	}
+
+	@Override
+	public CardinalityAggregationResult visit(
+		CardinalityAggregation cardinalityAggregation) {
+
+		CardinalityAggregate cardinalityAggregate = _aggregate.cardinality();
+
+		return _aggregationResults.cardinality(
+			cardinalityAggregation.getName(), cardinalityAggregate.value());
+	}
+
+	@Override
+	public ChildrenAggregationResult visit(
+		ChildrenAggregation childrenAggregation) {
+
+		ChildrenAggregate childrenAggregate = _aggregate.children();
+
+		ChildrenAggregationResult childrenAggregationResult =
+			_aggregationResults.children(
+				childrenAggregation.getName(), childrenAggregate.docCount());
+
+		childrenAggregationResult.addChildrenAggregationResults(
+			translate(childrenAggregation, childrenAggregate.aggregations()));
+
+		return childrenAggregationResult;
+	}
+
+	@Override
+	public DateHistogramAggregationResult visit(
+		DateHistogramAggregation dateHistogramAggregation) {
+
+		DateHistogramAggregate dateHistogramAggregate =
+			_aggregate.dateHistogram();
+
+		DateHistogramAggregationResult dateHistogramAggregationResult =
+			_aggregationResults.dateHistogram(
+				dateHistogramAggregation.getName());
+
+		Buckets<DateHistogramBucket> buckets = dateHistogramAggregate.buckets();
+
+		if (buckets.isArray()) {
+			ListUtil.isNotEmptyForEach(
+				buckets.array(),
+				dateHistogramBucket -> {
+					Bucket bucket = dateHistogramAggregationResult.addBucket(
+						dateHistogramBucket.keyAsString(),
+						dateHistogramBucket.docCount());
+
+					_addBucketChildAggregationResults(
+						dateHistogramAggregation,
+						dateHistogramBucket.aggregations(), bucket);
+				});
+		}
+		else {
+			MapUtil.isNotEmptyForEach(
+				buckets.keyed(),
+				(key, dateHistogramBucket) -> {
+					Bucket bucket = dateHistogramAggregationResult.addBucket(
+						key, dateHistogramBucket.docCount());
+
+					_addBucketChildAggregationResults(
+						dateHistogramAggregation,
+						dateHistogramBucket.aggregations(), bucket);
+				});
+		}
+
+		return dateHistogramAggregationResult;
+	}
+
+	@Override
+	public RangeAggregationResult visit(
+		DateRangeAggregation dateRangeAggregation) {
+
+		DateRangeAggregate dateRangeAggregate = _aggregate.dateRange();
+
+		return _translateRangeBuckets(
+			dateRangeAggregation, dateRangeAggregate.buckets(),
+			_aggregationResults.range(dateRangeAggregation.getName()));
+	}
+
+	@Override
+	public DiversifiedSamplerAggregationResult visit(
+		DiversifiedSamplerAggregation diversifiedSamplerAggregation) {
+
+		SamplerAggregate samplerAggregate = _aggregate.sampler();
+
+		DiversifiedSamplerAggregationResult
+			diversifiedSamplerAggregationResult =
+				_aggregationResults.diversifiedSampler(
+					diversifiedSamplerAggregation.getName(),
+					samplerAggregate.docCount());
+
+		diversifiedSamplerAggregationResult.addChildrenAggregationResults(
+			translate(
+				diversifiedSamplerAggregation,
+				samplerAggregate.aggregations()));
+
+		return diversifiedSamplerAggregationResult;
+	}
+
+	@Override
+	public ExtendedStatsAggregationResult visit(
+		ExtendedStatsAggregation extendedStatsAggregation) {
+
+		ExtendedStatsAggregate extendedStatsAggregate =
+			_aggregate.extendedStats();
+
+		return _aggregationResults.extendedStats(
+			extendedStatsAggregation.getName(), extendedStatsAggregate.avg(),
+			extendedStatsAggregate.count(), extendedStatsAggregate.min(),
+			extendedStatsAggregate.max(), extendedStatsAggregate.sum(),
+			extendedStatsAggregate.sumOfSquares(),
+			extendedStatsAggregate.variance(),
+			extendedStatsAggregate.stdDeviation());
+	}
+
+	@Override
+	public FilterAggregationResult visit(FilterAggregation filterAggregation) {
+		FilterAggregate filterAggregate = _aggregate.filter();
+
+		FilterAggregationResult filterAggregationResult =
+			_aggregationResults.filter(
+				filterAggregation.getName(), filterAggregate.docCount());
+
+		filterAggregationResult.addChildrenAggregationResults(
+			translate(filterAggregation, filterAggregate.aggregations()));
+
+		return filterAggregationResult;
+	}
+
+	@Override
+	public FiltersAggregationResult visit(
+		FiltersAggregation filtersAggregation) {
+
+		FiltersAggregate filtersAggregate = _aggregate.filters();
+
+		FiltersAggregationResult filtersAggregationResult =
+			_aggregationResults.filters(filtersAggregation.getName());
+
+		Buckets<FiltersBucket> buckets = filtersAggregate.buckets();
+
+		MapUtil.isNotEmptyForEach(
+			buckets.keyed(),
+			(key, filtersBucket) -> {
+				Bucket bucket = filtersAggregationResult.addBucket(
+					key, filtersBucket.docCount());
+
+				_addBucketChildAggregationResults(
+					filtersAggregation, filtersBucket.aggregations(), bucket);
+			});
+
+		return filtersAggregationResult;
+	}
+
+	@Override
+	public GeoBoundsAggregationResult visit(
+		GeoBoundsAggregation geoBoundsAggregation) {
+
+		GeoBoundsAggregate geoBoundsAggregate = _aggregate.geoBounds();
+
+		GeoBounds geoBounds = geoBoundsAggregate.bounds();
+
+		if (!geoBounds.isTlbr()) {
+			throw new UnsupportedOperationException();
+		}
+
+		TopLeftBottomRightGeoBounds topLeftBottomRightGeoBounds =
+			geoBounds.tlbr();
+
+		return _aggregationResults.geoBounds(
+			geoBoundsAggregation.getName(),
+			_translateGeoLocation(topLeftBottomRightGeoBounds.topLeft()),
+			_translateGeoLocation(topLeftBottomRightGeoBounds.bottomRight()));
+	}
+
+	@Override
+	public GeoCentroidAggregationResult visit(
+		GeoCentroidAggregation geoCentroidAggregation) {
+
+		GeoCentroidAggregate geoCentroidAggregate = _aggregate.geoCentroid();
+
+		GeoLocation geoLocation = geoCentroidAggregate.location();
+
+		return _aggregationResults.geoCentroid(
+			geoCentroidAggregation.getName(),
+			_translateGeoLocation(geoLocation), geoCentroidAggregate.count());
+	}
+
+	@Override
+	public GeoDistanceAggregationResult visit(
+		GeoDistanceAggregation geoDistanceAggregation) {
+
+		GeoDistanceAggregate geoDistanceAggregate = _aggregate.geoDistance();
+
+		return _translateRangeBuckets(
+			geoDistanceAggregation, geoDistanceAggregate.buckets(),
+			_aggregationResults.geoDistance(geoDistanceAggregation.getName()));
+	}
+
+	@Override
+	public GeoHashGridAggregationResult visit(
+		GeoHashGridAggregation geoHashGridAggregation) {
+
+		GeoHashGridAggregate geoHashGridAggregate = _aggregate.geohashGrid();
+
+		GeoHashGridAggregationResult geoHashGridAggregationResult =
+			_aggregationResults.geoHashGrid(geoHashGridAggregation.getName());
+
+		Buckets<GeoHashGridBucket> buckets = geoHashGridAggregate.buckets();
+
+		if (buckets.isArray()) {
+			ListUtil.isNotEmptyForEach(
+				buckets.array(),
+				geoHashGridBucket -> {
+					Bucket bucket = geoHashGridAggregationResult.addBucket(
+						geoHashGridBucket.key(), geoHashGridBucket.docCount());
+
+					_addBucketChildAggregationResults(
+						geoHashGridAggregation,
+						geoHashGridBucket.aggregations(), bucket);
+				});
+		}
+		else {
+			MapUtil.isNotEmptyForEach(
+				buckets.keyed(),
+				(key, geoHashGridBucket) -> {
+					Bucket bucket = geoHashGridAggregationResult.addBucket(
+						key, geoHashGridBucket.docCount());
+
+					_addBucketChildAggregationResults(
+						geoHashGridAggregation,
+						geoHashGridBucket.aggregations(), bucket);
+				});
+		}
+
+		return geoHashGridAggregationResult;
+	}
+
+	@Override
+	public GlobalAggregationResult visit(GlobalAggregation globalAggregation) {
+		GlobalAggregate globalAggregate = _aggregate.global();
+
+		GlobalAggregationResult globalAggregationResult =
+			_aggregationResults.global(
+				globalAggregation.getName(), globalAggregate.docCount());
+
+		globalAggregationResult.addChildrenAggregationResults(
+			translate(globalAggregation, globalAggregate.aggregations()));
+
+		return globalAggregationResult;
+	}
+
+	@Override
+	public HistogramAggregationResult visit(
+		HistogramAggregation histogramAggregation) {
+
+		HistogramAggregate histogramAggregate = _aggregate.histogram();
+
+		HistogramAggregationResult histogramAggregationResult =
+			_aggregationResults.histogram(histogramAggregation.getName());
+
+		Buckets<HistogramBucket> buckets = histogramAggregate.buckets();
+
+		if (buckets.isArray()) {
+			ListUtil.isNotEmptyForEach(
+				buckets.array(),
+				histogramBucket -> {
+					Bucket bucket = histogramAggregationResult.addBucket(
+						histogramBucket.keyAsString(),
+						histogramBucket.docCount());
+
+					_addBucketChildAggregationResults(
+						histogramAggregation, histogramBucket.aggregations(),
+						bucket);
+				});
+		}
+		else {
+			MapUtil.isNotEmptyForEach(
+				buckets.keyed(),
+				(key, histogramBucket) -> {
+					Bucket bucket = histogramAggregationResult.addBucket(
+						key, histogramBucket.docCount());
+
+					_addBucketChildAggregationResults(
+						histogramAggregation, histogramBucket.aggregations(),
+						bucket);
+				});
+		}
+
+		return histogramAggregationResult;
+	}
+
+	@Override
+	public MaxAggregationResult visit(MaxAggregation maxAggregation) {
+		MaxAggregate maxAggregate = _aggregate.max();
+
+		return _aggregationResults.max(
+			maxAggregation.getName(), maxAggregate.value());
+	}
+
+	@Override
+	public MinAggregationResult visit(MinAggregation minAggregation) {
+		MinAggregate minAggregate = _aggregate.min();
+
+		return _aggregationResults.min(
+			minAggregation.getName(), minAggregate.value());
+	}
+
+	@Override
+	public MissingAggregationResult visit(
+		MissingAggregation missingAggregation) {
+
+		MissingAggregate missingAggregate = _aggregate.missing();
+
+		MissingAggregationResult missingAggregationResult =
+			_aggregationResults.missing(
+				missingAggregation.getName(), missingAggregate.docCount());
+
+		missingAggregationResult.addChildrenAggregationResults(
+			translate(missingAggregation, missingAggregate.aggregations()));
+
+		return missingAggregationResult;
+	}
+
+	@Override
+	public NestedAggregationResult visit(NestedAggregation nestedAggregation) {
+		NestedAggregate nestedAggregate = _aggregate.nested();
+
+		NestedAggregationResult nestedAggregationResult =
+			_aggregationResults.nested(
+				nestedAggregation.getName(), nestedAggregate.docCount());
+
+		List<AggregationResult> aggregationResults = translate(
+			nestedAggregation, nestedAggregate.aggregations());
+
+		nestedAggregationResult.addChildrenAggregationResults(
+			aggregationResults);
+
+		return nestedAggregationResult;
+	}
+
+	@Override
+	public PercentileRanksAggregationResult visit(
+		PercentileRanksAggregation percentileRanksAggregation) {
+
+		Percentiles percentiles;
+
+		if (_aggregate.isHdrPercentileRanks()) {
+			HdrPercentileRanksAggregate hdrPercentileRanksAggregate =
+				_aggregate.hdrPercentileRanks();
+
+			percentiles = hdrPercentileRanksAggregate.values();
+		}
+		else if (_aggregate.isTdigestPercentileRanks()) {
+			TDigestPercentileRanksAggregate tDigestPercentileRanksAggregate =
+				_aggregate.tdigestPercentileRanks();
+
+			percentiles = tDigestPercentileRanksAggregate.values();
+		}
+		else {
+			throw new UnsupportedOperationException();
+		}
+
+		PercentileRanksAggregationResult percentileRanksAggregationResult =
+			_aggregationResults.percentileRanks(
+				percentileRanksAggregation.getName());
+
+		if (percentiles.isArray()) {
+			ListUtil.isNotEmptyForEach(
+				percentiles.array(),
+				arrayPercentilesItem ->
+					percentileRanksAggregationResult.addPercentile(
+						Double.valueOf(arrayPercentilesItem.key()),
+						arrayPercentilesItem.value()));
+		}
+		else {
+			MapUtil.isNotEmptyForEach(
+				percentiles.keyed(),
+				(key, value) -> percentileRanksAggregationResult.addPercentile(
+					Double.valueOf(key), GetterUtil.getDouble(value)));
+		}
+
+		return percentileRanksAggregationResult;
+	}
+
+	@Override
+	public PercentilesAggregationResult visit(
+		PercentilesAggregation percentilesAggregation) {
+
+		Percentiles percentiles;
+
+		if (_aggregate.isHdrPercentiles()) {
+			HdrPercentilesAggregate hdrPercentilesAggregate =
+				_aggregate.hdrPercentiles();
+
+			percentiles = hdrPercentilesAggregate.values();
+		}
+		else if (_aggregate.isTdigestPercentiles()) {
+			TDigestPercentilesAggregate tDigestPercentilesAggregate =
+				_aggregate.tdigestPercentiles();
+
+			percentiles = tDigestPercentilesAggregate.values();
+		}
+		else {
+			throw new UnsupportedOperationException();
+		}
+
+		PercentilesAggregationResult percentilesAggregationResult =
+			_aggregationResults.percentiles(percentilesAggregation.getName());
+
+		if (percentiles.isArray()) {
+			ListUtil.isNotEmptyForEach(
+				percentiles.array(),
+				percentilesItem -> percentilesAggregationResult.addPercentile(
+					Double.valueOf(percentilesItem.key()),
+					GetterUtil.getDouble(percentilesItem.value())));
+		}
+		else {
+			MapUtil.isNotEmptyForEach(
+				percentiles.keyed(),
+				(key, value) -> percentilesAggregationResult.addPercentile(
+					Double.valueOf(key), GetterUtil.getDouble(value)));
+		}
+
+		return percentilesAggregationResult;
+	}
+
+	@Override
+	public RangeAggregationResult visit(RangeAggregation rangeAggregation) {
+		RangeAggregate rangeAggregate = _aggregate.range();
+
+		return _translateRangeBuckets(
+			rangeAggregation, rangeAggregate.buckets(),
+			_aggregationResults.range(rangeAggregation.getName()));
+	}
+
+	@Override
+	public ReverseNestedAggregationResult visit(
+		ReverseNestedAggregation reverseNestedAggregation) {
+
+		ReverseNestedAggregate reverseNestedAggregate =
+			_aggregate.reverseNested();
+
+		ReverseNestedAggregationResult reverseNestedAggregationResult =
+			_aggregationResults.reverseNested(
+				reverseNestedAggregation.getName(),
+				reverseNestedAggregate.docCount());
+
+		reverseNestedAggregationResult.addChildrenAggregationResults(
+			translate(
+				reverseNestedAggregation,
+				reverseNestedAggregate.aggregations()));
+
+		return reverseNestedAggregationResult;
+	}
+
+	@Override
+	public SamplerAggregationResult visit(
+		SamplerAggregation samplerAggregation) {
+
+		SamplerAggregate samplerAggregate = _aggregate.sampler();
+
+		SamplerAggregationResult samplerAggregationResult =
+			_aggregationResults.sampler(
+				samplerAggregation.getName(), samplerAggregate.docCount());
+
+		samplerAggregationResult.addChildrenAggregationResults(
+			translate(samplerAggregation, samplerAggregate.aggregations()));
+
+		return samplerAggregationResult;
+	}
+
+	@Override
+	public ScriptedMetricAggregationResult visit(
+		ScriptedMetricAggregation scriptedMetricAggregation) {
+
+		ScriptedMetricAggregate scriptedMetricAggregate =
+			_aggregate.scriptedMetric();
+
+		return _aggregationResults.scriptedMetric(
+			scriptedMetricAggregation.getName(),
+			scriptedMetricAggregate.value());
+	}
+
+	@Override
+	public SignificantTermsAggregationResult visit(
+		SignificantTermsAggregation significantTermsAggregation) {
+
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public SignificantTextAggregationResult visit(
+		SignificantTextAggregation significantTextAggregation) {
+
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public StatsAggregationResult visit(StatsAggregation statsAggregation) {
+		StatsAggregate statsAggregate = _aggregate.stats();
+
+		return _aggregationResults.stats(
+			statsAggregation.getName(), statsAggregate.avg(),
+			statsAggregate.count(), statsAggregate.min(), statsAggregate.max(),
+			statsAggregate.sum());
+	}
+
+	@Override
+	public SumAggregationResult visit(SumAggregation sumAggregation) {
+		SumAggregate sumAggregate = _aggregate.sum();
+
+		return _aggregationResults.sum(
+			sumAggregation.getName(), sumAggregate.value());
+	}
+
+	@Override
+	public TermsAggregationResult visit(TermsAggregation termsAggregation) {
+		if (_aggregate.isSterms()) {
+			StringTermsAggregate stringTermsAggregate = _aggregate.sterms();
+
+			return _translateStringTermBuckets(
+				termsAggregation, stringTermsAggregate.buckets(),
+				_aggregationResults.terms(
+					termsAggregation.getName(),
+					stringTermsAggregate.docCountErrorUpperBound(),
+					stringTermsAggregate.sumOtherDocCount()));
+		}
+		else if (_aggregate.isLterms()) {
+			LongTermsAggregate longTermsAggregate = _aggregate.lterms();
+
+			return _translateLongTermBuckets(
+				termsAggregation, longTermsAggregate.buckets(),
+				_aggregationResults.terms(
+					termsAggregation.getName(),
+					longTermsAggregate.docCountErrorUpperBound(),
+					longTermsAggregate.sumOtherDocCount()));
+		}
+
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public TopHitsAggregationResult visit(
+		TopHitsAggregation topHitsAggregation) {
+
+		TopHitsAggregate topHitsAggregate = _aggregate.topHits();
+
+		return _aggregationResults.topHits(
+			topHitsAggregation.getName(),
+			_hitsMetadataTranslator.translate(topHitsAggregate.hits()));
+	}
+
+	@Override
+	public ValueCountAggregationResult visit(
+		ValueCountAggregation valueCountAggregation) {
+
+		ValueCountAggregate valueCountAggregate = _aggregate.valueCount();
+
+		Double value = Double.valueOf(valueCountAggregate.value());
+
+		return _aggregationResults.valueCount(
+			valueCountAggregation.getName(), value.longValue());
+	}
+
+	@Override
+	public WeightedAvgAggregationResult visit(
+		WeightedAvgAggregation weightedAvgAggregation) {
+
+		WeightedAvgAggregate weightedAvgAggregate = _aggregate.weightedAvg();
+
+		return _aggregationResults.weightedAvg(
+			weightedAvgAggregation.getName(), weightedAvgAggregate.value());
+	}
+
+	protected List<AggregationResult> translate(
+		Aggregation aggregation, Map<String, Aggregate> aggregations) {
+
+		OpenSearchAggregationResultsTranslator
+			openSearchAggregationResultsTranslator =
+				new OpenSearchAggregationResultsTranslator(
+					aggregation::getChildAggregation, this,
+					aggregation::getPipelineAggregation, this);
+
+		return openSearchAggregationResultsTranslator.translate(aggregations);
+	}
+
+	private void _addBucketChildAggregationResults(
+		Aggregation aggregation, Map<String, Aggregate> aggregations,
+		Bucket bucket) {
+
+		for (AggregationResult aggregationResult :
+				translate(aggregation, aggregations)) {
+
+			bucket.addChildAggregationResult(aggregationResult);
+		}
+	}
+
+	private GeoLocationPoint _translateGeoLocation(GeoLocation geoLocation) {
+		if ((geoLocation == null) || !geoLocation.isLatlon()) {
+			return null;
+		}
+
+		LatLonGeoLocation latLonGeoLocation = geoLocation.latlon();
+
+		return _geoBuilders.geoLocationPoint(
+			latLonGeoLocation.lat(), latLonGeoLocation.lon());
+	}
+
+	private <T extends BucketAggregationResult> T _translateLongTermBuckets(
+		Aggregation aggregation, Buckets<LongTermsBucket> buckets,
+		T bucketAggregationResult) {
+
+		if (buckets.isArray()) {
+			ListUtil.isNotEmptyForEach(
+				buckets.array(),
+				longTermsBucket -> {
+					Bucket bucket = bucketAggregationResult.addBucket(
+						longTermsBucket.key(), longTermsBucket.docCount());
+
+					_addBucketChildAggregationResults(
+						aggregation, longTermsBucket.aggregations(), bucket);
+				});
+		}
+		else {
+			MapUtil.isNotEmptyForEach(
+				buckets.keyed(),
+				(key, longTermsBucket) -> {
+					Bucket bucket = bucketAggregationResult.addBucket(
+						longTermsBucket.key(), longTermsBucket.docCount());
+
+					_addBucketChildAggregationResults(
+						aggregation, longTermsBucket.aggregations(), bucket);
+				});
+		}
+
+		return bucketAggregationResult;
+	}
+
+	private <T extends BucketAggregationResult> T _translateRangeBuckets(
+		Aggregation aggregation, Buckets<RangeBucket> buckets,
+		T bucketAggregationResult) {
+
+		if (buckets.isArray()) {
+			ListUtil.isNotEmptyForEach(
+				buckets.array(),
+				rangeBucket -> {
+					Bucket bucket = bucketAggregationResult.addBucket(
+						rangeBucket.key(), rangeBucket.docCount());
+
+					_addBucketChildAggregationResults(
+						aggregation, rangeBucket.aggregations(), bucket);
+				});
+		}
+		else {
+			MapUtil.isNotEmptyForEach(
+				buckets.keyed(),
+				(key, rangeBucket) -> {
+					Bucket bucket = bucketAggregationResult.addBucket(
+						rangeBucket.key(), rangeBucket.docCount());
+
+					_addBucketChildAggregationResults(
+						aggregation, rangeBucket.aggregations(), bucket);
+				});
+		}
+
+		return bucketAggregationResult;
+	}
+
+	private <T extends BucketAggregationResult> T _translateStringTermBuckets(
+		Aggregation aggregation, Buckets<StringTermsBucket> buckets,
+		T bucketAggregationResult) {
+
+		if (buckets.isArray()) {
+			ListUtil.isNotEmptyForEach(
+				buckets.array(),
+				stringTermsBucket -> {
+					Bucket bucket = bucketAggregationResult.addBucket(
+						stringTermsBucket.key(), stringTermsBucket.docCount());
+
+					_addBucketChildAggregationResults(
+						aggregation, stringTermsBucket.aggregations(), bucket);
+				});
+		}
+		else {
+			MapUtil.isNotEmptyForEach(
+				buckets.keyed(),
+				(key, stringTermsBucket) -> {
+					Bucket bucket = bucketAggregationResult.addBucket(
+						stringTermsBucket.key(), stringTermsBucket.docCount());
+
+					_addBucketChildAggregationResults(
+						aggregation, stringTermsBucket.aggregations(), bucket);
+				});
+		}
+
+		return bucketAggregationResult;
+	}
+
+	private final Aggregate _aggregate;
+	private final AggregationResults _aggregationResults;
+	private final GeoBuilders _geoBuilders;
+	private final HitsMetadataTranslator _hitsMetadataTranslator;
+
+}

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/aggregation/OpenSearchAggregationResultsTranslator.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/aggregation/OpenSearchAggregationResultsTranslator.java
@@ -1,0 +1,92 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.opensearch2.internal.aggregation;
+
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.search.aggregation.Aggregation;
+import com.liferay.portal.search.aggregation.AggregationResult;
+import com.liferay.portal.search.aggregation.pipeline.PipelineAggregation;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.opensearch.client.opensearch._types.aggregations.Aggregate;
+
+/**
+ * @author André de Oliveira
+ */
+public class OpenSearchAggregationResultsTranslator {
+
+	public OpenSearchAggregationResultsTranslator(
+		AggregationLookup aggregationLookup,
+		AggregationResultTranslatorFactory aggregationResultTranslatorFactory,
+		PipelineAggregationLookup pipelineAggregationLookup,
+		PipelineAggregationResultTranslatorFactory
+			pipelineAggregationResultTranslatorFactory) {
+
+		_aggregationLookup = aggregationLookup;
+		_aggregationResultTranslatorFactory =
+			aggregationResultTranslatorFactory;
+		_pipelineAggregationLookup = pipelineAggregationLookup;
+		_pipelineAggregationResultTranslatorFactory =
+			pipelineAggregationResultTranslatorFactory;
+	}
+
+	public List<AggregationResult> translate(
+		Map<String, Aggregate> aggregations) {
+
+		List<AggregationResult> aggregationResults = new ArrayList<>();
+
+		MapUtil.isNotEmptyForEach(
+			aggregations,
+			(name, aggregate) -> aggregationResults.add(
+				translate(aggregate, name)));
+
+		return aggregationResults;
+	}
+
+	public interface AggregationLookup {
+
+		public Aggregation lookup(String name);
+
+	}
+
+	public interface PipelineAggregationLookup {
+
+		public PipelineAggregation lookup(String name);
+
+	}
+
+	protected AggregationResult translate(Aggregate aggregate, String name) {
+		Aggregation aggregation = _aggregationLookup.lookup(name);
+
+		if (aggregation != null) {
+			return aggregation.accept(
+				_aggregationResultTranslatorFactory.
+					createAggregationResultTranslator(aggregate));
+		}
+
+		PipelineAggregation pipelineAggregation =
+			_pipelineAggregationLookup.lookup(name);
+
+		if (pipelineAggregation != null) {
+			return pipelineAggregation.accept(
+				_pipelineAggregationResultTranslatorFactory.
+					createPipelineAggregationResultTranslator(aggregate));
+		}
+
+		return null;
+	}
+
+	private final AggregationLookup _aggregationLookup;
+	private final AggregationResultTranslatorFactory
+		_aggregationResultTranslatorFactory;
+	private final PipelineAggregationLookup _pipelineAggregationLookup;
+	private final PipelineAggregationResultTranslatorFactory
+		_pipelineAggregationResultTranslatorFactory;
+
+}

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/aggregation/OpenSearchAggregationTranslator.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/aggregation/OpenSearchAggregationTranslator.java
@@ -1,0 +1,1813 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.opensearch2.internal.aggregation;
+
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.search.aggregation.Aggregation;
+import com.liferay.portal.search.aggregation.AggregationTranslator;
+import com.liferay.portal.search.aggregation.AggregationVisitor;
+import com.liferay.portal.search.aggregation.ValueType;
+import com.liferay.portal.search.aggregation.bucket.ChildrenAggregation;
+import com.liferay.portal.search.aggregation.bucket.CollectionMode;
+import com.liferay.portal.search.aggregation.bucket.DateHistogramAggregation;
+import com.liferay.portal.search.aggregation.bucket.DateRangeAggregation;
+import com.liferay.portal.search.aggregation.bucket.DiversifiedSamplerAggregation;
+import com.liferay.portal.search.aggregation.bucket.FilterAggregation;
+import com.liferay.portal.search.aggregation.bucket.FiltersAggregation;
+import com.liferay.portal.search.aggregation.bucket.GeoDistanceAggregation;
+import com.liferay.portal.search.aggregation.bucket.GeoHashGridAggregation;
+import com.liferay.portal.search.aggregation.bucket.GlobalAggregation;
+import com.liferay.portal.search.aggregation.bucket.HistogramAggregation;
+import com.liferay.portal.search.aggregation.bucket.IncludeExcludeClause;
+import com.liferay.portal.search.aggregation.bucket.MissingAggregation;
+import com.liferay.portal.search.aggregation.bucket.NestedAggregation;
+import com.liferay.portal.search.aggregation.bucket.Order;
+import com.liferay.portal.search.aggregation.bucket.Range;
+import com.liferay.portal.search.aggregation.bucket.RangeAggregation;
+import com.liferay.portal.search.aggregation.bucket.ReverseNestedAggregation;
+import com.liferay.portal.search.aggregation.bucket.SamplerAggregation;
+import com.liferay.portal.search.aggregation.bucket.SignificantTermsAggregation;
+import com.liferay.portal.search.aggregation.bucket.SignificantTextAggregation;
+import com.liferay.portal.search.aggregation.bucket.TermsAggregation;
+import com.liferay.portal.search.aggregation.metrics.AvgAggregation;
+import com.liferay.portal.search.aggregation.metrics.CardinalityAggregation;
+import com.liferay.portal.search.aggregation.metrics.ExtendedStatsAggregation;
+import com.liferay.portal.search.aggregation.metrics.GeoBoundsAggregation;
+import com.liferay.portal.search.aggregation.metrics.GeoCentroidAggregation;
+import com.liferay.portal.search.aggregation.metrics.MaxAggregation;
+import com.liferay.portal.search.aggregation.metrics.MinAggregation;
+import com.liferay.portal.search.aggregation.metrics.PercentileRanksAggregation;
+import com.liferay.portal.search.aggregation.metrics.PercentilesAggregation;
+import com.liferay.portal.search.aggregation.metrics.PercentilesMethod;
+import com.liferay.portal.search.aggregation.metrics.ScriptedMetricAggregation;
+import com.liferay.portal.search.aggregation.metrics.StatsAggregation;
+import com.liferay.portal.search.aggregation.metrics.SumAggregation;
+import com.liferay.portal.search.aggregation.metrics.TopHitsAggregation;
+import com.liferay.portal.search.aggregation.metrics.ValueCountAggregation;
+import com.liferay.portal.search.aggregation.metrics.WeightedAvgAggregation;
+import com.liferay.portal.search.aggregation.pipeline.PipelineAggregation;
+import com.liferay.portal.search.aggregation.pipeline.PipelineAggregationTranslator;
+import com.liferay.portal.search.opensearch2.internal.geolocation.GeoTranslator;
+import com.liferay.portal.search.opensearch2.internal.highlight.HighlightTranslator;
+import com.liferay.portal.search.opensearch2.internal.script.ScriptTranslator;
+import com.liferay.portal.search.opensearch2.internal.util.ConversionUtil;
+import com.liferay.portal.search.opensearch2.internal.util.SetterUtil;
+import com.liferay.portal.search.query.QueryTranslator;
+import com.liferay.portal.search.script.Script;
+import com.liferay.portal.search.significance.ChiSquareSignificanceHeuristic;
+import com.liferay.portal.search.significance.GNDSignificanceHeuristic;
+import com.liferay.portal.search.significance.MutualInformationSignificanceHeuristic;
+import com.liferay.portal.search.significance.PercentageScoreSignificanceHeuristic;
+import com.liferay.portal.search.significance.ScriptSignificanceHeuristic;
+import com.liferay.portal.search.significance.SignificanceHeuristic;
+import com.liferay.portal.search.sort.SortFieldTranslator;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import org.opensearch.client.opensearch._types.GeoHashPrecision;
+import org.opensearch.client.opensearch._types.SortOptions;
+import org.opensearch.client.opensearch._types.SortOrder;
+import org.opensearch.client.opensearch._types.aggregations.Aggregation.Builder.ContainerBuilder;
+import org.opensearch.client.opensearch._types.aggregations.AggregationBuilders;
+import org.opensearch.client.opensearch._types.aggregations.AggregationRange;
+import org.opensearch.client.opensearch._types.aggregations.AverageAggregation;
+import org.opensearch.client.opensearch._types.aggregations.Buckets;
+import org.opensearch.client.opensearch._types.aggregations.CalendarInterval;
+import org.opensearch.client.opensearch._types.aggregations.ChiSquareHeuristic;
+import org.opensearch.client.opensearch._types.aggregations.DateRangeExpression;
+import org.opensearch.client.opensearch._types.aggregations.ExtendedBounds;
+import org.opensearch.client.opensearch._types.aggregations.GoogleNormalizedDistanceHeuristic;
+import org.opensearch.client.opensearch._types.aggregations.HdrMethod;
+import org.opensearch.client.opensearch._types.aggregations.HistogramOrder;
+import org.opensearch.client.opensearch._types.aggregations.MutualInformationHeuristic;
+import org.opensearch.client.opensearch._types.aggregations.PercentageScoreHeuristic;
+import org.opensearch.client.opensearch._types.aggregations.SamplerAggregationExecutionHint;
+import org.opensearch.client.opensearch._types.aggregations.ScriptedHeuristic;
+import org.opensearch.client.opensearch._types.aggregations.TDigest;
+import org.opensearch.client.opensearch._types.aggregations.TermsAggregationCollectMode;
+import org.opensearch.client.opensearch._types.aggregations.TermsAggregationExecutionHint;
+import org.opensearch.client.opensearch._types.aggregations.TermsExclude;
+import org.opensearch.client.opensearch._types.aggregations.TermsInclude;
+import org.opensearch.client.opensearch._types.aggregations.WeightedAverageValue;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.opensearch.client.opensearch._types.query_dsl.QueryVariant;
+import org.opensearch.client.opensearch.core.search.SourceConfig;
+import org.opensearch.client.opensearch.core.search.SourceConfigBuilders;
+import org.opensearch.client.opensearch.core.search.SourceFilter;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Michael C. Han
+ * @author Petteri Karttunen
+ */
+@Component(
+	property = "search.engine.impl=OpenSearch",
+	service = AggregationTranslator.class
+)
+public class OpenSearchAggregationTranslator
+	implements AggregationTranslator
+		<org.opensearch.client.opensearch._types.aggregations.Aggregation>,
+			   AggregationVisitor
+				   <org.opensearch.client.opensearch._types.aggregations.
+					   Aggregation> {
+
+	@Override
+	public org.opensearch.client.opensearch._types.aggregations.Aggregation
+		translate(Aggregation aggregation) {
+
+		return aggregation.accept(this);
+	}
+
+	@Override
+	public org.opensearch.client.opensearch._types.aggregations.Aggregation
+		visit(AvgAggregation avgAggregation) {
+
+		AverageAggregation.Builder averageAggregationBuilder =
+			AggregationBuilders.avg();
+
+		averageAggregationBuilder.field(avgAggregation.getField());
+
+		SetterUtil.setNotNullFieldValue(
+			averageAggregationBuilder::missing, avgAggregation.getMissing());
+		SetterUtil.setNotNullScript(
+			averageAggregationBuilder::script, avgAggregation.getScript());
+
+		org.opensearch.client.opensearch._types.aggregations.Aggregation.Builder
+			aggregationBuilder =
+				new org.opensearch.client.opensearch._types.aggregations.
+					Aggregation.Builder();
+
+		return _translateChildAggregations(
+			avgAggregation,
+			aggregationBuilder.avg(averageAggregationBuilder.build()));
+	}
+
+	@Override
+	public org.opensearch.client.opensearch._types.aggregations.Aggregation
+		visit(CardinalityAggregation cardinalityAggregation) {
+
+		org.opensearch.client.opensearch._types.aggregations.
+			CardinalityAggregation.Builder cardinalityAggregationBuilder =
+				AggregationBuilders.cardinality();
+
+		cardinalityAggregationBuilder.field(cardinalityAggregation.getField());
+
+		SetterUtil.setNotNullFieldValue(
+			cardinalityAggregationBuilder::missing,
+			cardinalityAggregation.getMissing());
+		SetterUtil.setNotNullInteger(
+			cardinalityAggregationBuilder::precisionThreshold,
+			cardinalityAggregation.getPrecisionThreshold());
+		SetterUtil.setNotNullScript(
+			cardinalityAggregationBuilder::script,
+			cardinalityAggregation.getScript());
+
+		org.opensearch.client.opensearch._types.aggregations.Aggregation.Builder
+			aggregationBuilder =
+				new org.opensearch.client.opensearch._types.aggregations.
+					Aggregation.Builder();
+
+		return _translateChildAggregations(
+			cardinalityAggregation,
+			aggregationBuilder.cardinality(
+				cardinalityAggregationBuilder.build()));
+	}
+
+	@Override
+	public org.opensearch.client.opensearch._types.aggregations.Aggregation
+		visit(ChildrenAggregation childrenAggregation) {
+
+		org.opensearch.client.opensearch._types.aggregations.
+			ChildrenAggregation.Builder childrenAggregationBuilder =
+				AggregationBuilders.children();
+
+		SetterUtil.setNotBlankString(
+			childrenAggregationBuilder::type,
+			childrenAggregation.getChildType());
+
+		org.opensearch.client.opensearch._types.aggregations.Aggregation.Builder
+			aggregationBuilder =
+				new org.opensearch.client.opensearch._types.aggregations.
+					Aggregation.Builder();
+
+		return _translateChildAggregations(
+			childrenAggregation,
+			aggregationBuilder.children(childrenAggregationBuilder.build()));
+	}
+
+	@Override
+	public org.opensearch.client.opensearch._types.aggregations.Aggregation
+		visit(DateHistogramAggregation dateHistogramAggregation) {
+
+		org.opensearch.client.opensearch._types.aggregations.
+			DateHistogramAggregation.Builder dateHistogramAggregationBuilder =
+				AggregationBuilders.dateHistogram();
+
+		dateHistogramAggregationBuilder.field(
+			dateHistogramAggregation.getField());
+
+		if (dateHistogramAggregation.getDateHistogramInterval() != null) {
+			dateHistogramAggregationBuilder.calendarInterval(
+				_translateCalendarInterval(
+					dateHistogramAggregation.getDateHistogramInterval()));
+		}
+
+		if ((dateHistogramAggregation.getMaxBound() != null) &&
+			(dateHistogramAggregation.getMinBound() != null)) {
+
+			dateHistogramAggregationBuilder.extendedBounds(
+				ExtendedBounds.of(
+					openSearchExtendedBounds -> openSearchExtendedBounds.min(
+						ConversionUtil.toFieldDateMath(
+							null,
+							ConversionUtil.toDouble(
+								dateHistogramAggregation.getMinBound()))
+					).max(
+						ConversionUtil.toFieldDateMath(
+							null,
+							ConversionUtil.toDouble(
+								dateHistogramAggregation.getMaxBound()))
+					)));
+		}
+
+		if (dateHistogramAggregation.getMinDocCount() != null) {
+			dateHistogramAggregationBuilder.minDocCount(
+				Math.toIntExact(dateHistogramAggregation.getMinDocCount()));
+		}
+
+		if (ListUtil.isNotEmpty(dateHistogramAggregation.getOrders())) {
+			List<Order> orders = dateHistogramAggregation.getOrders();
+
+			dateHistogramAggregationBuilder.order(
+				_toOpenSearchHistogramOrder(orders.get(0)));
+		}
+
+		org.opensearch.client.opensearch._types.aggregations.Aggregation.Builder
+			aggregationBuilder =
+				new org.opensearch.client.opensearch._types.aggregations.
+					Aggregation.Builder();
+
+		return _translateChildAggregations(
+			dateHistogramAggregation,
+			aggregationBuilder.dateHistogram(
+				dateHistogramAggregationBuilder.build()));
+	}
+
+	@Override
+	public org.opensearch.client.opensearch._types.aggregations.Aggregation
+		visit(DateRangeAggregation dateRangeAggregation) {
+
+		org.opensearch.client.opensearch._types.aggregations.
+			DateRangeAggregation.Builder dateRangeAggregationBuilder =
+				AggregationBuilders.dateRange();
+
+		dateRangeAggregationBuilder.field(dateRangeAggregation.getField());
+
+		SetterUtil.setNotBlankString(
+			dateRangeAggregationBuilder::format,
+			dateRangeAggregation.getFormat());
+		SetterUtil.setNotNullBoolean(
+			dateRangeAggregationBuilder::keyed,
+			dateRangeAggregation.getKeyed());
+		SetterUtil.setNotNullFieldValue(
+			dateRangeAggregationBuilder::missing,
+			dateRangeAggregation.getMissing());
+		setRanges(dateRangeAggregationBuilder, dateRangeAggregation);
+
+		org.opensearch.client.opensearch._types.aggregations.Aggregation.Builder
+			aggregationBuilder =
+				new org.opensearch.client.opensearch._types.aggregations.
+					Aggregation.Builder();
+
+		return _translateChildAggregations(
+			dateRangeAggregation,
+			aggregationBuilder.dateRange(dateRangeAggregationBuilder.build()));
+	}
+
+	@Override
+	public org.opensearch.client.opensearch._types.aggregations.Aggregation
+		visit(DiversifiedSamplerAggregation diversifiedSamplerAggregation) {
+
+		org.opensearch.client.opensearch._types.aggregations.
+			DiversifiedSamplerAggregation.Builder
+				diversifiedSamplerAggregationBuilder =
+					AggregationBuilders.diversifiedSampler();
+
+		diversifiedSamplerAggregationBuilder.field(
+			diversifiedSamplerAggregation.getField());
+
+		if (diversifiedSamplerAggregation.getExecutionHint() != null) {
+			diversifiedSamplerAggregationBuilder.executionHint(
+				SamplerAggregationExecutionHint.valueOf(
+					diversifiedSamplerAggregation.getExecutionHint()));
+		}
+
+		SetterUtil.setNotNullInteger(
+			diversifiedSamplerAggregationBuilder::maxDocsPerValue,
+			diversifiedSamplerAggregation.getMaxDocsPerValue());
+		SetterUtil.setNotNullScript(
+			diversifiedSamplerAggregationBuilder::script,
+			diversifiedSamplerAggregation.getScript());
+		SetterUtil.setNotNullInteger(
+			diversifiedSamplerAggregationBuilder::shardSize,
+			diversifiedSamplerAggregation.getShardSize());
+
+		org.opensearch.client.opensearch._types.aggregations.Aggregation.Builder
+			aggregationBuilder =
+				new org.opensearch.client.opensearch._types.aggregations.
+					Aggregation.Builder();
+
+		return _translateChildAggregations(
+			diversifiedSamplerAggregation,
+			aggregationBuilder.diversifiedSampler(
+				diversifiedSamplerAggregationBuilder.build()));
+	}
+
+	@Override
+	public org.opensearch.client.opensearch._types.aggregations.Aggregation
+		visit(ExtendedStatsAggregation extendedStatsAggregation) {
+
+		org.opensearch.client.opensearch._types.aggregations.
+			ExtendedStatsAggregation.Builder extendedStatsAggregationBuilder =
+				AggregationBuilders.extendedStats();
+
+		extendedStatsAggregationBuilder.field(
+			extendedStatsAggregation.getField());
+
+		SetterUtil.setNotNullFieldValue(
+			extendedStatsAggregationBuilder::missing,
+			extendedStatsAggregation.getMissing());
+		SetterUtil.setNotNullScript(
+			extendedStatsAggregationBuilder::script,
+			extendedStatsAggregation.getScript());
+
+		Integer sigma = extendedStatsAggregation.getSigma();
+
+		SetterUtil.setNotNullDouble(
+			extendedStatsAggregationBuilder::sigma, sigma.doubleValue());
+
+		org.opensearch.client.opensearch._types.aggregations.Aggregation.Builder
+			aggregationBuilder =
+				new org.opensearch.client.opensearch._types.aggregations.
+					Aggregation.Builder();
+
+		return _translateChildAggregations(
+			extendedStatsAggregation,
+			aggregationBuilder.extendedStats(
+				extendedStatsAggregationBuilder.build()));
+	}
+
+	@Override
+	public org.opensearch.client.opensearch._types.aggregations.Aggregation
+		visit(FilterAggregation filterAggregation) {
+
+		org.opensearch.client.opensearch._types.aggregations.Aggregation.Builder
+			builder =
+				new org.opensearch.client.opensearch._types.aggregations.
+					Aggregation.Builder();
+
+		return _translateChildAggregations(
+			filterAggregation,
+			builder.filter(
+				new Query(
+					_queryTranslator.translate(
+						filterAggregation.getFilterQuery()))));
+	}
+
+	@Override
+	public org.opensearch.client.opensearch._types.aggregations.Aggregation
+		visit(FiltersAggregation filtersAggregation) {
+
+		org.opensearch.client.opensearch._types.aggregations.FiltersAggregation.
+			Builder filtersAggregationBuilder = AggregationBuilders.filters();
+
+		List<FiltersAggregation.KeyedQuery> keyedQueries =
+			filtersAggregation.getKeyedQueries();
+
+		Map<String, Query> keyedFilters = new HashMap<>();
+
+		keyedQueries.forEach(
+			keyedQuery -> keyedFilters.put(
+				keyedQuery.getKey(),
+				new Query(_queryTranslator.translate(keyedQuery.getQuery()))));
+
+		Buckets.Builder<Query> bucketsBuilder = new Buckets.Builder<>();
+
+		filtersAggregationBuilder.filters(
+			bucketsBuilder.keyed(
+				keyedFilters
+			).build());
+
+		SetterUtil.setNotNullBoolean(
+			filtersAggregationBuilder::otherBucket,
+			filtersAggregation.getOtherBucket());
+		SetterUtil.setNotBlankString(
+			filtersAggregationBuilder::otherBucketKey,
+			filtersAggregation.getOtherBucketKey());
+
+		org.opensearch.client.opensearch._types.aggregations.Aggregation.Builder
+			aggregationBuilder =
+				new org.opensearch.client.opensearch._types.aggregations.
+					Aggregation.Builder();
+
+		return _translateChildAggregations(
+			filtersAggregation,
+			aggregationBuilder.filters(filtersAggregationBuilder.build()));
+	}
+
+	@Override
+	public org.opensearch.client.opensearch._types.aggregations.Aggregation
+		visit(GeoBoundsAggregation geoBoundsAggregation) {
+
+		org.opensearch.client.opensearch._types.aggregations.
+			GeoBoundsAggregation.Builder geoBoundsAggregationBuilder =
+				AggregationBuilders.geoBounds();
+
+		geoBoundsAggregationBuilder.field(geoBoundsAggregation.getField());
+
+		SetterUtil.setNotNullFieldValue(
+			geoBoundsAggregationBuilder::missing,
+			geoBoundsAggregation.getMissing());
+		SetterUtil.setNotNullScript(
+			geoBoundsAggregationBuilder::script,
+			geoBoundsAggregation.getScript());
+		SetterUtil.setNotNullBoolean(
+			geoBoundsAggregationBuilder::wrapLongitude,
+			geoBoundsAggregation.getWrapLongitude());
+
+		org.opensearch.client.opensearch._types.aggregations.Aggregation.Builder
+			aggregationBuilder =
+				new org.opensearch.client.opensearch._types.aggregations.
+					Aggregation.Builder();
+
+		return _translateChildAggregations(
+			geoBoundsAggregation,
+			aggregationBuilder.geoBounds(geoBoundsAggregationBuilder.build()));
+	}
+
+	@Override
+	public org.opensearch.client.opensearch._types.aggregations.Aggregation
+		visit(GeoCentroidAggregation geoCentroidAggregation) {
+
+		org.opensearch.client.opensearch._types.aggregations.
+			GeoCentroidAggregation.Builder geoCentroidAggregationBuilder =
+				AggregationBuilders.geoCentroid();
+
+		geoCentroidAggregationBuilder.field(geoCentroidAggregation.getField());
+
+		SetterUtil.setNotNullFieldValue(
+			geoCentroidAggregationBuilder::missing,
+			geoCentroidAggregation.getMissing());
+		SetterUtil.setNotNullScript(
+			geoCentroidAggregationBuilder::script,
+			geoCentroidAggregation.getScript());
+
+		org.opensearch.client.opensearch._types.aggregations.Aggregation.Builder
+			aggregationBuilder =
+				new org.opensearch.client.opensearch._types.aggregations.
+					Aggregation.Builder();
+
+		return _translateChildAggregations(
+			geoCentroidAggregation,
+			aggregationBuilder.geoCentroid(
+				geoCentroidAggregationBuilder.build()));
+	}
+
+	@Override
+	public org.opensearch.client.opensearch._types.aggregations.Aggregation
+		visit(GeoDistanceAggregation geoDistanceAggregation) {
+
+		org.opensearch.client.opensearch._types.aggregations.
+			GeoDistanceAggregation.Builder geoDistanceAggregationBuilder =
+				AggregationBuilders.geoDistance();
+
+		geoDistanceAggregationBuilder.field(geoDistanceAggregation.getField());
+
+		if (geoDistanceAggregation.getGeoDistanceType() != null) {
+			geoDistanceAggregationBuilder.distanceType(
+				_geoTranslator.translateGeoDistanceType(
+					geoDistanceAggregation.getGeoDistanceType()));
+		}
+
+		geoDistanceAggregationBuilder.origin(
+			_geoTranslator.translateGeoLocationPoint(
+				geoDistanceAggregation.getGeoLocationPoint()));
+
+		if (geoDistanceAggregation.getDistanceUnit() != null) {
+			geoDistanceAggregationBuilder.unit(
+				_geoTranslator.translateDistanceUnit(
+					geoDistanceAggregation.getDistanceUnit()));
+		}
+
+		List<Range> rangeAggregationRanges = geoDistanceAggregation.getRanges();
+
+		rangeAggregationRanges.forEach(
+			rangeAggregationRange -> geoDistanceAggregationBuilder.ranges(
+				_createAggregationRange(
+					rangeAggregationRange.getFromAsString(),
+					rangeAggregationRange.getKey(),
+					rangeAggregationRange.getToAsString())));
+
+		org.opensearch.client.opensearch._types.aggregations.Aggregation.Builder
+			aggregationBuilder =
+				new org.opensearch.client.opensearch._types.aggregations.
+					Aggregation.Builder();
+
+		return _translateChildAggregations(
+			geoDistanceAggregation,
+			aggregationBuilder.geoDistance(
+				geoDistanceAggregationBuilder.build()));
+	}
+
+	@Override
+	public org.opensearch.client.opensearch._types.aggregations.Aggregation
+		visit(GeoHashGridAggregation geoHashGridAggregation) {
+
+		org.opensearch.client.opensearch._types.aggregations.
+			GeoHashGridAggregation.Builder geoHashGridAggregationBuilder =
+				new org.opensearch.client.opensearch._types.aggregations.
+					GeoHashGridAggregation.Builder();
+
+		geoHashGridAggregationBuilder.field(geoHashGridAggregation.getField());
+
+		if (geoHashGridAggregation.getPrecision() != null) {
+			geoHashGridAggregationBuilder.precision(
+				GeoHashPrecision.of(
+					geoHashPrecision -> geoHashPrecision.geohashLength(
+						geoHashGridAggregation.getPrecision())));
+		}
+
+		SetterUtil.setNotNullInteger(
+			geoHashGridAggregationBuilder::shardSize,
+			geoHashGridAggregation.getShardSize());
+		SetterUtil.setNotNullInteger(
+			geoHashGridAggregationBuilder::size,
+			geoHashGridAggregation.getSize());
+
+		org.opensearch.client.opensearch._types.aggregations.Aggregation.Builder
+			aggregationBuilder =
+				new org.opensearch.client.opensearch._types.aggregations.
+					Aggregation.Builder();
+
+		return _translateChildAggregations(
+			geoHashGridAggregation,
+			aggregationBuilder.geohashGrid(
+				geoHashGridAggregationBuilder.build()));
+	}
+
+	@Override
+	public org.opensearch.client.opensearch._types.aggregations.Aggregation
+		visit(GlobalAggregation globalAggregation) {
+
+		org.opensearch.client.opensearch._types.aggregations.GlobalAggregation.
+			Builder globalAggregationBuilder =
+				new org.opensearch.client.opensearch._types.aggregations.
+					GlobalAggregation.Builder();
+
+		org.opensearch.client.opensearch._types.aggregations.Aggregation.Builder
+			aggregationBuilder =
+				new org.opensearch.client.opensearch._types.aggregations.
+					Aggregation.Builder();
+
+		return _translateChildAggregations(
+			globalAggregation,
+			aggregationBuilder.global(globalAggregationBuilder.build()));
+	}
+
+	@Override
+	public org.opensearch.client.opensearch._types.aggregations.Aggregation
+		visit(HistogramAggregation histogramAggregation) {
+
+		org.opensearch.client.opensearch._types.aggregations.
+			HistogramAggregation.Builder histogramAggregationBuilder =
+				new org.opensearch.client.opensearch._types.aggregations.
+					HistogramAggregation.Builder();
+
+		histogramAggregationBuilder.field(histogramAggregation.getField());
+
+		if ((histogramAggregation.getMaxBound() != null) &&
+			(histogramAggregation.getMinBound() != null)) {
+
+			histogramAggregationBuilder.extendedBounds(
+				ExtendedBounds.of(
+					openSearchExtendedBounds -> openSearchExtendedBounds.min(
+						histogramAggregation.getMinBound()
+					).max(
+						histogramAggregation.getMaxBound()
+					)));
+		}
+
+		SetterUtil.setNotNullDouble(
+			histogramAggregationBuilder::interval,
+			histogramAggregation.getInterval());
+
+		if (histogramAggregation.getMinDocCount() != null) {
+			histogramAggregationBuilder.minDocCount(
+				Math.toIntExact(histogramAggregation.getMinDocCount()));
+		}
+
+		SetterUtil.setNotNullDouble(
+			histogramAggregationBuilder::missing,
+			GetterUtil.getDouble(histogramAggregation.getMissing()));
+		SetterUtil.setNotNullDouble(
+			histogramAggregationBuilder::offset,
+			histogramAggregation.getOffset());
+
+		if (ListUtil.isNotEmpty(histogramAggregation.getOrders())) {
+			List<Order> orders = histogramAggregation.getOrders();
+
+			histogramAggregationBuilder.order(
+				_toOpenSearchHistogramOrder(orders.get(0)));
+		}
+
+		SetterUtil.setNotNullScript(
+			histogramAggregationBuilder::script,
+			histogramAggregation.getScript());
+
+		org.opensearch.client.opensearch._types.aggregations.Aggregation.Builder
+			aggregationBuilder =
+				new org.opensearch.client.opensearch._types.aggregations.
+					Aggregation.Builder();
+
+		return _translateChildAggregations(
+			histogramAggregation,
+			aggregationBuilder.histogram(histogramAggregationBuilder.build()));
+	}
+
+	@Override
+	public org.opensearch.client.opensearch._types.aggregations.Aggregation
+		visit(MaxAggregation maxAggregation) {
+
+		org.opensearch.client.opensearch._types.aggregations.MaxAggregation.
+			Builder maxAggregationBuilder =
+				new org.opensearch.client.opensearch._types.aggregations.
+					MaxAggregation.Builder();
+
+		maxAggregationBuilder.field(maxAggregation.getField());
+
+		SetterUtil.setNotNullFieldValue(
+			maxAggregationBuilder::missing, maxAggregation.getMissing());
+		SetterUtil.setNotNullScript(
+			maxAggregationBuilder::script, maxAggregation.getScript());
+
+		org.opensearch.client.opensearch._types.aggregations.Aggregation.Builder
+			aggregationBuilder =
+				new org.opensearch.client.opensearch._types.aggregations.
+					Aggregation.Builder();
+
+		return _translateChildAggregations(
+			maxAggregation,
+			aggregationBuilder.max(maxAggregationBuilder.build()));
+	}
+
+	@Override
+	public org.opensearch.client.opensearch._types.aggregations.Aggregation
+		visit(MinAggregation minAggregation) {
+
+		org.opensearch.client.opensearch._types.aggregations.MinAggregation.
+			Builder minAggregationBuilder =
+				new org.opensearch.client.opensearch._types.aggregations.
+					MinAggregation.Builder();
+
+		minAggregationBuilder.field(minAggregation.getField());
+
+		SetterUtil.setNotNullFieldValue(
+			minAggregationBuilder::missing, minAggregation.getMissing());
+		SetterUtil.setNotNullScript(
+			minAggregationBuilder::script, minAggregation.getScript());
+
+		org.opensearch.client.opensearch._types.aggregations.Aggregation.Builder
+			aggregationBuilder =
+				new org.opensearch.client.opensearch._types.aggregations.
+					Aggregation.Builder();
+
+		return _translateChildAggregations(
+			minAggregation,
+			aggregationBuilder.min(minAggregationBuilder.build()));
+	}
+
+	@Override
+	public org.opensearch.client.opensearch._types.aggregations.Aggregation
+		visit(MissingAggregation missingAggregation) {
+
+		org.opensearch.client.opensearch._types.aggregations.MissingAggregation.
+			Builder missingAggregationBuilder =
+				new org.opensearch.client.opensearch._types.aggregations.
+					MissingAggregation.Builder();
+
+		missingAggregationBuilder.field(missingAggregation.getField());
+
+		SetterUtil.setNotNullFieldValue(
+			missingAggregationBuilder::missing,
+			missingAggregation.getMissing());
+
+		org.opensearch.client.opensearch._types.aggregations.Aggregation.Builder
+			aggregationBuilder =
+				new org.opensearch.client.opensearch._types.aggregations.
+					Aggregation.Builder();
+
+		return _translateChildAggregations(
+			missingAggregation,
+			aggregationBuilder.missing(missingAggregationBuilder.build()));
+	}
+
+	@Override
+	public org.opensearch.client.opensearch._types.aggregations.Aggregation
+		visit(NestedAggregation nestedAggregation) {
+
+		org.opensearch.client.opensearch._types.aggregations.NestedAggregation.
+			Builder nestedAggregationBuilder = AggregationBuilders.nested();
+
+		nestedAggregationBuilder.path(nestedAggregation.getPath());
+
+		org.opensearch.client.opensearch._types.aggregations.Aggregation.Builder
+			aggregationBuilder =
+				new org.opensearch.client.opensearch._types.aggregations.
+					Aggregation.Builder();
+
+		return _translateChildAggregations(
+			nestedAggregation,
+			aggregationBuilder.nested(nestedAggregationBuilder.build()));
+	}
+
+	@Override
+	public org.opensearch.client.opensearch._types.aggregations.Aggregation
+		visit(PercentileRanksAggregation percentileRanksAggregation) {
+
+		org.opensearch.client.opensearch._types.aggregations.
+			PercentileRanksAggregation.Builder
+				percentileRanksAggregationBuilder =
+					AggregationBuilders.percentileRanks();
+
+		percentileRanksAggregationBuilder.field(
+			percentileRanksAggregation.getField());
+
+		SetterUtil.setNotNullBoolean(
+			percentileRanksAggregationBuilder::keyed,
+			percentileRanksAggregation.getKeyed());
+		SetterUtil.setNotNullFieldValue(
+			percentileRanksAggregationBuilder::missing,
+			percentileRanksAggregation.getMissing());
+		SetterUtil.setNotNullScript(
+			percentileRanksAggregationBuilder::script,
+			percentileRanksAggregation.getScript());
+
+		if (percentileRanksAggregation.getPercentilesMethod() != null) {
+			PercentilesMethod percentilesMethod =
+				percentileRanksAggregation.getPercentilesMethod();
+
+			if (percentilesMethod.equals(PercentilesMethod.HDR)) {
+				percentileRanksAggregationBuilder.hdr(
+					HdrMethod.of(
+						hdrMethor -> hdrMethor.numberOfSignificantValueDigits(
+							percentileRanksAggregation.
+								getHdrSignificantValueDigits())));
+			}
+			else if (percentilesMethod.equals(PercentilesMethod.TDIGEST)) {
+				percentileRanksAggregationBuilder.tdigest(
+					TDigest.of(
+						tdigest -> tdigest.compression(
+							percentileRanksAggregation.getCompression())));
+			}
+		}
+
+		percentileRanksAggregationBuilder.values(
+			ConversionUtil.toDoubleList(
+				percentileRanksAggregation.getValues()));
+
+		org.opensearch.client.opensearch._types.aggregations.Aggregation.Builder
+			aggregationBuilder =
+				new org.opensearch.client.opensearch._types.aggregations.
+					Aggregation.Builder();
+
+		return _translateChildAggregations(
+			percentileRanksAggregation,
+			aggregationBuilder.percentileRanks(
+				percentileRanksAggregationBuilder.build()));
+	}
+
+	@Override
+	public org.opensearch.client.opensearch._types.aggregations.Aggregation
+		visit(PercentilesAggregation percentilesAggregation) {
+
+		org.opensearch.client.opensearch._types.aggregations.
+			PercentilesAggregation.Builder percentilesAggregationBuilder =
+				AggregationBuilders.percentiles();
+
+		percentilesAggregationBuilder.field(percentilesAggregation.getField());
+
+		SetterUtil.setNotNullBoolean(
+			percentilesAggregationBuilder::keyed,
+			percentilesAggregation.getKeyed());
+		SetterUtil.setNotNullFieldValue(
+			percentilesAggregationBuilder::missing,
+			percentilesAggregation.getMissing());
+		SetterUtil.setNotNullScript(
+			percentilesAggregationBuilder::script,
+			percentilesAggregation.getScript());
+
+		if (percentilesAggregation.getPercents() != null) {
+			percentilesAggregationBuilder.percents(
+				ConversionUtil.toDoubleList(
+					percentilesAggregation.getPercents()));
+		}
+
+		if (percentilesAggregation.getPercentilesMethod() != null) {
+			PercentilesMethod percentilesMethod =
+				percentilesAggregation.getPercentilesMethod();
+
+			if (percentilesMethod.equals(PercentilesMethod.HDR)) {
+				percentilesAggregationBuilder.hdr(
+					HdrMethod.of(
+						hdrMethor -> hdrMethor.numberOfSignificantValueDigits(
+							percentilesAggregation.
+								getHdrSignificantValueDigits())));
+			}
+			else if (percentilesMethod.equals(PercentilesMethod.TDIGEST)) {
+				percentilesAggregationBuilder.tdigest(
+					TDigest.of(
+						tdigest -> tdigest.compression(
+							percentilesAggregation.getCompression())));
+			}
+		}
+
+		org.opensearch.client.opensearch._types.aggregations.Aggregation.Builder
+			aggregationBuilder =
+				new org.opensearch.client.opensearch._types.aggregations.
+					Aggregation.Builder();
+
+		return _translateChildAggregations(
+			percentilesAggregation,
+			aggregationBuilder.percentiles(
+				percentilesAggregationBuilder.build()));
+	}
+
+	@Override
+	public org.opensearch.client.opensearch._types.aggregations.Aggregation
+		visit(RangeAggregation rangeAggregation) {
+
+		org.opensearch.client.opensearch._types.aggregations.RangeAggregation.
+			Builder rangeAggregationBuilder = AggregationBuilders.range();
+
+		rangeAggregationBuilder.field(rangeAggregation.getField());
+
+		SetterUtil.setNotNullBoolean(
+			rangeAggregationBuilder::keyed, rangeAggregation.getKeyed());
+		SetterUtil.setNotNullInteger(
+			rangeAggregationBuilder::missing,
+			GetterUtil.getInteger(rangeAggregation.getMissing()));
+		setRanges(rangeAggregationBuilder, rangeAggregation);
+		SetterUtil.setNotNullScript(
+			rangeAggregationBuilder::script, rangeAggregation.getScript());
+
+		org.opensearch.client.opensearch._types.aggregations.Aggregation.Builder
+			aggregationBuilder =
+				new org.opensearch.client.opensearch._types.aggregations.
+					Aggregation.Builder();
+
+		return _translateChildAggregations(
+			rangeAggregation,
+			aggregationBuilder.range(rangeAggregationBuilder.build()));
+	}
+
+	@Override
+	public org.opensearch.client.opensearch._types.aggregations.Aggregation
+		visit(ReverseNestedAggregation reverseNestedAggregation) {
+
+		org.opensearch.client.opensearch._types.aggregations.
+			ReverseNestedAggregation.Builder reverseNestedAggregationBuilder =
+				AggregationBuilders.reverseNested();
+
+		reverseNestedAggregationBuilder.path(
+			reverseNestedAggregation.getPath());
+
+		org.opensearch.client.opensearch._types.aggregations.Aggregation.Builder
+			aggregationBuilder =
+				new org.opensearch.client.opensearch._types.aggregations.
+					Aggregation.Builder();
+
+		return _translateChildAggregations(
+			reverseNestedAggregation,
+			aggregationBuilder.reverseNested(
+				reverseNestedAggregationBuilder.build()));
+	}
+
+	@Override
+	public org.opensearch.client.opensearch._types.aggregations.Aggregation
+		visit(SamplerAggregation samplerAggregation) {
+
+		org.opensearch.client.opensearch._types.aggregations.SamplerAggregation.
+			Builder samplerAggregationBuilder = AggregationBuilders.sampler();
+
+		SetterUtil.setNotNullInteger(
+			samplerAggregationBuilder::shardSize,
+			samplerAggregation.getShardSize());
+
+		org.opensearch.client.opensearch._types.aggregations.Aggregation.Builder
+			aggregationBuilder =
+				new org.opensearch.client.opensearch._types.aggregations.
+					Aggregation.Builder();
+
+		return _translateChildAggregations(
+			samplerAggregation,
+			aggregationBuilder.sampler(samplerAggregationBuilder.build()));
+	}
+
+	@Override
+	public org.opensearch.client.opensearch._types.aggregations.Aggregation
+		visit(ScriptedMetricAggregation scriptedMetricAggregation) {
+
+		org.opensearch.client.opensearch._types.aggregations.
+			ScriptedMetricAggregation.Builder scriptedMetricAggregationBuilder =
+				AggregationBuilders.scriptedMetric();
+
+		scriptedMetricAggregationBuilder.params(
+			ConversionUtil.toJsonDataMap(
+				scriptedMetricAggregation.getParameters()));
+
+		SetterUtil.setNotNullScript(
+			scriptedMetricAggregationBuilder::combineScript,
+			scriptedMetricAggregation.getCombineScript());
+		SetterUtil.setNotNullScript(
+			scriptedMetricAggregationBuilder::initScript,
+			scriptedMetricAggregation.getInitScript());
+		SetterUtil.setNotNullScript(
+			scriptedMetricAggregationBuilder::mapScript,
+			scriptedMetricAggregation.getMapScript());
+		SetterUtil.setNotNullScript(
+			scriptedMetricAggregationBuilder::reduceScript,
+			scriptedMetricAggregation.getReduceScript());
+
+		org.opensearch.client.opensearch._types.aggregations.Aggregation.Builder
+			aggregationBuilder =
+				new org.opensearch.client.opensearch._types.aggregations.
+					Aggregation.Builder();
+
+		return _translateChildAggregations(
+			scriptedMetricAggregation,
+			aggregationBuilder.scriptedMetric(
+				scriptedMetricAggregationBuilder.build()));
+	}
+
+	@Override
+	public org.opensearch.client.opensearch._types.aggregations.Aggregation
+		visit(SignificantTermsAggregation significantTermsAggregation) {
+
+		org.opensearch.client.opensearch._types.aggregations.
+			SignificantTermsAggregation.Builder
+				significantTermsAggregationBuilder =
+					AggregationBuilders.significantTerms();
+
+		significantTermsAggregationBuilder.field(
+			significantTermsAggregation.getField());
+
+		setNotNullQuery(
+			significantTermsAggregationBuilder::backgroundFilter,
+			significantTermsAggregation.getBackgroundFilterQuery());
+
+		if (significantTermsAggregation.getExecutionHint() != null) {
+			significantTermsAggregationBuilder.executionHint(
+				_translateExecutionHint(
+					significantTermsAggregation.getExecutionHint()));
+		}
+
+		if (significantTermsAggregation.getIncludeExcludeClause() != null) {
+			IncludeExcludeClause includeExcludeClause =
+				significantTermsAggregation.getIncludeExcludeClause();
+
+			if (includeExcludeClause.getIncludedValues() != null) {
+				significantTermsAggregationBuilder.include(
+					Arrays.asList(includeExcludeClause.getIncludedValues()));
+			}
+
+			if (includeExcludeClause.getExcludeRegex() != null) {
+				significantTermsAggregationBuilder.exclude(
+					TermsExclude.of(
+						termsExclude -> termsExclude.regexp(
+							includeExcludeClause.getExcludeRegex())));
+			}
+			else if (includeExcludeClause.getExcludedValues() != null) {
+				significantTermsAggregationBuilder.exclude(
+					TermsExclude.of(
+						termsExclude -> termsExclude.terms(
+							Arrays.asList(
+								includeExcludeClause.getExcludedValues()))));
+			}
+		}
+
+		SetterUtil.setNotNullLong(
+			significantTermsAggregationBuilder::minDocCount,
+			significantTermsAggregation.getMinDocCount());
+		SetterUtil.setNotNullLong(
+			significantTermsAggregationBuilder::shardMinDocCount,
+			significantTermsAggregation.getShardMinDocCount());
+		SetterUtil.setNotNullInteger(
+			significantTermsAggregationBuilder::shardSize,
+			significantTermsAggregation.getShardSize());
+
+		if (significantTermsAggregation.getSignificanceHeuristic() != null) {
+			SignificanceHeuristic significanceHeuristic =
+				significantTermsAggregation.getSignificanceHeuristic();
+
+			if (significanceHeuristic instanceof
+					ChiSquareSignificanceHeuristic) {
+
+				significantTermsAggregationBuilder.chiSquare(
+					_translateChiSquareHeuristic(
+						(ChiSquareSignificanceHeuristic)significanceHeuristic));
+			}
+			else if (significanceHeuristic instanceof
+						GNDSignificanceHeuristic) {
+
+				significantTermsAggregationBuilder.gnd(
+					_translateGNDSignificanceHeuristic(
+						(GNDSignificanceHeuristic)significanceHeuristic));
+			}
+			else if (significanceHeuristic instanceof
+						MutualInformationSignificanceHeuristic) {
+
+				significantTermsAggregationBuilder.mutualInformation(
+					_translateMutualInformationSignificanceHeuristic(
+						(MutualInformationSignificanceHeuristic)
+							significanceHeuristic));
+			}
+			else if (significanceHeuristic instanceof
+						PercentageScoreSignificanceHeuristic) {
+
+				significantTermsAggregationBuilder.percentage(
+					new PercentageScoreHeuristic());
+			}
+			else if (significanceHeuristic instanceof
+						ScriptSignificanceHeuristic) {
+
+				significantTermsAggregationBuilder.scriptHeuristic(
+					_translateScriptSignificanceHeuristic(
+						(ScriptSignificanceHeuristic)significanceHeuristic));
+			}
+		}
+
+		SetterUtil.setNotNullInteger(
+			significantTermsAggregationBuilder::size,
+			significantTermsAggregation.getSize());
+
+		org.opensearch.client.opensearch._types.aggregations.Aggregation.Builder
+			aggregationBuilder =
+				new org.opensearch.client.opensearch._types.aggregations.
+					Aggregation.Builder();
+
+		return _translateChildAggregations(
+			significantTermsAggregation,
+			aggregationBuilder.significantTerms(
+				significantTermsAggregationBuilder.build()));
+	}
+
+	@Override
+	public org.opensearch.client.opensearch._types.aggregations.Aggregation
+		visit(SignificantTextAggregation significantTextAggregation) {
+
+		org.opensearch.client.opensearch._types.aggregations.
+			SignificantTextAggregation.Builder
+				significantTextAggregationBuilder =
+					AggregationBuilders.significantText();
+
+		significantTextAggregationBuilder.field(
+			significantTextAggregation.getField());
+
+		setNotNullQuery(
+			significantTextAggregationBuilder::backgroundFilter,
+			significantTextAggregation.getBackgroundFilterQuery());
+
+		if (significantTextAggregation.getExecutionHint() != null) {
+			significantTextAggregationBuilder.executionHint(
+				_translateExecutionHint(
+					significantTextAggregation.getExecutionHint()));
+		}
+
+		if (significantTextAggregation.getIncludeExcludeClause() != null) {
+			IncludeExcludeClause includeExcludeClause =
+				significantTextAggregation.getIncludeExcludeClause();
+
+			if (includeExcludeClause.getIncludedValues() != null) {
+				significantTextAggregationBuilder.include(
+					Arrays.asList(includeExcludeClause.getIncludedValues()));
+			}
+
+			if (includeExcludeClause.getExcludeRegex() != null) {
+				significantTextAggregationBuilder.exclude(
+					TermsExclude.of(
+						termsExclude -> termsExclude.regexp(
+							includeExcludeClause.getExcludeRegex())));
+			}
+			else if (includeExcludeClause.getExcludedValues() != null) {
+				significantTextAggregationBuilder.exclude(
+					TermsExclude.of(
+						termsExclude -> termsExclude.terms(
+							Arrays.asList(
+								includeExcludeClause.getExcludedValues()))));
+			}
+		}
+
+		SetterUtil.setNotNullLong(
+			significantTextAggregationBuilder::minDocCount,
+			significantTextAggregation.getMinDocCount());
+		SetterUtil.setNotNullLong(
+			significantTextAggregationBuilder::shardMinDocCount,
+			significantTextAggregation.getShardMinDocCount());
+		SetterUtil.setNotNullInteger(
+			significantTextAggregationBuilder::shardSize,
+			significantTextAggregation.getShardSize());
+
+		if (significantTextAggregation.getSignificanceHeuristic() != null) {
+			SignificanceHeuristic significanceHeuristic =
+				significantTextAggregation.getSignificanceHeuristic();
+
+			if (significanceHeuristic instanceof
+					ChiSquareSignificanceHeuristic) {
+
+				significantTextAggregationBuilder.chiSquare(
+					_translateChiSquareHeuristic(
+						(ChiSquareSignificanceHeuristic)significanceHeuristic));
+			}
+			else if (significanceHeuristic instanceof
+						GNDSignificanceHeuristic) {
+
+				significantTextAggregationBuilder.gnd(
+					_translateGNDSignificanceHeuristic(
+						(GNDSignificanceHeuristic)significanceHeuristic));
+			}
+			else if (significanceHeuristic instanceof
+						MutualInformationSignificanceHeuristic) {
+
+				significantTextAggregationBuilder.mutualInformation(
+					_translateMutualInformationSignificanceHeuristic(
+						(MutualInformationSignificanceHeuristic)
+							significanceHeuristic));
+			}
+			else if (significanceHeuristic instanceof
+						PercentageScoreSignificanceHeuristic) {
+
+				significantTextAggregationBuilder.percentage(
+					new PercentageScoreHeuristic());
+			}
+			else if (significanceHeuristic instanceof
+						ScriptSignificanceHeuristic) {
+
+				significantTextAggregationBuilder.scriptHeuristic(
+					_translateScriptSignificanceHeuristic(
+						(ScriptSignificanceHeuristic)significanceHeuristic));
+			}
+		}
+
+		SetterUtil.setNotNullBoolean(
+			significantTextAggregationBuilder::filterDuplicateText,
+			significantTextAggregation.getFilterDuplicateText());
+		SetterUtil.setNotNullInteger(
+			significantTextAggregationBuilder::size,
+			significantTextAggregation.getSize());
+		SetterUtil.setNotEmptyStringList(
+			significantTextAggregationBuilder::sourceFields,
+			significantTextAggregation.getSourceFields());
+
+		org.opensearch.client.opensearch._types.aggregations.Aggregation.Builder
+			aggregationBuilder =
+				new org.opensearch.client.opensearch._types.aggregations.
+					Aggregation.Builder();
+
+		return _translateChildAggregations(
+			significantTextAggregation,
+			aggregationBuilder.significantText(
+				significantTextAggregationBuilder.build()));
+	}
+
+	@Override
+	public org.opensearch.client.opensearch._types.aggregations.Aggregation
+		visit(StatsAggregation statsAggregation) {
+
+		org.opensearch.client.opensearch._types.aggregations.StatsAggregation.
+			Builder statsAggregationBuilder = AggregationBuilders.stats();
+
+		statsAggregationBuilder.field(statsAggregation.getField());
+
+		SetterUtil.setNotNullFieldValue(
+			statsAggregationBuilder::missing, statsAggregation.getMissing());
+		SetterUtil.setNotNullScript(
+			statsAggregationBuilder::script, statsAggregation.getScript());
+
+		org.opensearch.client.opensearch._types.aggregations.Aggregation.Builder
+			aggregationBuilder =
+				new org.opensearch.client.opensearch._types.aggregations.
+					Aggregation.Builder();
+
+		return _translateChildAggregations(
+			statsAggregation,
+			aggregationBuilder.stats(statsAggregationBuilder.build()));
+	}
+
+	@Override
+	public org.opensearch.client.opensearch._types.aggregations.Aggregation
+		visit(SumAggregation sumAggregation) {
+
+		org.opensearch.client.opensearch._types.aggregations.SumAggregation.
+			Builder sumAggregationBuilder = AggregationBuilders.sum();
+
+		sumAggregationBuilder.field(sumAggregation.getField());
+
+		SetterUtil.setNotNullFieldValue(
+			sumAggregationBuilder::missing, sumAggregation.getMissing());
+		SetterUtil.setNotNullScript(
+			sumAggregationBuilder::script, sumAggregation.getScript());
+
+		org.opensearch.client.opensearch._types.aggregations.Aggregation.Builder
+			aggregationBuilder =
+				new org.opensearch.client.opensearch._types.aggregations.
+					Aggregation.Builder();
+
+		return _translateChildAggregations(
+			sumAggregation,
+			aggregationBuilder.sum(sumAggregationBuilder.build()));
+	}
+
+	@Override
+	public org.opensearch.client.opensearch._types.aggregations.Aggregation
+		visit(TermsAggregation termsAggregation) {
+
+		org.opensearch.client.opensearch._types.aggregations.TermsAggregation.
+			Builder termsAggregationBuilder =
+				new org.opensearch.client.opensearch._types.aggregations.
+					TermsAggregation.Builder();
+
+		termsAggregationBuilder.field(termsAggregation.getField());
+
+		if (termsAggregation.getCollectionMode() != null) {
+			termsAggregationBuilder.collectMode(
+				_translateCollectMode(termsAggregation.getCollectionMode()));
+		}
+
+		if (termsAggregation.getExecutionHint() != null) {
+			termsAggregationBuilder.executionHint(
+				_translateExecutionHint(termsAggregation.getExecutionHint()));
+		}
+
+		SetterUtil.setNotNullInteger(
+			termsAggregationBuilder::minDocCount,
+			termsAggregation.getMinDocCount());
+		SetterUtil.setNotNullFieldValue(
+			termsAggregationBuilder::missing, termsAggregation.getMissing());
+
+		if (termsAggregation.getIncludeExcludeClause() != null) {
+			IncludeExcludeClause includeExcludeClause =
+				termsAggregation.getIncludeExcludeClause();
+
+			if (includeExcludeClause.getIncludeRegex() != null) {
+				termsAggregationBuilder.include(
+					TermsInclude.of(
+						termsInclude -> termsInclude.regexp(
+							includeExcludeClause.getIncludeRegex())));
+			}
+			else if (includeExcludeClause.getIncludedValues() != null) {
+				termsAggregationBuilder.include(
+					TermsInclude.of(
+						termsInclude -> termsInclude.terms(
+							Arrays.asList(
+								includeExcludeClause.getIncludedValues()))));
+			}
+
+			if (includeExcludeClause.getExcludeRegex() != null) {
+				termsAggregationBuilder.exclude(
+					TermsExclude.of(
+						termsExclude -> termsExclude.regexp(
+							includeExcludeClause.getExcludeRegex())));
+			}
+			else if (includeExcludeClause.getExcludedValues() != null) {
+				termsAggregationBuilder.exclude(
+					TermsExclude.of(
+						termsInclude -> termsInclude.terms(
+							Arrays.asList(
+								includeExcludeClause.getExcludedValues()))));
+			}
+		}
+
+		if (ListUtil.isNotEmpty(termsAggregation.getOrders())) {
+			termsAggregationBuilder.order(
+				_translateOrders(termsAggregation.getOrders()));
+		}
+
+		SetterUtil.setNotNullScript(
+			termsAggregationBuilder::script, termsAggregation.getScript());
+		SetterUtil.setNotNullInteger(
+			termsAggregationBuilder::shardSize,
+			termsAggregation.getShardSize());
+		SetterUtil.setNotNullBoolean(
+			termsAggregationBuilder::showTermDocCountError,
+			termsAggregation.getShowTermDocCountError());
+		SetterUtil.setNotNullInteger(
+			termsAggregationBuilder::size, termsAggregation.getSize());
+
+		org.opensearch.client.opensearch._types.aggregations.Aggregation.Builder
+			aggregationBuilder =
+				new org.opensearch.client.opensearch._types.aggregations.
+					Aggregation.Builder();
+
+		return _translateChildAggregations(
+			termsAggregation,
+			aggregationBuilder.terms(termsAggregationBuilder.build()));
+	}
+
+	@Override
+	public org.opensearch.client.opensearch._types.aggregations.Aggregation
+		visit(TopHitsAggregation topHitsAggregation) {
+
+		org.opensearch.client.opensearch._types.aggregations.TopHitsAggregation.
+			Builder topHitsAggregationBuilder = AggregationBuilders.topHits();
+
+		SetterUtil.setNotEmptyStringList(
+			topHitsAggregationBuilder::docvalueFields,
+			topHitsAggregation.getSelectedFields());
+		SetterUtil.setNotNullBoolean(
+			topHitsAggregationBuilder::explain,
+			topHitsAggregation.getExplain());
+		SetterUtil.setNotNullInteger(
+			topHitsAggregationBuilder::from, topHitsAggregation.getFrom());
+
+		if (topHitsAggregation.getHighlight() != null) {
+			topHitsAggregationBuilder.highlight(
+				_highlightTranslator.translate(
+					topHitsAggregation.getHighlight(), _queryTranslator));
+		}
+
+		SetterUtil.setNotNullInteger(
+			topHitsAggregationBuilder::size, topHitsAggregation.getSize());
+		SetterUtil.setNotNullBoolean(
+			topHitsAggregationBuilder::trackScores,
+			topHitsAggregation.getTrackScores());
+		SetterUtil.setNotNullBoolean(
+			topHitsAggregationBuilder::version,
+			topHitsAggregation.getVersion());
+
+		if (topHitsAggregation.getFetchSource() != null) {
+			SourceConfig.Builder sourceConfigBuilder =
+				new SourceConfig.Builder();
+
+			sourceConfigBuilder.fetch(topHitsAggregation.getFetchSource());
+
+			SourceFilter.Builder sourceFilterbuilder =
+				SourceConfigBuilders.filter();
+
+			if (topHitsAggregation.getFetchSourceInclude() != null) {
+				sourceFilterbuilder.includes(
+					Arrays.asList(topHitsAggregation.getFetchSourceInclude()));
+			}
+
+			if (topHitsAggregation.getFetchSourceExclude() != null) {
+				sourceFilterbuilder.includes(
+					Arrays.asList(topHitsAggregation.getFetchSourceExclude()));
+			}
+
+			sourceConfigBuilder.filter(sourceFilterbuilder.build());
+
+			topHitsAggregationBuilder.source(sourceConfigBuilder.build());
+		}
+
+		ListUtil.isNotEmptyForEach(
+			topHitsAggregation.getScriptFields(),
+			scriptField -> topHitsAggregationBuilder.scriptFields(
+				scriptField.getField(),
+				org.opensearch.client.opensearch._types.ScriptField.of(
+					openSearchScriptField ->
+						openSearchScriptField.ignoreFailure(
+							scriptField.isIgnoreFailure()
+						).script(
+							scriptTranslator.translate(scriptField.getScript())
+						))));
+
+		ListUtil.isNotEmptyForEach(
+			topHitsAggregation.getSortFields(),
+			sortField -> topHitsAggregationBuilder.sort(
+				_sortFieldTranslator.translate(sortField)));
+
+		org.opensearch.client.opensearch._types.aggregations.Aggregation.Builder
+			aggregationBuilder =
+				new org.opensearch.client.opensearch._types.aggregations.
+					Aggregation.Builder();
+
+		return _translateChildAggregations(
+			topHitsAggregation,
+			aggregationBuilder.topHits(topHitsAggregationBuilder.build()));
+	}
+
+	@Override
+	public org.opensearch.client.opensearch._types.aggregations.Aggregation
+		visit(ValueCountAggregation valueCountAggregation) {
+
+		org.opensearch.client.opensearch._types.aggregations.
+			ValueCountAggregation.Builder valueCountAggregationBuilder =
+				AggregationBuilders.valueCount();
+
+		valueCountAggregationBuilder.field(valueCountAggregation.getField());
+
+		SetterUtil.setNotNullFieldValue(
+			valueCountAggregationBuilder::missing,
+			valueCountAggregation.getMissing());
+		SetterUtil.setNotNullScript(
+			valueCountAggregationBuilder::script,
+			valueCountAggregation.getScript());
+
+		org.opensearch.client.opensearch._types.aggregations.Aggregation.Builder
+			aggregationBuilder =
+				new org.opensearch.client.opensearch._types.aggregations.
+					Aggregation.Builder();
+
+		return _translateChildAggregations(
+			valueCountAggregation,
+			aggregationBuilder.valueCount(
+				valueCountAggregationBuilder.build()));
+	}
+
+	@Override
+	public org.opensearch.client.opensearch._types.aggregations.Aggregation
+		visit(WeightedAvgAggregation weightedAvgAggregation) {
+
+		org.opensearch.client.opensearch._types.aggregations.
+			WeightedAverageAggregation.Builder
+				weightedAverageAggregationBuilder =
+					AggregationBuilders.weightedAvg();
+
+		weightedAverageAggregationBuilder.value(
+			_getWeightedAverageValue(
+				weightedAvgAggregation.getValueField(),
+				weightedAvgAggregation.getValueMissing(),
+				weightedAvgAggregation.getValueScript()));
+		weightedAverageAggregationBuilder.weight(
+			_getWeightedAverageValue(
+				weightedAvgAggregation.getWeightField(),
+				weightedAvgAggregation.getWeightMissing(),
+				weightedAvgAggregation.getWeightScript()));
+
+		SetterUtil.setNotBlankString(
+			weightedAverageAggregationBuilder::format,
+			weightedAvgAggregation.getFormat());
+
+		if (weightedAvgAggregation.getValueType() != null) {
+			weightedAverageAggregationBuilder.valueType(
+				translateValueType(weightedAvgAggregation.getValueType()));
+		}
+
+		org.opensearch.client.opensearch._types.aggregations.Aggregation.Builder
+			aggregationBuilder =
+				new org.opensearch.client.opensearch._types.aggregations.
+					Aggregation.Builder();
+
+		return _translateChildAggregations(
+			weightedAvgAggregation,
+			aggregationBuilder.weightedAvg(
+				weightedAverageAggregationBuilder.build()));
+	}
+
+	protected void setNotNullQuery(
+		Consumer<Query> consumer, com.liferay.portal.search.query.Query query) {
+
+		if (query != null) {
+			consumer.accept(new Query(_queryTranslator.translate(query)));
+		}
+	}
+
+	protected void setRanges(
+		org.opensearch.client.opensearch._types.aggregations.
+			DateRangeAggregation.Builder builder,
+		DateRangeAggregation dateRangeAggregation) {
+
+		List<Range> ranges = dateRangeAggregation.getRanges();
+
+		ranges.forEach(
+			range -> builder.ranges(
+				DateRangeExpression.of(
+					dateRangeExpression -> dateRangeExpression.from(
+						ConversionUtil.toFieldDateMath(
+							range.getFromAsString(), range.getFrom())
+					).key(
+						range.getKey()
+					).to(
+						ConversionUtil.toFieldDateMath(
+							range.getToAsString(), range.getTo())
+					))));
+	}
+
+	protected void setRanges(
+		org.opensearch.client.opensearch._types.aggregations.RangeAggregation.
+			Builder builder,
+		RangeAggregation rangeAggregation) {
+
+		List<Range> ranges = rangeAggregation.getRanges();
+
+		ranges.forEach(
+			range -> builder.ranges(
+				_createAggregationRange(
+					range.getFromAsString(), range.getKey(),
+					range.getToAsString())));
+	}
+
+	protected org.opensearch.client.opensearch._types.aggregations.ValueType
+		translateValueType(ValueType valueType) {
+
+		if (valueType == ValueType.BOOLEAN) {
+			return org.opensearch.client.opensearch._types.aggregations.
+				ValueType.Boolean;
+		}
+		else if (valueType == ValueType.DATE) {
+			return org.opensearch.client.opensearch._types.aggregations.
+				ValueType.Date;
+		}
+		else if (valueType == ValueType.DOUBLE) {
+			return org.opensearch.client.opensearch._types.aggregations.
+				ValueType.Double;
+		}
+		else if (valueType == ValueType.GEOPOINT) {
+			return org.opensearch.client.opensearch._types.aggregations.
+				ValueType.GeoPoint;
+		}
+		else if (valueType == ValueType.IP) {
+			return org.opensearch.client.opensearch._types.aggregations.
+				ValueType.Ip;
+		}
+		else if (valueType == ValueType.LONG) {
+			return org.opensearch.client.opensearch._types.aggregations.
+				ValueType.Long;
+		}
+		else if (valueType == ValueType.NUMBER) {
+			return org.opensearch.client.opensearch._types.aggregations.
+				ValueType.Number;
+		}
+		else if (valueType == ValueType.NUMERIC) {
+			return org.opensearch.client.opensearch._types.aggregations.
+				ValueType.Numeric;
+		}
+		else if (valueType == ValueType.STRING) {
+			return org.opensearch.client.opensearch._types.aggregations.
+				ValueType.String;
+		}
+
+		throw new IllegalArgumentException("Invalid value type " + valueType);
+	}
+
+	protected final ScriptTranslator scriptTranslator = new ScriptTranslator();
+
+	private AggregationRange _createAggregationRange(
+		String from, String key, String to) {
+
+		AggregationRange.Builder aggregationRangeBuilder =
+			new AggregationRange.Builder();
+
+		if (!Validator.isBlank(from)) {
+			aggregationRangeBuilder.from(from);
+		}
+
+		if (!Validator.isBlank(key)) {
+			aggregationRangeBuilder.key(key);
+		}
+
+		if (!Validator.isBlank(to)) {
+			aggregationRangeBuilder.to(to);
+		}
+
+		return aggregationRangeBuilder.build();
+	}
+
+	private WeightedAverageValue _getWeightedAverageValue(
+		String field, Object missing, Script script) {
+
+		WeightedAverageValue.Builder builder =
+			new WeightedAverageValue.Builder();
+
+		builder.field(field);
+
+		if (missing != null) {
+			builder.missing(ConversionUtil.toDouble(missing));
+		}
+
+		if (script != null) {
+			builder.script(scriptTranslator.translate(script));
+		}
+
+		return builder.build();
+	}
+
+	private HistogramOrder _toOpenSearchHistogramOrder(Order order) {
+		SortOrder sortOrder;
+
+		if (order.isAscending()) {
+			sortOrder = SortOrder.Asc;
+		}
+		else {
+			sortOrder = SortOrder.Desc;
+		}
+
+		if (Order.COUNT_METRIC_NAME.equals(order.getMetricName())) {
+			return HistogramOrder.of(
+				histogramOrder -> histogramOrder.count(sortOrder));
+		}
+		else if (Order.KEY_METRIC_NAME.equals(order.getMetricName())) {
+			return HistogramOrder.of(
+				histogramOrder -> histogramOrder.key(sortOrder));
+		}
+
+		throw new IllegalArgumentException("Invalid order " + order);
+	}
+
+	private CalendarInterval _translateCalendarInterval(
+		String calendarInterval) {
+
+		if (calendarInterval.equals("second") ||
+			calendarInterval.equals("1s")) {
+
+			return CalendarInterval.Second;
+		}
+		else if (calendarInterval.equals("minute") ||
+				 calendarInterval.equals("1m")) {
+
+			return CalendarInterval.Minute;
+		}
+		else if (calendarInterval.equals("hour") ||
+				 calendarInterval.equals("1h")) {
+
+			return CalendarInterval.Hour;
+		}
+		else if (calendarInterval.equals("day") ||
+				 calendarInterval.equals("1d")) {
+
+			return CalendarInterval.Day;
+		}
+		else if (calendarInterval.equals("week") ||
+				 calendarInterval.equals("1w")) {
+
+			return CalendarInterval.Week;
+		}
+		else if (calendarInterval.equals("month") ||
+				 calendarInterval.equals("1M")) {
+
+			return CalendarInterval.Month;
+		}
+		else if (calendarInterval.equals("quarter") ||
+				 calendarInterval.equals("1q")) {
+
+			return CalendarInterval.Quarter;
+		}
+		else if (calendarInterval.equals("year") ||
+				 calendarInterval.equals("1y")) {
+
+			return CalendarInterval.Year;
+		}
+
+		throw new IllegalArgumentException(
+			"Invalid calendar interval " + calendarInterval);
+	}
+
+	private org.opensearch.client.opensearch._types.aggregations.Aggregation
+		_translateChildAggregations(
+			Aggregation aggregation, ContainerBuilder containerBuilder) {
+
+		for (Aggregation childAggregation :
+				aggregation.getChildrenAggregations()) {
+
+			containerBuilder.aggregations(
+				childAggregation.getName(), translate(childAggregation));
+		}
+
+		for (PipelineAggregation pipelineAggregation :
+				aggregation.getPipelineAggregations()) {
+
+			containerBuilder.aggregations(
+				pipelineAggregation.getName(),
+				_pipelineAggregationTranslator.translate(pipelineAggregation));
+		}
+
+		return containerBuilder.build();
+	}
+
+	private ChiSquareHeuristic _translateChiSquareHeuristic(
+		ChiSquareSignificanceHeuristic chiSquareSignificanceHeuristic) {
+
+		return ChiSquareHeuristic.of(
+			chiSquareHeuristic -> chiSquareHeuristic.backgroundIsSuperset(
+				chiSquareSignificanceHeuristic.isBackgroundIsSuperset()
+			).includeNegatives(
+				chiSquareSignificanceHeuristic.isIncludeNegatives()
+			));
+	}
+
+	private TermsAggregationCollectMode _translateCollectMode(
+		CollectionMode collectionMode) {
+
+		if (collectionMode == CollectionMode.BREADTH_FIRST) {
+			return TermsAggregationCollectMode.BreadthFirst;
+		}
+		else if (collectionMode == CollectionMode.DEPTH_FIRST) {
+			return TermsAggregationCollectMode.DepthFirst;
+		}
+
+		throw new IllegalArgumentException(
+			"Invalid collection mode " + collectionMode);
+	}
+
+	private TermsAggregationExecutionHint _translateExecutionHint(
+		String executionHint) {
+
+		if (executionHint.equals("global_ordinals")) {
+			return TermsAggregationExecutionHint.GlobalOrdinals;
+		}
+		else if (executionHint.equals("global_ordinals_hash")) {
+			return TermsAggregationExecutionHint.GlobalOrdinalsHash;
+		}
+		else if (executionHint.equals("global_ordinals_low_cardinality")) {
+			return TermsAggregationExecutionHint.GlobalOrdinalsLowCardinality;
+		}
+
+		throw new IllegalArgumentException(
+			"Invalid execution hint " + executionHint);
+	}
+
+	private GoogleNormalizedDistanceHeuristic
+		_translateGNDSignificanceHeuristic(
+			GNDSignificanceHeuristic gndSignificanceHeuristic) {
+
+		return GoogleNormalizedDistanceHeuristic.of(
+			googleNormalizedDistanceHeuristic ->
+				googleNormalizedDistanceHeuristic.backgroundIsSuperset(
+					gndSignificanceHeuristic.isBackgroundIsSuperset()));
+	}
+
+	private MutualInformationHeuristic
+		_translateMutualInformationSignificanceHeuristic(
+			MutualInformationSignificanceHeuristic
+				mutualInformationSignificanceHeuristic) {
+
+		return MutualInformationHeuristic.of(
+			mutualInformationHeuristic ->
+				mutualInformationHeuristic.backgroundIsSuperset(
+					mutualInformationSignificanceHeuristic.
+						isBackgroundIsSuperset()
+				).includeNegatives(
+					mutualInformationSignificanceHeuristic.isIncludeNegatives()
+				));
+	}
+
+	private Map<String, SortOrder> _translateOrders(List<Order> orders) {
+		Map<String, SortOrder> sortOrders = new HashMap<>();
+
+		orders.forEach(
+			order -> {
+				SortOrder sortOrder;
+
+				if (order.isAscending()) {
+					sortOrder = SortOrder.Asc;
+				}
+				else {
+					sortOrder = SortOrder.Desc;
+				}
+
+				if (Order.COUNT_METRIC_NAME.equals(order.getMetricName())) {
+					sortOrders.put(Order.COUNT_METRIC_NAME, sortOrder);
+				}
+				else if (Order.KEY_METRIC_NAME.equals(order.getMetricName())) {
+					sortOrders.put(Order.KEY_METRIC_NAME, sortOrder);
+				}
+			});
+
+		return sortOrders;
+	}
+
+	private ScriptedHeuristic _translateScriptSignificanceHeuristic(
+		ScriptSignificanceHeuristic scriptSignificanceHeuristic) {
+
+		return ScriptedHeuristic.of(
+			scriptedHeuristic -> scriptedHeuristic.script(
+				scriptTranslator.translate(
+					scriptSignificanceHeuristic.getScript())));
+	}
+
+	private final GeoTranslator _geoTranslator = new GeoTranslator();
+	private final HighlightTranslator _highlightTranslator =
+		new HighlightTranslator();
+
+	@Reference(target = "(search.engine.impl=OpenSearch)")
+	private PipelineAggregationTranslator
+		<org.opensearch.client.opensearch._types.aggregations.Aggregation>
+			_pipelineAggregationTranslator;
+
+	@Reference(target = "(search.engine.impl=OpenSearch)")
+	private QueryTranslator<QueryVariant> _queryTranslator;
+
+	@Reference(target = "(search.engine.impl=OpenSearch)")
+	private SortFieldTranslator<SortOptions> _sortFieldTranslator;
+
+}

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/aggregation/OpenSearchPipelineAggregationResultTranslator.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/aggregation/OpenSearchPipelineAggregationResultTranslator.java
@@ -1,0 +1,274 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.opensearch2.internal.aggregation;
+
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.search.aggregation.AggregationResult;
+import com.liferay.portal.search.aggregation.AggregationResults;
+import com.liferay.portal.search.aggregation.pipeline.AvgBucketPipelineAggregation;
+import com.liferay.portal.search.aggregation.pipeline.AvgBucketPipelineAggregationResult;
+import com.liferay.portal.search.aggregation.pipeline.BucketScriptPipelineAggregation;
+import com.liferay.portal.search.aggregation.pipeline.BucketScriptPipelineAggregationResult;
+import com.liferay.portal.search.aggregation.pipeline.BucketSelectorPipelineAggregation;
+import com.liferay.portal.search.aggregation.pipeline.BucketSortPipelineAggregation;
+import com.liferay.portal.search.aggregation.pipeline.CumulativeSumPipelineAggregation;
+import com.liferay.portal.search.aggregation.pipeline.CumulativeSumPipelineAggregationResult;
+import com.liferay.portal.search.aggregation.pipeline.DerivativePipelineAggregation;
+import com.liferay.portal.search.aggregation.pipeline.DerivativePipelineAggregationResult;
+import com.liferay.portal.search.aggregation.pipeline.ExtendedStatsBucketPipelineAggregation;
+import com.liferay.portal.search.aggregation.pipeline.ExtendedStatsBucketPipelineAggregationResult;
+import com.liferay.portal.search.aggregation.pipeline.MaxBucketPipelineAggregation;
+import com.liferay.portal.search.aggregation.pipeline.MaxBucketPipelineAggregationResult;
+import com.liferay.portal.search.aggregation.pipeline.MinBucketPipelineAggregation;
+import com.liferay.portal.search.aggregation.pipeline.MinBucketPipelineAggregationResult;
+import com.liferay.portal.search.aggregation.pipeline.MovingFunctionPipelineAggregation;
+import com.liferay.portal.search.aggregation.pipeline.MovingFunctionPipelineAggregationResult;
+import com.liferay.portal.search.aggregation.pipeline.PercentilesBucketPipelineAggregation;
+import com.liferay.portal.search.aggregation.pipeline.PercentilesBucketPipelineAggregationResult;
+import com.liferay.portal.search.aggregation.pipeline.PipelineAggregationResultTranslator;
+import com.liferay.portal.search.aggregation.pipeline.SerialDiffPipelineAggregation;
+import com.liferay.portal.search.aggregation.pipeline.SerialDiffPipelineAggregationResult;
+import com.liferay.portal.search.aggregation.pipeline.StatsBucketPipelineAggregation;
+import com.liferay.portal.search.aggregation.pipeline.StatsBucketPipelineAggregationResult;
+import com.liferay.portal.search.aggregation.pipeline.SumBucketPipelineAggregation;
+import com.liferay.portal.search.aggregation.pipeline.SumBucketPipelineAggregationResult;
+
+import org.opensearch.client.opensearch._types.aggregations.Aggregate;
+import org.opensearch.client.opensearch._types.aggregations.BucketMetricValueAggregate;
+import org.opensearch.client.opensearch._types.aggregations.DerivativeAggregate;
+import org.opensearch.client.opensearch._types.aggregations.ExtendedStatsBucketAggregate;
+import org.opensearch.client.opensearch._types.aggregations.Percentiles;
+import org.opensearch.client.opensearch._types.aggregations.PercentilesBucketAggregate;
+import org.opensearch.client.opensearch._types.aggregations.SimpleValueAggregate;
+import org.opensearch.client.opensearch._types.aggregations.StatsBucketAggregate;
+
+/**
+ * @author Michael C. Han
+ * @author Petteri Karttunen
+ */
+public class OpenSearchPipelineAggregationResultTranslator
+	implements PipelineAggregationResultTranslator {
+
+	public OpenSearchPipelineAggregationResultTranslator(
+		Aggregate aggregate, AggregationResults aggregationResults) {
+
+		_aggregate = aggregate;
+		_aggregationResults = aggregationResults;
+	}
+
+	@Override
+	public AvgBucketPipelineAggregationResult visit(
+		AvgBucketPipelineAggregation avgBucketPipelineAggregation) {
+
+		SimpleValueAggregate simpleValueAggregate = _aggregate.simpleValue();
+
+		return _aggregationResults.avgBucket(
+			avgBucketPipelineAggregation.getName(),
+			simpleValueAggregate.value());
+	}
+
+	@Override
+	public BucketScriptPipelineAggregationResult visit(
+		BucketScriptPipelineAggregation bucketScriptPipelineAggregation) {
+
+		SimpleValueAggregate simpleValueAggregate = _aggregate.simpleValue();
+
+		return _aggregationResults.bucketScript(
+			bucketScriptPipelineAggregation.getName(),
+			simpleValueAggregate.value());
+	}
+
+	@Override
+	public AggregationResult visit(
+		BucketSelectorPipelineAggregation bucketSelectorPipelineAggregation) {
+
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public AggregationResult visit(
+		BucketSortPipelineAggregation bucketSortPipelineAggregation) {
+
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public CumulativeSumPipelineAggregationResult visit(
+		CumulativeSumPipelineAggregation cumulativeSumPipelineAggregation) {
+
+		SimpleValueAggregate simpleValueAggregate = _aggregate.simpleValue();
+
+		return _aggregationResults.cumulativeSum(
+			cumulativeSumPipelineAggregation.getName(),
+			simpleValueAggregate.value());
+	}
+
+	@Override
+	public DerivativePipelineAggregationResult visit(
+		DerivativePipelineAggregation derivativePipelineAggregation) {
+
+		DerivativeAggregate derivativeAggregate = _aggregate.derivative();
+
+		if (derivativePipelineAggregation.getUnit() != null) {
+			return _aggregationResults.derivative(
+				derivativePipelineAggregation.getName(),
+				derivativeAggregate.normalizedValue());
+		}
+
+		return _aggregationResults.derivative(
+			derivativePipelineAggregation.getName(),
+			derivativeAggregate.value());
+	}
+
+	@Override
+	public ExtendedStatsBucketPipelineAggregationResult visit(
+		ExtendedStatsBucketPipelineAggregation
+			extendedStatsBucketPipelineAggregation) {
+
+		ExtendedStatsBucketAggregate extendedStatsBucketAggregate =
+			_aggregate.extendedStatsBucket();
+
+		return _aggregationResults.extendedStatsBucket(
+			extendedStatsBucketPipelineAggregation.getName(),
+			extendedStatsBucketAggregate.avg(),
+			extendedStatsBucketAggregate.count(),
+			extendedStatsBucketAggregate.min(),
+			extendedStatsBucketAggregate.max(),
+			extendedStatsBucketAggregate.sum(),
+			extendedStatsBucketAggregate.sumOfSquares(),
+			extendedStatsBucketAggregate.variance(),
+			extendedStatsBucketAggregate.stdDeviation());
+	}
+
+	@Override
+	public MaxBucketPipelineAggregationResult visit(
+		MaxBucketPipelineAggregation maxBucketPipelineAggregation) {
+
+		BucketMetricValueAggregate bucketMetricValueAggregate =
+			_aggregate.bucketMetricValue();
+
+		MaxBucketPipelineAggregationResult maxBucketPipelineAggregationResult =
+			_aggregationResults.maxBucket(
+				maxBucketPipelineAggregation.getName(),
+				bucketMetricValueAggregate.value());
+
+		maxBucketPipelineAggregationResult.setKeys(
+			bucketMetricValueAggregate.keys(
+			).toArray(
+				new String[0]
+			));
+
+		return maxBucketPipelineAggregationResult;
+	}
+
+	@Override
+	public MinBucketPipelineAggregationResult visit(
+		MinBucketPipelineAggregation minBucketPipelineAggregation) {
+
+		BucketMetricValueAggregate bucketMetricValueAggregate =
+			_aggregate.bucketMetricValue();
+
+		MinBucketPipelineAggregationResult minBucketPipelineAggregationResult =
+			_aggregationResults.minBucket(
+				minBucketPipelineAggregation.getName(),
+				bucketMetricValueAggregate.value());
+
+		minBucketPipelineAggregationResult.setKeys(
+			bucketMetricValueAggregate.keys(
+			).toArray(
+				new String[0]
+			));
+
+		return minBucketPipelineAggregationResult;
+	}
+
+	@Override
+	public MovingFunctionPipelineAggregationResult visit(
+		MovingFunctionPipelineAggregation movingFunctionPipelineAggregation) {
+
+		SimpleValueAggregate simpleValueAggregate = _aggregate.simpleValue();
+
+		return _aggregationResults.movingFunction(
+			movingFunctionPipelineAggregation.getName(),
+			simpleValueAggregate.value());
+	}
+
+	@Override
+	public PercentilesBucketPipelineAggregationResult visit(
+		PercentilesBucketPipelineAggregation
+			percentilesBucketPipelineAggregation) {
+
+		PercentilesBucketAggregate percentilesBucketAggregate =
+			_aggregate.percentilesBucket();
+
+		PercentilesBucketPipelineAggregationResult
+			percentilesBucketPipelineAggregationResult =
+				_aggregationResults.percentilesBucket(
+					percentilesBucketPipelineAggregation.getName());
+
+		Percentiles percentiles = percentilesBucketAggregate.values();
+
+		if (percentiles.isArray()) {
+			ListUtil.isNotEmptyForEach(
+				percentiles.array(),
+				percentile ->
+					percentilesBucketPipelineAggregationResult.addPercentile(
+						Double.valueOf(percentile.key()),
+						GetterUtil.getDouble(percentile.value())));
+		}
+		else {
+			MapUtil.isNotEmptyForEach(
+				percentiles.keyed(),
+				(key, percentile) ->
+					percentilesBucketPipelineAggregationResult.addPercentile(
+						Double.valueOf(percentile),
+						GetterUtil.getDouble(percentile)));
+		}
+
+		return percentilesBucketPipelineAggregationResult;
+	}
+
+	@Override
+	public SerialDiffPipelineAggregationResult visit(
+		SerialDiffPipelineAggregation serialDiffPipelineAggregation) {
+
+		SimpleValueAggregate simpleValueAggregate = _aggregate.simpleValue();
+
+		return _aggregationResults.serialDiff(
+			serialDiffPipelineAggregation.getName(),
+			simpleValueAggregate.value());
+	}
+
+	@Override
+	public StatsBucketPipelineAggregationResult visit(
+		StatsBucketPipelineAggregation statsBucketPipelineAggregation) {
+
+		StatsBucketAggregate statsBucketAggregate = _aggregate.statsBucket();
+
+		return _aggregationResults.statsBucket(
+			statsBucketPipelineAggregation.getName(),
+			statsBucketAggregate.avg(), statsBucketAggregate.count(),
+			statsBucketAggregate.min(), statsBucketAggregate.max(),
+			statsBucketAggregate.sum());
+	}
+
+	@Override
+	public SumBucketPipelineAggregationResult visit(
+		SumBucketPipelineAggregation sumBucketPipelineAggregation) {
+
+		SimpleValueAggregate simpleValueAggregate = _aggregate.simpleValue();
+
+		return _aggregationResults.sumBucket(
+			sumBucketPipelineAggregation.getName(),
+			simpleValueAggregate.value());
+	}
+
+	private final Aggregate _aggregate;
+	private final AggregationResults _aggregationResults;
+
+}

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/aggregation/OpenSearchPipelineAggregationTranslator.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/aggregation/OpenSearchPipelineAggregationTranslator.java
@@ -1,0 +1,407 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.opensearch2.internal.aggregation;
+
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.search.aggregation.pipeline.AvgBucketPipelineAggregation;
+import com.liferay.portal.search.aggregation.pipeline.BucketScriptPipelineAggregation;
+import com.liferay.portal.search.aggregation.pipeline.BucketSelectorPipelineAggregation;
+import com.liferay.portal.search.aggregation.pipeline.BucketSortPipelineAggregation;
+import com.liferay.portal.search.aggregation.pipeline.CumulativeSumPipelineAggregation;
+import com.liferay.portal.search.aggregation.pipeline.DerivativePipelineAggregation;
+import com.liferay.portal.search.aggregation.pipeline.ExtendedStatsBucketPipelineAggregation;
+import com.liferay.portal.search.aggregation.pipeline.GapPolicy;
+import com.liferay.portal.search.aggregation.pipeline.MaxBucketPipelineAggregation;
+import com.liferay.portal.search.aggregation.pipeline.MinBucketPipelineAggregation;
+import com.liferay.portal.search.aggregation.pipeline.MovingFunctionPipelineAggregation;
+import com.liferay.portal.search.aggregation.pipeline.PercentilesBucketPipelineAggregation;
+import com.liferay.portal.search.aggregation.pipeline.PipelineAggregation;
+import com.liferay.portal.search.aggregation.pipeline.PipelineAggregationTranslator;
+import com.liferay.portal.search.aggregation.pipeline.PipelineAggregationVisitor;
+import com.liferay.portal.search.aggregation.pipeline.SerialDiffPipelineAggregation;
+import com.liferay.portal.search.aggregation.pipeline.StatsBucketPipelineAggregation;
+import com.liferay.portal.search.aggregation.pipeline.SumBucketPipelineAggregation;
+import com.liferay.portal.search.opensearch2.internal.util.SetterUtil;
+import com.liferay.portal.search.script.Script;
+import com.liferay.portal.search.sort.FieldSort;
+import com.liferay.portal.search.sort.SortFieldTranslator;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import org.apache.commons.lang.ArrayUtils;
+
+import org.opensearch.client.opensearch._types.SortOptions;
+import org.opensearch.client.opensearch._types.aggregations.Aggregation;
+import org.opensearch.client.opensearch._types.aggregations.AggregationBuilders;
+import org.opensearch.client.opensearch._types.aggregations.AverageBucketAggregation;
+import org.opensearch.client.opensearch._types.aggregations.BucketScriptAggregation;
+import org.opensearch.client.opensearch._types.aggregations.BucketSelectorAggregation;
+import org.opensearch.client.opensearch._types.aggregations.BucketSortAggregation;
+import org.opensearch.client.opensearch._types.aggregations.BucketsPath;
+import org.opensearch.client.opensearch._types.aggregations.CumulativeSumAggregation;
+import org.opensearch.client.opensearch._types.aggregations.DerivativeAggregation;
+import org.opensearch.client.opensearch._types.aggregations.ExtendedStatsBucketAggregation;
+import org.opensearch.client.opensearch._types.aggregations.MaxBucketAggregation;
+import org.opensearch.client.opensearch._types.aggregations.MinBucketAggregation;
+import org.opensearch.client.opensearch._types.aggregations.MovingFunctionAggregation;
+import org.opensearch.client.opensearch._types.aggregations.PercentilesBucketAggregation;
+import org.opensearch.client.opensearch._types.aggregations.SerialDifferencingAggregation;
+import org.opensearch.client.opensearch._types.aggregations.StatsBucketAggregation;
+import org.opensearch.client.opensearch._types.aggregations.SumBucketAggregation;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Michael C. Han
+ * @author Petteri Karttunen
+ */
+@Component(
+	property = "search.engine.impl=OpenSearch",
+	service = PipelineAggregationTranslator.class
+)
+public class OpenSearchPipelineAggregationTranslator
+	implements PipelineAggregationTranslator<Aggregation>,
+			   PipelineAggregationVisitor<Aggregation> {
+
+	@Override
+	public Aggregation translate(PipelineAggregation pipelineAggregation) {
+		return pipelineAggregation.accept(this);
+	}
+
+	@Override
+	public Aggregation visit(
+		AvgBucketPipelineAggregation avgBucketPipelineAggregation) {
+
+		AverageBucketAggregation.Builder builder =
+			AggregationBuilders.avgBucket();
+
+		_setNotBlankBucketsPath(
+			builder::bucketsPath,
+			avgBucketPipelineAggregation.getBucketsPath());
+		SetterUtil.setNotBlankString(
+			builder::format, avgBucketPipelineAggregation.getFormat());
+		_setNotNullGapPolicy(
+			builder::gapPolicy, avgBucketPipelineAggregation.getGapPolicy());
+
+		return new Aggregation(builder.build());
+	}
+
+	@Override
+	public Aggregation visit(
+		BucketScriptPipelineAggregation bucketScriptPipelineAggregation) {
+
+		BucketScriptAggregation.Builder builder =
+			AggregationBuilders.bucketScript();
+
+		_setNotEmptyBucketsPathMap(
+			builder::bucketsPath,
+			bucketScriptPipelineAggregation.getBucketsPathsMap());
+		SetterUtil.setNotBlankString(
+			builder::format, bucketScriptPipelineAggregation.getFormat());
+		SetterUtil.setNotNullScript(
+			builder::script, bucketScriptPipelineAggregation.getScript());
+
+		return new Aggregation(builder.build());
+	}
+
+	@Override
+	public Aggregation visit(
+		BucketSelectorPipelineAggregation bucketSelectorPipelineAggregation) {
+
+		BucketSelectorAggregation.Builder builder =
+			AggregationBuilders.bucketSelector();
+
+		_setNotEmptyBucketsPathMap(
+			builder::bucketsPath,
+			bucketSelectorPipelineAggregation.getBucketsPathsMap());
+		_setNotNullGapPolicy(
+			builder::gapPolicy,
+			bucketSelectorPipelineAggregation.getGapPolicy());
+		SetterUtil.setNotNullScript(
+			builder::script, bucketSelectorPipelineAggregation.getScript());
+
+		return new Aggregation(builder.build());
+	}
+
+	@Override
+	public Aggregation visit(
+		BucketSortPipelineAggregation bucketSortPipelineAggregation) {
+
+		BucketSortAggregation.Builder builder =
+			AggregationBuilders.bucketSort();
+
+		SetterUtil.setNotNullInteger(
+			builder::from, bucketSortPipelineAggregation.getFrom());
+		_setNotNullGapPolicy(
+			builder::gapPolicy, bucketSortPipelineAggregation.getGapPolicy());
+		SetterUtil.setNotNullInteger(
+			builder::size, bucketSortPipelineAggregation.getSize());
+
+		List<FieldSort> fieldSorts =
+			bucketSortPipelineAggregation.getFieldSorts();
+
+		fieldSorts.forEach(
+			fieldSort -> builder.sort(
+				_sortFieldTranslator.translate(fieldSort)));
+
+		return new Aggregation(builder.build());
+	}
+
+	@Override
+	public Aggregation visit(
+		CumulativeSumPipelineAggregation cumulativeSumPipelineAggregation) {
+
+		CumulativeSumAggregation.Builder builder =
+			AggregationBuilders.cumulativeSum();
+
+		_setNotBlankBucketsPath(
+			builder::bucketsPath,
+			cumulativeSumPipelineAggregation.getBucketsPath());
+		SetterUtil.setNotBlankString(
+			builder::format, cumulativeSumPipelineAggregation.getFormat());
+
+		return new Aggregation(builder.build());
+	}
+
+	@Override
+	public Aggregation visit(
+		DerivativePipelineAggregation derivativePipelineAggregation) {
+
+		DerivativeAggregation.Builder builder =
+			AggregationBuilders.derivative();
+
+		_setNotBlankBucketsPath(
+			builder::bucketsPath,
+			derivativePipelineAggregation.getBucketsPath());
+		SetterUtil.setNotBlankString(
+			builder::format, derivativePipelineAggregation.getFormat());
+		_setNotNullGapPolicy(
+			builder::gapPolicy, derivativePipelineAggregation.getGapPolicy());
+
+		return new Aggregation(builder.build());
+	}
+
+	@Override
+	public Aggregation visit(
+		ExtendedStatsBucketPipelineAggregation
+			extendedStatsBucketPipelineAggregation) {
+
+		ExtendedStatsBucketAggregation.Builder builder =
+			AggregationBuilders.extendedStatsBucket();
+
+		_setNotBlankBucketsPath(
+			builder::bucketsPath,
+			extendedStatsBucketPipelineAggregation.getBucketsPath());
+		SetterUtil.setNotBlankString(
+			builder::format,
+			extendedStatsBucketPipelineAggregation.getFormat());
+		_setNotNullGapPolicy(
+			builder::gapPolicy,
+			extendedStatsBucketPipelineAggregation.getGapPolicy());
+
+		if (extendedStatsBucketPipelineAggregation.getSigma() != null) {
+			builder.sigma(extendedStatsBucketPipelineAggregation.getSigma());
+		}
+
+		return new Aggregation(builder.build());
+	}
+
+	@Override
+	public Aggregation visit(
+		MaxBucketPipelineAggregation maxBucketPipelineAggregation) {
+
+		MaxBucketAggregation.Builder builder = AggregationBuilders.maxBucket();
+
+		_setNotBlankBucketsPath(
+			builder::bucketsPath,
+			maxBucketPipelineAggregation.getBucketsPath());
+		SetterUtil.setNotBlankString(
+			builder::format, maxBucketPipelineAggregation.getFormat());
+		_setNotNullGapPolicy(
+			builder::gapPolicy, maxBucketPipelineAggregation.getGapPolicy());
+
+		return new Aggregation(builder.build());
+	}
+
+	@Override
+	public Aggregation visit(
+		MinBucketPipelineAggregation minBucketPipelineAggregation) {
+
+		MinBucketAggregation.Builder builder = AggregationBuilders.minBucket();
+
+		_setNotBlankBucketsPath(
+			builder::bucketsPath,
+			minBucketPipelineAggregation.getBucketsPath());
+		SetterUtil.setNotBlankString(
+			builder::format, minBucketPipelineAggregation.getFormat());
+		_setNotNullGapPolicy(
+			builder::gapPolicy, minBucketPipelineAggregation.getGapPolicy());
+
+		return new Aggregation(builder.build());
+	}
+
+	@Override
+	public Aggregation visit(
+		MovingFunctionPipelineAggregation movingFunctionPipelineAggregation) {
+
+		MovingFunctionAggregation.Builder builder =
+			AggregationBuilders.movingFn();
+
+		Script script = movingFunctionPipelineAggregation.getScript();
+
+		builder.script(script.getIdOrCode());
+
+		_setNotBlankBucketsPath(
+			builder::bucketsPath,
+			movingFunctionPipelineAggregation.getBucketsPath());
+		SetterUtil.setNotBlankString(
+			builder::format, movingFunctionPipelineAggregation.getFormat());
+		_setNotNullGapPolicy(
+			builder::gapPolicy,
+			movingFunctionPipelineAggregation.getGapPolicy());
+		SetterUtil.setNotNullInteger(
+			builder::window, movingFunctionPipelineAggregation.getWindow());
+
+		return new Aggregation(builder.build());
+	}
+
+	@Override
+	public Aggregation visit(
+		PercentilesBucketPipelineAggregation
+			percentilesBucketPipelineAggregation) {
+
+		PercentilesBucketAggregation.Builder builder =
+			AggregationBuilders.percentilesBucket();
+
+		_setNotBlankBucketsPath(
+			builder::bucketsPath,
+			percentilesBucketPipelineAggregation.getBucketsPath());
+		SetterUtil.setNotBlankString(
+			builder::format, percentilesBucketPipelineAggregation.getFormat());
+		_setNotNullGapPolicy(
+			builder::gapPolicy,
+			percentilesBucketPipelineAggregation.getGapPolicy());
+
+		if (!ArrayUtil.isEmpty(
+				percentilesBucketPipelineAggregation.getPercents())) {
+
+			builder.percents(
+				Arrays.asList(
+					ArrayUtils.toObject(
+						percentilesBucketPipelineAggregation.getPercents())));
+		}
+
+		return new Aggregation(builder.build());
+	}
+
+	@Override
+	public Aggregation visit(
+		SerialDiffPipelineAggregation serialDiffPipelineAggregation) {
+
+		SerialDifferencingAggregation.Builder builder =
+			AggregationBuilders.serialDiff();
+
+		_setNotBlankBucketsPath(
+			builder::bucketsPath,
+			serialDiffPipelineAggregation.getBucketsPath());
+		SetterUtil.setNotBlankString(
+			builder::format, serialDiffPipelineAggregation.getFormat());
+		_setNotNullGapPolicy(
+			builder::gapPolicy, serialDiffPipelineAggregation.getGapPolicy());
+		SetterUtil.setNotNullInteger(
+			builder::lag, serialDiffPipelineAggregation.getLag());
+
+		return new Aggregation(builder.build());
+	}
+
+	@Override
+	public Aggregation visit(
+		StatsBucketPipelineAggregation statsBucketPipelineAggregation) {
+
+		StatsBucketAggregation.Builder builder =
+			AggregationBuilders.statsBucket();
+
+		_setNotBlankBucketsPath(
+			builder::bucketsPath,
+			statsBucketPipelineAggregation.getBucketsPath());
+		SetterUtil.setNotBlankString(
+			builder::format, statsBucketPipelineAggregation.getFormat());
+		_setNotNullGapPolicy(
+			builder::gapPolicy, statsBucketPipelineAggregation.getGapPolicy());
+
+		return new Aggregation(builder.build());
+	}
+
+	@Override
+	public Aggregation visit(
+		SumBucketPipelineAggregation sumBucketPipelineAggregation) {
+
+		SumBucketAggregation.Builder builder = AggregationBuilders.sumBucket();
+
+		_setNotBlankBucketsPath(
+			builder::bucketsPath,
+			sumBucketPipelineAggregation.getBucketsPath());
+		SetterUtil.setNotBlankString(
+			builder::format, sumBucketPipelineAggregation.getFormat());
+		_setNotNullGapPolicy(
+			builder::gapPolicy, sumBucketPipelineAggregation.getGapPolicy());
+
+		return new Aggregation(builder.build());
+	}
+
+	private void _setNotBlankBucketsPath(
+		Consumer<BucketsPath> consumer, String value) {
+
+		if (!Validator.isBlank(value)) {
+			consumer.accept(
+				BucketsPath.of(bucketsPath -> bucketsPath.single(value)));
+		}
+	}
+
+	private void _setNotEmptyBucketsPathMap(
+		Consumer<BucketsPath> consumer, Map<String, String> values) {
+
+		if (MapUtil.isNotEmpty(values)) {
+			consumer.accept(
+				BucketsPath.of(bucketsPath -> bucketsPath.dict(values)));
+		}
+	}
+
+	private void _setNotNullGapPolicy(
+		Consumer<org.opensearch.client.opensearch._types.aggregations.GapPolicy>
+			consumer,
+		GapPolicy gapPolicy) {
+
+		if (gapPolicy != null) {
+			consumer.accept(_translateGapPolicy(gapPolicy));
+		}
+	}
+
+	private org.opensearch.client.opensearch._types.aggregations.GapPolicy
+		_translateGapPolicy(GapPolicy gapPolicy) {
+
+		if (gapPolicy == GapPolicy.INSTANT_ZEROS) {
+			return org.opensearch.client.opensearch._types.aggregations.
+				GapPolicy.InsertZeros;
+		}
+		else if (gapPolicy == GapPolicy.SKIP) {
+			return org.opensearch.client.opensearch._types.aggregations.
+				GapPolicy.Skip;
+		}
+
+		throw new IllegalArgumentException("Invalid gap policy " + gapPolicy);
+	}
+
+	@Reference(target = "(search.engine.impl=OpenSearch)")
+	private SortFieldTranslator<SortOptions> _sortFieldTranslator;
+
+}

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/aggregation/PipelineAggregationResultTranslatorFactory.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/aggregation/PipelineAggregationResultTranslatorFactory.java
@@ -1,0 +1,21 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.opensearch2.internal.aggregation;
+
+import com.liferay.portal.search.aggregation.pipeline.PipelineAggregationResultTranslator;
+
+import org.opensearch.client.opensearch._types.aggregations.Aggregate;
+
+/**
+ * @author André de Oliveira
+ * @author Petteri Karttunen
+ */
+public interface PipelineAggregationResultTranslatorFactory {
+
+	public PipelineAggregationResultTranslator
+		createPipelineAggregationResultTranslator(Aggregate aggregate);
+
+}

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/facet/AggregationFilteringFacetProcessorContext.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/facet/AggregationFilteringFacetProcessorContext.java
@@ -1,0 +1,269 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.opensearch2.internal.facet;
+
+import com.liferay.portal.kernel.search.facet.Facet;
+import com.liferay.portal.kernel.search.facet.RangeFacet;
+import com.liferay.portal.kernel.search.facet.util.RangeParserUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.search.aggregation.Aggregation;
+import com.liferay.portal.search.aggregation.bucket.DateRangeAggregation;
+import com.liferay.portal.search.facet.nested.NestedFacet;
+import com.liferay.portal.search.opensearch2.internal.util.ConversionUtil;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.opensearch.client.json.JsonData;
+import org.opensearch.client.opensearch._types.aggregations.Aggregation.Builder;
+import org.opensearch.client.opensearch._types.query_dsl.BoolQuery;
+import org.opensearch.client.opensearch._types.query_dsl.ChildScoreMode;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.opensearch.client.opensearch._types.query_dsl.QueryBuilders;
+import org.opensearch.client.opensearch._types.query_dsl.RangeQuery;
+import org.opensearch.client.opensearch._types.query_dsl.TermsQueryField;
+
+/**
+ * @author Bryan Engler
+ * @author André de Oliveira
+ * @author Petteri Karttunen
+ */
+public class AggregationFilteringFacetProcessorContext
+	implements FacetProcessorContext {
+
+	public static FacetProcessorContext newInstance(Collection<Facet> facets) {
+		return new AggregationFilteringFacetProcessorContext(
+			_getSelectionFiltersMap(facets));
+	}
+
+	@Override
+	public Builder.ContainerBuilder postProcessAggregationBuilder(
+		Builder.ContainerBuilder containerBuilder, String facetName) {
+
+		Builder.ContainerBuilder filterContainerBuilder =
+			_getFilterContainerBuilder(facetName);
+
+		if (filterContainerBuilder != null) {
+			return filterContainerBuilder.aggregations(
+				facetName, containerBuilder.build());
+		}
+
+		return containerBuilder;
+	}
+
+	private static void _addNestedFacetChildAggregationFilters(
+		BoolQuery.Builder builder, String fieldName, NestedFacet nestedFacet) {
+
+		if (nestedFacet.getChildAggregation() instanceof DateRangeAggregation) {
+			for (String value : nestedFacet.getSelections()) {
+				DateRangeAggregation dateRangeAggregation =
+					(DateRangeAggregation)nestedFacet.getChildAggregation();
+
+				builder.must(
+					_rangeQuery(
+						fieldName, dateRangeAggregation.getFormat(),
+						RangeParserUtil.parserRange(value)));
+			}
+		}
+		else {
+			Aggregation childAggregation = nestedFacet.getChildAggregation();
+
+			Class<?> clazz = childAggregation.getClass();
+
+			throw new UnsupportedOperationException(
+				"Nested facet does not support child aggregation " +
+					clazz.getName());
+		}
+	}
+
+	private static List<Query> _getSelectionFilters(
+		com.liferay.portal.search.facet.Facet facet) {
+
+		List<Query> queries = new ArrayList<>();
+
+		String fieldName = facet.getFieldName();
+
+		if (facet instanceof NestedFacet) {
+			NestedFacet nestedFacet = (NestedFacet)facet;
+
+			BoolQuery.Builder builder = QueryBuilders.bool();
+
+			if (Validator.isNotNull(nestedFacet.getFilterField())) {
+				builder.must(
+					new Query(
+						QueryBuilders.terms(
+						).field(
+							nestedFacet.getFilterField()
+						).terms(
+							TermsQueryField.of(
+								termsQueryField -> termsQueryField.value(
+									ConversionUtil.toFieldValues(
+										nestedFacet.getFilterValue())))
+						).build()));
+			}
+
+			if (nestedFacet.getChildAggregation() != null) {
+				_addNestedFacetChildAggregationFilters(
+					builder, fieldName, nestedFacet);
+			}
+			else {
+				builder.must(
+					new Query(
+						QueryBuilders.terms(
+						).field(
+							fieldName
+						).terms(
+							TermsQueryField.of(
+								termsQueryField -> termsQueryField.value(
+									ConversionUtil.toFieldValues(
+										facet.getSelections())))
+						).build()));
+			}
+
+			queries.add(
+				new Query(
+					QueryBuilders.nested(
+					).path(
+						nestedFacet.getPath()
+					).query(
+						new Query(builder.build())
+					).scoreMode(
+						ChildScoreMode.Sum
+					).build()));
+		}
+		else if (facet instanceof RangeFacet) {
+			for (String value : facet.getSelections()) {
+				queries.add(
+					_rangeQuery(
+						fieldName, null, RangeParserUtil.parserRange(value)));
+			}
+		}
+		else {
+			queries.add(
+				new Query(
+					QueryBuilders.terms(
+					).field(
+						fieldName
+					).terms(
+						TermsQueryField.of(
+							termsQueryField -> termsQueryField.value(
+								ConversionUtil.toFieldValues(
+									facet.getSelections())))
+					).build()));
+		}
+
+		return queries;
+	}
+
+	private static Map<String, List<Query>> _getSelectionFiltersMap(
+		Collection<Facet> facets) {
+
+		Map<String, List<Query>> map = new HashMap<>();
+
+		for (Facet facet : facets) {
+			if ((facet instanceof com.liferay.portal.search.facet.Facet) &&
+				!facet.isStatic()) {
+
+				com.liferay.portal.search.facet.Facet osgiFacet =
+					(com.liferay.portal.search.facet.Facet)facet;
+
+				if (!ArrayUtil.isEmpty(osgiFacet.getSelections())) {
+					map.put(
+						osgiFacet.getAggregationName(),
+						_getSelectionFilters(osgiFacet));
+				}
+			}
+		}
+
+		return map;
+	}
+
+	private static Query _rangeQuery(
+		String fieldName, String format, String[] rangeParts) {
+
+		RangeQuery.Builder builder = new RangeQuery.Builder();
+
+		builder.field(fieldName);
+		builder.gte(JsonData.of(rangeParts[0]));
+		builder.lte(JsonData.of(rangeParts[1]));
+
+		if (!Validator.isBlank(format)) {
+			builder.format(format);
+		}
+
+		return new Query(builder.build());
+	}
+
+	private AggregationFilteringFacetProcessorContext(
+		Map<String, List<Query>> selectionFiltersMap) {
+
+		_selectionFiltersMap = selectionFiltersMap;
+	}
+
+	private Builder.ContainerBuilder _getFilterContainerBuilder(
+		String aggregationName) {
+
+		if (_selectionFiltersMap.isEmpty()) {
+			return null;
+		}
+
+		BoolQuery boolQuery = _getSelectionFiltersOfOthersAsBoolQuery(
+			aggregationName);
+
+		if (ListUtil.isEmpty(boolQuery.must()) &&
+			ListUtil.isEmpty(boolQuery.mustNot()) &&
+			ListUtil.isEmpty(boolQuery.should())) {
+
+			return null;
+		}
+
+		Builder builder = new Builder();
+
+		return builder.filter(new Query(boolQuery));
+	}
+
+	private BoolQuery _getSelectionFiltersOfOthersAsBoolQuery(
+		String aggregationName) {
+
+		BoolQuery.Builder boolQueryBuilder = QueryBuilders.bool();
+
+		for (Map.Entry<String, List<Query>> entry :
+				_selectionFiltersMap.entrySet()) {
+
+			String filterAggregationName = entry.getKey();
+
+			if (filterAggregationName.equals(aggregationName)) {
+				continue;
+			}
+
+			List<Query> queries = entry.getValue();
+
+			if (queries.size() == 1) {
+				boolQueryBuilder.must(queries.get(0));
+			}
+			else if (queries.size() > 1) {
+				BoolQuery.Builder filterBoolQueryBuilder = QueryBuilders.bool();
+
+				for (Query query : queries) {
+					filterBoolQueryBuilder.should(query);
+				}
+
+				boolQueryBuilder.must(
+					new Query(filterBoolQueryBuilder.build()));
+			}
+		}
+
+		return boolQueryBuilder.build();
+	}
+
+	private final Map<String, List<Query>> _selectionFiltersMap;
+
+}

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/facet/DateRangeFacetProcessor.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/facet/DateRangeFacetProcessor.java
@@ -1,0 +1,97 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.opensearch2.internal.facet;
+
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.search.facet.Facet;
+import com.liferay.portal.kernel.search.facet.config.FacetConfiguration;
+import com.liferay.portal.kernel.search.facet.util.RangeParserUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.search.opensearch2.internal.util.SetterUtil;
+
+import org.opensearch.client.opensearch._types.aggregations.Aggregation;
+import org.opensearch.client.opensearch._types.aggregations.AggregationBuilders;
+import org.opensearch.client.opensearch._types.aggregations.DateRangeAggregation;
+import org.opensearch.client.opensearch._types.aggregations.DateRangeExpression;
+import org.opensearch.client.opensearch._types.aggregations.FieldDateMath;
+import org.opensearch.client.opensearch.core.SearchRequest;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Michael C. Han
+ * @author Petteri Karttunen
+ */
+@Component(
+	property = {
+		"class.name=com.liferay.portal.kernel.search.facet.DateRangeFacet",
+		"class.name=com.liferay.portal.search.internal.facet.DateRangeFacetImpl"
+	},
+	service = FacetProcessor.class
+)
+public class DateRangeFacetProcessor
+	implements FacetProcessor<SearchRequest.Builder> {
+
+	@Override
+	public Aggregation.Builder.ContainerBuilder processFacet(Facet facet) {
+		FacetConfiguration facetConfiguration = facet.getFacetConfiguration();
+
+		JSONObject jsonObject = facetConfiguration.getData();
+
+		JSONArray jsonArray = jsonObject.getJSONArray("ranges");
+
+		if (jsonArray == null) {
+			return null;
+		}
+
+		DateRangeAggregation.Builder dateRangeAggregationBuilder =
+			AggregationBuilders.dateRange();
+
+		dateRangeAggregationBuilder.field(facetConfiguration.getFieldName());
+
+		SetterUtil.setNotBlankString(
+			dateRangeAggregationBuilder::format,
+			jsonObject.getString("format"));
+
+		for (int i = 0; i < jsonArray.length(); i++) {
+			JSONObject rangeJSONObject = jsonArray.getJSONObject(i);
+
+			String label = rangeJSONObject.getString("label");
+
+			if (Validator.isBlank(label)) {
+				label = rangeJSONObject.getString("range");
+			}
+
+			dateRangeAggregationBuilder.ranges(
+				_createAggregationRange(
+					label,
+					RangeParserUtil.parserRange(
+						rangeJSONObject.getString("range"))));
+		}
+
+		Aggregation.Builder aggregationBuilder = new Aggregation.Builder();
+
+		return aggregationBuilder.dateRange(
+			dateRangeAggregationBuilder.build());
+	}
+
+	private DateRangeExpression _createAggregationRange(
+		String key, String[] rangeParts) {
+
+		return DateRangeExpression.of(
+			dateRangeExpression -> dateRangeExpression.key(
+				key
+			).from(
+				FieldDateMath.of(
+					fieldDateMath -> fieldDateMath.expr(rangeParts[0]))
+			).to(
+				FieldDateMath.of(
+					fieldDateMath -> fieldDateMath.expr(rangeParts[1]))
+			));
+	}
+
+}

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/facet/FacetCollectorFactory.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/facet/FacetCollectorFactory.java
@@ -1,0 +1,61 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.opensearch2.internal.facet;
+
+import com.liferay.portal.kernel.search.facet.collector.FacetCollector;
+
+import java.util.Map;
+
+import org.opensearch.client.opensearch._types.aggregations.Aggregate;
+import org.opensearch.client.opensearch._types.aggregations.DateRangeAggregate;
+import org.opensearch.client.opensearch._types.aggregations.MultiBucketAggregateBase;
+import org.opensearch.client.opensearch._types.aggregations.RangeAggregate;
+import org.opensearch.client.opensearch._types.aggregations.SingleBucketAggregateBase;
+import org.opensearch.client.util.TaggedUnionUtils;
+
+/**
+ * @author André de Oliveira
+ * @author Petteri Karttunen
+ */
+public class FacetCollectorFactory {
+
+	public FacetCollector getFacetCollector(Aggregate aggregate, String name) {
+		Object object = TaggedUnionUtils.get(aggregate, aggregate._kind());
+
+		if (object instanceof SingleBucketAggregateBase) {
+			SingleBucketAggregateBase singleBucketAggregateBase =
+				(SingleBucketAggregateBase)object;
+
+			Map<String, Aggregate> aggregations =
+				singleBucketAggregateBase.aggregations();
+
+			return getFacetCollector(aggregations.get(name), name);
+		}
+
+		if (object instanceof DateRangeAggregate) {
+			DateRangeAggregate dateRangeAggregate = aggregate.dateRange();
+
+			return new RangeFacetCollector(name, dateRangeAggregate.buckets());
+		}
+
+		if (object instanceof RangeAggregate) {
+			RangeAggregate rangeAggregate = aggregate.range();
+
+			return new RangeFacetCollector(name, rangeAggregate.buckets());
+		}
+
+		if (object instanceof MultiBucketAggregateBase) {
+			MultiBucketAggregateBase multiBucketAggregateBase =
+				(MultiBucketAggregateBase)object;
+
+			return new MultiBucketsAggregationFacetCollector(
+				multiBucketAggregateBase, name);
+		}
+
+		return new OpenSearchFacetFieldCollector(aggregate, name);
+	}
+
+}

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/facet/FacetProcessor.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/facet/FacetProcessor.java
@@ -1,0 +1,20 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.opensearch2.internal.facet;
+
+import com.liferay.portal.kernel.search.facet.Facet;
+
+import org.opensearch.client.opensearch._types.aggregations.Aggregation;
+
+/**
+ * @author Michael C. Han
+ * @author Petteri Karttunen
+ */
+public interface FacetProcessor<T> {
+
+	public Aggregation.Builder.ContainerBuilder processFacet(Facet facet);
+
+}

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/facet/FacetProcessorContext.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/facet/FacetProcessorContext.java
@@ -1,0 +1,19 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.opensearch2.internal.facet;
+
+import org.opensearch.client.opensearch._types.aggregations.Aggregation;
+
+/**
+ * @author André de Oliveira
+ * @author Petteri Karttunen
+ */
+public interface FacetProcessorContext {
+
+	public Aggregation.Builder.ContainerBuilder postProcessAggregationBuilder(
+		Aggregation.Builder.ContainerBuilder containerBuilder, String name);
+
+}

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/facet/FacetTranslator.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/facet/FacetTranslator.java
@@ -1,0 +1,25 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.opensearch2.internal.facet;
+
+import com.liferay.portal.kernel.search.Query;
+import com.liferay.portal.kernel.search.facet.Facet;
+
+import java.util.Map;
+
+import org.opensearch.client.opensearch.core.SearchRequest;
+
+/**
+ * @author Michael C. Han
+ * @author Petteri Karttunen
+ */
+public interface FacetTranslator {
+
+	public void translate(
+		boolean basicFacetSelection, Map<String, Facet> facetsMap, Query query,
+		SearchRequest.Builder searchRequestBuilder);
+
+}

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/facet/FacetTranslatorImpl.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/facet/FacetTranslatorImpl.java
@@ -1,0 +1,259 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.opensearch2.internal.facet;
+
+import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
+import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.search.BooleanClause;
+import com.liferay.portal.kernel.search.Query;
+import com.liferay.portal.kernel.search.facet.Facet;
+import com.liferay.portal.kernel.search.facet.config.FacetConfiguration;
+import com.liferay.portal.kernel.search.filter.BooleanFilter;
+import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.search.filter.FilterTranslator;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import org.opensearch.client.opensearch._types.SortOrder;
+import org.opensearch.client.opensearch._types.aggregations.Aggregation;
+import org.opensearch.client.opensearch._types.aggregations.AggregationBuilders;
+import org.opensearch.client.opensearch._types.aggregations.TermsAggregation;
+import org.opensearch.client.opensearch._types.aggregations.TermsInclude;
+import org.opensearch.client.opensearch._types.query_dsl.BoolQuery;
+import org.opensearch.client.opensearch._types.query_dsl.QueryBuilders;
+import org.opensearch.client.opensearch._types.query_dsl.QueryVariant;
+import org.opensearch.client.opensearch.core.SearchRequest;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Michael C. Han
+ * @author Petteri Karttunen
+ */
+@Component(service = FacetTranslator.class)
+public class FacetTranslatorImpl implements FacetTranslator {
+
+	@Override
+	public void translate(
+		boolean basicFacetSelection, Map<String, Facet> facetsMap, Query query,
+		SearchRequest.Builder searchRequestBuilder) {
+
+		if (MapUtil.isEmpty(facetsMap)) {
+			return;
+		}
+
+		Collection<Facet> facets = facetsMap.values();
+
+		FacetProcessorContext facetProcessorContext = _getFacetProcessorContext(
+			facets, basicFacetSelection);
+
+		List<org.opensearch.client.opensearch._types.query_dsl.Query>
+			postFilterQueries = new ArrayList<>();
+
+		if ((query != null) && (query.getPostFilter() != null)) {
+			postFilterQueries.add(
+				new org.opensearch.client.opensearch._types.query_dsl.Query(
+					_filterTranslator.translate(query.getPostFilter(), null)));
+		}
+
+		for (Facet facet : facets) {
+			if (facet.isStatic()) {
+				continue;
+			}
+
+			BooleanClause<Filter> booleanClause =
+				facet.getFacetFilterBooleanClause();
+
+			if (booleanClause != null) {
+				org.opensearch.client.opensearch._types.query_dsl.Query
+					postFilterQuery = _translateBooleanClause(booleanClause);
+
+				if (postFilterQuery != null) {
+					postFilterQueries.add(postFilterQuery);
+				}
+			}
+
+			Aggregation.Builder.ContainerBuilder containerBuilder =
+				_processFacet(facet);
+
+			if (containerBuilder == null) {
+				continue;
+			}
+
+			String facetName = FacetUtil.getAggregationName(facet);
+
+			Aggregation.Builder.ContainerBuilder postProcessContainerBuilder =
+				postProcessAggregation(
+					containerBuilder, facetProcessorContext, facetName);
+
+			if (postProcessContainerBuilder != null) {
+				searchRequestBuilder.aggregations(
+					facetName, postProcessContainerBuilder.build());
+			}
+		}
+
+		if (ListUtil.isNotEmpty(postFilterQueries)) {
+			searchRequestBuilder.postFilter(_getPostFilter(postFilterQueries));
+		}
+	}
+
+	@Activate
+	protected void activate(BundleContext bundleContext) {
+		_serviceTrackerMap = ServiceTrackerMapFactory.openSingleValueMap(
+			bundleContext, FacetProcessor.class,
+			"(&(class.name=*)(!(class.name=DEFAULT)))",
+			(serviceReference, emitter) -> {
+				List<String> classNames = StringUtil.asList(
+					serviceReference.getProperty("class.name"));
+
+				for (String className : classNames) {
+					emitter.emit(className);
+				}
+			});
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		_serviceTrackerMap.close();
+	}
+
+	protected Aggregation.Builder.ContainerBuilder postProcessAggregation(
+		Aggregation.Builder.ContainerBuilder containerBuilder,
+		FacetProcessorContext facetProcessorContext, String facetName) {
+
+		if (facetProcessorContext != null) {
+			return facetProcessorContext.postProcessAggregationBuilder(
+				containerBuilder, facetName);
+		}
+
+		return containerBuilder;
+	}
+
+	private FacetProcessorContext _getFacetProcessorContext(
+		Collection<Facet> facets, boolean basicFacetSelection) {
+
+		if (basicFacetSelection) {
+			return null;
+		}
+
+		return AggregationFilteringFacetProcessorContext.newInstance(facets);
+	}
+
+	private org.opensearch.client.opensearch._types.query_dsl.Query
+		_getPostFilter(
+			List<org.opensearch.client.opensearch._types.query_dsl.Query>
+				queries) {
+
+		if (queries.size() == 1) {
+			return queries.get(0);
+		}
+
+		BoolQuery.Builder builder = QueryBuilders.bool();
+
+		for (org.opensearch.client.opensearch._types.query_dsl.Query query :
+				queries) {
+
+			builder.must(query);
+		}
+
+		return new org.opensearch.client.opensearch._types.query_dsl.Query(
+			builder.build());
+	}
+
+	private Aggregation.Builder.ContainerBuilder _processFacet(Facet facet) {
+		Class<?> clazz = facet.getClass();
+
+		FacetProcessor<SearchRequest.Builder> facetProcessor =
+			_serviceTrackerMap.getService(clazz.getName());
+
+		if (facetProcessor == null) {
+			facetProcessor = _defaultFacetProcessor;
+		}
+
+		return facetProcessor.processFacet(facet);
+	}
+
+	private org.opensearch.client.opensearch._types.query_dsl.Query
+		_translateBooleanClause(BooleanClause<Filter> booleanClause) {
+
+		BooleanFilter booleanFilter = new BooleanFilter();
+
+		booleanFilter.add(
+			booleanClause.getClause(), booleanClause.getBooleanClauseOccur());
+
+		return new org.opensearch.client.opensearch._types.query_dsl.Query(
+			_filterTranslator.translate(booleanFilter, null));
+	}
+
+	private final FacetProcessor<SearchRequest.Builder> _defaultFacetProcessor =
+		new FacetProcessor<SearchRequest.Builder>() {
+
+			@Override
+			public Aggregation.Builder.ContainerBuilder processFacet(
+				Facet facet) {
+
+				TermsAggregation.Builder builder = AggregationBuilders.terms();
+
+				builder.field(facet.getFieldName());
+
+				FacetConfiguration facetConfiguration =
+					facet.getFacetConfiguration();
+
+				JSONObject dataJSONObject = facetConfiguration.getData();
+
+				String include = dataJSONObject.getString("include", null);
+
+				if (include != null) {
+					builder.include(
+						TermsInclude.of(
+							termsInclude -> termsInclude.regexp(include)));
+				}
+
+				int minDocCount = dataJSONObject.getInt(
+					"frequencyThreshold", -1);
+
+				if (minDocCount >= 0) {
+					builder.minDocCount(minDocCount);
+				}
+
+				builder.order(
+					HashMapBuilder.<String, SortOrder>put(
+						"_count", SortOrder.Desc
+					).build());
+
+				int size = dataJSONObject.getInt("maxTerms");
+
+				if (size > 0) {
+					builder.size(size);
+				}
+
+				Aggregation.Builder aggregationBuilder =
+					new Aggregation.Builder();
+
+				return aggregationBuilder.terms(builder.build());
+			}
+
+		};
+
+	@Reference(target = "(search.engine.impl=OpenSearch)")
+	private FilterTranslator<QueryVariant> _filterTranslator;
+
+	@SuppressWarnings("rawtypes")
+	private ServiceTrackerMap<String, FacetProcessor> _serviceTrackerMap;
+
+}

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/facet/FacetUtil.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/facet/FacetUtil.java
@@ -1,0 +1,26 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.opensearch2.internal.facet;
+
+import com.liferay.portal.kernel.search.facet.Facet;
+
+/**
+ * @author André de Oliveira
+ */
+public class FacetUtil {
+
+	public static String getAggregationName(Facet facet) {
+		if (facet instanceof com.liferay.portal.search.facet.Facet) {
+			com.liferay.portal.search.facet.Facet osgiFacet =
+				(com.liferay.portal.search.facet.Facet)facet;
+
+			return osgiFacet.getAggregationName();
+		}
+
+		return facet.getFieldName();
+	}
+
+}

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/facet/MultiBucketsAggregationFacetCollector.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/facet/MultiBucketsAggregationFacetCollector.java
@@ -1,0 +1,110 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.opensearch2.internal.facet;
+
+import com.liferay.portal.kernel.search.facet.collector.FacetCollector;
+import com.liferay.portal.kernel.search.facet.collector.TermCollector;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.List;
+
+import org.opensearch.client.opensearch._types.aggregations.Buckets;
+import org.opensearch.client.opensearch._types.aggregations.DoubleTermsBucket;
+import org.opensearch.client.opensearch._types.aggregations.LongTermsBucket;
+import org.opensearch.client.opensearch._types.aggregations.MultiBucketAggregateBase;
+import org.opensearch.client.opensearch._types.aggregations.MultiBucketBase;
+import org.opensearch.client.opensearch._types.aggregations.MultiTermsBucket;
+import org.opensearch.client.opensearch._types.aggregations.StringTermsBucket;
+
+/**
+ * @author André de Oliveira
+ * @author Petteri Karttunen
+ */
+public class MultiBucketsAggregationFacetCollector implements FacetCollector {
+
+	public MultiBucketsAggregationFacetCollector(
+		MultiBucketAggregateBase multiBucketAggregateBase, String fieldName) {
+
+		_fieldName = fieldName;
+
+		_termCollectorHolder = getTermCollectorHolder(multiBucketAggregateBase);
+	}
+
+	@Override
+	public String getFieldName() {
+		return _fieldName;
+	}
+
+	@Override
+	public TermCollector getTermCollector(String term) {
+		return _termCollectorHolder.getTermCollector(term);
+	}
+
+	@Override
+	public List<TermCollector> getTermCollectors() {
+		return _termCollectorHolder.getTermCollectors();
+	}
+
+	protected TermCollectorHolder getTermCollectorHolder(
+		MultiBucketAggregateBase multiBucketAggregateBase) {
+
+		Buckets<? extends MultiBucketBase> buckets =
+			multiBucketAggregateBase.buckets();
+
+		List<? extends MultiBucketBase> bucketsList = buckets.array();
+
+		TermCollectorHolder termCollectorHolder = new TermCollectorHolder(
+			bucketsList.size());
+
+		for (MultiBucketBase multiBucketBase : bucketsList) {
+			if (multiBucketBase instanceof StringTermsBucket) {
+				StringTermsBucket stringTermsBucket =
+					(StringTermsBucket)multiBucketBase;
+
+				termCollectorHolder.add(
+					stringTermsBucket.key(), (int)stringTermsBucket.docCount());
+			}
+			else if (multiBucketBase instanceof DoubleTermsBucket) {
+				DoubleTermsBucket doubleTermsBucket =
+					(DoubleTermsBucket)multiBucketBase;
+
+				String key = doubleTermsBucket.keyAsString();
+
+				if (Validator.isBlank(key)) {
+					key = String.valueOf(doubleTermsBucket.key());
+				}
+
+				termCollectorHolder.add(key, (int)doubleTermsBucket.docCount());
+			}
+			else if (multiBucketBase instanceof LongTermsBucket) {
+				LongTermsBucket longTermsBucket =
+					(LongTermsBucket)multiBucketBase;
+
+				String key = longTermsBucket.keyAsString();
+
+				if (Validator.isBlank(key)) {
+					key = longTermsBucket.key();
+				}
+
+				termCollectorHolder.add(key, (int)longTermsBucket.docCount());
+			}
+			else if (multiBucketBase instanceof MultiTermsBucket) {
+				MultiTermsBucket multiTermsBucket =
+					(MultiTermsBucket)multiBucketBase;
+
+				termCollectorHolder.add(
+					multiTermsBucket.keyAsString(),
+					(int)multiTermsBucket.docCount());
+			}
+		}
+
+		return termCollectorHolder;
+	}
+
+	private final String _fieldName;
+	private final TermCollectorHolder _termCollectorHolder;
+
+}

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/facet/NestedFacetProcessor.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/facet/NestedFacetProcessor.java
@@ -1,0 +1,167 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.opensearch2.internal.facet;
+
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.search.facet.Facet;
+import com.liferay.portal.kernel.search.facet.config.FacetConfiguration;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.search.aggregation.Aggregation;
+import com.liferay.portal.search.aggregation.bucket.DateRangeAggregation;
+import com.liferay.portal.search.aggregation.bucket.Range;
+import com.liferay.portal.search.facet.nested.NestedFacet;
+import com.liferay.portal.search.opensearch2.internal.util.ConversionUtil;
+
+import org.opensearch.client.opensearch._types.FieldValue;
+import org.opensearch.client.opensearch._types.aggregations.Aggregation.Builder.ContainerBuilder;
+import org.opensearch.client.opensearch._types.aggregations.AggregationBuilders;
+import org.opensearch.client.opensearch._types.aggregations.DateRangeExpression;
+import org.opensearch.client.opensearch._types.aggregations.TermsAggregation;
+import org.opensearch.client.opensearch.core.SearchRequest;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Jorge Díaz
+ * @author Petteri Karttunen
+ */
+@Component(
+	property = "class.name=com.liferay.portal.search.internal.facet.NestedFacetImpl",
+	service = FacetProcessor.class
+)
+public class NestedFacetProcessor
+	implements FacetProcessor<SearchRequest.Builder> {
+
+	@Override
+	public ContainerBuilder processFacet(Facet facet) {
+		if (!(facet instanceof NestedFacet)) {
+			return null;
+		}
+
+		NestedFacet nestedFacet = (NestedFacet)facet;
+
+		org.opensearch.client.opensearch._types.aggregations.Aggregation.Builder
+			nestedAggregationBuilder =
+				new org.opensearch.client.opensearch._types.aggregations.
+					Aggregation.Builder();
+
+		ContainerBuilder nestedAggregationContainerBuilder =
+			nestedAggregationBuilder.nested(
+				nestedAggregation -> nestedAggregation.path(
+					nestedFacet.getPath()));
+
+		org.opensearch.client.opensearch._types.aggregations.Aggregation
+			termsAggregation =
+				new org.opensearch.client.opensearch._types.aggregations.
+					Aggregation(_getTermsAggregation(nestedFacet));
+
+		if ((nestedFacet.getChildAggregation() != null) ||
+			Validator.isNotNull(nestedFacet.getFilterField())) {
+
+			org.opensearch.client.opensearch._types.aggregations.Aggregation.
+				Builder filterAggregationBuilder =
+					new org.opensearch.client.opensearch._types.aggregations.
+						Aggregation.Builder();
+
+			ContainerBuilder filterAggregationContainerBuilder =
+				filterAggregationBuilder.filter(
+					query -> query.term(
+						termQuery -> termQuery.field(
+							nestedFacet.getFilterField()
+						).value(
+							FieldValue.of(nestedFacet.getFilterValue())
+						)));
+
+			if (nestedFacet.getChildAggregation() != null) {
+				filterAggregationContainerBuilder.aggregations(
+					FacetUtil.getAggregationName(facet),
+					_getChildAggregation(nestedFacet.getChildAggregation()));
+			}
+			else {
+				filterAggregationContainerBuilder.aggregations(
+					FacetUtil.getAggregationName(facet), termsAggregation);
+			}
+
+			nestedAggregationContainerBuilder.aggregations(
+				FacetUtil.getAggregationName(facet),
+				filterAggregationContainerBuilder.build());
+		}
+		else {
+			nestedAggregationContainerBuilder.aggregations(
+				FacetUtil.getAggregationName(facet), termsAggregation);
+		}
+
+		return nestedAggregationContainerBuilder;
+	}
+
+	private org.opensearch.client.opensearch._types.aggregations.Aggregation
+		_getChildAggregation(Aggregation aggregation) {
+
+		if (aggregation instanceof DateRangeAggregation) {
+			return _getDateRangeAggregation((DateRangeAggregation)aggregation);
+		}
+
+		Class<?> clazz = aggregation.getClass();
+
+		throw new UnsupportedOperationException(
+			"Nested facet does not support child aggregation " +
+				clazz.getName());
+	}
+
+	private org.opensearch.client.opensearch._types.aggregations.Aggregation
+		_getDateRangeAggregation(DateRangeAggregation dateRangeAggregation) {
+
+		org.opensearch.client.opensearch._types.aggregations.
+			DateRangeAggregation.Builder builder =
+				AggregationBuilders.dateRange();
+
+		builder.field(dateRangeAggregation.getField());
+		builder.format(dateRangeAggregation.getFormat());
+
+		for (Range range : dateRangeAggregation.getRanges()) {
+			builder.ranges(
+				DateRangeExpression.of(
+					dateRangeExpression -> dateRangeExpression.from(
+						ConversionUtil.toFieldDateMath(
+							range.getFromAsString(), range.getFrom())
+					).key(
+						range.getKey()
+					).to(
+						ConversionUtil.toFieldDateMath(
+							range.getToAsString(), range.getTo())
+					)));
+		}
+
+		return new org.opensearch.client.opensearch._types.aggregations.
+			Aggregation(builder.build());
+	}
+
+	private TermsAggregation _getTermsAggregation(NestedFacet nestedFacet) {
+		TermsAggregation.Builder builder = AggregationBuilders.terms();
+
+		builder.field(nestedFacet.getFieldName());
+
+		FacetConfiguration facetConfiguration =
+			nestedFacet.getFacetConfiguration();
+
+		JSONObject dataJSONObject = facetConfiguration.getData();
+
+		int minDocCount = dataJSONObject.getInt("frequencyThreshold", -1);
+
+		if (minDocCount >= 0) {
+			builder.minDocCount(minDocCount);
+		}
+
+		int size = dataJSONObject.getInt("maxTerms");
+
+		if (size > 0) {
+			builder.size(size);
+		}
+
+		return builder.build();
+	}
+
+}

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/facet/OpenSearchFacetFieldCollector.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/facet/OpenSearchFacetFieldCollector.java
@@ -1,0 +1,47 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.opensearch2.internal.facet;
+
+import com.liferay.portal.kernel.search.facet.collector.DefaultTermCollector;
+import com.liferay.portal.kernel.search.facet.collector.FacetCollector;
+import com.liferay.portal.kernel.search.facet.collector.TermCollector;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.opensearch.client.opensearch._types.aggregations.Aggregate;
+
+/**
+ * @author Michael C. Han
+ * @author Milen Dyankov
+ * @author Petteri Karttunen
+ */
+public class OpenSearchFacetFieldCollector implements FacetCollector {
+
+	public OpenSearchFacetFieldCollector(
+		Aggregate aggregate, String fieldName) {
+
+		_fieldName = fieldName;
+	}
+
+	@Override
+	public String getFieldName() {
+		return _fieldName;
+	}
+
+	@Override
+	public TermCollector getTermCollector(String term) {
+		return new DefaultTermCollector(term, 0);
+	}
+
+	@Override
+	public List<TermCollector> getTermCollectors() {
+		return Collections.emptyList();
+	}
+
+	private final String _fieldName;
+
+}

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/facet/RangeFacetCollector.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/facet/RangeFacetCollector.java
@@ -1,0 +1,61 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.opensearch2.internal.facet;
+
+import com.liferay.portal.kernel.search.facet.collector.FacetCollector;
+import com.liferay.portal.kernel.search.facet.collector.TermCollector;
+
+import java.util.List;
+
+import org.opensearch.client.opensearch._types.aggregations.Buckets;
+import org.opensearch.client.opensearch._types.aggregations.RangeBucket;
+
+/**
+ * @author André de Oliveira
+ * @author Petteri Karttunen
+ */
+public class RangeFacetCollector implements FacetCollector {
+
+	public RangeFacetCollector(String fieldName, Buckets<RangeBucket> buckets) {
+		this.fieldName = fieldName;
+
+		termCollectorHolder = getTermCollectorHolder(buckets);
+	}
+
+	@Override
+	public String getFieldName() {
+		return fieldName;
+	}
+
+	@Override
+	public TermCollector getTermCollector(String term) {
+		return termCollectorHolder.getTermCollector(term);
+	}
+
+	@Override
+	public List<TermCollector> getTermCollectors() {
+		return termCollectorHolder.getTermCollectors();
+	}
+
+	protected TermCollectorHolder getTermCollectorHolder(
+		Buckets<RangeBucket> buckets) {
+
+		List<RangeBucket> bucketsList = buckets.array();
+
+		TermCollectorHolder termCollectorHolder = new TermCollectorHolder(
+			bucketsList.size());
+
+		for (RangeBucket bucket : bucketsList) {
+			termCollectorHolder.add(bucket.key(), (int)bucket.docCount());
+		}
+
+		return termCollectorHolder;
+	}
+
+	protected final String fieldName;
+	protected final TermCollectorHolder termCollectorHolder;
+
+}

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/facet/RangeFacetProcessor.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/facet/RangeFacetProcessor.java
@@ -1,0 +1,105 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.opensearch2.internal.facet;
+
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.search.facet.Facet;
+import com.liferay.portal.kernel.search.facet.config.FacetConfiguration;
+import com.liferay.portal.kernel.search.facet.util.RangeParserUtil;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.Validator;
+
+import org.opensearch.client.opensearch._types.aggregations.Aggregation;
+import org.opensearch.client.opensearch._types.aggregations.AggregationBuilders;
+import org.opensearch.client.opensearch._types.aggregations.AggregationRange;
+import org.opensearch.client.opensearch._types.aggregations.RangeAggregation;
+import org.opensearch.client.opensearch.core.SearchRequest;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Michael C. Han
+ * @author Milen Dyankov
+ * @author Tibor Lipusz
+ * @author Petteri Karttunen
+ */
+@Component(
+	property = {
+		"class.name=com.liferay.portal.kernel.search.facet.RangeFacet",
+		"class.name=com.liferay.portal.search.internal.facet.ModifiedFacetImpl",
+		"class.name=com.liferay.portal.search.internal.facet.RangeFacetImpl"
+	},
+	service = FacetProcessor.class
+)
+public class RangeFacetProcessor
+	implements FacetProcessor<SearchRequest.Builder> {
+
+	@Override
+	public Aggregation.Builder.ContainerBuilder processFacet(Facet facet) {
+		FacetConfiguration facetConfiguration = facet.getFacetConfiguration();
+
+		RangeAggregation.Builder rangeAggregationBuilder =
+			AggregationBuilders.range();
+
+		rangeAggregationBuilder.field(facetConfiguration.getFieldName());
+
+		_addConfigurationRanges(rangeAggregationBuilder, facetConfiguration);
+
+		RangeAggregation rangeAggregation = rangeAggregationBuilder.build();
+
+		if (ListUtil.isEmpty(rangeAggregation.ranges())) {
+			return null;
+		}
+
+		Aggregation.Builder aggregationBuilder = new Aggregation.Builder();
+
+		return aggregationBuilder.range(rangeAggregation);
+	}
+
+	private void _addConfigurationRanges(
+		RangeAggregation.Builder builder,
+		FacetConfiguration facetConfiguration) {
+
+		JSONObject jsonObject = facetConfiguration.getData();
+
+		JSONArray jsonArray = jsonObject.getJSONArray("ranges");
+
+		if (jsonArray == null) {
+			return;
+		}
+
+		for (int i = 0; i < jsonArray.length(); i++) {
+			JSONObject rangeJSONObject = jsonArray.getJSONObject(i);
+
+			String label = rangeJSONObject.getString("label");
+
+			if (Validator.isBlank(label)) {
+				label = rangeJSONObject.getString("range");
+			}
+
+			builder.ranges(
+				_createAggregationRange(
+					label,
+					RangeParserUtil.parserRange(
+						rangeJSONObject.getString("range"))));
+		}
+	}
+
+	private AggregationRange _createAggregationRange(
+		String key, String[] rangeParts) {
+
+		return AggregationRange.of(
+			aggregationRange -> aggregationRange.key(
+				key
+			).from(
+				rangeParts[0]
+			).to(
+				rangeParts[1]
+			));
+	}
+
+}

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/facet/TermCollectorHolder.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/facet/TermCollectorHolder.java
@@ -1,0 +1,50 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.opensearch2.internal.facet;
+
+import com.liferay.portal.kernel.search.facet.collector.DefaultTermCollector;
+import com.liferay.portal.kernel.search.facet.collector.TermCollector;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author André de Oliveira
+ */
+public class TermCollectorHolder {
+
+	public TermCollectorHolder(int size) {
+		_termCollectors = new ArrayList<>(size);
+		_termCollectorsByName = new HashMap<>(size);
+	}
+
+	public void add(String term, int frequency) {
+		TermCollector termCollector = new DefaultTermCollector(term, frequency);
+
+		_termCollectors.add(termCollector);
+		_termCollectorsByName.put(term, termCollector);
+	}
+
+	public TermCollector getTermCollector(String term) {
+		TermCollector termCollector = _termCollectorsByName.get(term);
+
+		if (termCollector != null) {
+			return termCollector;
+		}
+
+		return new DefaultTermCollector(term, 0);
+	}
+
+	public List<TermCollector> getTermCollectors() {
+		return _termCollectors;
+	}
+
+	private final List<TermCollector> _termCollectors;
+	private final Map<String, TermCollector> _termCollectorsByName;
+
+}

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/geolocation/GeoTranslator.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/geolocation/GeoTranslator.java
@@ -1,0 +1,172 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.opensearch2.internal.geolocation;
+
+import com.liferay.portal.search.geolocation.DistanceUnit;
+import com.liferay.portal.search.geolocation.GeoDistance;
+import com.liferay.portal.search.geolocation.GeoDistanceType;
+import com.liferay.portal.search.geolocation.GeoLocationPoint;
+import com.liferay.portal.search.query.geolocation.GeoExecType;
+import com.liferay.portal.search.query.geolocation.GeoValidationMethod;
+
+import org.opensearch.client.opensearch._types.GeoBounds;
+import org.opensearch.client.opensearch._types.GeoHashLocation;
+import org.opensearch.client.opensearch._types.GeoLocation;
+import org.opensearch.client.opensearch._types.LatLonGeoLocation;
+import org.opensearch.client.opensearch._types.TopLeftBottomRightGeoBounds;
+import org.opensearch.client.opensearch._types.query_dsl.GeoExecution;
+
+/**
+ * @author Michael C. Han
+ * @author Petteri Karttunen
+ */
+public class GeoTranslator {
+
+	public GeoBounds toGeoBounds(
+		GeoLocationPoint topLeftGeoLocationPoint,
+		GeoLocationPoint bottomRightGeoLocationPoint) {
+
+		TopLeftBottomRightGeoBounds tlbr = TopLeftBottomRightGeoBounds.of(
+			topLeftBottomRightGeoBounds ->
+				topLeftBottomRightGeoBounds.bottomRight(
+					translateGeoLocationPoint(bottomRightGeoLocationPoint)
+				).topLeft(
+					translateGeoLocationPoint(topLeftGeoLocationPoint)
+				));
+
+		return GeoBounds.of(geoBounds -> geoBounds.tlbr(tlbr));
+	}
+
+	public String toStringWithUnit(GeoDistance geoDistance) {
+		org.opensearch.client.opensearch._types.DistanceUnit distanceUnit =
+			translateDistanceUnit(geoDistance.getDistanceUnit());
+
+		return geoDistance.getDistance() + distanceUnit.jsonValue();
+	}
+
+	public org.opensearch.client.opensearch._types.DistanceUnit
+		translateDistanceUnit(DistanceUnit distanceUnit) {
+
+		if (distanceUnit == DistanceUnit.CENTIMETERS) {
+			return org.opensearch.client.opensearch._types.DistanceUnit.
+				Centimeters;
+		}
+		else if (distanceUnit == DistanceUnit.FEET) {
+			return org.opensearch.client.opensearch._types.DistanceUnit.Feet;
+		}
+		else if (distanceUnit == DistanceUnit.INCHES) {
+			return org.opensearch.client.opensearch._types.DistanceUnit.Inches;
+		}
+		else if (distanceUnit == DistanceUnit.KILOMETERS) {
+			return org.opensearch.client.opensearch._types.DistanceUnit.
+				Kilometers;
+		}
+		else if (distanceUnit == DistanceUnit.METERS) {
+			return org.opensearch.client.opensearch._types.DistanceUnit.Meters;
+		}
+		else if (distanceUnit == DistanceUnit.MILES) {
+			return org.opensearch.client.opensearch._types.DistanceUnit.Miles;
+		}
+		else if (distanceUnit == DistanceUnit.MILLIMETERS) {
+			return org.opensearch.client.opensearch._types.DistanceUnit.
+				Millimeters;
+		}
+		else if (distanceUnit == DistanceUnit.YARDS) {
+			return org.opensearch.client.opensearch._types.DistanceUnit.Yards;
+		}
+
+		throw new IllegalArgumentException(
+			"Invalid distance unit: " + distanceUnit);
+	}
+
+	public org.opensearch.client.opensearch._types.GeoDistanceType
+		translateGeoDistanceType(GeoDistanceType geoDistanceType) {
+
+		if (geoDistanceType == GeoDistanceType.ARC) {
+			return org.opensearch.client.opensearch._types.GeoDistanceType.Arc;
+		}
+		else if (geoDistanceType == GeoDistanceType.PLANE) {
+			return org.opensearch.client.opensearch._types.GeoDistanceType.
+				Plane;
+		}
+
+		throw new IllegalArgumentException(
+			"Invalid geodistance type: " + geoDistanceType);
+	}
+
+	public GeoExecution translateGeoExecType(GeoExecType geoExecType) {
+		if (geoExecType == GeoExecType.INDEXED) {
+			return GeoExecution.Indexed;
+		}
+		else if (geoExecType == GeoExecType.MEMORY) {
+			return GeoExecution.Memory;
+		}
+
+		throw new IllegalArgumentException(
+			"Invalid geoexec type " + geoExecType);
+	}
+
+	public GeoLocation translateGeoLocationPoint(
+		com.liferay.portal.kernel.search.geolocation.GeoLocationPoint
+			geoLocationPoint) {
+
+		return GeoLocation.of(
+			geolocation -> geolocation.latlon(
+				LatLonGeoLocation.of(
+					latLonGeoLocation -> latLonGeoLocation.lat(
+						geoLocationPoint.getLatitude()
+					).lon(
+						geoLocationPoint.getLongitude()
+					))));
+	}
+
+	public GeoLocation translateGeoLocationPoint(
+		GeoLocationPoint geoLocationPoint) {
+
+		if (geoLocationPoint.getGeoHash() != null) {
+			return GeoLocation.of(
+				geolocation -> geolocation.geohash(
+					GeoHashLocation.of(
+						geoHashLocation -> geoHashLocation.geohash(
+							geoLocationPoint.getGeoHash()))));
+		}
+		else if ((geoLocationPoint.getLatitude() != null) &&
+				 (geoLocationPoint.getLongitude() != null)) {
+
+			return GeoLocation.of(
+				geolocation -> geolocation.latlon(
+					LatLonGeoLocation.of(
+						latLonGeoLocation -> latLonGeoLocation.lat(
+							geoLocationPoint.getLatitude()
+						).lon(
+							geoLocationPoint.getLongitude()
+						))));
+		}
+
+		throw new UnsupportedOperationException();
+	}
+
+	public org.opensearch.client.opensearch._types.query_dsl.GeoValidationMethod
+		translateGeoValidationMethod(GeoValidationMethod geoValidationMethod) {
+
+		if (geoValidationMethod == GeoValidationMethod.COERCE) {
+			return org.opensearch.client.opensearch._types.query_dsl.
+				GeoValidationMethod.Coerce;
+		}
+		else if (geoValidationMethod == GeoValidationMethod.IGNORE_MALFORMED) {
+			return org.opensearch.client.opensearch._types.query_dsl.
+				GeoValidationMethod.IgnoreMalformed;
+		}
+		else if (geoValidationMethod == GeoValidationMethod.STRICT) {
+			return org.opensearch.client.opensearch._types.query_dsl.
+				GeoValidationMethod.Strict;
+		}
+
+		throw new IllegalArgumentException(
+			"Invalid geo validation method " + geoValidationMethod);
+	}
+
+}

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/highlight/HighlightTranslator.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/highlight/HighlightTranslator.java
@@ -1,0 +1,304 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.opensearch2.internal.highlight;
+
+import com.liferay.portal.kernel.search.highlight.HighlightUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.search.highlight.FieldConfig;
+import com.liferay.portal.search.highlight.Highlight;
+import com.liferay.portal.search.opensearch2.internal.util.SetterUtil;
+import com.liferay.portal.search.query.QueryTranslator;
+
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.opensearch.client.opensearch._types.query_dsl.QueryVariant;
+import org.opensearch.client.opensearch.core.search.BoundaryScanner;
+import org.opensearch.client.opensearch.core.search.BuiltinHighlighterType;
+import org.opensearch.client.opensearch.core.search.HighlightField;
+import org.opensearch.client.opensearch.core.search.HighlighterEncoder;
+import org.opensearch.client.opensearch.core.search.HighlighterFragmenter;
+import org.opensearch.client.opensearch.core.search.HighlighterOrder;
+import org.opensearch.client.opensearch.core.search.HighlighterTagsSchema;
+import org.opensearch.client.opensearch.core.search.HighlighterType;
+
+/**
+ * @author Michael C. Han
+ * @author Petteri Karttunen
+ */
+public class HighlightTranslator {
+
+	public org.opensearch.client.opensearch.core.search.Highlight translate(
+		Highlight highlight, QueryTranslator<QueryVariant> queryTranslator) {
+
+		org.opensearch.client.opensearch.core.search.Highlight.Builder builder =
+			new org.opensearch.client.opensearch.core.search.Highlight.
+				Builder();
+
+		if (ArrayUtil.isNotEmpty(highlight.getBoundaryChars())) {
+			builder.boundaryChars(String.valueOf(highlight.getBoundaryChars()));
+		}
+
+		SetterUtil.setNotNullInteger(
+			builder::boundaryMaxScan, highlight.getBoundaryMaxScan());
+		SetterUtil.setNotBlankString(
+			builder::boundaryScannerLocale,
+			highlight.getBoundaryScannerLocale());
+
+		if (highlight.getBoundaryScannerType() != null) {
+			builder.boundaryScanner(
+				_translateBoundaryScannerType(
+					highlight.getBoundaryScannerType()));
+		}
+
+		if (highlight.getEncoder() != null) {
+			builder.encoder(_translateEncoder(highlight.getEncoder()));
+		}
+
+		for (FieldConfig fieldConfig : highlight.getFieldConfigs()) {
+			builder.fields(
+				fieldConfig.getFieldName(),
+				_translateFieldConfigs(fieldConfig, queryTranslator));
+		}
+
+		if (highlight.getFragmenter() != null) {
+			builder.fragmenter(_translateFragmenter(highlight.getFragmenter()));
+		}
+
+		SetterUtil.setNotNullInteger(
+			builder::fragmentSize, highlight.getFragmentSize());
+
+		if (highlight.getHighlighterType() != null) {
+			builder.type(
+				_translateHighlighterType(highlight.getHighlighterType()));
+		}
+
+		if (highlight.getHighlightQuery() != null) {
+			builder.highlightQuery(
+				new Query(
+					queryTranslator.translate(highlight.getHighlightQuery())));
+		}
+
+		SetterUtil.setNotNullInteger(
+			builder::noMatchSize, highlight.getNoMatchSize());
+		SetterUtil.setNotNullInteger(
+			builder::numberOfFragments, highlight.getNumOfFragments());
+
+		if (highlight.getOrder() != null) {
+			builder.order(_translateOrder(highlight.getOrder()));
+		}
+
+		SetterUtil.setNotNullEmptyStringArrayAsList(
+			builder::preTags, highlight.getPreTags());
+		SetterUtil.setNotNullEmptyStringArrayAsList(
+			builder::postTags, highlight.getPostTags());
+		SetterUtil.setNotNullBoolean(
+			builder::requireFieldMatch, highlight.getRequireFieldMatch());
+
+		if (highlight.getTagsSchema() != null) {
+			builder.tagsSchema(_translateTagsSchema(highlight.getTagsSchema()));
+		}
+
+		return builder.build();
+	}
+
+	public org.opensearch.client.opensearch.core.search.Highlight translate(
+		String[] highlightFieldNames, int highlightFragmentSize,
+		boolean highlightRequireFieldMatch, boolean luceneSyntax,
+		int numberOfFragments) {
+
+		if (ArrayUtil.isEmpty(highlightFieldNames)) {
+			return null;
+		}
+
+		org.opensearch.client.opensearch.core.search.Highlight.Builder builder =
+			new org.opensearch.client.opensearch.core.search.Highlight.
+				Builder();
+
+		for (String highlightFieldName : highlightFieldNames) {
+			builder.fields(
+				highlightFieldName,
+				HighlightField.of(
+					highlightField -> highlightField.fragmentSize(
+						highlightFragmentSize
+					).numberOfFragments(
+						numberOfFragments
+					)));
+		}
+
+		builder.postTags(HighlightUtil.HIGHLIGHT_TAG_CLOSE);
+		builder.preTags(HighlightUtil.HIGHLIGHT_TAG_OPEN);
+
+		if (luceneSyntax) {
+			highlightRequireFieldMatch = false;
+		}
+
+		builder.requireFieldMatch(highlightRequireFieldMatch);
+
+		return builder.build();
+	}
+
+	private BoundaryScanner _translateBoundaryScannerType(
+		String boundaryScannerType) {
+
+		if (boundaryScannerType.equals("chars")) {
+			return BoundaryScanner.Chars;
+		}
+		else if (boundaryScannerType.equals("sentence")) {
+			return BoundaryScanner.Sentence;
+		}
+		else if (boundaryScannerType.equals("word")) {
+			return BoundaryScanner.Word;
+		}
+
+		throw new IllegalArgumentException(
+			"Invalid boundary scanner type " + boundaryScannerType);
+	}
+
+	private HighlighterEncoder _translateEncoder(String encoder) {
+		if (encoder.equals("default")) {
+			return HighlighterEncoder.Default;
+		}
+		else if (encoder.equals("html")) {
+			return HighlighterEncoder.Html;
+		}
+
+		throw new IllegalArgumentException(
+			"Invalid highlight encoder scanner for " + encoder);
+	}
+
+	private HighlightField _translateFieldConfigs(
+		FieldConfig fieldConfig,
+		QueryTranslator<QueryVariant> queryTranslator) {
+
+		HighlightField.Builder highlightFieldBuilder =
+			new HighlightField.Builder();
+
+		if (ArrayUtil.isNotEmpty(fieldConfig.getBoundaryChars())) {
+			highlightFieldBuilder.boundaryChars(
+				String.valueOf(fieldConfig.getBoundaryChars()));
+		}
+
+		SetterUtil.setNotNullInteger(
+			highlightFieldBuilder::boundaryMaxScan,
+			fieldConfig.getBoundaryMaxScan());
+		SetterUtil.setNotBlankString(
+			highlightFieldBuilder::boundaryScannerLocale,
+			fieldConfig.getBoundaryScannerLocale());
+
+		if (fieldConfig.getBoundaryScannerType() != null) {
+			highlightFieldBuilder.boundaryScanner(
+				_translateBoundaryScannerType(
+					fieldConfig.getBoundaryScannerType()));
+		}
+
+		SetterUtil.setNotNullBoolean(
+			highlightFieldBuilder::forceSource, fieldConfig.getForceSource());
+
+		if (fieldConfig.getFragmenter() != null) {
+			highlightFieldBuilder.fragmenter(
+				_translateFragmenter(fieldConfig.getFragmenter()));
+		}
+
+		SetterUtil.setNotNullInteger(
+			highlightFieldBuilder::fragmentOffset,
+			fieldConfig.getFragmentOffset());
+		SetterUtil.setNotNullInteger(
+			highlightFieldBuilder::fragmentSize, fieldConfig.getFragmentSize());
+
+		if (fieldConfig.getHighlighterType() != null) {
+			highlightFieldBuilder.type(
+				_translateHighlighterType(fieldConfig.getHighlighterType()));
+		}
+
+		if (fieldConfig.getHighlightQuery() != null) {
+			highlightFieldBuilder.highlightQuery(
+				new Query(
+					queryTranslator.translate(
+						fieldConfig.getHighlightQuery())));
+		}
+
+		SetterUtil.setNotNullEmptyStringArrayAsList(
+			highlightFieldBuilder::matchedFields,
+			fieldConfig.getMatchedFields());
+		SetterUtil.setNotNullInteger(
+			highlightFieldBuilder::noMatchSize, fieldConfig.getNoMatchSize());
+		SetterUtil.setNotNullInteger(
+			highlightFieldBuilder::numberOfFragments,
+			fieldConfig.getNumFragments());
+
+		if (fieldConfig.getOrder() != null) {
+			highlightFieldBuilder.order(
+				_translateOrder(fieldConfig.getOrder()));
+		}
+
+		SetterUtil.setNotNullInteger(
+			highlightFieldBuilder::phraseLimit, fieldConfig.getPhraseLimit());
+		SetterUtil.setNotNullEmptyStringArrayAsList(
+			highlightFieldBuilder::postTags, fieldConfig.getPostTags());
+		SetterUtil.setNotNullEmptyStringArrayAsList(
+			highlightFieldBuilder::preTags, fieldConfig.getPreTags());
+		SetterUtil.setNotNullBoolean(
+			highlightFieldBuilder::requireFieldMatch,
+			fieldConfig.getRequireFieldMatch());
+
+		return highlightFieldBuilder.build();
+	}
+
+	private HighlighterFragmenter _translateFragmenter(String fragmenter) {
+		if (fragmenter.equals("simple")) {
+			return HighlighterFragmenter.Simple;
+		}
+		else if (fragmenter.equals("span")) {
+			return HighlighterFragmenter.Span;
+		}
+
+		throw new IllegalArgumentException(
+			"No available highlight fragmenter for " + fragmenter);
+	}
+
+	private HighlighterType _translateHighlighterType(String highlighterType) {
+		BuiltinHighlighterType builtinHighlighterType = null;
+
+		if (highlighterType.equals("FastVector")) {
+			builtinHighlighterType = BuiltinHighlighterType.FastVector;
+		}
+		else if (highlighterType.equals("plain")) {
+			builtinHighlighterType = BuiltinHighlighterType.Plain;
+		}
+		else if (highlighterType.equals("unified")) {
+			builtinHighlighterType = BuiltinHighlighterType.Unified;
+		}
+
+		if (builtinHighlighterType != null) {
+			HighlighterType.Builder highlighterTypeBuilder =
+				new HighlighterType.Builder();
+
+			return highlighterTypeBuilder.builtin(
+				builtinHighlighterType
+			).build();
+		}
+
+		throw new IllegalArgumentException(
+			"invalid highlighter type " + highlighterType);
+	}
+
+	private HighlighterOrder _translateOrder(String order) {
+		if (order.equals("score")) {
+			return HighlighterOrder.Score;
+		}
+
+		throw new IllegalArgumentException(
+			"Invalid highlighter order " + order);
+	}
+
+	private HighlighterTagsSchema _translateTagsSchema(String tagsSchema) {
+		if (tagsSchema.equals("styled")) {
+			return HighlighterTagsSchema.Styled;
+		}
+
+		throw new IllegalArgumentException("Invalid tags schema" + tagsSchema);
+	}
+
+}

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/hits/FieldsTranslator.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/hits/FieldsTranslator.java
@@ -1,0 +1,231 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.opensearch2.internal.hits;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.search.document.DocumentBuilder;
+import com.liferay.portal.search.geolocation.GeoBuilders;
+import com.liferay.portal.search.opensearch2.internal.util.JsonpUtil;
+
+import jakarta.json.JsonArray;
+import jakarta.json.JsonNumber;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonString;
+import jakarta.json.JsonValue;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.opensearch.client.json.JsonData;
+import org.opensearch.client.opensearch._types.GeoHashLocation;
+import org.opensearch.client.opensearch._types.GeoLocation;
+import org.opensearch.client.opensearch._types.LatLonGeoLocation;
+
+/**
+ * @author Bryan Engler
+ * @author Petteri Karttunen
+ */
+public class FieldsTranslator {
+
+	public FieldsTranslator(GeoBuilders geoBuilders) {
+		_geoBuilders = geoBuilders;
+	}
+
+	public void populateAlternateUID(
+		String alternateUidFieldName, DocumentBuilder documentBuilder,
+		Map<String, JsonData> documentFieldsMap) {
+
+		if (MapUtil.isEmpty(documentFieldsMap) ||
+			documentFieldsMap.containsKey(_UID_FIELD_NAME) ||
+			Validator.isBlank(alternateUidFieldName)) {
+
+			return;
+		}
+
+		JsonData jsonData = documentFieldsMap.get(alternateUidFieldName);
+
+		if (jsonData != null) {
+			documentBuilder.setValues(
+				_UID_FIELD_NAME,
+				_toCollectionValue(
+					jsonData.toJson(JsonpUtil.getJsonpMapper())));
+		}
+	}
+
+	public void translateFields(
+		DocumentBuilder documentBuilder, Map<String, JsonData> fields) {
+
+		if (MapUtil.isEmpty(fields)) {
+			return;
+		}
+
+		fields.forEach(
+			(fieldName, jsonData) -> translateField(
+				documentBuilder, fieldName, fields, jsonData));
+	}
+
+	public void translateSource(
+		DocumentBuilder documentBuilder, JsonData jsonData) {
+
+		if (jsonData == null) {
+			return;
+		}
+
+		JsonValue jsonValue = jsonData.toJson(JsonpUtil.getJsonpMapper());
+
+		JsonObject jsonObject = jsonValue.asJsonObject();
+
+		jsonObject.forEach(
+			(fieldName, value) -> translateSourceField(
+				documentBuilder, fieldName, value));
+	}
+
+	protected void translateField(
+		DocumentBuilder documentBuilder, String fieldName,
+		Map<String, JsonData> fields, JsonData jsonData) {
+
+		if (fieldName.endsWith(_GEOPOINT_SUFFIX)) {
+			return;
+		}
+
+		JsonData geoPointJsonData = fields.get(
+			fieldName.concat(_GEOPOINT_SUFFIX));
+
+		if (geoPointJsonData != null) {
+			_translateGeoPoint(documentBuilder, fieldName, geoPointJsonData);
+		}
+		else {
+			documentBuilder.setValues(
+				fieldName,
+				_toCollectionValue(
+					jsonData.toJson(JsonpUtil.getJsonpMapper())));
+		}
+	}
+
+	protected void translateSourceField(
+		DocumentBuilder documentBuilder, String fieldName,
+		JsonValue jsonValue) {
+
+		if (fieldName.endsWith(_GEOPOINT_SUFFIX)) {
+			documentBuilder.setGeoLocationPoint(
+				fieldName, _geoBuilders.geoLocationPoint(jsonValue.toString()));
+		}
+		else {
+			JsonValue.ValueType valueType = jsonValue.getValueType();
+
+			if ((valueType == JsonValue.ValueType.ARRAY) ||
+				(valueType == JsonValue.ValueType.OBJECT)) {
+
+				documentBuilder.setValues(
+					fieldName, _toCollectionValue(jsonValue));
+			}
+			else {
+				documentBuilder.setValue(fieldName, _toSingleValue(jsonValue));
+			}
+		}
+	}
+
+	private Collection<Object> _toCollectionValue(JsonValue jsonValue) {
+		List<Object> values = new ArrayList<>();
+
+		JsonValue.ValueType valueType = jsonValue.getValueType();
+
+		if (valueType == JsonValue.ValueType.ARRAY) {
+			JsonArray jsonArray = jsonValue.asJsonArray();
+
+			jsonArray.forEach(value -> values.add(_toSingleValue(value)));
+		}
+		else {
+			values.add(_toSingleValue(jsonValue));
+		}
+
+		return values;
+	}
+
+	private Map<String, String> _toMap(JsonObject jsonObject) {
+		try {
+			ObjectMapper objectMapper = new ObjectMapper();
+
+			TypeReference<HashMap<String, String>> typeReference =
+				new TypeReference<HashMap<String, String>>() {
+				};
+
+			return objectMapper.readValue(jsonObject.toString(), typeReference);
+		}
+		catch (JsonProcessingException jsonProcessingException) {
+			throw new RuntimeException(jsonProcessingException);
+		}
+	}
+
+	private Object _toSingleValue(JsonValue jsonValue) {
+		JsonValue.ValueType valueType = jsonValue.getValueType();
+
+		if ((valueType == JsonValue.ValueType.FALSE) ||
+			(valueType == JsonValue.ValueType.TRUE)) {
+
+			return Boolean.valueOf(jsonValue.toString());
+		}
+		else if (valueType == JsonValue.ValueType.OBJECT) {
+			return _toMap((JsonObject)jsonValue);
+		}
+		else if (valueType == JsonValue.ValueType.NUMBER) {
+			JsonNumber jsonNumber = (JsonNumber)jsonValue;
+
+			return jsonNumber.numberValue();
+		}
+		else if (valueType == JsonValue.ValueType.NULL) {
+			return null;
+		}
+		else if (valueType == JsonValue.ValueType.STRING) {
+			JsonString jsonString = (JsonString)jsonValue;
+
+			return jsonString.getString();
+		}
+
+		return jsonValue.toString();
+	}
+
+	private void _translateGeoPoint(
+		DocumentBuilder documentBuilder, String fieldName, JsonData jsonData) {
+
+		GeoLocation geoLocation = GeoLocation.of(
+			openSearchGeoLocation -> openSearchGeoLocation.geohash(
+				GeoHashLocation.of(
+					geoHashLocation -> geoHashLocation.geohash(
+						jsonData.toString()))));
+
+		if (geoLocation.isGeohash()) {
+			GeoHashLocation geoHashLocation = geoLocation.geohash();
+
+			documentBuilder.setGeoLocationPoint(
+				fieldName,
+				_geoBuilders.geoLocationPoint(geoHashLocation.geohash()));
+		}
+		else if (geoLocation.isLatlon()) {
+			LatLonGeoLocation latLonGeoLocation = geoLocation.latlon();
+
+			documentBuilder.setGeoLocationPoint(
+				fieldName,
+				_geoBuilders.geoLocationPoint(
+					latLonGeoLocation.lat(), latLonGeoLocation.lon()));
+		}
+	}
+
+	private static final String _GEOPOINT_SUFFIX = ".geopoint";
+
+	private static final String _UID_FIELD_NAME = "uid";
+
+	private final GeoBuilders _geoBuilders;
+
+}

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/hits/HitsMetadataTranslator.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/hits/HitsMetadataTranslator.java
@@ -1,0 +1,189 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.opensearch2.internal.hits;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.search.document.Document;
+import com.liferay.portal.search.document.DocumentBuilder;
+import com.liferay.portal.search.document.DocumentBuilderFactory;
+import com.liferay.portal.search.geolocation.GeoBuilders;
+import com.liferay.portal.search.highlight.HighlightField;
+import com.liferay.portal.search.highlight.HighlightFieldBuilderFactory;
+import com.liferay.portal.search.hits.SearchHit;
+import com.liferay.portal.search.hits.SearchHitBuilder;
+import com.liferay.portal.search.hits.SearchHitBuilderFactory;
+import com.liferay.portal.search.hits.SearchHits;
+import com.liferay.portal.search.hits.SearchHitsBuilder;
+import com.liferay.portal.search.hits.SearchHitsBuilderFactory;
+import com.liferay.portal.search.opensearch2.internal.util.ConversionUtil;
+import com.liferay.portal.search.opensearch2.internal.util.JsonpUtil;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.opensearch.client.json.JsonData;
+import org.opensearch.client.opensearch.core.explain.Explanation;
+import org.opensearch.client.opensearch.core.search.Hit;
+import org.opensearch.client.opensearch.core.search.HitsMetadata;
+import org.opensearch.client.opensearch.core.search.TotalHits;
+
+/**
+ * @author Michael C. Han
+ * @author Petteri Karttunen
+ */
+public class HitsMetadataTranslator {
+
+	public HitsMetadataTranslator(
+		DocumentBuilderFactory documentBuilderFactory, GeoBuilders geoBuilders,
+		HighlightFieldBuilderFactory highlightFieldBuilderFactory,
+		SearchHitBuilderFactory searchHitBuilderFactory,
+		SearchHitsBuilderFactory searchHitsBuilderFactory) {
+
+		_documentBuilderFactory = documentBuilderFactory;
+		_geoBuilders = geoBuilders;
+		_highlightFieldBuilderFactory = highlightFieldBuilderFactory;
+		_searchHitBuilderFactory = searchHitBuilderFactory;
+		_searchHitsBuilderFactory = searchHitsBuilderFactory;
+	}
+
+	public SearchHits translate(HitsMetadata<JsonData> hitsMetadata) {
+		return translate(null, hitsMetadata);
+	}
+
+	public SearchHits translate(
+		String alternateUidFieldName, HitsMetadata<JsonData> hitsMetadata) {
+
+		SearchHitsBuilder searchHitsBuilder =
+			_searchHitsBuilderFactory.getSearchHitsBuilder();
+
+		List<Hit<JsonData>> hits = hitsMetadata.hits();
+
+		List<SearchHit> searchHits = new ArrayList<>(hits.size());
+
+		for (Hit<JsonData> hit : hits) {
+			searchHits.add(translate(alternateUidFieldName, hit));
+		}
+
+		TotalHits totalHits = hitsMetadata.total();
+
+		return searchHitsBuilder.addSearchHits(
+			searchHits
+		).maxScore(
+			ConversionUtil.toFloat(hitsMetadata.maxScore(), 0.0F)
+		).totalHits(
+			totalHits.value()
+		).build();
+	}
+
+	protected SearchHit translate(
+		String alternateUidFieldName, Hit<JsonData> hit) {
+
+		SearchHitBuilder searchHitBuilder =
+			_searchHitBuilderFactory.getSearchHitBuilder();
+
+		return searchHitBuilder.addHighlightFields(
+			_translateHighlightFields(hit.highlight())
+		).addSources(
+			_translateSource(hit.source())
+		).document(
+			_translateDocument(alternateUidFieldName, hit)
+		).explanation(
+			_getExplanationString(hit)
+		).id(
+			hit.id()
+		).matchedQueries(
+			ArrayUtil.toStringArray(hit.matchedQueries())
+		).score(
+			ConversionUtil.toFloat(hit.score(), 0.0F)
+		).sortValues(
+			ArrayUtil.toStringArray(hit.sort())
+		).version(
+			GetterUtil.getLong(hit.version())
+		).build();
+	}
+
+	private String _getExplanationString(Hit<JsonData> hit) {
+		Explanation explanation = hit.explanation();
+
+		if (explanation != null) {
+			return JsonpUtil.toString(explanation);
+		}
+
+		return StringPool.BLANK;
+	}
+
+	private Document _translateDocument(
+		String alternateUidFieldName, Hit<JsonData> hit) {
+
+		DocumentBuilder documentBuilder = _documentBuilderFactory.builder();
+
+		FieldsTranslator fieldsTranslator = new FieldsTranslator(_geoBuilders);
+
+		fieldsTranslator.translateSource(documentBuilder, hit.source());
+
+		Map<String, JsonData> fields = hit.fields();
+
+		fieldsTranslator.translateFields(documentBuilder, fields);
+
+		fieldsTranslator.populateAlternateUID(
+			alternateUidFieldName, documentBuilder, fields);
+
+		return documentBuilder.build();
+	}
+
+	private List<HighlightField> _translateHighlightFields(
+		Map<String, List<String>> highlight) {
+
+		List<HighlightField> highlightFields = new ArrayList<>();
+
+		for (Map.Entry<String, List<String>> entry : highlight.entrySet()) {
+			highlightFields.add(
+				_highlightFieldBuilderFactory.builder(
+				).fragments(
+					entry.getValue()
+				).name(
+					entry.getKey()
+				).build());
+		}
+
+		return highlightFields;
+	}
+
+	private Map<String, Object> _translateSource(JsonData jsonData) {
+		if (jsonData == null) {
+			return Collections.emptyMap();
+		}
+
+		try {
+			ObjectMapper objectMapper = new ObjectMapper();
+
+			TypeReference<HashMap<String, Object>> typeReference =
+				new TypeReference<HashMap<String, Object>>() {
+				};
+
+			return objectMapper.readValue(jsonData.toString(), typeReference);
+		}
+		catch (JsonProcessingException jsonProcessingException) {
+			throw new RuntimeException(jsonProcessingException);
+		}
+	}
+
+	private final DocumentBuilderFactory _documentBuilderFactory;
+	private final GeoBuilders _geoBuilders;
+	private final HighlightFieldBuilderFactory _highlightFieldBuilderFactory;
+	private final SearchHitBuilderFactory _searchHitBuilderFactory;
+	private final SearchHitsBuilderFactory _searchHitsBuilderFactory;
+
+}

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/legacy/hits/HitDocumentTranslator.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/legacy/hits/HitDocumentTranslator.java
@@ -1,0 +1,21 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.opensearch2.internal.legacy.hits;
+
+import com.liferay.portal.kernel.search.Document;
+
+import org.opensearch.client.json.JsonData;
+import org.opensearch.client.opensearch.core.search.Hit;
+
+/**
+ * @author Michael C. Han
+ * @author Petteri Karttunen
+ */
+public interface HitDocumentTranslator {
+
+	public Document translate(Hit<JsonData> hit);
+
+}

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/legacy/hits/HitDocumentTranslatorImpl.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/legacy/hits/HitDocumentTranslatorImpl.java
@@ -1,0 +1,186 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.opensearch2.internal.legacy.hits;
+
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.DocumentImpl;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.geolocation.GeoLocationPoint;
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.search.opensearch2.internal.util.JsonpUtil;
+
+import jakarta.json.JsonArray;
+import jakarta.json.JsonNumber;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonString;
+import jakarta.json.JsonValue;
+
+import java.util.Map;
+
+import org.opensearch.client.json.JsonData;
+import org.opensearch.client.opensearch.core.search.Hit;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author André de Oliveira
+ * @author Petteri Karttunen
+ */
+@Component(service = HitDocumentTranslator.class)
+public class HitDocumentTranslatorImpl implements HitDocumentTranslator {
+
+	@Override
+	public Document translate(Hit<JsonData> hit) {
+		Document document = new DocumentImpl();
+
+		Map<String, JsonData> fields = hit.fields();
+
+		if (MapUtil.isNotEmpty(fields)) {
+			for (String fieldName : fields.keySet()) {
+				_addField(document, fieldName, fields);
+			}
+		}
+
+		JsonData jsonData = hit.source();
+
+		if (jsonData != null) {
+			JsonValue jsonValue = jsonData.toJson(JsonpUtil.getJsonpMapper());
+
+			JsonObject jsonObject = jsonValue.asJsonObject();
+
+			jsonObject.keySet();
+
+			for (String fieldName : jsonObject.keySet()) {
+				if (document.getField(fieldName) == null) {
+					_addFieldFromSource(document, fieldName, jsonObject);
+				}
+			}
+		}
+
+		return document;
+	}
+
+	protected Field translate(String fieldName, JsonValue jsonValue) {
+		JsonValue.ValueType valueType = jsonValue.getValueType();
+
+		if (valueType == JsonValue.ValueType.ARRAY) {
+			return new Field(
+				fieldName, _toStringArray(jsonValue.asJsonArray()));
+		}
+		else if (valueType == JsonValue.ValueType.OBJECT) {
+			JsonObject jsonObject = jsonValue.asJsonObject();
+
+			return new Field(fieldName, new String[] {jsonObject.toString()});
+		}
+
+		return new Field(fieldName, jsonValue.toString());
+	}
+
+	private void _addField(
+		Document document, String fieldName, Map<String, JsonData> fields) {
+
+		Field field = _getField(fieldName, fields);
+
+		if (field != null) {
+			document.add(field);
+		}
+	}
+
+	private void _addFieldFromSource(
+		Document document, String fieldName, JsonObject jsonObject) {
+
+		Field field = _getFieldFromSource(fieldName, jsonObject);
+
+		if (field != null) {
+			document.add(field);
+		}
+	}
+
+	private Field _getField(String fieldName, Map<String, JsonData> fields) {
+		if (_isInvalidFieldName(fieldName)) {
+			return null;
+		}
+
+		JsonData jsonData = fields.get(fieldName);
+
+		JsonValue jsonValue = jsonData.toJson(JsonpUtil.getJsonpMapper());
+
+		if (fields.containsKey(fieldName.concat(".geopoint"))) {
+			return _translateGeoPoint(fieldName, jsonValue);
+		}
+
+		return translate(fieldName, jsonValue);
+	}
+
+	private Field _getFieldFromSource(String fieldName, JsonObject jsonObject) {
+		if (_isInvalidFieldName(fieldName)) {
+			return null;
+		}
+
+		JsonValue jsonValue = jsonObject.get(fieldName);
+
+		if (jsonObject.containsKey(fieldName.concat(".geopoint"))) {
+			return _translateGeoPoint(fieldName, jsonValue);
+		}
+
+		return translate(fieldName, jsonValue);
+	}
+
+	private boolean _isInvalidFieldName(String fieldName) {
+		if (fieldName.endsWith(".geopoint") || fieldName.equals("_ignored")) {
+			return true;
+		}
+
+		return false;
+	}
+
+	private String[] _toStringArray(JsonArray jsonArray) {
+		if (jsonArray == null) {
+			return new String[0];
+		}
+
+		String[] values = new String[jsonArray.size()];
+
+		for (int i = 0; i < jsonArray.size(); i++) {
+			JsonValue jsonValue = jsonArray.get(i);
+
+			if (jsonValue.getValueType() == JsonValue.ValueType.NUMBER) {
+				JsonNumber jsonNumber = (JsonNumber)jsonValue;
+
+				values[i] = jsonNumber.toString();
+			}
+			else if (jsonValue.getValueType() == JsonValue.ValueType.STRING) {
+				JsonString jsonString = (JsonString)jsonValue;
+
+				values[i] = jsonString.getString();
+			}
+			else {
+				values[i] = jsonValue.toString();
+			}
+		}
+
+		return values;
+	}
+
+	private Field _translateGeoPoint(String fieldName, JsonValue jsonValue) {
+		Field field = new Field(fieldName);
+
+		JsonArray jsonArray = jsonValue.asJsonArray();
+
+		String location = jsonArray.getString(0);
+
+		String[] locationParts = location.split(",");
+
+		field.setGeoLocationPoint(
+			new GeoLocationPoint(
+				Double.valueOf(StringUtil.trim(locationParts[0])),
+				Double.valueOf(StringUtil.trim(locationParts[1]))));
+
+		return field;
+	}
+
+}

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/legacy/sort/SortTranslator.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/legacy/sort/SortTranslator.java
@@ -1,0 +1,22 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.opensearch2.internal.legacy.sort;
+
+import com.liferay.portal.kernel.search.Sort;
+
+import java.util.List;
+
+import org.opensearch.client.opensearch._types.SortOptions;
+
+/**
+ * @author Michael C. Han
+ * @author Petteri Karttunen
+ */
+public interface SortTranslator {
+
+	public List<SortOptions> translateSorts(Sort[] sorts);
+
+}

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/legacy/sort/SortTranslatorImpl.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/legacy/sort/SortTranslatorImpl.java
@@ -1,0 +1,186 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.opensearch2.internal.legacy.sort;
+
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.GeoDistanceSort;
+import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.search.opensearch2.internal.geolocation.GeoTranslator;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+import org.opensearch.client.opensearch._types.FieldValue;
+import org.opensearch.client.opensearch._types.GeoDistanceType;
+import org.opensearch.client.opensearch._types.NestedSortValue;
+import org.opensearch.client.opensearch._types.SortOptions;
+import org.opensearch.client.opensearch._types.SortOptionsBuilders;
+import org.opensearch.client.opensearch._types.SortOrder;
+import org.opensearch.client.opensearch._types.mapping.FieldType;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.opensearch.client.opensearch._types.query_dsl.QueryBuilders;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Michael C. Han
+ * @author Petteri Karttunen
+ */
+@Component(service = SortTranslator.class)
+public class SortTranslatorImpl implements SortTranslator {
+
+	@Override
+	public List<SortOptions> translateSorts(Sort[] sorts) {
+		List<SortOptions> sortOptions = new ArrayList<>();
+
+		if (ArrayUtil.isEmpty(sorts)) {
+			return sortOptions;
+		}
+
+		Set<String> sortFieldNames = new HashSet<>();
+
+		for (Sort sort : sorts) {
+			if (sort == null) {
+				continue;
+			}
+
+			String sortFieldName = _getSortFieldName(sort);
+
+			if (sortFieldNames.contains(sortFieldName)) {
+				continue;
+			}
+
+			sortFieldNames.add(sortFieldName);
+
+			sortOptions.add(_getSortOptions(sortFieldName, sort));
+		}
+
+		return sortOptions;
+	}
+
+	private SortOptions _getFieldSortOptions(String fieldName, Sort sort) {
+		org.opensearch.client.opensearch._types.FieldSort.Builder builder =
+			SortOptionsBuilders.field();
+
+		builder.field(fieldName);
+		builder.unmappedType(FieldType.Keyword);
+
+		if (sort.isReverse()) {
+			builder.order(SortOrder.Desc);
+		}
+
+		return SortOptions.of(
+			sortOptions -> sortOptions.field(builder.build()));
+	}
+
+	private SortOptions _getGeoDistanceSortOptions(
+		String fieldName, Sort sort) {
+
+		GeoDistanceSort geoDistanceSort = (GeoDistanceSort)sort;
+
+		org.opensearch.client.opensearch._types.GeoDistanceSort.Builder
+			builder = SortOptionsBuilders.geoDistance();
+
+		builder.distanceType(GeoDistanceType.Arc);
+		builder.field(fieldName);
+		builder.location(
+			TransformUtil.transform(
+				geoDistanceSort.getGeoLocationPoints(),
+				_geoTranslator::translateGeoLocationPoint));
+
+		if (geoDistanceSort.isReverse()) {
+			builder.order(SortOrder.Desc);
+		}
+
+		return SortOptions.of(
+			sortOptions -> sortOptions.geoDistance(builder.build()));
+	}
+
+	private SortOptions _getNestedFieldSortOptions(
+		String fieldName, Sort sort) {
+
+		org.opensearch.client.opensearch._types.FieldSort.Builder builder =
+			SortOptionsBuilders.field();
+
+		String[] fieldNameParts = StringUtil.split(fieldName, StringPool.POUND);
+
+		builder.field(fieldNameParts[0]);
+
+		builder.nested(
+			NestedSortValue.of(
+				nestedSortValue -> nestedSortValue.path(
+					"nestedFieldArray"
+				).filter(
+					new Query(
+						QueryBuilders.term(
+						).field(
+							"nestedFieldArray.fieldName"
+						).value(
+							FieldValue.of(fieldNameParts[1])
+						).build())
+				)));
+
+		if (sort.isReverse()) {
+			builder.order(SortOrder.Desc);
+		}
+
+		return SortOptions.of(
+			sortOptions -> sortOptions.field(builder.build()));
+	}
+
+	private SortOptions _getScoreSortOptions(Sort sort) {
+		org.opensearch.client.opensearch._types.ScoreSort.Builder builder =
+			SortOptionsBuilders.score();
+
+		if (sort.isReverse()) {
+			builder.order(SortOrder.Asc);
+		}
+
+		return SortOptions.of(
+			sortOptions -> sortOptions.score(builder.build()));
+	}
+
+	private String _getSortFieldName(Sort sort) {
+		String sortFieldName = sort.getFieldName();
+
+		if (Objects.equals(sortFieldName, Field.PRIORITY) ||
+			Objects.equals(sortFieldName, _SCORE_FIELD_NAME) ||
+			StringUtil.startsWith(sortFieldName, "nestedFieldArray.")) {
+
+			return sortFieldName;
+		}
+
+		return Field.getSortFieldName(sort, _SCORE_FIELD_NAME);
+	}
+
+	private SortOptions _getSortOptions(String fieldName, Sort sort) {
+		if (fieldName.equals(_SCORE_FIELD_NAME)) {
+			return _getScoreSortOptions(sort);
+		}
+
+		if (sort.getType() == Sort.GEO_DISTANCE_TYPE) {
+			return _getGeoDistanceSortOptions(fieldName, sort);
+		}
+
+		if (fieldName.startsWith("nestedFieldArray.")) {
+			return _getNestedFieldSortOptions(fieldName, sort);
+		}
+
+		return _getFieldSortOptions(fieldName, sort);
+	}
+
+	private static final String _SCORE_FIELD_NAME = "_score";
+
+	private final GeoTranslator _geoTranslator = new GeoTranslator();
+
+}

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/sort/OpenSearchSortFieldTranslator.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/sort/OpenSearchSortFieldTranslator.java
@@ -1,0 +1,211 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.opensearch2.internal.sort;
+
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.search.opensearch2.internal.geolocation.GeoTranslator;
+import com.liferay.portal.search.opensearch2.internal.script.ScriptTranslator;
+import com.liferay.portal.search.query.QueryTranslator;
+import com.liferay.portal.search.sort.FieldSort;
+import com.liferay.portal.search.sort.GeoDistanceSort;
+import com.liferay.portal.search.sort.NestedSort;
+import com.liferay.portal.search.sort.ScoreSort;
+import com.liferay.portal.search.sort.ScriptSort;
+import com.liferay.portal.search.sort.Sort;
+import com.liferay.portal.search.sort.SortFieldTranslator;
+import com.liferay.portal.search.sort.SortMode;
+import com.liferay.portal.search.sort.SortOrder;
+import com.liferay.portal.search.sort.SortVisitor;
+
+import org.opensearch.client.opensearch._types.FieldValue;
+import org.opensearch.client.opensearch._types.NestedSortValue;
+import org.opensearch.client.opensearch._types.ScriptSortType;
+import org.opensearch.client.opensearch._types.SortOptions;
+import org.opensearch.client.opensearch._types.SortOptionsBuilders;
+import org.opensearch.client.opensearch._types.mapping.FieldType;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.opensearch.client.opensearch._types.query_dsl.QueryVariant;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Michael C. Han
+ * @author Petteri Karttunen
+ */
+@Component(
+	property = "search.engine.impl=OpenSearch",
+	service = SortFieldTranslator.class
+)
+public class OpenSearchSortFieldTranslator
+	implements SortFieldTranslator<SortOptions>, SortVisitor<SortOptions> {
+
+	@Override
+	public SortOptions translate(Sort sort) {
+		return sort.accept(this);
+	}
+
+	@Override
+	public SortOptions visit(FieldSort fieldSort) {
+		org.opensearch.client.opensearch._types.FieldSort.Builder builder =
+			SortOptionsBuilders.field();
+
+		builder.field(fieldSort.getField());
+		builder.order(translateSortOrder(fieldSort.getSortOrder()));
+		builder.unmappedType(FieldType.Keyword);
+
+		if (fieldSort.getMissing() != null) {
+			builder.missing(FieldValue.of((long)fieldSort.getMissing()));
+		}
+
+		if (fieldSort.getNestedSort() != null) {
+			builder.nested(translateNestedSort(fieldSort.getNestedSort()));
+		}
+
+		if (fieldSort.getSortMode() != null) {
+			builder.mode(translateSortMode(fieldSort.getSortMode()));
+		}
+
+		return SortOptions.of(
+			sortOptions -> sortOptions.field(builder.build()));
+	}
+
+	@Override
+	public SortOptions visit(GeoDistanceSort geoDistanceSort) {
+		org.opensearch.client.opensearch._types.GeoDistanceSort.Builder
+			builder = SortOptionsBuilders.geoDistance();
+
+		builder.field(geoDistanceSort.getField());
+		builder.location(
+			TransformUtil.transform(
+				geoDistanceSort.getGeoLocationPoints(),
+				_geoTranslator::translateGeoLocationPoint));
+
+		if (geoDistanceSort.getGeoDistanceType() != null) {
+			builder.distanceType(
+				_geoTranslator.translateGeoDistanceType(
+					geoDistanceSort.getGeoDistanceType()));
+		}
+
+		if (geoDistanceSort.getSortMode() != null) {
+			builder.mode(translateSortMode(geoDistanceSort.getSortMode()));
+		}
+
+		if (geoDistanceSort.getSortOrder() != null) {
+			builder.order(translateSortOrder(geoDistanceSort.getSortOrder()));
+		}
+
+		if (geoDistanceSort.getDistanceUnit() != null) {
+			builder.unit(
+				_geoTranslator.translateDistanceUnit(
+					geoDistanceSort.getDistanceUnit()));
+		}
+
+		return SortOptions.of(
+			sortOptions -> sortOptions.geoDistance(builder.build()));
+	}
+
+	@Override
+	public SortOptions visit(ScoreSort scoreSort) {
+		org.opensearch.client.opensearch._types.ScoreSort.Builder builder =
+			SortOptionsBuilders.score();
+
+		if (scoreSort.getSortOrder() != null) {
+			builder.order(translateSortOrder(scoreSort.getSortOrder()));
+		}
+
+		return SortOptions.of(
+			sortOptions -> sortOptions.score(builder.build()));
+	}
+
+	@Override
+	public SortOptions visit(ScriptSort scriptSort) {
+		org.opensearch.client.opensearch._types.ScriptSort.Builder builder =
+			SortOptionsBuilders.script();
+
+		builder.order(translateSortOrder(scriptSort.getSortOrder()));
+		builder.script(_scriptTranslator.translate(scriptSort.getScript()));
+
+		if (scriptSort.getNestedSort() != null) {
+			builder.nested(translateNestedSort(scriptSort.getNestedSort()));
+		}
+
+		if (scriptSort.getSortMode() != null) {
+			builder.mode(translateSortMode(scriptSort.getSortMode()));
+		}
+
+		if (scriptSort.getScriptSortType() ==
+				ScriptSort.ScriptSortType.NUMBER) {
+
+			builder.type(ScriptSortType.Number);
+		}
+		else {
+			builder.type(ScriptSortType.String);
+		}
+
+		return SortOptions.of(
+			sortOptions -> sortOptions.script(builder.build()));
+	}
+
+	protected NestedSortValue translateNestedSort(NestedSort nestedSort) {
+		NestedSortValue.Builder builder = new NestedSortValue.Builder();
+
+		builder.maxChildren(nestedSort.getMaxChildren());
+		builder.path(nestedSort.getPath());
+
+		if (nestedSort.getFilterQuery() != null) {
+			builder.filter(
+				new Query(
+					_queryTranslator.translate(nestedSort.getFilterQuery())));
+		}
+
+		if (nestedSort.getNestedSort() != null) {
+			builder.nested(translateNestedSort(nestedSort.getNestedSort()));
+		}
+
+		return builder.build();
+	}
+
+	protected org.opensearch.client.opensearch._types.SortMode
+		translateSortMode(SortMode sortMode) {
+
+		if (sortMode == SortMode.AVG) {
+			return org.opensearch.client.opensearch._types.SortMode.Avg;
+		}
+		else if (sortMode == SortMode.MAX) {
+			return org.opensearch.client.opensearch._types.SortMode.Max;
+		}
+		else if (sortMode == SortMode.MEDIAN) {
+			return org.opensearch.client.opensearch._types.SortMode.Median;
+		}
+		else if (sortMode == SortMode.MIN) {
+			return org.opensearch.client.opensearch._types.SortMode.Min;
+		}
+		else if (sortMode == SortMode.SUM) {
+			return org.opensearch.client.opensearch._types.SortMode.Sum;
+		}
+
+		throw new IllegalArgumentException("Invalid sort mode " + sortMode);
+	}
+
+	protected org.opensearch.client.opensearch._types.SortOrder
+		translateSortOrder(SortOrder sortOrder) {
+
+		if ((sortOrder == SortOrder.ASC) || (sortOrder == null)) {
+			return org.opensearch.client.opensearch._types.SortOrder.Asc;
+		}
+
+		return org.opensearch.client.opensearch._types.SortOrder.Desc;
+	}
+
+	private final GeoTranslator _geoTranslator = new GeoTranslator();
+
+	@Reference(target = "(search.engine.impl=OpenSearch)")
+	private QueryTranslator<QueryVariant> _queryTranslator;
+
+	private final ScriptTranslator _scriptTranslator = new ScriptTranslator();
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-196453

Resend of https://github.com/brianchandotcom/liferay-portal/pull/145380:

- Fixed the sort order in BucketScriptAggregation translator
- Renamed instances of `xyzBuilder` to `builder`, when only 1 builder in the method