### PR TITLE
LPD-15633 Mute the annoying "Found corrupt leading log [0.002s][warni…

### DIFF
--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/sidecar/Sidecar.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/sidecar/Sidecar.java
@@ -374,6 +374,8 @@ public class Sidecar {
 		arguments.add("-Djava.io.tmpdir=" + _sidecarTempDirPath);
 
 		if (JavaDetector.isJDK21()) {
+			arguments.add("-XX:-UseContainerSupport");
+
 			arguments.add("-Djava.security.manager=allow");
 		}
 


### PR DESCRIPTION
…ng][os.container] Duplicate cpuset controllers detected. Picking /sys/fs/cgroup/cpuset. skipping /sys/fs/cgroup/cpuset." from sidecar