### PR TITLE
LPS-202984 Generate OpenAPI structures for the request bodies in API Builder

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/vulcan/openapi/contributor/APIApplicationOpenApiContributor.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/vulcan/openapi/contributor/APIApplicationOpenApiContributor.java
@@ -16,6 +16,7 @@ import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.vulcan.openapi.OpenAPIContext;
 import com.liferay.portal.vulcan.openapi.contributor.OpenAPIContributor;
@@ -241,23 +242,23 @@ public class APIApplicationOpenApiContributor implements OpenAPIContributor {
 				endpoint.getMethod(), _formatPath(endpoint),
 				endpoint.getRetrieveType(), responseSchemaName));
 
+		List<Parameter> parameters = new ArrayList<>();
+
+		if (Objects.equals(
+				endpoint.getScope(), APIApplication.Endpoint.Scope.SITE)) {
+
+			parameters.add(
+				new Parameter() {
+					{
+						setIn("path");
+						setName("scopeKey");
+						setRequired(true);
+						setSchema(new StringSchema());
+					}
+				});
+		}
+
 		if (Objects.equals(endpoint.getMethod(), Http.Method.GET)) {
-			List<Parameter> parameters = new ArrayList<>();
-
-			if (Objects.equals(
-					endpoint.getScope(), APIApplication.Endpoint.Scope.SITE)) {
-
-				parameters.add(
-					new Parameter() {
-						{
-							setIn("path");
-							setName("scopeKey");
-							setRequired(true);
-							setSchema(new StringSchema());
-						}
-					});
-			}
-
 			if (Objects.equals(
 					endpoint.getRetrieveType(),
 					APIApplication.Endpoint.RetrieveType.COLLECTION)) {
@@ -314,7 +315,9 @@ public class APIApplicationOpenApiContributor implements OpenAPIContributor {
 						}
 					});
 			}
+		}
 
+		if (ListUtil.isNotEmpty(parameters)) {
 			operation.setParameters(parameters);
 		}
 

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/vulcan/openapi/contributor/APIApplicationOpenApiContributor.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/vulcan/openapi/contributor/APIApplicationOpenApiContributor.java
@@ -41,11 +41,13 @@ import io.swagger.v3.oas.models.media.ObjectSchema;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.media.StringSchema;
 import io.swagger.v3.oas.models.parameters.Parameter;
+import io.swagger.v3.oas.models.parameters.RequestBody;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.responses.ApiResponses;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -149,6 +151,12 @@ public class APIApplicationOpenApiContributor implements OpenAPIContributor {
 					schemasSet.add(responseSchema.getName());
 				}
 			}
+
+			APIApplication.Schema requestSchema = endpoint.getRequestSchema();
+
+			if (requestSchema != null) {
+				schemasSet.add(requestSchema.getName());
+			}
 		}
 
 		components.setSchemas(_removedUnusedPageSchema(schemas, schemasSet));
