### PR TITLE
LPS-205933 Use the attribute model name if sent

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/PortletDataContextImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/PortletDataContextImpl.java
@@ -1313,7 +1313,7 @@ public class PortletDataContextImpl implements PortletDataContext {
 			}
 		}
 
-		_importWorkflowDefinitionLink(newClassedModel);
+		_importWorkflowDefinitionLink(clazz, newClassedModel);
 
 		importLocks(
 			clazz, String.valueOf(primaryKeyObj),
@@ -2484,15 +2484,18 @@ public class PortletDataContextImpl implements PortletDataContext {
 		return StringBundler.concat(className, StringPool.POUND, classPK);
 	}
 
-	private void _importWorkflowDefinitionLink(ClassedModel classedModel)
+	private void _importWorkflowDefinitionLink(
+			Class<?> clazz, ClassedModel classedModel)
 		throws PortletDataException {
 
 		Element stagedGroupedWorkflowDefinitionLinkElements =
 			getImportDataGroupElement(
 				StagedGroupedWorkflowDefinitionLink.class);
 
+		String className = clazz.getName();
+
 		Map<Long, Long> primaryKeys = (Map<Long, Long>)getNewPrimaryKeysMap(
-			classedModel.getModelClass());
+			className);
 
 		for (Element stagedGroupedWorkflowDefinitionLinkElement :
 				stagedGroupedWorkflowDefinitionLinkElements.elements()) {
@@ -2503,8 +2506,6 @@ public class PortletDataContextImpl implements PortletDataContext {
 			long referrerClassPK = GetterUtil.getLong(
 				stagedGroupedWorkflowDefinitionLinkElement.attributeValue(
 					"referrer-class-pk"));
-
-			String className = classedModel.getModelClassName();
 
 			long newPrimaryKey = GetterUtil.getLong(
 				classedModel.getPrimaryKeyObj());

--- a/modules/test/playwright/fixtures/documentLibraryPages.fixtures.ts
+++ b/modules/test/playwright/fixtures/documentLibraryPages.fixtures.ts
@@ -1,0 +1,25 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+// @ts-ignore
+
+import {test} from '@playwright/test';
+
+import {DocumentLibraryPage} from '../pages/document-library-web/documentLibrary.page';
+import {DocumentLibraryEditFolderPage} from '../pages/document-library-web/documentLibraryEditFolder.page';
+
+const documentLibraryPagesTest = test.extend<{
+	_documentLibraryEditFolderPage: DocumentLibraryEditFolderPage;
+	_documentLibraryPage: DocumentLibraryPage;
+}>({
+	_documentLibraryEditFolderPage: async ({page}, use) => {
+		await use(new DocumentLibraryEditFolderPage(page));
+	},
+	_documentLibraryPage: async ({page}, use) => {
+		await use(new DocumentLibraryPage(page));
+	},
+});
+
+export {documentLibraryPagesTest};

--- a/modules/test/playwright/fixtures/exportImportPages.fixtures.ts
+++ b/modules/test/playwright/fixtures/exportImportPages.fixtures.ts
@@ -1,0 +1,20 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+// @ts-ignore
+
+import {test} from '@playwright/test';
+
+import {ExportImportFramePage} from '../pages/export-import-web/exportImportFrame.page';
+
+const exportImportPagesTest = test.extend<{
+	_exportImportFramePage: ExportImportFramePage;
+}>({
+	_exportImportFramePage: async ({page}, use) => {
+		await use(new ExportImportFramePage(page));
+	},
+});
+
+export {exportImportPagesTest};

--- a/modules/test/playwright/helpers/ApiHelpers.ts
+++ b/modules/test/playwright/helpers/ApiHelpers.ts
@@ -7,10 +7,12 @@ import {Page} from '@playwright/test';
 
 import {liferayConfig} from '../liferay.config';
 import {FeatureFlagApiHelper} from './FeatureFlagApiHelper';
+import {HeadlessDeliveryApiHelper} from './HeadlessDeliveryApiHelper';
 import {ObjectAdminApiHelper} from './ObjectAdminApiHelper';
 
 export class ApiHelpers {
 	readonly baseUrl: string;
+	readonly headlessDelivery: HeadlessDeliveryApiHelper;
 	readonly featureFlag: FeatureFlagApiHelper;
 	readonly objectAdmin: ObjectAdminApiHelper;
 	readonly page: Page;
@@ -18,6 +20,7 @@ export class ApiHelpers {
 	constructor(page: Page) {
 		this.baseUrl = liferayConfig.environment.baseUrl + '/o/';
 		this.featureFlag = new FeatureFlagApiHelper(page);
+		this.headlessDelivery = new HeadlessDeliveryApiHelper(this);
 		this.objectAdmin = new ObjectAdminApiHelper(this);
 		this.page = page;
 	}

--- a/modules/test/playwright/helpers/HeadlessDeliveryApiHelper.ts
+++ b/modules/test/playwright/helpers/HeadlessDeliveryApiHelper.ts
@@ -1,0 +1,24 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {ApiHelpers} from './ApiHelpers';
+
+export class HeadlessDeliveryApiHelper {
+	readonly apiHelpers: ApiHelpers;
+	readonly basePath: string;
+
+	constructor(apiHelpers: ApiHelpers) {
+		this.apiHelpers = apiHelpers;
+		this.basePath = 'headless-delivery/v1.0';
+	}
+
+	async deleteSiteDocumentsFolderByExternalReferenceCode(
+		externalReferenceCode: string
+	) {
+		return this.apiHelpers.delete(
+			`${this.apiHelpers.baseUrl}${this.basePath}/sites/Guest/documents-folder/by-external-reference-code/${externalReferenceCode}`
+		);
+	}
+}

--- a/modules/test/playwright/package-lock.json
+++ b/modules/test/playwright/package-lock.json
@@ -12,7 +12,8 @@
 				"@liferay/eslint-plugin": "1.5.0",
 				"@liferay/npm-scripts": "49.1.0",
 				"@playwright/test": "1.39.0",
-				"@types/node": "^20.9.0"
+				"@types/node": "^20.9.0",
+				"zip-a-folder": "^3.1.6"
 			}
 		},
 		"node_modules/@aashutoshrathi/word-wrap": {
@@ -2058,6 +2059,102 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/@isaacs/cliui": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+			"integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+			"dev": true,
+			"dependencies": {
+				"string-width": "^5.1.2",
+				"string-width-cjs": "npm:string-width@^4.2.0",
+				"strip-ansi": "^7.0.1",
+				"strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+				"wrap-ansi": "^8.1.0",
+				"wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+			"integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+			"integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+			"version": "9.2.2",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+			"dev": true
+		},
+		"node_modules/@isaacs/cliui/node_modules/string-width": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+			"integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+			"dev": true,
+			"dependencies": {
+				"eastasianwidth": "^0.2.0",
+				"emoji-regex": "^9.2.2",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+			"integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+			"dev": true,
+			"dependencies": {
+				"ansi-regex": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+			"integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^6.1.0",
+				"string-width": "^5.0.1",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
 		"node_modules/@istanbuljs/load-nyc-config": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -3964,6 +4061,16 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/@pkgjs/parseargs": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+			"integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+			"dev": true,
+			"optional": true,
+			"engines": {
+				"node": ">=14"
+			}
+		},
 		"node_modules/@playwright/test": {
 			"version": "1.39.0",
 			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.39.0.tgz",
@@ -5439,6 +5546,126 @@
 			"dev": true,
 			"peer": true
 		},
+		"node_modules/archiver": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/archiver/-/archiver-6.0.1.tgz",
+			"integrity": "sha512-CXGy4poOLBKptiZH//VlWdFuUC1RESbdZjGjILwBuZ73P7WkAUN0htfSfBq/7k6FRFlpu7bg4JOkj1vU9G6jcQ==",
+			"dev": true,
+			"dependencies": {
+				"archiver-utils": "^4.0.1",
+				"async": "^3.2.4",
+				"buffer-crc32": "^0.2.1",
+				"readable-stream": "^3.6.0",
+				"readdir-glob": "^1.1.2",
+				"tar-stream": "^3.0.0",
+				"zip-stream": "^5.0.1"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/archiver-utils": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-4.0.1.tgz",
+			"integrity": "sha512-Q4Q99idbvzmgCTEAAhi32BkOyq8iVI5EwdO0PmBDSGIzzjYNdcFn7Q7k3OzbLy4kLUPXfJtG6fO2RjftXbobBg==",
+			"dev": true,
+			"dependencies": {
+				"glob": "^8.0.0",
+				"graceful-fs": "^4.2.0",
+				"lazystream": "^1.0.0",
+				"lodash": "^4.17.15",
+				"normalize-path": "^3.0.0",
+				"readable-stream": "^3.6.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/archiver-utils/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/archiver-utils/node_modules/glob": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+			"integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+			"dev": true,
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^5.0.1",
+				"once": "^1.3.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/archiver-utils/node_modules/minimatch": {
+			"version": "5.1.6",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+			"integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/archiver-utils/node_modules/readable-stream": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"dev": true,
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/archiver/node_modules/async": {
+			"version": "3.2.5",
+			"resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
+			"integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==",
+			"dev": true
+		},
+		"node_modules/archiver/node_modules/readable-stream": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"dev": true,
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/archiver/node_modules/tar-stream": {
+			"version": "3.1.6",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.6.tgz",
+			"integrity": "sha512-B/UyjYwPpMBv+PaFSWAmtYjwdrlEaZQEhMIBFNC5oEG8lpiW8XjcSdmEaClj28ArfKScKHs2nshz3k2le6crsg==",
+			"dev": true,
+			"dependencies": {
+				"b4a": "^1.6.4",
+				"fast-fifo": "^1.2.0",
+				"streamx": "^2.15.0"
+			}
+		},
 		"node_modules/archy": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
@@ -5976,6 +6203,12 @@
 			"version": "1.12.0",
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
 			"integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==",
+			"dev": true
+		},
+		"node_modules/b4a": {
+			"version": "1.6.4",
+			"resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.4.tgz",
+			"integrity": "sha512-fpWrvyVHEKyeEvbKZTVOeZF3VSKKWtJxFIxX/jaVPf+cLbGUSitjb49pHLqPV2BUNNZ0LcoeEGfE/YCpyDYHIw==",
 			"dev": true
 		},
 		"node_modules/babel-code-frame": {
@@ -8130,6 +8363,35 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/compress-commons": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-5.0.1.tgz",
+			"integrity": "sha512-MPh//1cERdLtqwO3pOFLeXtpuai0Y2WCd5AhtKxznqM7WtaMYaOEMSgn45d9D10sIHSfIKE603HlOp8OPGrvag==",
+			"dev": true,
+			"dependencies": {
+				"crc-32": "^1.2.0",
+				"crc32-stream": "^5.0.0",
+				"normalize-path": "^3.0.0",
+				"readable-stream": "^3.6.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/compress-commons/node_modules/readable-stream": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"dev": true,
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/compressible": {
 			"version": "2.0.18",
 			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
@@ -8370,6 +8632,45 @@
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/crc-32": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+			"integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+			"dev": true,
+			"bin": {
+				"crc32": "bin/crc32.njs"
+			},
+			"engines": {
+				"node": ">=0.8"
+			}
+		},
+		"node_modules/crc32-stream": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-5.0.0.tgz",
+			"integrity": "sha512-B0EPa1UK+qnpBZpG+7FgPCu0J2ETLpXq09o9BkLkEAhdB6Z61Qo4pJ3JYu0c+Qi+/SAL7QThqnzS06pmSSyZaw==",
+			"dev": true,
+			"dependencies": {
+				"crc-32": "^1.2.0",
+				"readable-stream": "^3.4.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/crc32-stream/node_modules/readable-stream": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"dev": true,
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
 			}
 		},
 		"node_modules/create-ecdh": {
@@ -9495,6 +9796,12 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/eastasianwidth": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+			"integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+			"dev": true
 		},
 		"node_modules/ecc-jsbn": {
 			"version": "0.1.2",
@@ -11062,6 +11369,12 @@
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
 			"dev": true
 		},
+		"node_modules/fast-fifo": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+			"integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+			"dev": true
+		},
 		"node_modules/fast-glob": {
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
@@ -11591,6 +11904,34 @@
 			},
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/foreground-child": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
+			"integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
+			"dev": true,
+			"dependencies": {
+				"cross-spawn": "^7.0.0",
+				"signal-exit": "^4.0.1"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/foreground-child/node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"dev": true,
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/forever-agent": {
@@ -15894,6 +16235,24 @@
 			},
 			"engines": {
 				"node": ">= 4"
+			}
+		},
+		"node_modules/jackspeak": {
+			"version": "2.3.6",
+			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
+			"integrity": "sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==",
+			"dev": true,
+			"dependencies": {
+				"@isaacs/cliui": "^8.0.2"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			},
+			"optionalDependencies": {
+				"@pkgjs/parseargs": "^0.11.0"
 			}
 		},
 		"node_modules/jest": {
@@ -20896,6 +21255,15 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/minipass": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
+			"integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			}
+		},
 		"node_modules/mississippi": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
@@ -22365,6 +22733,31 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/path-scurry": {
+			"version": "1.10.1",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.1.tgz",
+			"integrity": "sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==",
+			"dev": true,
+			"dependencies": {
+				"lru-cache": "^9.1.1 || ^10.0.0",
+				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/path-scurry/node_modules/lru-cache": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.1.0.tgz",
+			"integrity": "sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==",
+			"dev": true,
+			"engines": {
+				"node": "14 || >=16.14"
+			}
+		},
 		"node_modules/path-to-regexp": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
@@ -23275,6 +23668,12 @@
 				}
 			]
 		},
