### PR TITLE
LPS-206642 Apply sample CET to client extension description

### DIFF
--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-editor-config-contributor/client-extension.yaml
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-editor-config-contributor/client-extension.yaml
@@ -5,6 +5,7 @@ liferay-sample-editor-config-contributor:
     editorConfigKeys:
         - sampleClassicEditor
         - sampleLegacyEditor
+        - description
     name: Liferay Sample Editor Config Contributor
     type: editorConfigContributor
     url: index.js

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-editor-config-contributor/src/index.ts
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-editor-config-contributor/src/index.ts
@@ -9,14 +9,35 @@ import {
 } from '@liferay/js-api/editor';
 
 const editorConfigTransformer: EditorConfigTransformer<any> = (config) => {
-	const toolbar: [string[]] = config.toolbar_liferay;
+	const toolbar: string | [string[]] = config.toolbar;
 
-	toolbar.push(['ImageSelector']);
+	const buttonName = 'AICreator';
+	let transformedConfig: any;
+
+	if (typeof toolbar === 'string') {
+		const activeToolbar = config[`toolbar_${toolbar}`];
+
+		activeToolbar.push([buttonName]);
+
+		transformedConfig = {
+			...config,
+			[`toolbar_${toolbar}`]: activeToolbar,
+		};
+	}
+	else {
+		toolbar.push([buttonName]);
+
+		transformedConfig = {
+			...config,
+			toolbar,
+		};
+	}
+
+	const extraPlugins: string = config.extraPlugins;
 
 	return {
-		...config,
-		extraPlugins: 'itemselector',
-		toolbar_liferay: toolbar,
+		...transformedConfig,
+		extraPlugins: extraPlugins ? `${extraPlugins},aicreator` : 'aicreator',
 	};
 };
 


### PR DESCRIPTION
Manual forward. There are no unique failures, based on https://github.com/liferay-frontend/liferay-portal/pull/3945#issuecomment-1903641897

--- 

### References

- Parent story: [LPS-187309 Apply editor config contributor client extensions to CKEditor](https://issues.liferay.com/browse/LPS-187309)

### What is the goal of this PR?

After this change, we can more easily write playwright tests for applying editor CET, as the target editor is on our module (client-extension-web). Test themselves need to wait https://github.com/brianchandotcom/liferay-portal/pull/146409 is merged.

As the scope of this PR is just the workspace sample, it is super safe, I won't delay much forwarding it. FYI @dsanz @izaera 

Sidenote, I changed from image selector to AI Creator because
1. Image selector already exists.
2. AI needs to be in everything nowadays.

### What does it look like?

![image](https://github.com/liferay-frontend/liferay-portal/assets/5435511/a715aed8-2590-43fe-a590-952dbed7efed)

