### PR TITLE
LPD-17388 Fix NewEnv test Rule behavior after using the ClassLoader#getSystemClassLoader as parent classLoader

### DIFF
--- a/portal-test/src/com/liferay/portal/kernel/test/rule/NewEnvTestRule.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/NewEnvTestRule.java
@@ -194,9 +194,11 @@ public class NewEnvTestRule implements TestRule {
 
 	protected ClassLoader createClassLoader(Description description) {
 		try {
+			ClassLoader systemClassLoader = ClassLoader.getSystemClassLoader();
+
 			return new URLClassLoader(
 				ClassPathUtil.getClassPathURLs(CLASS_PATH),
-				ClassLoader.getSystemClassLoader());
+				systemClassLoader.getParent());
 		}
 		catch (MalformedURLException malformedURLException) {
 			throw new RuntimeException(malformedURLException);


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPD-17388

/cc @tinatian