+		"node_modules/queue-tick": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
+			"integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==",
+			"dev": true
+		},
 		"node_modules/quick-lru": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
@@ -23545,6 +23944,36 @@
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
 			"dev": true
+		},
+		"node_modules/readdir-glob": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+			"integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+			"dev": true,
+			"dependencies": {
+				"minimatch": "^5.1.0"
+			}
+		},
+		"node_modules/readdir-glob/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/readdir-glob/node_modules/minimatch": {
+			"version": "5.1.6",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+			"integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=10"
+			}
 		},
 		"node_modules/readdirp": {
 			"version": "3.6.0",
@@ -25897,6 +26326,16 @@
 			"integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
 			"dev": true
 		},
+		"node_modules/streamx": {
+			"version": "2.15.6",
+			"resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.6.tgz",
+			"integrity": "sha512-q+vQL4AAz+FdfT137VF69Cc/APqUbxy+MDOImRrMvchJpigHj9GksgDU2LYbO9rx7RX6osWgxJB2WxhYv4SZAw==",
+			"dev": true,
+			"dependencies": {
+				"fast-fifo": "^1.1.0",
+				"queue-tick": "^1.0.1"
+			}
+		},
 		"node_modules/strict-uri-encode": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
@@ -25973,6 +26412,51 @@
 			},
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/string-width-cjs": {
+			"name": "string-width",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/string-width-cjs/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/string-width-cjs/node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/string-width-cjs/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/string-width/node_modules/strip-ansi": {
@@ -26060,6 +26544,28 @@
 			"dependencies": {
 				"ansi-regex": "^5.0.0"
 			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-ansi-cjs": {
+			"name": "strip-ansi",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -30087,6 +30593,101 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/wrap-ansi-cjs": {
+			"name": "wrap-ansi",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/wrap-ansi/node_modules/strip-ansi": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
@@ -30357,6 +30958,91 @@
 			"dev": true,
 			"dependencies": {
 				"buffer-crc32": "~0.2.3"
+			}
+		},
+		"node_modules/zip-a-folder": {
+			"version": "3.1.6",
+			"resolved": "https://registry.npmjs.org/zip-a-folder/-/zip-a-folder-3.1.6.tgz",
+			"integrity": "sha512-u+qRL0sSsq2T2mDFcDzdgCSVO8sChsJ4swd2aZlzyoIoNwyVL7HBHPKDQVq1t0utd8nPXzCq44gAKzXAhbvpXA==",
+			"dev": true,
+			"dependencies": {
+				"archiver": "^6.0.1",
+				"glob": "^10.3.10",
+				"is-glob": "^4.0.3"
+			}
+		},
+		"node_modules/zip-a-folder/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/zip-a-folder/node_modules/glob": {
+			"version": "10.3.10",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
+			"integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
+			"dev": true,
+			"dependencies": {
+				"foreground-child": "^3.1.0",
+				"jackspeak": "^2.3.5",
+				"minimatch": "^9.0.1",
+				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
+				"path-scurry": "^1.10.1"
+			},
+			"bin": {
+				"glob": "dist/esm/bin.mjs"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/zip-a-folder/node_modules/minimatch": {
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+			"integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/zip-stream": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-5.0.1.tgz",
+			"integrity": "sha512-UfZ0oa0C8LI58wJ+moL46BDIMgCQbnsb+2PoiJYtonhBsMh2bq1eRBVkvjfVsqbEHd9/EgKPUuL9saSSsec8OA==",
+			"dev": true,
+			"dependencies": {
+				"archiver-utils": "^4.0.1",
+				"compress-commons": "^5.0.1",
+				"readable-stream": "^3.6.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/zip-stream/node_modules/readable-stream": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"dev": true,
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
 			}
 		},
 		"node_modules/zwitch": {
@@ -31765,6 +32451,71 @@
 					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
 					"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
 					"dev": true
+				}
+			}
+		},
+		"@isaacs/cliui": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+			"integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+			"dev": true,
+			"requires": {
+				"string-width": "^5.1.2",
+				"string-width-cjs": "npm:string-width@^4.2.0",
+				"strip-ansi": "^7.0.1",
+				"strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+				"wrap-ansi": "^8.1.0",
+				"wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+					"integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "6.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+					"integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+					"dev": true
+				},
+				"emoji-regex": {
+					"version": "9.2.2",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+					"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+					"dev": true
+				},
+				"string-width": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+					"integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+					"dev": true,
+					"requires": {
+						"eastasianwidth": "^0.2.0",
+						"emoji-regex": "^9.2.2",
+						"strip-ansi": "^7.0.1"
+					}
+				},
+				"strip-ansi": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+					"integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^6.0.1"
+					}
+				},
+				"wrap-ansi": {
+					"version": "8.1.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+					"integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^6.1.0",
+						"string-width": "^5.0.1",
+						"strip-ansi": "^7.0.1"
+					}
 				}
 			}
 		},
