### PR TITLE
LPS-201696: Display published Object Definitions as options for API Schema

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]DefineAPISchemasWithinAnAPIGroup/AllowUsersToEditSchemaProperties.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]DefineAPISchemasWithinAnAPIGroup/AllowUsersToEditSchemaProperties.testcase
@@ -12,8 +12,8 @@ definition {
 
 		User.firstLoginPG();
 
-		task ("Given Custom Object Definition University with text field 'name' created and one-to-many relationship UniversityAddresses created") {
-			var universityId = ObjectDefinitionAPI.createObjectDefinition(
+		task ("Given Custom Object Definition University with text field 'name' created and one-to-many relationship UniversityAddresses created and published") {
+			var universityId = ObjectDefinitionAPI.createAndPublishObjectDefinition(
 				en_US_label = "University",
 				en_US_plural_label = "Universities",
 				name = "University",

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]DefineAPISchemasWithinAnAPIGroup/CreateAPIApplicationSchema.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]DefineAPISchemasWithinAnAPIGroup/CreateAPIApplicationSchema.testcase
@@ -41,7 +41,7 @@ definition {
 	test AllObjectDefinitionsAreAvailableInTheObjectMenu {
 		property portal.acceptance = "true";
 
-		task ("Given multiple custom object definitions created without publishing") {
+		task ("Given multiple custom object definitions created and published") {
 			ObjectAdmin.openObjectAdmin();
 
 			var i = 0;
@@ -53,7 +53,7 @@ definition {
 			while (${moreThanTwenty} != "Showing 1 to 20 of 21 entries.") {
 				var i = ${i} + 1;
 
-				ObjectDefinitionAPI.createObjectDefinition(
+				ObjectDefinitionAPI.createAndPublishObjectDefinition(
 					en_US_label = "Student${i}",
 					en_US_plural_label = "Student${i}s",
 					name = "Student${i}",

--- a/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/baseComponents/BaseAPISchemaFields.tsx
+++ b/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/baseComponents/BaseAPISchemaFields.tsx
@@ -34,6 +34,7 @@ export default function BaseAPISchemaFields({
 
 	useEffect(() => {
 		getAllItems<ObjectDefinition>({
+			filter: 'status/any(k:k eq 0)',
 			url: '/o/object-admin/v1.0/object-definitions',
 		}).then((result) => {
 			const options = result

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/odata/entity/v1_0/ObjectDefinitionEntityModel.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/odata/entity/v1_0/ObjectDefinitionEntityModel.java
@@ -7,6 +7,7 @@ package com.liferay.object.admin.rest.internal.odata.entity.v1_0;
 
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.odata.entity.CollectionEntityField;
 import com.liferay.portal.odata.entity.DateTimeEntityField;
 import com.liferay.portal.odata.entity.EntityField;
 import com.liferay.portal.odata.entity.EntityModel;
@@ -40,7 +41,9 @@ public class ObjectDefinitionEntityModel implements EntityModel {
 				"name", locale -> Field.getSortableFieldName("name")),
 			new StringEntityField(
 				"objectFolderExternalReferenceCode",
-				locale -> "objectFolderExternalReferenceCode"));
+				locale -> "objectFolderExternalReferenceCode"),
+			new CollectionEntityField(
+				new IntegerEntityField("status", locale -> Field.STATUS)));
 	}
 
 	@Override

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
@@ -125,6 +125,55 @@ public class ObjectDefinitionResourceTest
 
 	@Override
 	@Test
+	public void testGetObjectDefinitionsPage() throws Exception {
+		super.testGetObjectDefinitionsPage();
+
+		Page<ObjectDefinition> objectDefinitionsPage =
+			objectDefinitionResource.getObjectDefinitionsPage(
+				null, null, "status/any(k:k eq 2)", Pagination.of(1, 20), null);
+
+		long totalCount = objectDefinitionsPage.getTotalCount();
+
+		ObjectDefinition objectDefinition =
+			testGetObjectDefinitionsPage_addObjectDefinition(
+				randomObjectDefinition());
+
+		ObjectDefinition randomObjectDefinition = randomObjectDefinition();
+
+		Status status = new Status() {
+			{
+				code = WorkflowConstants.STATUS_APPROVED;
+				label = WorkflowConstants.getStatusLabel(
+					WorkflowConstants.STATUS_APPROVED);
+				label_i18n = _language.get(
+					LanguageResources.getResourceBundle(
+						LocaleUtil.getDefault()),
+					WorkflowConstants.getStatusLabel(
+						WorkflowConstants.STATUS_APPROVED));
+			}
+		};
+
+		randomObjectDefinition.setStatus(status);
+
+		testGetObjectDefinitionsPage_addObjectDefinition(
+			randomObjectDefinition);
+
+		// Filter by status
+
+		objectDefinitionsPage =
+			objectDefinitionResource.getObjectDefinitionsPage(
+				null, null, "status/any(k:k eq 2)", Pagination.of(1, 20), null);
+
+		Assert.assertEquals(
+			totalCount + 1, objectDefinitionsPage.getTotalCount());
+
+		assertContains(
+			objectDefinition,
+			(List<ObjectDefinition>)objectDefinitionsPage.getItems());
+	}
+
+	@Override
+	@Test
 	public void testGetObjectDefinitionsPageWithSortString() throws Exception {
 		ObjectDefinition objectDefinition1 = randomObjectDefinition();
 

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionLocalService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionLocalService.java
@@ -399,10 +399,12 @@ public interface ObjectDefinitionLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public boolean hasObjectRelationship(long objectDefinitionId);
 
+	@Indexable(type = IndexableType.REINDEX)
 	public ObjectDefinition publishCustomObjectDefinition(
 			long userId, long objectDefinitionId)
 		throws PortalException;
 
+	@Indexable(type = IndexableType.REINDEX)
 	public ObjectDefinition publishSystemObjectDefinition(
 			long userId, long objectDefinitionId)
 		throws PortalException;

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/service/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/service/packageinfo
@@ -1,1 +1,1 @@
-version 55.1.0
+version 55.1.1

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectDefinitionModelDocumentContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectDefinitionModelDocumentContributor.java
@@ -32,6 +32,7 @@ public class ObjectDefinitionModelDocumentContributor
 		document.addKeyword(
 			"objectFolderExternalReferenceCode",
 			objectDefinition.getObjectFolderExternalReferenceCode(), true);
+		document.addKeyword(Field.STATUS, objectDefinition.getStatus());
 
 		document.remove(Field.USER_NAME);
 	}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -822,6 +822,7 @@ public class ObjectDefinitionLocalServiceImpl
 		return false;
 	}
 
+	@Indexable(type = IndexableType.REINDEX)
 	@Override
 	public ObjectDefinition publishCustomObjectDefinition(
 			long userId, long objectDefinitionId)
@@ -859,6 +860,7 @@ public class ObjectDefinitionLocalServiceImpl
 		return getObjectDefinition(objectDefinitionId);
 	}
 
+	@Indexable(type = IndexableType.REINDEX)
 	@Override
 	public ObjectDefinition publishSystemObjectDefinition(
 			long userId, long objectDefinitionId)


### PR DESCRIPTION
## Motivation
The idea of this PR is to show all the published Object Definitions as options to select when you create an API Schema.

**What is new?**
- Define `status` as new property to be filtered, same infrastructure as Object Entry.
- Define a test case in `ObjectDefinitionResourceTest`.
- Annotate `@Indexable(type = IndexableType.REINDEX)` in `publishCustomObjectDefinition` and `publishSystemObjectDefinition` from `object-service`, with the aim of updating the status `ObjectDefinitionModelDocumentContributor`.
-  Edit `APISchema` creation modal to show all the published Object Definitions.

**JIRA Related Ticket**
https://liferay.atlassian.net/browse/LPS-201696