### PR TITLE
Lpd 15305

### DIFF
--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/connection/ElasticsearchInstanceSettingsBuilder.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/connection/ElasticsearchInstanceSettingsBuilder.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.search.elasticsearch7.internal.connection;
 
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.JavaDetector;
 import com.liferay.portal.kernel.util.PortalRunMode;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.search.elasticsearch7.internal.configuration.ElasticsearchConfigurationWrapper;
@@ -273,6 +274,10 @@ public class ElasticsearchInstanceSettingsBuilder {
 		_configurePaths();
 
 		_configureTestMode();
+
+		if (JavaDetector.isJDK21()) {
+			put("thread_pool.warmer.max", "20");
+		}
 
 		_disableGeoipDownloader();
 

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/sidecar/Sidecar.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/sidecar/Sidecar.java
@@ -18,6 +18,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.JavaDetector;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -369,6 +370,10 @@ public class Sidecar {
 		arguments.add("-Dio.netty.recycler.maxCapacityPerThread=0");
 		arguments.add("-Dfile.encoding=UTF-8");
 		arguments.add("-Djava.io.tmpdir=" + _sidecarTempDirPath);
+
+		if (JavaDetector.isJDK21()) {
+			arguments.add("-Djava.security.manager=allow");
+		}
 
 		arguments.add(
 			"-Djava.security.policy=" +


### PR DESCRIPTION
@brianchandotcom after this pull, we are able to boot up cleanly and do basically stuff on JDK21 without any special settings(no need of remote es8 anymore). In case you want to try it, make sure you regenerate your tomcat bundle to refresh your setenv.sh (or just manually copy the new content from https://github.com/liferay/liferay-portal/blob/master/tools/servers/tomcat/bin/setenv.sh#L3)

We are trying to push this to run max runtime regression checking on CI now. Hopefully we get to know the full list of issues in next 1~2 days.