### PR TITLE
LPD-15817 DBPartitionUtil submits companies into a threadpool one by …

### DIFF
--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionUtilTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionUtilTest.java
@@ -220,7 +220,6 @@ public class DBPartitionUtilTest extends BaseDBPartitionTestCase {
 			insertPartitionRequiredData();
 
 			Set<Long> companyIds = new ConcurrentSkipListSet<>();
-			Set<Long> threadIds = new ConcurrentSkipListSet<>();
 
 			CompanyThreadLocal.setCompanyId(CompanyConstants.SYSTEM);
 
@@ -232,14 +231,9 @@ public class DBPartitionUtilTest extends BaseDBPartitionTestCase {
 					Assert.assertTrue(CompanyThreadLocal.isLocked());
 
 					companyIds.add(companyId);
-
-					Thread thread = Thread.currentThread();
-
-					threadIds.add(thread.getId());
 				});
 
 			Assert.assertEquals(companyIds.toString(), 3, companyIds.size());
-			Assert.assertEquals(threadIds.toString(), 3, threadIds.size());
 		}
 		finally {
 			deletePartitionRequiredData();


### PR DESCRIPTION
…one to execute. In case a company finsihes very quickly, the following company may get dispatch to the same thread. This thread id count assertion is logically broken.