@@ -33280,6 +34031,13 @@
 				"fastq": "^1.6.0"
 			}
 		},
+		"@pkgjs/parseargs": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+			"integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+			"dev": true,
+			"optional": true
+		},
 		"@playwright/test": {
 			"version": "1.39.0",
 			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.39.0.tgz",
@@ -34498,6 +35256,109 @@
 			"dev": true,
 			"peer": true
 		},
+		"archiver": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/archiver/-/archiver-6.0.1.tgz",
+			"integrity": "sha512-CXGy4poOLBKptiZH//VlWdFuUC1RESbdZjGjILwBuZ73P7WkAUN0htfSfBq/7k6FRFlpu7bg4JOkj1vU9G6jcQ==",
+			"dev": true,
+			"requires": {
+				"archiver-utils": "^4.0.1",
+				"async": "^3.2.4",
+				"buffer-crc32": "^0.2.1",
+				"readable-stream": "^3.6.0",
+				"readdir-glob": "^1.1.2",
+				"tar-stream": "^3.0.0",
+				"zip-stream": "^5.0.1"
+			},
+			"dependencies": {
+				"async": {
+					"version": "3.2.5",
+					"resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
+					"integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==",
+					"dev": true
+				},
+				"readable-stream": {
+					"version": "3.6.2",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+					"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				},
+				"tar-stream": {
+					"version": "3.1.6",
+					"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.6.tgz",
+					"integrity": "sha512-B/UyjYwPpMBv+PaFSWAmtYjwdrlEaZQEhMIBFNC5oEG8lpiW8XjcSdmEaClj28ArfKScKHs2nshz3k2le6crsg==",
+					"dev": true,
+					"requires": {
+						"b4a": "^1.6.4",
+						"fast-fifo": "^1.2.0",
+						"streamx": "^2.15.0"
+					}
+				}
+			}
+		},
+		"archiver-utils": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-4.0.1.tgz",
+			"integrity": "sha512-Q4Q99idbvzmgCTEAAhi32BkOyq8iVI5EwdO0PmBDSGIzzjYNdcFn7Q7k3OzbLy4kLUPXfJtG6fO2RjftXbobBg==",
+			"dev": true,
+			"requires": {
+				"glob": "^8.0.0",
+				"graceful-fs": "^4.2.0",
+				"lazystream": "^1.0.0",
+				"lodash": "^4.17.15",
+				"normalize-path": "^3.0.0",
+				"readable-stream": "^3.6.0"
+			},
+			"dependencies": {
+				"brace-expansion": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+					"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+					"dev": true,
+					"requires": {
+						"balanced-match": "^1.0.0"
+					}
+				},
+				"glob": {
+					"version": "8.1.0",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+					"integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+					"dev": true,
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^5.0.1",
+						"once": "^1.3.0"
+					}
+				},
+				"minimatch": {
+					"version": "5.1.6",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+					"integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+					"dev": true,
+					"requires": {
+						"brace-expansion": "^2.0.1"
+					}
+				},
+				"readable-stream": {
+					"version": "3.6.2",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+					"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
+			}
+		},
 		"archy": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
