### PR TITLE
LPD-15519 java.time.Clock's resolution has been improved from millise…

### DIFF
--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -138,6 +138,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -906,7 +907,10 @@ public class DefaultObjectEntryManagerImplTest
 
 		// Date time
 
-		LocalDateTime localDateTime = LocalDateTime.now();
+		LocalDateTime nowLocalDateTime = LocalDateTime.now();
+
+		LocalDateTime localDateTime = nowLocalDateTime.truncatedTo(
+			ChronoUnit.MILLIS);
 
 		assertEquals(
 			_defaultObjectEntryManager.addObjectEntry(


### PR DESCRIPTION
…cond to nanosecond, time truncated must be done to avoid parsing failure