### PR TITLE
LPS-201144 Make the Learning Message Resource Key More Specific and Add a New One

### DIFF
--- a/learn-resources/object-web.json
+++ b/learn-resources/object-web.json
@@ -1,5 +1,11 @@
 {
-	"general": {
+	"accessing-accounts-data-from-custom-objects": {
+		"en_US": {
+			"message": "Learn more.",
+			"url": "https://learn.liferay.com/web/guest/w/dxp/building-applications/objects/creating-and-managing-objects/using-system-objects-with-custom-objects/accessing-accounts-data-from-custom-objects"
+		}
+	},
+	"expression-builder-validations-reference": {
 		"en_US": {
 			"message": "Learn more.",
 			"url": "https://learn.liferay.com/en/w/dxp/building-applications/objects/creating-and-managing-objects/validations/expression-builder-validations-reference"

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/Tabs/Advanced/DefaultValueContainer.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/Tabs/Advanced/DefaultValueContainer.tsx
@@ -139,7 +139,7 @@ export function DefaultValueContainer({
 						<LearnMessage
 							className="alert-link"
 							resource="object-web"
-							resourceKey="general"
+							resourceKey="expression-builder-validations-reference"
 						/>
 					</LearnResourcesContext.Provider>
 				</ClayAlert>

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectValidation/Conditions.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectValidation/Conditions.tsx
@@ -83,7 +83,7 @@ export function Conditions({
 					<LearnMessage
 						className="alert-link"
 						resource="object-web"
-						resourceKey="general"
+						resourceKey="expression-builder-validations-reference"
 					/>
 				</LearnResourcesContext.Provider>
 			</ClayAlert>


### PR DESCRIPTION
Hey Brian, I'm working on a task and I need to include a new resourceKey `accessing-accounts-data-from-custom-objects`, but for that I needed to rename the pre-existing item in json, since the learn-message documentation guidelines specify that we should only use the general key for this case there is only one resource key.