### PR TITLE
LRCI-3993 Limit playwright tests to use one worker on CI; LRCI-3994 Bypass relevant for playwright only changes

### DIFF
--- a/ci.properties
+++ b/ci.properties
@@ -230,6 +230,7 @@ ci.test.relevant.bypass.file.path.patterns=\
     .*/liferay-portal[^/]*/modules/sdk/.*,\
     .*/liferay-portal[^/]*/modules/test/jenkins-plugin-events/.*,\
     .*/liferay-portal[^/]*/modules/test/jenkins-results-parser/.*,\
+    .*/liferay-portal[^/]*/modules/test/playwright/.*,\
     .*/liferay-portal[^/]*/modules/test/poshi/.*,\
     .*/liferay-portal[^/]*/portal-web/build-test.gradle,\
     .*/liferay-portal[^/]*/portal-web/test/functional/com/liferay/portalweb/.*,\

--- a/ci.properties
+++ b/ci.properties
@@ -347,6 +347,7 @@ ci.test.suite.description[password-policies]=Test Password Policies tests.
 ci.test.suite.description[platform-experience]=Test Platform Experience team tests.
 ci.test.suite.description[platform-experience-acceptance]=Test Platform Experience team acceptance tests.
 ci.test.suite.description[platform-experience-accessibility]=Test Platform Experience team accessibility framework tests.
+ci.test.suite.description[playwright]=Test all playwright tests.
 ci.test.suite.description[portlet-deployment]=Test deployment of all demo portlet plugins.
 ci.test.suite.description[project-templates]=Test project-templates tests.
 ci.test.suite.description[publications]=Test publications tests.

--- a/modules/test/playwright/playwright.config.js
+++ b/modules/test/playwright/playwright.config.js
@@ -35,5 +35,5 @@ export default defineConfig({
 		screenshot: 'only-on-failure',
 		trace: 'retain-on-failure',
 	},
-	workers: process.env.CI ? 3 : undefined,
+	workers: process.env.CI ? 1 : undefined,
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-3993
https://liferay.atlassian.net/browse/LRCI-3994

Tested here: 
https://github.com/kenjiheigel/liferay-portal/pull/1530 (`sf` and `playwright`)

Discussed with @izaera and @gabrielwas