@@ -34912,6 +35773,12 @@
 			"version": "1.12.0",
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
 			"integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==",
+			"dev": true
+		},
+		"b4a": {
+			"version": "1.6.4",
+			"resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.4.tgz",
+			"integrity": "sha512-fpWrvyVHEKyeEvbKZTVOeZF3VSKKWtJxFIxX/jaVPf+cLbGUSitjb49pHLqPV2BUNNZ0LcoeEGfE/YCpyDYHIw==",
 			"dev": true
 		},
 		"babel-code-frame": {
@@ -36711,6 +37578,31 @@
 			"integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
 			"dev": true
 		},
+		"compress-commons": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-5.0.1.tgz",
+			"integrity": "sha512-MPh//1cERdLtqwO3pOFLeXtpuai0Y2WCd5AhtKxznqM7WtaMYaOEMSgn45d9D10sIHSfIKE603HlOp8OPGrvag==",
+			"dev": true,
+			"requires": {
+				"crc-32": "^1.2.0",
+				"crc32-stream": "^5.0.0",
+				"normalize-path": "^3.0.0",
+				"readable-stream": "^3.6.0"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.6.2",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+					"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
+			}
+		},
 		"compressible": {
 			"version": "2.0.18",
 			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
@@ -36916,6 +37808,35 @@
 				"parse-json": "^5.0.0",
 				"path-type": "^4.0.0",
 				"yaml": "^1.10.0"
+			}
+		},
+		"crc-32": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+			"integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+			"dev": true
+		},
+		"crc32-stream": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-5.0.0.tgz",
+			"integrity": "sha512-B0EPa1UK+qnpBZpG+7FgPCu0J2ETLpXq09o9BkLkEAhdB6Z61Qo4pJ3JYu0c+Qi+/SAL7QThqnzS06pmSSyZaw==",
+			"dev": true,
+			"requires": {
+				"crc-32": "^1.2.0",
+				"readable-stream": "^3.4.0"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.6.2",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+					"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
 			}
 		},
 		"create-ecdh": {
@@ -37836,6 +38757,12 @@
 					}
 				}
 			}
+		},
+		"eastasianwidth": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+			"integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+			"dev": true
 		},
 		"ecc-jsbn": {
 			"version": "0.1.2",
@@ -39083,6 +40010,12 @@
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
 			"dev": true
 		},
+		"fast-fifo": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+			"integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+			"dev": true
+		},
 		"fast-glob": {
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
@@ -39511,6 +40444,24 @@
 			"dev": true,
 			"requires": {
 				"for-in": "^1.0.1"
+			}
+		},
+		"foreground-child": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
+			"integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
+			"dev": true,
+			"requires": {
+				"cross-spawn": "^7.0.0",
+				"signal-exit": "^4.0.1"
+			},
+			"dependencies": {
+				"signal-exit": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+					"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+					"dev": true
+				}
 			}
 		},
 		"forever-agent": {
@@ -42849,6 +43800,16 @@
 			"requires": {
 				"has-to-string-tag-x": "^1.2.0",
 				"is-object": "^1.0.1"
+			}
+		},
+		"jackspeak": {
+			"version": "2.3.6",
+			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
+			"integrity": "sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==",
+			"dev": true,
+			"requires": {
+				"@isaacs/cliui": "^8.0.2",
+				"@pkgjs/parseargs": "^0.11.0"
 			}
 		},
 		"jest": {
@@ -46883,6 +47844,12 @@
 				}
 			}
 		},
+		"minipass": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
+			"integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
+			"dev": true
+		},
 		"mississippi": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
@@ -48062,6 +49029,24 @@
 			"integrity": "sha512-4GlJ6rZDhQZFE0DPVKh0e9jmZ5egZfxTkp7bcRDuPlJXbAwhxcl2dINPUAsjLdejqaLsCeg8axcLjIbvBjN4pQ==",
 			"dev": true
 		},
+		"path-scurry": {
+			"version": "1.10.1",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.1.tgz",
+			"integrity": "sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==",
+			"dev": true,
+			"requires": {
+				"lru-cache": "^9.1.1 || ^10.0.0",
+				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+			},
+			"dependencies": {
+				"lru-cache": {
+					"version": "10.1.0",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.1.0.tgz",
+					"integrity": "sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==",
+					"dev": true
+				}
+			}
+		},
 		"path-to-regexp": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
@@ -48787,6 +49772,12 @@
 			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
 			"dev": true
 		},
+		"queue-tick": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
+			"integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==",
+			"dev": true
+		},
 		"quick-lru": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
@@ -49016,6 +50007,35 @@
 					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
 					"dev": true
+				}
+			}
+		},
+		"readdir-glob": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+			"integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+			"dev": true,
+			"requires": {
+				"minimatch": "^5.1.0"
+			},
+			"dependencies": {
+				"brace-expansion": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+					"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+					"dev": true,
+					"requires": {
+						"balanced-match": "^1.0.0"
+					}
+				},
+				"minimatch": {
+					"version": "5.1.6",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+					"integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+					"dev": true,
+					"requires": {
+						"brace-expansion": "^2.0.1"
+					}
 				}
 			}
 		},
@@ -50905,6 +51925,16 @@
 				}
 			}
 		},
+		"streamx": {
+			"version": "2.15.6",
+			"resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.6.tgz",
+			"integrity": "sha512-q+vQL4AAz+FdfT137VF69Cc/APqUbxy+MDOImRrMvchJpigHj9GksgDU2LYbO9rx7RX6osWgxJB2WxhYv4SZAw==",
+			"dev": true,
+			"requires": {
+				"fast-fifo": "^1.1.0",
+				"queue-tick": "^1.0.1"
+			}
+		},
 		"strict-uri-encode": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
@@ -50983,6 +52013,40 @@
 				}
 			}
 		},
+		"string-width-cjs": {
+			"version": "npm:string-width@4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"requires": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+					"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+					"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^5.0.1"
+					}
+				}
+			}
+		},
 		"string.prototype.matchall": {
 			"version": "4.0.10",
 			"resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.10.tgz",
@@ -51040,6 +52104,23 @@
 			"dev": true,
 			"requires": {
 				"ansi-regex": "^5.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+					"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+					"dev": true
+				}
+			}
+		},
+		"strip-ansi-cjs": {
+			"version": "npm:strip-ansi@6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"requires": {
+				"ansi-regex": "^5.0.1"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -54295,6 +55376,75 @@
 				}
 			}
 		},
