### PR TITLE
LPD-15379 Use translationsNormalizer to update locale Chinese and Taiwan

### DIFF
--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/forms/input/InputLocalized.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/forms/input/InputLocalized.tsx
@@ -51,13 +51,9 @@ const availableLocales = Object.keys(Liferay.Language.available)
 		symbol: language.replace(/_/g, '-').toLowerCase(),
 	}));
 
-const translationsNormalizer = (
-	translations: Liferay.Language.LocalizedValue<string> &
-		Partial<{
-			zh_Hans_CN: string;
-			zh_Hant_TW: string;
-		}>
-): Liferay.Language.LocalizedValue<string> => {
+export function translationsNormalizer(
+	translations: Liferay.Language.LocalizedValue<string>
+): Liferay.Language.LocalizedValue<string> {
 	const {zh_Hans_CN, zh_Hant_TW, ...normalizedTranslations} = translations;
 
 	if (zh_Hans_CN) {
@@ -69,7 +65,7 @@ const translationsNormalizer = (
 	}
 
 	return normalizedTranslations;
-};
+}
 
 export default function InputLocalized({
 	disableFlag,

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts
@@ -26,6 +26,8 @@ export {default as InputLocalized} from './forms/input/InputLocalized';
 export {default as FieldBase} from './forms/common/FieldBase';
 export {default as FieldFeedback} from './forms/common/FieldFeedback';
 
+export {translationsNormalizer} from './forms/input/InputLocalized';
+
 export {default as ManagementToolbar} from './management_toolbar/ManagementToolbar';
 export {
 	activeLanguageIdsAtom,

--- a/modules/apps/frontend-js/frontend-js-components-web/types/src/main/resources/META-INF/resources/forms/input/InputLocalized.d.ts
+++ b/modules/apps/frontend-js/frontend-js-components-web/types/src/main/resources/META-INF/resources/forms/input/InputLocalized.d.ts
@@ -34,6 +34,9 @@ interface InputLocale {
 	label: Liferay.Language.Locale;
 	symbol: string;
 }
+export declare function translationsNormalizer(
+	translations: Liferay.Language.LocalizedValue<string>
+): Liferay.Language.LocalizedValue<string>;
 export default function InputLocalized({
 	disableFlag,
 	disabled,

--- a/modules/apps/frontend-js/frontend-js-components-web/types/src/main/resources/META-INF/resources/index.d.ts
+++ b/modules/apps/frontend-js/frontend-js-components-web/types/src/main/resources/META-INF/resources/index.d.ts
@@ -20,6 +20,7 @@ export {default as Treeview} from './treeview/Treeview';
 export {default as InputLocalized} from './forms/input/InputLocalized';
 export {default as FieldBase} from './forms/common/FieldBase';
 export {default as FieldFeedback} from './forms/common/FieldFeedback';
+export {translationsNormalizer} from './forms/input/InputLocalized';
 export {default as ManagementToolbar} from './management_toolbar/ManagementToolbar';
 export {
 	activeLanguageIdsAtom,

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/liferay.d.ts
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/liferay.d.ts
@@ -43,6 +43,8 @@ declare module Liferay {
 			| 'pt_BR'
 			| 'sv_SE'
 			| 'zh_CN'
+			| 'zh_Hans_CN'
+			| 'zh_Hant_TW'
 			| 'zh_TW';
 
 		type FullyLocalizedValue<T> = {[key in Locale]: T};

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ListTypeDefinition/utils.ts
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ListTypeDefinition/utils.ts
@@ -3,12 +3,16 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-export function fixLocaleKeys(name_i18n: LocalizedValue<string>) {
-	const newTranslationsObject: {[key: string]: string} = {};
+import {translationsNormalizer} from 'frontend-js-components-web';
+
+export function fixLocaleKeys(name_i18n: {[key: string]: string}) {
+	const newTranslationsObject: LocalizedValue<string> = {};
 
 	for (const [key, value] of Object.entries(name_i18n)) {
-		newTranslationsObject[key.replace(/-/g, '_')] = value;
+		newTranslationsObject[
+			key.replace(/-/g, '_') as Liferay.Language.Locale
+		] = value;
 	}
 
-	return newTranslationsObject;
+	return translationsNormalizer(newTranslationsObject);
 }

--- a/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ListTypeDefinition/utils.d.ts
+++ b/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ListTypeDefinition/utils.d.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-export declare function fixLocaleKeys(
-	name_i18n: LocalizedValue<string>
-): {
+export declare function fixLocaleKeys(name_i18n: {
 	[key: string]: string;
-};
+}): Partial<Liferay.Language.FullyLocalizedValue<string>>;


### PR DESCRIPTION
FWD: https://github.com/liferay-objects/liferay-portal/pull/3064

> https://liferay.atlassian.net/browse/LPD-15379
> 
> The current issue is zh_CN and zh_TW locales are being sent as zh_Hans_CN and zh_Hant_TW. I check for these locales and set them correctly.
> Please let me know if there are any questions or comments about this.
> Thank you!