### PR TITLE
LPD-16091 Remove message assertion since JDK 21 shows a different mes…

### DIFF
--- a/modules/apps/portal/portal-log4j/src/test/java/com/liferay/portal/log4j/internal/Log4jConfigUtilTest.java
+++ b/modules/apps/portal/portal-log4j/src/test/java/com/liferay/portal/log4j/internal/Log4jConfigUtilTest.java
@@ -195,8 +195,6 @@ public class Log4jConfigUtilTest {
 
 			LogEntry logEntry = logEntries.get(0);
 
-			Assert.assertNull(logEntry.getMessage());
-
 			Throwable throwable = logEntry.getThrowable();
 
 			Assert.assertSame(NullPointerException.class, throwable.getClass());


### PR DESCRIPTION
…sage due to the Helpful NullPointerExceptions feature, which details the cause of the exception (in this case, the message does not show "null", it shows "Cannot invoke "String.length()" because "string" is "null""). Furthermore, this assertion is not necessary because in the line 200 of the Log4jConfigUtilTest class, the test validates that the error is a NullPointer, which is the main problem that the test is looking for.