+		"wrap-ansi-cjs": {
+			"version": "npm:wrap-ansi@7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+					"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+					"dev": true
+				},
+				"string-width": {
+					"version": "4.2.3",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+					"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.1"
+					}
+				},
+				"strip-ansi": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+					"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^5.0.1"
+					}
+				}
+			}
+		},
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -54502,6 +55652,74 @@
 			"dev": true,
 			"requires": {
 				"buffer-crc32": "~0.2.3"
+			}
+		},
+		"zip-a-folder": {
+			"version": "3.1.6",
+			"resolved": "https://registry.npmjs.org/zip-a-folder/-/zip-a-folder-3.1.6.tgz",
+			"integrity": "sha512-u+qRL0sSsq2T2mDFcDzdgCSVO8sChsJ4swd2aZlzyoIoNwyVL7HBHPKDQVq1t0utd8nPXzCq44gAKzXAhbvpXA==",
+			"dev": true,
+			"requires": {
+				"archiver": "^6.0.1",
+				"glob": "^10.3.10",
+				"is-glob": "^4.0.3"
+			},
+			"dependencies": {
+				"brace-expansion": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+					"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+					"dev": true,
+					"requires": {
+						"balanced-match": "^1.0.0"
+					}
+				},
+				"glob": {
+					"version": "10.3.10",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
+					"integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
+					"dev": true,
+					"requires": {
+						"foreground-child": "^3.1.0",
+						"jackspeak": "^2.3.5",
+						"minimatch": "^9.0.1",
+						"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
+						"path-scurry": "^1.10.1"
+					}
+				},
+				"minimatch": {
+					"version": "9.0.3",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+					"integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+					"dev": true,
+					"requires": {
+						"brace-expansion": "^2.0.1"
+					}
+				}
+			}
+		},
+		"zip-stream": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-5.0.1.tgz",
+			"integrity": "sha512-UfZ0oa0C8LI58wJ+moL46BDIMgCQbnsb+2PoiJYtonhBsMh2bq1eRBVkvjfVsqbEHd9/EgKPUuL9saSSsec8OA==",
+			"dev": true,
+			"requires": {
+				"archiver-utils": "^4.0.1",
+				"compress-commons": "^5.0.1",
+				"readable-stream": "^3.6.0"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.6.2",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+					"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
 			}
 		},
 		"zwitch": {

--- a/modules/test/playwright/package.json
+++ b/modules/test/playwright/package.json
@@ -5,7 +5,8 @@
 		"@liferay/eslint-plugin": "1.5.0",
 		"@liferay/npm-scripts": "49.1.0",
 		"@playwright/test": "1.39.0",
-		"@types/node": "^20.9.0"
+		"@types/node": "^20.9.0",
+		"zip-a-folder": "^3.1.6"
 	},
 	"keywords": [
 	],

--- a/modules/test/playwright/pages/document-library-web/documentLibrary.page.ts
+++ b/modules/test/playwright/pages/document-library-web/documentLibrary.page.ts
@@ -37,6 +37,7 @@ export class DocumentLibraryPage {
 	}
 
 	async openOptionsMenu() {
+		await this.page.waitForLoadState('networkidle');
 		await this.optionsMenu.click();
 	}
 }

--- a/modules/test/playwright/pages/document-library-web/documentLibrary.page.ts
+++ b/modules/test/playwright/pages/document-library-web/documentLibrary.page.ts
@@ -26,6 +26,7 @@ export class DocumentLibraryPage {
 		await this.page.goto(
 			'/group/guest/~/control_panel/manage?p_p_id=com_liferay_document_library_web_portlet_DLAdminPortlet'
 		);
+		await this.page.waitForLoadState();
 	}
 
 	async editEntry(entryTitle: string) {
@@ -37,7 +38,6 @@ export class DocumentLibraryPage {
 	}
 
 	async openOptionsMenu() {
-		await this.page.waitForLoadState('networkidle');
 		await this.optionsMenu.click();
 	}
 }

--- a/modules/test/playwright/pages/document-library-web/documentLibrary.page.ts
+++ b/modules/test/playwright/pages/document-library-web/documentLibrary.page.ts
@@ -1,0 +1,42 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+// @ts-ignore
+
+import {Locator, Page} from '@playwright/test';
+
+export class DocumentLibraryPage {
+	readonly optionsMenu: Locator;
+	readonly page: Page;
+	readonly exportImportOptionsMenuItem: Locator;
+
+	constructor(page: Page) {
+		this.exportImportOptionsMenuItem = page.getByRole('menuitem', {
+			name: 'Export / Import',
+		});
+		this.optionsMenu = page
+			.getByTestId('headerOptions')
+			.getByLabel('Options');
+		this.page = page;
+	}
+
+	async goto() {
+		await this.page.goto(
+			'/group/guest/~/control_panel/manage?p_p_id=com_liferay_document_library_web_portlet_DLAdminPortlet'
+		);
+	}
+
+	async editEntry(entryTitle: string) {
+		await this.page
+			.locator(`.card-body:has-text('${entryTitle}')`)
+			.getByLabel('More actions')
+			.click();
+		await this.page.getByRole('menuitem', {name: 'Edit'}).click();
+	}
+
+	async openOptionsMenu() {
+		await this.optionsMenu.click();
+	}
+}

--- a/modules/test/playwright/pages/document-library-web/documentLibraryEditFolder.page.ts
+++ b/modules/test/playwright/pages/document-library-web/documentLibraryEditFolder.page.ts
@@ -1,0 +1,25 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+// @ts-ignore
+
+import {Page} from '@playwright/test';
+
+export class DocumentLibraryEditFolderPage {
+	readonly page: Page;
+
+	constructor(page: Page) {
+		this.page = page;
+	}
+
+	async getSelectedWorkflowDefinition() {
+		return await this.page
+			.getByTitle('Workflow Definition')
+			.evaluate(
+				(select: HTMLSelectElement) =>
+					select.options[select.selectedIndex].value
+			);
+	}
+}

--- a/modules/test/playwright/pages/export-import-web/exportImportFrame.page.ts
+++ b/modules/test/playwright/pages/export-import-web/exportImportFrame.page.ts
@@ -21,6 +21,7 @@ export class ExportImportFramePage {
 			'iframe[title="Export \\/ Import"]'
 		);
 
+		await this.page.waitForLoadState('networkidle');
 		await exportImportFrame.getByRole('link', {name: 'Import'}).click();
 
 		const fileChooserPromise = this.page.waitForEvent('filechooser');