@@ -220,18 +228,18 @@ public class APIApplicationOpenApiContributor implements OpenAPIContributor {
 	private PathItem _toOpenAPIPathItem(APIApplication.Endpoint endpoint) {
 		Operation operation = new Operation();
 
-		String schemaName = null;
+		String responseSchemaName = null;
 
 		APIApplication.Schema responseSchema = endpoint.getResponseSchema();
 
 		if (responseSchema != null) {
-			schemaName = responseSchema.getName();
+			responseSchemaName = responseSchema.getName();
 		}
 
 		operation.setOperationId(
 			OpenAPIUtil.getOperationId(
 				endpoint.getMethod(), _formatPath(endpoint),
-				endpoint.getRetrieveType(), schemaName));
+				endpoint.getRetrieveType(), responseSchemaName));
 
 		if (Objects.equals(endpoint.getMethod(), Http.Method.GET)) {
 			List<Parameter> parameters = new ArrayList<>();
@@ -308,6 +316,39 @@ public class APIApplicationOpenApiContributor implements OpenAPIContributor {
 			}
 
 			operation.setParameters(parameters);
+		}
+
+		APIApplication.Schema requestSchema = endpoint.getRequestSchema();
+
+		if (requestSchema != null) {
+			MediaType mediaType = new MediaType() {
+				{
+					setSchema(
+						new Schema() {
+							{
+								set$ref(requestSchema.getName());
+							}
+						});
+				}
+			};
+
+			RequestBody requestBody = new RequestBody() {
+				{
+					setContent(
+						new Content() {
+							{
+								put("application/json", mediaType);
+								put("application/xml", mediaType);
+							}
+						});
+					setDescription("default response");
+				}
+			};
+
+			operation.setRequestBody(requestBody);
+
+			operation.setTags(
+				Collections.singletonList(requestSchema.getName()));
 		}
 
 		if (responseSchema != null) {

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[APIRest]APIGenerator/ExposeQueryParametersInAPIExplorerForGeneratedAPI.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[APIRest]APIGenerator/ExposeQueryParametersInAPIExplorerForGeneratedAPI.testcase
@@ -65,10 +65,6 @@ definition {
 				status = "published",
 				title = "My-app");
 
-			SchemaAPI.relateRequestSchemaToEndpointByErc(
-				endpointErc = "My-app_testendpoint",
-				requestSchemaErc = "My-app_testSchema");
-
 			SchemaAPI.relateResponseSchemaToEndpointByErc(
 				endpointErc = "My-app_testendpoint",
 				responseSchemaErc = "My-app_testSchema");
@@ -114,10 +110,6 @@ definition {
 				schemaName = "testSchema",
 				status = "published",
 				title = "My-app");
-
-			SchemaAPI.relateRequestSchemaToEndpointByErc(
-				endpointErc = "My-app_testendpoint",
-				requestSchemaErc = "My-app_testSchema");
 
 			SchemaAPI.relateResponseSchemaToEndpointByErc(
 				endpointErc = "My-app_testendpoint",
@@ -203,10 +195,6 @@ definition {
 				status = "published",
 				title = "My-app");
 
-			SchemaAPI.relateRequestSchemaToEndpointByErc(
-				endpointErc = "My-app_testendpoint",
-				requestSchemaErc = "My-app_testSchema");
-
 			SchemaAPI.relateResponseSchemaToEndpointByErc(
 				endpointErc = "My-app_testendpoint",
 				responseSchemaErc = "My-app_testSchema");
@@ -266,10 +254,6 @@ definition {
 				status = "published",
 				title = "My-app");
 
-			SchemaAPI.relateRequestSchemaToEndpointByErc(
-				endpointErc = "My-app_testendpoint",
-				requestSchemaErc = "My-app_testSchema");
-
 			SchemaAPI.relateResponseSchemaToEndpointByErc(
 				endpointErc = "My-app_testendpoint",
 				responseSchemaErc = "My-app_testSchema");
@@ -315,10 +299,6 @@ definition {
 				schemaName = "testSchema",
 				status = "published",
 				title = "My-app");
-
-			SchemaAPI.relateRequestSchemaToEndpointByErc(
-				endpointErc = "My-app_testendpoint",
-				requestSchemaErc = "My-app_testSchema");
 
 			SchemaAPI.relateResponseSchemaToEndpointByErc(
 				endpointErc = "My-app_testendpoint",

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefineAPIApplicationEndpoints/AllowUsersToDefineEndpointsForObjectsWithSiteScope.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefineAPIApplicationEndpoints/AllowUsersToDefineEndpointsForObjectsWithSiteScope.testcase
@@ -56,10 +56,6 @@ definition {
 			var endpointId = JSONUtil.getWithJSONPath(${response}, "$.apiApplicationToAPIEndpoints[*].id");
 			var schemaId = JSONUtil.getWithJSONPath(${response}, "$.apiApplicationToAPISchemas[*].id");
 
-			SchemaAPI.relateRequestSchemaToEndpointByIds(
-				endpointId = ${endpointId},
-				requestSchemaId = ${schemaId});
-
 			SchemaAPI.relateResponseSchemaToEndpointByIds(
 				endpointId = ${endpointId},
 				responseSchemaId = ${schemaId});

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefinePrefiltersAndSorts/AllowUsersToDefineSorts.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefinePrefiltersAndSorts/AllowUsersToDefineSorts.testcase
@@ -48,10 +48,6 @@ definition {
 				mainObjectDefinitionERC = "student",
 				name = "testSchema");
 
-			SchemaAPI.relateRequestSchemaToEndpointByErc(
-				endpointErc = "My-app_testendpoint",
-				requestSchemaErc = "testSchema");
-
 			SchemaAPI.relateResponseSchemaToEndpointByErc(
 				endpointErc = "My-app_testendpoint",
 				responseSchemaErc = "testSchema");

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderOpenAPIResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderOpenAPIResourceTest.java
@@ -470,6 +470,24 @@ public class HeadlessBuilderOpenAPIResourceTest extends BaseTestCase {
 						APIApplication.Endpoint.Scope.COMPANY.getValue()
 					),
 					JSONUtil.put(
+						"description", "post description"
+					).put(
+						"externalReferenceCode", _POST_API_ENDPOINT_ERC
+					).put(
+						"httpMethod", "post"
+					).put(
+						"name", "post endpoint"
+					).put(
+						"path", "/path/post"
+					).put(
+						"retrieveType",
+						APIApplication.Endpoint.RetrieveType.SINGLE_ELEMENT.
+							getValue()
+					).put(
+						"scope",
+						APIApplication.Endpoint.Scope.COMPANY.getValue()
+					),
+					JSONUtil.put(
 						"description", "site scoped description"
 					).put(
 						"externalReferenceCode", _API_SITE_SCOPED_ENDPOINT_ERC
@@ -727,6 +745,13 @@ public class HeadlessBuilderOpenAPIResourceTest extends BaseTestCase {
 			null,
 			StringBundler.concat(
 				"headless-builder/schemas/by-external-reference-code/",
+				_API_SCHEMA_ERC, "/requestAPISchemaToAPIEndpoints/",
+				_POST_API_ENDPOINT_ERC),
+			Http.Method.PUT);
+		assertSuccessfulJSONObject(
+			null,
+			StringBundler.concat(
+				"headless-builder/schemas/by-external-reference-code/",
 				_API_SCHEMA_ERC, "/responseAPISchemaToAPIEndpoints/",
 				_GET_API_ENDPOINT_ERC),
 			Http.Method.PUT);
@@ -872,6 +897,9 @@ public class HeadlessBuilderOpenAPIResourceTest extends BaseTestCase {
 		RandomTestUtil.randomString();
 
 	private static final String _GET_API_ENDPOINT_ERC =
+		RandomTestUtil.randomString();
+
+	private static final String _POST_API_ENDPOINT_ERC =
 		RandomTestUtil.randomString();
 
 	private ListTypeDefinition _listTypeDefinition;

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderOpenAPIResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderOpenAPIResourceTest.java
@@ -529,7 +529,26 @@ public class HeadlessBuilderOpenAPIResourceTest extends BaseTestCase {
 					).put(
 						"name", "post endpoint"
 					).put(
-						"path", "/path/post"
+						"path", "/post-path"
+					).put(
+						"retrieveType",
+						APIApplication.Endpoint.RetrieveType.SINGLE_ELEMENT.
+							getValue()
+					).put(
+						"scope",
+						APIApplication.Endpoint.Scope.COMPANY.getValue()
+					),
+					JSONUtil.put(
+						"description", "site scoped post description"
+					).put(
+						"externalReferenceCode",
+						_SITE_SCOPED_POST_API_ENDPOINT_ERC
+					).put(
+						"httpMethod", "post"
+					).put(
+						"name", "site scoped post endpoint"
+					).put(
+						"path", "/site-scoped-post-path"
 					).put(
 						"retrieveType",
 						APIApplication.Endpoint.RetrieveType.SINGLE_ELEMENT.
@@ -751,6 +770,21 @@ public class HeadlessBuilderOpenAPIResourceTest extends BaseTestCase {
 			null,
 			StringBundler.concat(
 				"headless-builder/schemas/by-external-reference-code/",
+				_API_SITE_SCOPED_SCHEMA_ERC, "/requestAPISchemaToAPIEndpoints/",
+				_SITE_SCOPED_POST_API_ENDPOINT_ERC),
+			Http.Method.PUT);
+		assertSuccessfulJSONObject(
+			null,
+			StringBundler.concat(
+				"headless-builder/schemas/by-external-reference-code/",
+				_API_SITE_SCOPED_SCHEMA_ERC,
+				"/responseAPISchemaToAPIEndpoints/",
+				_SITE_SCOPED_POST_API_ENDPOINT_ERC),
+			Http.Method.PUT);
+		assertSuccessfulJSONObject(
+			null,
+			StringBundler.concat(
+				"headless-builder/schemas/by-external-reference-code/",
 				_API_SCHEMA_ERC, "/responseAPISchemaToAPIEndpoints/",
 				_GET_API_ENDPOINT_ERC),
 			Http.Method.PUT);
@@ -899,6 +933,9 @@ public class HeadlessBuilderOpenAPIResourceTest extends BaseTestCase {
 		RandomTestUtil.randomString();
 
 	private static final String _POST_API_ENDPOINT_ERC =
+		RandomTestUtil.randomString();
+
+	private static final String _SITE_SCOPED_POST_API_ENDPOINT_ERC =
 		RandomTestUtil.randomString();
 
 	private ListTypeDefinition _listTypeDefinition;

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderOpenAPIResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderOpenAPIResourceTest.java
@@ -452,33 +452,17 @@ public class HeadlessBuilderOpenAPIResourceTest extends BaseTestCase {
 						"scope", APIApplication.Endpoint.Scope.SITE.getValue()
 					),
 					JSONUtil.put(
-						"description", "description"
+						"description",
+						"post endpoint no request schema description"
 					).put(
-						"externalReferenceCode", _GET_API_ENDPOINT_ERC
-					).put(
-						"httpMethod", "get"
-					).put(
-						"name", "name"
-					).put(
-						"path", "/path"
-					).put(
-						"retrieveType",
-						APIApplication.Endpoint.RetrieveType.COLLECTION.
-							getValue()
-					).put(
-						"scope",
-						APIApplication.Endpoint.Scope.COMPANY.getValue()
-					),
-					JSONUtil.put(
-						"description", "post description"
-					).put(
-						"externalReferenceCode", _POST_API_ENDPOINT_ERC
+						"externalReferenceCode",
+						_API_POST_COMPANY_SCOPED_NO_SCHEMA_ENDPOINT_ERC
 					).put(
 						"httpMethod", "post"
 					).put(
-						"name", "post endpoint"
+						"name", "company scoped post no schema"
 					).put(
-						"path", "/path/post"
+						"path", "/no-schema"
 					).put(
 						"retrieveType",
 						APIApplication.Endpoint.RetrieveType.SINGLE_ELEMENT.
@@ -519,24 +503,39 @@ public class HeadlessBuilderOpenAPIResourceTest extends BaseTestCase {
 						"scope", APIApplication.Endpoint.Scope.SITE.getValue()
 					),
 					JSONUtil.put(
-						"description",
-						"post endpoint no request schema description"
+						"description", "description"
 					).put(
-						"externalReferenceCode",
-						_API_POST_COMPANY_SCOPED_NO_SCHEMA_ENDPOINT_ERC
+						"externalReferenceCode", _GET_API_ENDPOINT_ERC
+					).put(
+						"httpMethod", "get"
+					).put(
+						"name", "name"
+					).put(
+						"path", "/path"
+					).put(
+						"retrieveType",
+						APIApplication.Endpoint.RetrieveType.COLLECTION.
+							getValue()
+					).put(
+						"scope",
+						APIApplication.Endpoint.Scope.COMPANY.getValue()
+					),
+					JSONUtil.put(
+						"description", "post description"
+					).put(
+						"externalReferenceCode", _POST_API_ENDPOINT_ERC
 					).put(
 						"httpMethod", "post"
 					).put(
-						"name", "company scoped post no schema"
+						"name", "post endpoint"
 					).put(
-						"path", "/no-schema"
+						"path", "/path/post"
 					).put(
 						"retrieveType",
 						APIApplication.Endpoint.RetrieveType.SINGLE_ELEMENT.
 							getValue()
 					).put(
-						"scope",
-						APIApplication.Endpoint.Scope.COMPANY.getValue()
+						"scope", APIApplication.Endpoint.Scope.SITE.getValue()
 					))
 			).put(
 				"apiApplicationToAPISchemas",

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderOpenAPIResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderOpenAPIResourceTest.java
@@ -505,7 +505,7 @@ public class HeadlessBuilderOpenAPIResourceTest extends BaseTestCase {
 					JSONUtil.put(
 						"description", "description"
 					).put(
-						"externalReferenceCode", _GET_API_ENDPOINT_ERC
+						"externalReferenceCode", _API_GET_ENDPOINT_ERC
 					).put(
 						"httpMethod", "get"
 					).put(
@@ -523,7 +523,7 @@ public class HeadlessBuilderOpenAPIResourceTest extends BaseTestCase {
 					JSONUtil.put(
 						"description", "post description"
 					).put(
-						"externalReferenceCode", _POST_API_ENDPOINT_ERC
+						"externalReferenceCode", _API_POST_ENDPOINT_ERC
 					).put(
 						"httpMethod", "post"
 					).put(
@@ -542,7 +542,7 @@ public class HeadlessBuilderOpenAPIResourceTest extends BaseTestCase {
 						"description", "site scoped post description"
 					).put(
 						"externalReferenceCode",
-						_SITE_SCOPED_POST_API_ENDPOINT_ERC
+						_API_SITE_SCOPED_POST_ENDPOINT_ERC
 					).put(
 						"httpMethod", "post"
 					).put(
@@ -764,14 +764,14 @@ public class HeadlessBuilderOpenAPIResourceTest extends BaseTestCase {
 			StringBundler.concat(
 				"headless-builder/schemas/by-external-reference-code/",
 				_API_SCHEMA_ERC, "/requestAPISchemaToAPIEndpoints/",
-				_POST_API_ENDPOINT_ERC),
+				_API_POST_ENDPOINT_ERC),
 			Http.Method.PUT);
 		assertSuccessfulJSONObject(
 			null,
 			StringBundler.concat(
 				"headless-builder/schemas/by-external-reference-code/",
 				_API_SITE_SCOPED_SCHEMA_ERC, "/requestAPISchemaToAPIEndpoints/",
-				_SITE_SCOPED_POST_API_ENDPOINT_ERC),
+				_API_SITE_SCOPED_POST_ENDPOINT_ERC),
 			Http.Method.PUT);
 		assertSuccessfulJSONObject(
 			null,
@@ -779,14 +779,14 @@ public class HeadlessBuilderOpenAPIResourceTest extends BaseTestCase {
 				"headless-builder/schemas/by-external-reference-code/",
 				_API_SITE_SCOPED_SCHEMA_ERC,
 				"/responseAPISchemaToAPIEndpoints/",
-				_SITE_SCOPED_POST_API_ENDPOINT_ERC),
+				_API_SITE_SCOPED_POST_ENDPOINT_ERC),
 			Http.Method.PUT);
 		assertSuccessfulJSONObject(
 			null,
 			StringBundler.concat(
 				"headless-builder/schemas/by-external-reference-code/",
 				_API_SCHEMA_ERC, "/responseAPISchemaToAPIEndpoints/",
-				_GET_API_ENDPOINT_ERC),
+				_API_GET_ENDPOINT_ERC),
 			Http.Method.PUT);
 		assertSuccessfulJSONObject(
 			null,
@@ -850,9 +850,15 @@ public class HeadlessBuilderOpenAPIResourceTest extends BaseTestCase {
 	private static final String _API_BASE_URL = StringUtil.toLowerCase(
 		RandomTestUtil.randomString());
 
+	private static final String _API_GET_ENDPOINT_ERC =
+		RandomTestUtil.randomString();
+
 	private static final String
 		_API_POST_COMPANY_SCOPED_NO_SCHEMA_ENDPOINT_ERC =
 			RandomTestUtil.randomString();
+
+	private static final String _API_POST_ENDPOINT_ERC =
+		RandomTestUtil.randomString();
 
 	private static final String _API_SCHEMA_AGGREGATION_FIELD_ERC =
 		RandomTestUtil.randomString();
@@ -923,19 +929,13 @@ public class HeadlessBuilderOpenAPIResourceTest extends BaseTestCase {
 	private static final String _API_SITE_SCOPED_NO_SCHEMA_ENDPOINT_ERC =
 		RandomTestUtil.randomString();
 
+	private static final String _API_SITE_SCOPED_POST_ENDPOINT_ERC =
+		RandomTestUtil.randomString();
+
 	private static final String _API_SITE_SCOPED_SCHEMA_ERC =
 		RandomTestUtil.randomString();
 
 	private static final String _API_SITE_SCOPED_SCHEMA_TEXT_FIELD_ERC =
-		RandomTestUtil.randomString();
-
-	private static final String _GET_API_ENDPOINT_ERC =
-		RandomTestUtil.randomString();
-
-	private static final String _POST_API_ENDPOINT_ERC =
-		RandomTestUtil.randomString();
-
-	private static final String _SITE_SCOPED_POST_API_ENDPOINT_ERC =
 		RandomTestUtil.randomString();
 
 	private ListTypeDefinition _listTypeDefinition;

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderOpenAPIResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderOpenAPIResourceTest.java
@@ -454,7 +454,7 @@ public class HeadlessBuilderOpenAPIResourceTest extends BaseTestCase {
 					JSONUtil.put(
 						"description", "description"
 					).put(
-						"externalReferenceCode", _API_ENDPOINT_ERC
+						"externalReferenceCode", _GET_API_ENDPOINT_ERC
 					).put(
 						"httpMethod", "get"
 					).put(
@@ -727,23 +727,8 @@ public class HeadlessBuilderOpenAPIResourceTest extends BaseTestCase {
 			null,
 			StringBundler.concat(
 				"headless-builder/schemas/by-external-reference-code/",
-				_API_SCHEMA_ERC, "/requestAPISchemaToAPIEndpoints/",
-				_API_ENDPOINT_ERC),
-			Http.Method.PUT);
-		assertSuccessfulJSONObject(
-			null,
-			StringBundler.concat(
-				"headless-builder/schemas/by-external-reference-code/",
 				_API_SCHEMA_ERC, "/responseAPISchemaToAPIEndpoints/",
-				_API_ENDPOINT_ERC),
-			Http.Method.PUT);
-		assertSuccessfulJSONObject(
-			null,
-			StringBundler.concat(
-				"headless-builder/schemas/by-external-reference-code/",
-				_API_SINGLE_ELEMENT_SCHEMA_ERC,
-				"/requestAPISchemaToAPIEndpoints/",
-				_API_SINGLE_ELEMENT_ENDPOINT_ERC),
+				_GET_API_ENDPOINT_ERC),
 			Http.Method.PUT);
 		assertSuccessfulJSONObject(
 			null,
@@ -758,23 +743,8 @@ public class HeadlessBuilderOpenAPIResourceTest extends BaseTestCase {
 			StringBundler.concat(
 				"headless-builder/schemas/by-external-reference-code/",
 				_API_SINGLE_ELEMENT_SITE_SCOPED_SCHEMA_ERC,
-				"/requestAPISchemaToAPIEndpoints/",
-				_API_SINGLE_ELEMENT_SITE_SCOPED_ENDPOINT_ERC),
-			Http.Method.PUT);
-		assertSuccessfulJSONObject(
-			null,
-			StringBundler.concat(
-				"headless-builder/schemas/by-external-reference-code/",
-				_API_SINGLE_ELEMENT_SITE_SCOPED_SCHEMA_ERC,
 				"/responseAPISchemaToAPIEndpoints/",
 				_API_SINGLE_ELEMENT_SITE_SCOPED_ENDPOINT_ERC),
-			Http.Method.PUT);
-		assertSuccessfulJSONObject(
-			null,
-			StringBundler.concat(
-				"headless-builder/schemas/by-external-reference-code/",
-				_API_SITE_SCOPED_SCHEMA_ERC, "/requestAPISchemaToAPIEndpoints/",
-				_API_SITE_SCOPED_ENDPOINT_ERC),
 			Http.Method.PUT);
 		assertSuccessfulJSONObject(
 			null,
@@ -821,9 +791,6 @@ public class HeadlessBuilderOpenAPIResourceTest extends BaseTestCase {
 
 	private static final String _API_BASE_URL = StringUtil.toLowerCase(
 		RandomTestUtil.randomString());
-
-	private static final String _API_ENDPOINT_ERC =
-		RandomTestUtil.randomString();
 
 	private static final String
 		_API_POST_COMPANY_SCOPED_NO_SCHEMA_ENDPOINT_ERC =
@@ -902,6 +869,9 @@ public class HeadlessBuilderOpenAPIResourceTest extends BaseTestCase {
 		RandomTestUtil.randomString();
 
 	private static final String _API_SITE_SCOPED_SCHEMA_TEXT_FIELD_ERC =
+		RandomTestUtil.randomString();
+
+	private static final String _GET_API_ENDPOINT_ERC =
 		RandomTestUtil.randomString();
 
 	private ListTypeDefinition _listTypeDefinition;

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/resources/com/liferay/headless/builder/resource/test/dependencies/expected_openapi.json
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/resources/com/liferay/headless/builder/resource/test/dependencies/expected_openapi.json
@@ -402,6 +402,34 @@
 				]
 			}
 		},
+		"/path/post": {
+			"post": {
+				"operationId": "postPathPost",
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/SchemaName"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/SchemaName"
+							}
+						}
+					},
+					"description": "default response"
+				},
+				"responses": {
+					"default": {
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"SchemaName"
+				]
+			}
+		},
 		"/scopes/{scopeKey}/no-schema": {
 			"get": {
 				"operationId": "getScopeScopeKeyNoSchemaPage",

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/resources/com/liferay/headless/builder/resource/test/dependencies/expected_openapi.json
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/resources/com/liferay/headless/builder/resource/test/dependencies/expected_openapi.json
@@ -402,9 +402,9 @@
 				]
 			}
 		},
-		"/path/post": {
+		"/post-path": {
 			"post": {
-				"operationId": "postPathPost",
+				"operationId": "postPostPath",
 				"requestBody": {
 					"content": {
 						"application/json": {
@@ -573,6 +573,56 @@
 							"application/xml": {
 								"schema": {
 									"$ref": "#/components/schemas/PageSiteScopedSchemaName"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"SiteScopedSchemaName"
+				]
+			}
+		},
+		"/scopes/{scopeKey}/site-scoped-post-path": {
+			"post": {
+				"operationId": "postScopeScopeKeySiteScopedPostPath",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "scopeKey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/SiteScopedSchemaName"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/SiteScopedSchemaName"
+							}
+						}
+					},
+					"description": "default response"
+				},
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/SiteScopedSchemaName"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/SiteScopedSchemaName"
 								}
 							}
 						},


### PR DESCRIPTION
**Original PR:** https://github.com/liferay-headless/liferay-portal/pull/1790

**Purpose of this PR:**
This PR improves the messages of the responses given by POST API Endpoints created through API Builder.

**This is done through:**
- Adapting the Headless Builder OpenAPI Contributor in order to recognise and process request API Schemas.
- Generate the corresponding Response Bodies for each type of request API Schema.
- Modifying the OpenAPIResource tests and the expected output, adapting it to the newly defined behavior.

See the following **Jira Ticket**: [LPS-202984](https://liferay.atlassian.net/browse/LPS-202984).

**NOTE**: Manually forwarded with the changes asked in the following [comment](https://github.com/brianchandotcom/liferay-portal/pull/145817#issuecomment-1872100258).



<summary> 
Steps to test:
</summary>

<details>

- Create an API Application, API Schema with API Properties and a POST API Endpoint with a request API Schema through UI or through API calls. Here's a code-snippet to create such a structure:

```bash
curl -X 'POST' \
  'http://localhost:8080/o/object-admin/v1.0/object-definitions' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -u 'test@liferay.com:test' \
  -d '{"enableComments":false,"objectRelationships":[],"enableCategorization":true,"accountEntryRestrictedObjectFieldName":"","objectActions":[],"accountEntryRestricted":false,"externalReferenceCode":"boss-object-erc","objectFields":[{"indexed":false,"objectFieldSettings":[],"readOnly":"true","DBType":"String","label":{"en_US":"Author"},"type":"String","required":false,"externalReferenceCode":"c130234e-14a4-e181-840e-9894ad6d81de","indexedAsKeyword":false,"system":true,"indexedLanguageId":"","name":"creator","state":false,"businessType":"Text","readOnlyConditionExpression":""},{"indexed":false,"objectFieldSettings":[],"readOnly":"true","DBType":"Date","label":{"en_US":"Create Date"},"type":"Date","required":false,"externalReferenceCode":"41c453fa-77c3-241f-65fc-4381c74ad603","indexedAsKeyword":false,"system":true,"indexedLanguageId":"","name":"createDate","state":false,"businessType":"Date","readOnlyConditionExpression":""},{"indexed":false,"objectFieldSettings":[],"readOnly":"false","DBType":"String","label":{"en_US":"External Reference Code"},"type":"String","required":false,"externalReferenceCode":"fcab3cce-d9cb-96e2-8c8c-d6f6e79e87ad","indexedAsKeyword":false,"system":true,"indexedLanguageId":"","name":"externalReferenceCode","state":false,"businessType":"Text","readOnlyConditionExpression":""},{"indexed":true,"objectFieldSettings":[],"readOnly":"true","DBType":"Long","label":{"en_US":"ID"},"type":"Long","required":false,"externalReferenceCode":"6db8c8ea-4009-a83b-2b3b-be03ba7148b2","indexedAsKeyword":true,"system":true,"indexedLanguageId":"","name":"id","state":false,"businessType":"LongInteger","readOnlyConditionExpression":""},{"indexed":false,"objectFieldSettings":[],"readOnly":"true","DBType":"Date","label":{"en_US":"Modified Date"},"type":"Date","required":false,"externalReferenceCode":"88cd1e66-639c-f402-c416-83796df67037","indexedAsKeyword":false,"system":true,"indexedLanguageId":"","name":"modifiedDate","state":false,"businessType":"Date","readOnlyConditionExpression":""},{"indexed":false,"objectFieldSettings":[],"readOnly":"true","DBType":"String","label":{"en_US":"Status"},"type":"String","required":false,"externalReferenceCode":"5e2a7c7d-b92b-70b1-c289-eaed0bb720fa","indexedAsKeyword":false,"system":true,"indexedLanguageId":"","name":"status","state":false,"businessType":"Text","readOnlyConditionExpression":""},{"indexed":true,"objectFieldSettings":[],"readOnly":"false","DBType":"String","label":{"en_US":"Boss name"},"type":"String","required":true,"externalReferenceCode":"1e9b697c-2f66-2298-cf68-2dac6a8e6b0f","indexedAsKeyword":false,"system":false,"indexedLanguageId":"en_US","name":"bossName","state":false,"businessType":"Text","readOnlyConditionExpression":""}],"restContextPath":"/o/c/bosses","scope":"company","portlet":true,"modifiable":true,"parameterRequired":false,"enableObjectEntryHistory":false,"titleObjectFieldName":"id","objectValidationRules":[],"active":true,"defaultLanguageId":"en_US","label":{"en_US":"Boss"},"panelCategoryKey":"","pluralLabel":{"en_US":"Bosses"},"objectLayouts":[],"system":false,"objectViews":[],"name":"Boss","actions":{"permissions":{},"get":{},"update":{},"delete":{}},"status":{"label_i18n":"Approved","code":0,"label":"approved"}}'
  
  curl -X 'POST' \
  'http://localhost:8080/o/object-admin/v1.0/object-definitions' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -u 'test@liferay.com:test' \
  -d '{"enableComments":false,"objectRelationships":[],"enableCategorization":true,"accountEntryRestrictedObjectFieldName":"","objectActions":[],"accountEntryRestricted":false,"externalReferenceCode":"employee-object-erc","objectFields":[{"indexed":false,"objectFieldSettings":[],"readOnly":"true","DBType":"String","label":{"en_US":"Author"},"type":"String","required":false,"externalReferenceCode":"f9943aa1-7acf-d968-7b99-b469b1f575ab","indexedAsKeyword":false,"system":true,"indexedLanguageId":"","name":"creator","state":false,"businessType":"Text","readOnlyConditionExpression":""},{"indexed":false,"objectFieldSettings":[],"readOnly":"true","DBType":"Date","label":{"en_US":"Create Date"},"type":"Date","required":false,"externalReferenceCode":"60a273b0-ccab-1933-4a32-cb05e36d2a05","indexedAsKeyword":false,"system":true,"indexedLanguageId":"","name":"createDate","state":false,"businessType":"Date","readOnlyConditionExpression":""},{"indexed":false,"objectFieldSettings":[],"readOnly":"false","DBType":"String","label":{"en_US":"External Reference Code"},"type":"String","required":false,"externalReferenceCode":"1841633b-6398-7958-5ba3-bfc12f70191d","indexedAsKeyword":false,"system":true,"indexedLanguageId":"","name":"externalReferenceCode","state":false,"businessType":"Text","readOnlyConditionExpression":""},{"indexed":true,"objectFieldSettings":[],"readOnly":"true","DBType":"Long","label":{"en_US":"ID"},"type":"Long","required":false,"externalReferenceCode":"d60809bd-66fa-3bca-d907-252dbc3fb52a","indexedAsKeyword":true,"system":true,"indexedLanguageId":"","name":"id","state":false,"businessType":"LongInteger","readOnlyConditionExpression":""},{"indexed":false,"objectFieldSettings":[],"readOnly":"true","DBType":"Date","label":{"en_US":"Modified Date"},"type":"Date","required":false,"externalReferenceCode":"7645fa33-8eaa-70ec-d376-89010c32330f","indexedAsKeyword":false,"system":true,"indexedLanguageId":"","name":"modifiedDate","state":false,"businessType":"Date","readOnlyConditionExpression":""},{"indexed":false,"objectFieldSettings":[],"readOnly":"true","DBType":"String","label":{"en_US":"Status"},"type":"String","required":false,"externalReferenceCode":"1620c918-d7f8-be9c-1553-9848da72fd72","indexedAsKeyword":false,"system":true,"indexedLanguageId":"","name":"status","state":false,"businessType":"Text","readOnlyConditionExpression":""},{"indexed":true,"objectFieldSettings":[],"readOnly":"false","DBType":"String","label":{"en_US":"employeeName"},"type":"String","required":true,"externalReferenceCode":"122b6735-1664-915d-aa00-46ab0368d958","indexedAsKeyword":false,"system":false,"indexedLanguageId":"en_US","name":"employeeName","state":false,"businessType":"Text","readOnlyConditionExpression":""}],"restContextPath":"/o/c/employees","scope":"company","portlet":true,"modifiable":true,"parameterRequired":false,"enableObjectEntryHistory":false,"titleObjectFieldName":"id","objectValidationRules":[],"active":true,"defaultLanguageId":"en_US","label":{"en_US":"Employee"},"panelCategoryKey":"","pluralLabel":{"en_US":"Employees"},"objectLayouts":[],"system":false,"objectViews":[],"name":"Employee","actions":{"permissions":{},"get":{},"update":{},"delete":{}},"status":{"label_i18n":"Approved","code":0,"label":"approved"}}'
  
  curl -X 'POST' \
  'http://localhost:8080/o/object-admin/v1.0/object-definitions' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -u 'test@liferay.com:test' \
  -d '{"enableComments":false,"objectRelationships":[{"objectDefinitionSystem2":false,"parameterObjectFieldName":"","parameterObjectFieldId":0,"label":{"en_US":"companyBosses"},"reverse":false,"type":"oneToMany","objectDefinitionModifiable2":true,"name":"companyBosses","deletionType":"prevent","objectDefinitionExternalReferenceCode1":"company-object-erc","objectDefinitionExternalReferenceCode2":"boss-object-erc","objectDefinitionName2":"Boss"},{"objectDefinitionSystem2":false,"parameterObjectFieldName":"","parameterObjectFieldId":0,"label":{"en_US":"companyEmployees"},"reverse":false,"type":"oneToMany","objectDefinitionModifiable2":true,"name":"companyEmployees","deletionType":"prevent","objectDefinitionExternalReferenceCode1":"company-object-erc","objectDefinitionExternalReferenceCode2":"employee-object-erc","objectDefinitionName2":"Employee"}],"enableCategorization":true,"accountEntryRestrictedObjectFieldName":"","objectActions":[],"accountEntryRestricted":false,"externalReferenceCode":"company-object-erc","objectFields":[{"indexed":false,"objectFieldSettings":[],"readOnly":"true","DBType":"String","label":{"en_US":"Author"},"type":"String","required":false,"externalReferenceCode":"dc58e5db-c00a-2d4c-b09b-8534091d4417","indexedAsKeyword":false,"system":true,"indexedLanguageId":"","name":"creator","state":false,"businessType":"Text","readOnlyConditionExpression":""},{"indexed":false,"objectFieldSettings":[],"readOnly":"true","DBType":"Date","label":{"en_US":"Create Date"},"type":"Date","required":false,"externalReferenceCode":"cd18c9b1-aa57-7f56-0dd9-643b4336e005","indexedAsKeyword":false,"system":true,"indexedLanguageId":"","name":"createDate","state":false,"businessType":"Date","readOnlyConditionExpression":""},{"indexed":false,"objectFieldSettings":[],"readOnly":"false","DBType":"String","label":{"en_US":"External Reference Code"},"type":"String","required":false,"externalReferenceCode":"232f7ef6-dc4d-7796-6e21-a95b010b3382","indexedAsKeyword":false,"system":true,"indexedLanguageId":"","name":"externalReferenceCode","state":false,"businessType":"Text","readOnlyConditionExpression":""},{"indexed":true,"objectFieldSettings":[],"readOnly":"true","DBType":"Long","label":{"en_US":"ID"},"type":"Long","required":false,"externalReferenceCode":"1443c4e0-e5d0-2b18-cdca-1642dc7e58c3","indexedAsKeyword":true,"system":true,"indexedLanguageId":"","name":"id","state":false,"businessType":"LongInteger","readOnlyConditionExpression":""},{"indexed":false,"objectFieldSettings":[],"readOnly":"true","DBType":"Date","label":{"en_US":"Modified Date"},"type":"Date","required":false,"externalReferenceCode":"c39b7bc9-a38b-388a-cfb9-438834cca715","indexedAsKeyword":false,"system":true,"indexedLanguageId":"","name":"modifiedDate","state":false,"businessType":"Date","readOnlyConditionExpression":""},{"indexed":false,"objectFieldSettings":[],"readOnly":"true","DBType":"String","label":{"en_US":"Status"},"type":"String","required":false,"externalReferenceCode":"d53001b3-baa2-96a2-b729-71b2f339e21f","indexedAsKeyword":false,"system":true,"indexedLanguageId":"","name":"status","state":false,"businessType":"Text","readOnlyConditionExpression":""},{"indexed":true,"objectFieldSettings":[],"readOnly":"false","DBType":"String","label":{"en_US":"Company name"},"type":"String","required":true,"externalReferenceCode":"d32476e9-3978-c559-29f2-b611aef28115","indexedAsKeyword":false,"system":false,"indexedLanguageId":"en_US","name":"companyName","state":false,"businessType":"Text","readOnlyConditionExpression":""}],"restContextPath":"/o/c/companies","scope":"company","portlet":true,"modifiable":true,"parameterRequired":false,"enableObjectEntryHistory":false,"titleObjectFieldName":"id","objectValidationRules":[],"active":true,"defaultLanguageId":"en_US","label":{"en_US":"Company"},"panelCategoryKey":"","pluralLabel":{"en_US":"Companies"},"objectLayouts":[],"system":false,"objectViews":[],"name":"Company","actions":{"permissions":{},"get":{},"update":{},"delete":{}},"status":{"label_i18n":"Approved","code":0,"label":"approved"}}'
  
curl -X 'POST' \
  'http://localhost:8080/o/c/companies/' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -u 'test@liferay.com:test' \
  -d '{
  "externalReferenceCode": "google-erc",
  "companyName": "Google",
  "companyBosses": [
    {
      "externalReferenceCode": "john-erc",
      "bossName": "John"
    },
    {
      "externalReferenceCode": "enmma-erc",
      "bossName": "Enmma"
    }
  ],
  "companyEmployees": [
    {
      "externalReferenceCode": "albert-erc",
      "employeeName": "Albert"
    },
    {
      "externalReferenceCode": "emily-erc",
      "employeeName": "Emily"
    },
    {
      "externalReferenceCode": "jacob-erc",
      "employeeName": "Jacob"
    }
  ]
}'

curl -X 'POST' \
  'http://localhost:8080/o/c/companies/' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -u 'test@liferay.com:test' \
  -d '{
  "externalReferenceCode": "liferay-erc",
  "companyName": "Liferay",
  "companyBosses": [
    {
      "externalReferenceCode": "brian-erc",
      "bossName": "Brian"
    },
    {
      "externalReferenceCode": "marco-erc",
      "bossName": "Marco"
    }
  ],
  "companyEmployees": [
    {
      "externalReferenceCode": "alex-erc",
      "employeeName": "Alex"
    },
    {
      "externalReferenceCode": "sergio-erc",
      "employeeName": "Sergio"
    },
    {
      "externalReferenceCode": "bruno-erc",
      "employeeName": "Bruno"
    }
  ]
}'

curl -X 'POST' \
  'http://localhost:8080/o/c/companies/' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -u 'test@liferay.com:test' \
  -d '{
  "externalReferenceCode": "oracle-erc",
  "companyName": "Oracle",
  "companyBosses": [
    {
      "externalReferenceCode": "keanu-erc",
      "bossName": "Keanu"
    }
  ],
  "companyEmployees": [
    {
      "externalReferenceCode": "stewart-erc",
      "employeeName": "Stewart"
    },
    {
      "externalReferenceCode": "james-erc",
      "employeeName": "James"
    }
  ]
}'

curl -X 'POST' \
  'http://localhost:8080/o/headless-builder/applications/' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -u 'test@liferay.com:test' \
  -d '{
  "externalReferenceCode": "companies-manager-erc",
  "applicationStatus": "published",
  "baseURL": "companymanager",
  "description": "Retrive the data from the different companies, bosses and employees.",
  "title": "Companies manager"
}'

curl -X 'POST' \
  'http://localhost:8080/o/headless-builder/endpoints/' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -u 'test@liferay.com:test' \
  -d '{
  "externalReferenceCode": "get-all-boss-employees-erc",
  "description": "This endpoint returns the names of all the existing bosses and their employees",
  "httpMethod": "get",
  "name": "getBossEmployee",
  "path": "/getbossemployee",
  "r_apiApplicationToAPIEndpoints_c_apiApplicationERC": "companies-manager-erc",
  "responseAPISchemaToAPIEndpoints": {
    "externalReferenceCode": "boss-schema-erc",
    "description": "The boss schema",
    "mainObjectDefinitionERC": "boss-object-erc",
    "name": "Boss",
    "r_apiApplicationToAPISchemas_c_apiApplicationERC": "companies-manager-erc",
    "apiSchemaToAPIProperties": [
      {
        "externalReferenceCode": "boss-name-property-erc",
        "description": "The name of the desired boss",
        "name": "bossName",
        "objectFieldERC": "1e9b697c-2f66-2298-cf68-2dac6a8e6b0f"
      },
      {
        "externalReferenceCode": "employee-name-property-erc",
        "description": "The name of the desired employee",
        "name": "employeeName",
        "objectFieldERC": "122b6735-1664-915d-aa00-46ab0368d958",
        "objectRelationshipNames": "companyBosses,companyEmployees"
      }
    ]
  },
  "retrieveType": "collection",
  "scope": "company"
}'

curl -X 'POST' \
  'http://localhost:8080/o/headless-builder/endpoints/' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -u 'test@liferay.com:test' \
  -d '{
  "externalReferenceCode": "post-boss-endpoint-erc",
  "description": "This is a post boss endpoint",
  "httpMethod": "post",
  "name": "Post boss",
  "path": "/boss",
  "r_apiApplicationToAPIEndpoints_c_apiApplicationERC": "companies-manager-erc",
  "r_requestAPISchemaToAPIEndpoints_c_apiSchemaERC": "boss-schema-erc",
  "r_responseAPISchemaToAPIEndpoints_c_apiSchemaERC": "boss-schema-erc",
  "retrieveType": "singleElement",
  "scope": "company"
}'
```

- Access the API Explorer page and see if the body of the request generated are the expected. In the aforementioned case, the link would be http://localhost:8080/o/api?endpoint=http://localhost:8080/o/c/companymanager/openapi.json

</details>