### PR TITLE
LPS-205902 Make onKeyPress event for Clear link

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ResultsBar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ResultsBar.js
@@ -150,6 +150,16 @@ const ResultsBar = ({
 
 							navigate(clearResultsURL);
 						}}
+						onKeyPress={(event) => {
+							if (event.key === 'Enter') {
+								event.preventDefault();
+
+								searchContainerRef.current?.fire('clearFilter');
+
+								navigate(clearResultsURL);
+							}
+						}}
+						tabIndex={0}
 					>
 						{Liferay.Language.get('clear')}
 					</ClayLink>


### PR DESCRIPTION
FWD: https://github.com/liferay-frontend/liferay-portal/pull/3925

> https://liferay.atlassian.net/browse/LPS-205902
> 
> I added tabIndex and onKeyPress event so that the user will be able to tab to the Clear link and select it with an Enter press.
> Let me know if there are any questions or comments about this.
> Thank you!