--- a/modules/test/playwright/pages/export-import-web/exportImportFrame.page.ts
+++ b/modules/test/playwright/pages/export-import-web/exportImportFrame.page.ts
@@ -1,0 +1,43 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+// @ts-ignore
+
+import {Page} from '@playwright/test';
+
+import {zipFolder} from '../../utils/util';
+
+export class ExportImportFramePage {
+	readonly page: Page;
+
+	constructor(page: Page) {
+		this.page = page;
+	}
+
+	async importLARFile(folderPath: string) {
+		const exportImportFrame = this.page.frameLocator(
+			'iframe[title="Export \\/ Import"]'
+		);
+
+		await exportImportFrame.getByRole('link', {name: 'Import'}).click();
+
+		const fileChooserPromise = this.page.waitForEvent('filechooser');
+
+		await exportImportFrame
+			.getByRole('button', {name: 'Select File'})
+			.click();
+
+		const fileChooser = await fileChooserPromise;
+
+		await fileChooser.setFiles(await zipFolder(folderPath));
+
+		await exportImportFrame.getByRole('button', {name: 'Continue'}).click();
+		await exportImportFrame.getByRole('button', {name: 'Import'}).click();
+	}
+
+	async close() {
+		await this.page.getByLabel('close', {exact: true}).click();
+	}
+}

--- a/modules/test/playwright/pages/export-import-web/exportImportFrame.page.ts
+++ b/modules/test/playwright/pages/export-import-web/exportImportFrame.page.ts
@@ -5,7 +5,7 @@
 
 // @ts-ignore
 
-import {Page} from '@playwright/test';
+import {expect, Page} from '@playwright/test';
 
 import {zipFolder} from '../../utils/util';
 
