### PR TITLE
LPD-16396 Add opens to make sidecar work with unit test. This is only…

### DIFF
--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/connection/ElasticsearchConnectionFixture.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/connection/ElasticsearchConnectionFixture.java
@@ -178,7 +178,8 @@ public class ElasticsearchConnectionFixture
 			).put(
 				"sidecarHttpPort", HttpPortRange.AUTO
 			).put(
-				"sidecarJVMOptions", "-Xmx256m"
+				"sidecarJVMOptions",
+				"-Xmx256m|--add-opens=java.base/java.lang=ALL-UNNAMED"
 			).putAll(
 				elasticsearchConfigurationProperties
 			).build();


### PR DESCRIPTION
… needed in unit test because gradle added "--add-opens" settings to its jvm arguments rather than setting env "JDK_JAVA_OPTIONS", while sidecar starting logic only respects parent JVM's env setting, not arguments.