### PR TITLE
LPD-17121 Use ConcurrentHashMap instead of HashMap for BasePermission…

### DIFF
--- a/portal-impl/src/com/liferay/portal/security/permission/BasePermissionChecker.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/BasePermissionChecker.java
@@ -18,8 +18,8 @@ import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.util.PropsValues;
 import com.liferay.portlet.admin.util.OmniadminUtil;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * @author Brian Wing Shun Chan
@@ -155,6 +155,7 @@ public abstract class BasePermissionChecker implements PermissionChecker {
 	private static final Log _log = LogFactoryUtil.getLog(
 		BasePermissionChecker.class);
 
-	private final Map<Object, Object> _permissionChecksMap = new HashMap<>();
+	private final Map<Object, Object> _permissionChecksMap =
+		new ConcurrentHashMap<>();
 
 }


### PR DESCRIPTION
…Checker#_permissionChecksMap. In some processes such as ExportPortlet and ImportPortlet processing Lar files, background tasks attempt to modify the permissionChecksMap from different threads resulting in ConcurrentModificationException. We never saw this exception in jdk8 because HashMap from newer jdk adds additional checks to throw ConcurrentModificationException when being used by multiple threads.