@@ -17,11 +17,12 @@ export class ExportImportFramePage {
 	}
 
 	async importLARFile(folderPath: string) {
+		await this.page.frame({url: /.*localhost.*/}).waitForLoadState();
+
 		const exportImportFrame = this.page.frameLocator(
 			'iframe[title="Export \\/ Import"]'
 		);
 
-		await this.page.waitForLoadState('networkidle');
 		await exportImportFrame.getByRole('link', {name: 'Import'}).click();
 
 		const fileChooserPromise = this.page.waitForEvent('filechooser');
@@ -36,6 +37,12 @@ export class ExportImportFramePage {
 
 		await exportImportFrame.getByRole('button', {name: 'Continue'}).click();
 		await exportImportFrame.getByRole('button', {name: 'Import'}).click();
+		await expect(
+			exportImportFrame
+				.getByTestId('row')
+				.nth(0)
+				.locator('.background-task-status-successful')
+		).toBeVisible();
 	}
 
 	async close() {

--- a/modules/test/playwright/playwright.config.ts
+++ b/modules/test/playwright/playwright.config.ts
@@ -5,6 +5,7 @@
 
 import {defineConfig} from '@playwright/test';
 
+import {config as exportImportWeb} from './tests/export-import-web/config';
 import {config as setup} from './tests/global.setup.config';
 import {config as object} from './tests/object-web/config';
 import {config as portalWeb} from './tests/portal-web/config';
@@ -12,7 +13,7 @@ import {config as usersAdminWeb} from './tests/users-admin-web/config';
 
 export default defineConfig({
 	forbidOnly: !!process.env.CI,
-	projects: [object, portalWeb, setup, usersAdminWeb],
+	projects: [exportImportWeb, object, portalWeb, setup, usersAdminWeb],
 	reporter: [
 		[
 			'html',

--- a/modules/test/playwright/tests/export-import-web/config.ts
+++ b/modules/test/playwright/tests/export-import-web/config.ts
@@ -1,0 +1,19 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+// @ts-ignore
+
+import {devices} from '@playwright/test';
+
+export const config = {
+	dependencies: ['setup'],
+	name: 'export-import-web',
+	testDir: 'tests/export-import-web',
+	use: {
+		...devices['Desktop Chrome'],
+		storageState: 'tmp/.auth/user.json',
+		testIdAttribute: 'data-qa-id',
+	},
+};

--- a/modules/test/playwright/tests/export-import-web/dependencies/folder.portlet.lar/group/20117/com.liferay.document.library.kernel.model.DLFolder/34060.xml
+++ b/modules/test/playwright/tests/export-import-web/dependencies/folder.portlet.lar/group/20117/com.liferay.document.library.kernel.model.DLFolder/34060.xml
@@ -5,7 +5,7 @@
     <__mvccVersion>1</__mvccVersion>
     <__ctCollectionId>0</__ctCollectionId>
     <__uuid>47fbd8b1-375d-6ce7-3978-86b01f91fcf2</__uuid>
-    <__externalReferenceCode>47fbd8b1-375d-6ce7-3978-86b01f91fcf2</__externalReferenceCode>
+    <__externalReferenceCode>LPS-205933</__externalReferenceCode>
     <__folderId>34060</__folderId>
     <__groupId>20117</__groupId>
     <__companyId>232203238598875178</__companyId>

--- a/modules/test/playwright/tests/export-import-web/dependencies/folder.portlet.lar/group/20117/com.liferay.document.library.kernel.model.DLFolder/34060.xml
+++ b/modules/test/playwright/tests/export-import-web/dependencies/folder.portlet.lar/group/20117/com.liferay.document.library.kernel.model.DLFolder/34060.xml
@@ -1,0 +1,33 @@
+<com.liferay.portal.repository.liferayrepository.model.LiferayFolder>
+  <__dlFolder class="DLFolder">
+    <__cachedModel>true</__cachedModel>
+    <__new>false</__new>
+    <__mvccVersion>1</__mvccVersion>
+    <__ctCollectionId>0</__ctCollectionId>
+    <__uuid>47fbd8b1-375d-6ce7-3978-86b01f91fcf2</__uuid>
+    <__externalReferenceCode>47fbd8b1-375d-6ce7-3978-86b01f91fcf2</__externalReferenceCode>
+    <__folderId>34060</__folderId>
+    <__groupId>20117</__groupId>
+    <__companyId>232203238598875178</__companyId>
+    <__userId>20122</__userId>
+    <__userName>Test Test</__userName>
+    <__createDate>2024-01-15 10:49:16.749 UTC</__createDate>
+    <__modifiedDate>2024-01-15 10:49:41.840 UTC</__modifiedDate>
+    <__setModifiedDate>false</__setModifiedDate>
+    <__repositoryId>20117</__repositoryId>
+    <__mountPoint>false</__mountPoint>
+    <__parentFolderId>0</__parentFolderId>
+    <__treePath>/34060/</__treePath>
+    <__name>LPS-205933</__name>
+    <__description></__description>
+    <__lastPostDate>2024-01-15 10:49:16.748 UTC</__lastPostDate>
+    <__defaultFileEntryTypeId>0</__defaultFileEntryTypeId>
+    <__hidden>false</__hidden>
+    <__restrictionType>1</__restrictionType>
+    <__status>0</__status>
+    <__statusByUserId>0</__statusByUserId>
+    <__statusByUserName></__statusByUserName>
+    <__columnBitmask>0</__columnBitmask>
+  </__dlFolder>
+  <__escapedModel>false</__escapedModel>
+</com.liferay.portal.repository.liferayrepository.model.LiferayFolder>

--- a/modules/test/playwright/tests/export-import-web/dependencies/folder.portlet.lar/group/20117/deletion-system-events.xml
+++ b/modules/test/playwright/tests/export-import-web/dependencies/folder.portlet.lar/group/20117/deletion-system-events.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0"?>
+
+<deletion-system-events/>

--- a/modules/test/playwright/tests/export-import-web/dependencies/folder.portlet.lar/group/20117/links.xml
+++ b/modules/test/playwright/tests/export-import-web/dependencies/folder.portlet.lar/group/20117/links.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0"?>
+
+<links/>

--- a/modules/test/playwright/tests/export-import-web/dependencies/folder.portlet.lar/group/20117/locks.xml
+++ b/modules/test/playwright/tests/export-import-web/dependencies/folder.portlet.lar/group/20117/locks.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0"?>
+
+<locks/>

--- a/modules/test/playwright/tests/export-import-web/dependencies/folder.portlet.lar/group/20117/portlet/com_liferay_document_library_web_portlet_DLAdminPortlet/1/portlet.xml
+++ b/modules/test/playwright/tests/export-import-web/dependencies/folder.portlet.lar/group/20117/portlet/com_liferay_document_library_web_portlet_DLAdminPortlet/1/portlet.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+
+<portlet portlet-id="com_liferay_document_library_web_portlet_DLAdminPortlet" root-portlet-id="com_liferay_document_library_web_portlet_DLAdminPortlet" scope-group-id="20117" scope-layout-type="" scope-layout-uuid="" private-layout="false" self-path="/group/20117/portlet/com_liferay_document_library_web_portlet_DLAdminPortlet/1/portlet.xml">
+	<portlet-data path="/group/20117/portlet/com_liferay_document_library_web_portlet_DLAdminPortlet/20117/portlet-data.xml"/>
+	<portlet-preferences path="/group/20117/portlet/com_liferay_document_library_web_portlet_DLAdminPortlet/preferences/group/20117/0/portlet-preferences.xml">
+		<preference-data/>
+	</portlet-preferences>
+</portlet>

--- a/modules/test/playwright/tests/export-import-web/dependencies/folder.portlet.lar/group/20117/portlet/com_liferay_document_library_web_portlet_DLAdminPortlet/20117/portlet-data.xml
+++ b/modules/test/playwright/tests/export-import-web/dependencies/folder.portlet.lar/group/20117/portlet/com_liferay_document_library_web_portlet_DLAdminPortlet/20117/portlet-data.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+
+<DLAdminPortletDataHandler self-path="/group/20117/portlet/com_liferay_document_library_web_portlet_DLAdminPortlet/20117/portlet-data.xml" group-id="20117">
+	<DLFolder>
+		<staged-model group-id="20117" uuid="47fbd8b1-375d-6ce7-3978-86b01f91fcf2" basic-document="true" defaultFileEntryTypeUuid="" path="/group/20117/com.liferay.document.library.kernel.model.DLFolder/34060.xml" user-uuid="4679b121-0e91-3b7e-182f-31ddcab4125b" asset-entry-priority="0.0"/>
+	</DLFolder>
+	<StagedGroupedWorkflowDefinitionLink>
+		<staged-model group-id="20117" uuid="34063" display-name="Single Approver" referrer-class-pk="34060" referrer-class-name="com.liferay.document.library.kernel.model.DLFolder" type-pk="0" version="1"/>
+	</StagedGroupedWorkflowDefinitionLink>
+</DLAdminPortletDataHandler>

--- a/modules/test/playwright/tests/export-import-web/dependencies/folder.portlet.lar/group/20117/portlet/com_liferay_document_library_web_portlet_DLAdminPortlet/preferences/group/20117/0/portlet-preferences.xml
+++ b/modules/test/playwright/tests/export-import-web/dependencies/folder.portlet.lar/group/20117/portlet/com_liferay_document_library_web_portlet_DLAdminPortlet/preferences/group/20117/0/portlet-preferences.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0"?>
+
+<portlet-preferences owner-id="20117" owner-type="2" default-user="false" plid="0" portlet-id="com_liferay_document_library_web_portlet_DLAdminPortlet"/>

--- a/modules/test/playwright/tests/export-import-web/dependencies/folder.portlet.lar/manifest.xml
+++ b/modules/test/playwright/tests/export-import-web/dependencies/folder.portlet.lar/manifest.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+
+<root>
+	<header available-locales="en_US,ar_SA,ca_ES,zh_CN,nl_NL,fi_FI,fr_FR,de_DE,hu_HU,ja_JP,pt_BR,es_ES,sv_SE" build-number="7403" export-date="Mon, 15 Jan 2024 10:49:49 +0000" type="portlet" company-id="232203238598875178" company-group-id="20119" group-id="20117" user-personal-site-group-id="20118" private-layout="true" root-portlet-id="com_liferay_document_library_web_portlet_DLAdminPortlet" schema-version="4.0.0"/>
+	<missing-references/>
+	<portlet portlet-id="com_liferay_document_library_web_portlet_DLAdminPortlet" layout-id="1" path="/group/20117/portlet/com_liferay_document_library_web_portlet_DLAdminPortlet/1/portlet.xml" portlet-data="true" schema-version="4.0.0" portlet-configuration="setup,user-preferences"/>
+	<manifest-summary>
+		<staged-model manifest-summary-key="com.liferay.document.library.kernel.model.DLFileEntryType"/>
+		<staged-model manifest-summary-key="com.liferay.document.library.kernel.model.DLFileEntry"/>
+		<staged-model manifest-summary-key="com.liferay.portal.kernel.model.Repository#referrer-class-name-all"/>
+		<staged-model manifest-summary-key="com.liferay.document.library.kernel.model.DLFileShortcut"/>
+		<staged-model manifest-summary-key="com.liferay.portal.kernel.model.adapter.StagedGroupedWorkflowDefinitionLink" addition-count="1"/>
+		<staged-model manifest-summary-key="com.liferay.document.library.kernel.model.DLFolder" addition-count="1"/>
+	</manifest-summary>
+</root>

--- a/modules/test/playwright/tests/export-import-web/import.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/import.spec.ts
@@ -8,12 +8,18 @@
 import {expect, mergeTests} from '@playwright/test';
 import * as path from 'path';
 
+import {apiHelpersTest} from '../../fixtures/apiHelpers.fixture';
 import {documentLibraryPagesTest} from '../../fixtures/documentLibraryPages.fixtures';
 import {exportImportPagesTest} from '../../fixtures/exportImportPages.fixtures';
 
-export const test = mergeTests(documentLibraryPagesTest, exportImportPagesTest);
+export const test = mergeTests(
+	apiHelpersTest,
+	documentLibraryPagesTest,
+	exportImportPagesTest
+);
 
 test('can import a folder with document type restrictions and workflow', async ({
+	_apiHelpers,
 	_documentLibraryEditFolderPage,
 	_documentLibraryPage,
 	_exportImportFramePage,
@@ -30,4 +36,8 @@ test('can import a folder with document type restrictions and workflow', async (
 	expect(
 		await _documentLibraryEditFolderPage.getSelectedWorkflowDefinition()
 	).toBe('Single Approver@1');
+
+	await _apiHelpers.headlessDelivery.deleteSiteDocumentsFolderByExternalReferenceCode(
+		'LPS-205933'
+	);
 });

--- a/modules/test/playwright/tests/export-import-web/import.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/import.spec.ts
@@ -5,60 +5,29 @@
 
 // @ts-ignore
 
-import {expect, test} from '@playwright/test';
+import {expect, mergeTests} from '@playwright/test';
 import * as path from 'path';
 
-import {zipFolder} from '../../utils/util';
+import {documentLibraryPagesTest} from '../../fixtures/documentLibraryPages.fixtures';
+import {exportImportPagesTest} from '../../fixtures/exportImportPages.fixtures';
+
+export const test = mergeTests(documentLibraryPagesTest, exportImportPagesTest);
 
 test('can import a folder with document type restrictions and workflow', async ({
-	page,
+	_documentLibraryEditFolderPage,
+	_documentLibraryPage,
+	_exportImportFramePage,
 }) => {
-	await page.goto('/');
-	const openProductMenu = page.getByLabel('Open Product Menu');
-	if (await openProductMenu.isVisible()) {
-		await openProductMenu.click();
-	}
-	await page.getByRole('menuitem', {name: 'Content & Data'}).click();
-	await page.getByRole('menuitem', {name: 'Documents and Media'}).click();
-	await page.getByTestId('headerOptions').getByLabel('Options').click();
-	await page.getByRole('menuitem', {name: 'Export / Import'}).click();
-
-	const exportImportFrame = page.frameLocator(
-		'iframe[title="Export \\/ Import"]'
+	await _documentLibraryPage.goto();
+	await _documentLibraryPage.openOptionsMenu();
+	await _documentLibraryPage.exportImportOptionsMenuItem.click();
+	await _exportImportFramePage.importLARFile(
+		path.join(__dirname, '/dependencies/folder.portlet.lar')
 	);
-
-	await exportImportFrame.getByRole('link', {name: 'Import'}).click();
-
-	const fileChooserPromise = page.waitForEvent('filechooser');
-
-	await exportImportFrame.getByRole('button', {name: 'Select File'}).click();
-
-	const fileChooser = await fileChooserPromise;
-
-	await fileChooser.setFiles(
-		await zipFolder(
-			path.join(__dirname, '/dependencies/folder.portlet.lar')
-		)
-	);
-
-	await exportImportFrame.getByRole('button', {name: 'Continue'}).click();
-	await exportImportFrame.getByRole('button', {name: 'Import'}).click();
-
-	await page.getByLabel('close', {exact: true}).click();
-	await page
-		.locator(
-			'[id="_com_liferay_document_library_web_portlet_DLAdminPortlet_entries_1"]'
-		)
-		.getByLabel('More actions')
-		.click();
-	await page.getByRole('menuitem', {name: 'Edit'}).click();
+	await _exportImportFramePage.close();
+	await _documentLibraryPage.editEntry('LPS-205933');
 
 	expect(
-		await page
-			.getByTitle('Workflow Definition')
-			.evaluate(
-				(select: HTMLSelectElement) =>
-					select.options[select.selectedIndex].value
-			)
+		await _documentLibraryEditFolderPage.getSelectedWorkflowDefinition()
 	).toBe('Single Approver@1');
 });

--- a/modules/test/playwright/tests/export-import-web/import.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/import.spec.ts
@@ -22,7 +22,7 @@ test('can import a folder with document type restrictions and workflow', async (
 	await _documentLibraryPage.openOptionsMenu();
 	await _documentLibraryPage.exportImportOptionsMenuItem.click();
 	await _exportImportFramePage.importLARFile(
-		path.join(__dirname, '/dependencies/folder.portlet.lar')
+		path.join(__dirname, 'dependencies', 'folder.portlet.lar')
 	);
 	await _exportImportFramePage.close();
 	await _documentLibraryPage.editEntry('LPS-205933');

--- a/modules/test/playwright/tests/export-import-web/import.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/import.spec.ts
@@ -1,0 +1,64 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+// @ts-ignore
+
+import {expect, test} from '@playwright/test';
+import * as path from 'path';
+
+import {zipFolder} from '../../utils/util';
+
+test('can import a folder with document type restrictions and workflow', async ({
+	page,
+}) => {
+	await page.goto('/');
+	const openProductMenu = page.getByLabel('Open Product Menu');
+	if (await openProductMenu.isVisible()) {
+		await openProductMenu.click();
+	}
+	await page.getByRole('menuitem', {name: 'Content & Data'}).click();
+	await page.getByRole('menuitem', {name: 'Documents and Media'}).click();
+	await page.getByTestId('headerOptions').getByLabel('Options').click();
+	await page.getByRole('menuitem', {name: 'Export / Import'}).click();
+
+	const exportImportFrame = page.frameLocator(
+		'iframe[title="Export \\/ Import"]'
+	);
+
+	await exportImportFrame.getByRole('link', {name: 'Import'}).click();
+
+	const fileChooserPromise = page.waitForEvent('filechooser');
+
+	await exportImportFrame.getByRole('button', {name: 'Select File'}).click();
+
+	const fileChooser = await fileChooserPromise;
+
+	await fileChooser.setFiles(
+		await zipFolder(
+			path.join(__dirname, '/dependencies/folder.portlet.lar')
+		)
+	);
+
+	await exportImportFrame.getByRole('button', {name: 'Continue'}).click();
+	await exportImportFrame.getByRole('button', {name: 'Import'}).click();
+
+	await page.getByLabel('close', {exact: true}).click();
+	await page
+		.locator(
+			'[id="_com_liferay_document_library_web_portlet_DLAdminPortlet_entries_1"]'
+		)
+		.getByLabel('More actions')
+		.click();
+	await page.getByRole('menuitem', {name: 'Edit'}).click();
+
+	expect(
+		await page
+			.getByTitle('Workflow Definition')
+			.evaluate(
+				(select: HTMLSelectElement) =>
+					select.options[select.selectedIndex].value
+			)
+	).toBe('Single Approver@1');
+});

--- a/modules/test/playwright/utils/util.ts
+++ b/modules/test/playwright/utils/util.ts
@@ -3,6 +3,17 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import * as os from 'node:os'; // eslint-disable-line @liferay/no-extraneous-dependencies
+import * as path from 'path';
+import {zip} from 'zip-a-folder';
+
 export function getRandomInt(): number {
 	return Math.floor(Math.random() * 9999999999);
+}
+
+export async function zipFolder(folderPath: string) {
+	const tempFilePath = path.join(os.tmpdir(), path.basename(folderPath));
+	await zip(folderPath, tempFilePath);
+
+	return tempFilePath;
 }


### PR DESCRIPTION
From https://github.com/liferay-headless/liferay-portal/pull/1812:

Steps to reproduce in https://liferay.atlassian.net/browse/LPS-205933

In this case the problem seems related with the current use of the method parameters in the export-import API:

In com.liferay.document.library.internal.exportimport.data.handler.FolderStagedModelDataHandler#doImportStagedModel we are doing this:

```
portletDataContext.importClassedModel(
			folder, importedFolder, DLFolder.class);
```

The third parameter in other cases (importLocks or importPermissions) is been used to set the right class name, but in the case of _importWorkflowDefinitionLink it is been extracted from the classed model.

I've changed this and use this className as when sent, and it fixes the issue.