### PR TITLE
LPD-17763 Reverting LPD-1721 commits that cause home page to fail on different locale

### DIFF
--- a/portal-kernel/bnd.bnd
+++ b/portal-kernel/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 134.0.1
+Bundle-Version: 135.0.0
 Export-Package:\
 	!com.liferay.portal.kernel.internal.*,\
 	!com.liferay.portal.kernel.module.util,\

--- a/portal-kernel/src/com/liferay/portal/kernel/security/auth/CompanyThreadLocal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/auth/CompanyThreadLocal.java
@@ -221,12 +221,14 @@ public class CompanyThreadLocal {
 
 		if (companyId > 0) {
 			_companyId.set(companyId);
+
+			_clearUserThreadLocals();
 		}
 		else {
 			_companyId.set(CompanyConstants.SYSTEM);
-		}
 
-		_clearUserThreadLocals();
+			_clearUserThreadLocals();
+		}
 
 		return true;
 	}

--- a/portal-kernel/src/com/liferay/portal/kernel/security/auth/CompanyThreadLocal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/auth/CompanyThreadLocal.java
@@ -171,17 +171,18 @@ public class CompanyThreadLocal {
 
 		SafeCloseable localeSafeCloseable =
 			LocaleThreadLocal.setWithSafeCloseable(null);
+
 		SafeCloseable timeZoneSafeCloseable =
 			TimeZoneThreadLocal.setWithSafeCloseable(null);
 
-		boolean modified = _setCompanyId(companyId, false);
+		boolean changed = _setCompanyId(companyId, false);
 
 		SafeCloseable ctCollectionSafeCloseable =
 			CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
 				ctCollectionId);
 
 		return () -> {
-			if (modified) {
+			if (changed) {
 				_syncLastDBPartitionSessionState();
 			}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/security/auth/CompanyThreadLocal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/auth/CompanyThreadLocal.java
@@ -169,15 +169,16 @@ public class CompanyThreadLocal {
 
 		long currentCompanyId = _companyId.get();
 
+		SafeCloseable localeSafeCloseable =
+			LocaleThreadLocal.setWithSafeCloseable(null);
+		SafeCloseable timeZoneSafeCloseable =
+			TimeZoneThreadLocal.setWithSafeCloseable(null);
+
 		boolean modified = _setCompanyId(companyId, false);
 
 		SafeCloseable ctCollectionSafeCloseable =
 			CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
 				ctCollectionId);
-		SafeCloseable localeSafeCloseable =
-			LocaleThreadLocal.setWithSafeCloseable(null);
-		SafeCloseable timeZoneSafeCloseable =
-			TimeZoneThreadLocal.setWithSafeCloseable(null);
 
 		return () -> {
 			if (modified) {

--- a/portal-kernel/src/com/liferay/portal/kernel/security/auth/CompanyThreadLocal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/auth/CompanyThreadLocal.java
@@ -137,7 +137,7 @@ public class CompanyThreadLocal {
 	}
 
 	public static void setCompanyId(Long companyId) {
-		if (_setCompanyId(companyId, true)) {
+		if (_setCompanyId(companyId)) {
 			CTCollectionThreadLocal.removeCTCollectionId();
 		}
 	}
@@ -169,13 +169,7 @@ public class CompanyThreadLocal {
 
 		long currentCompanyId = _companyId.get();
 
-		SafeCloseable localeSafeCloseable =
-			LocaleThreadLocal.clearDefaultLocaleWithSafeCloseable();
-
-		SafeCloseable timeZoneSafeCloseable =
-			TimeZoneThreadLocal.clearDefaultTimeZoneWithSafeCloseable();
-
-		boolean changed = _setCompanyId(companyId, false);
+		boolean changed = _setCompanyId(companyId);
 
 		SafeCloseable ctCollectionSafeCloseable =
 			CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
@@ -188,9 +182,9 @@ public class CompanyThreadLocal {
 
 			_companyId.set(currentCompanyId);
 
+			_clearUserThreadLocals();
+
 			ctCollectionSafeCloseable.close();
-			localeSafeCloseable.close();
-			timeZoneSafeCloseable.close();
 		};
 	}
 
@@ -199,9 +193,7 @@ public class CompanyThreadLocal {
 		TimeZoneThreadLocal.removeDefaultTimeZone();
 	}
 
-	private static boolean _setCompanyId(
-		Long companyId, boolean clearUserThreadLocals) {
-
+	private static boolean _setCompanyId(Long companyId) {
 		if (companyId.equals(_companyId.get())) {
 			if (!isLocked()) {
 				return false;
@@ -234,9 +226,7 @@ public class CompanyThreadLocal {
 			_companyId.set(CompanyConstants.SYSTEM);
 		}
 
-		if (clearUserThreadLocals) {
-			_clearUserThreadLocals();
-		}
+		_clearUserThreadLocals();
 
 		return true;
 	}

--- a/portal-kernel/src/com/liferay/portal/kernel/security/auth/CompanyThreadLocal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/auth/CompanyThreadLocal.java
@@ -170,10 +170,10 @@ public class CompanyThreadLocal {
 		long currentCompanyId = _companyId.get();
 
 		SafeCloseable localeSafeCloseable =
-			LocaleThreadLocal.setWithSafeCloseable(null);
+			LocaleThreadLocal.clearDefaultLocaleWithSafeCloseable();
 
 		SafeCloseable timeZoneSafeCloseable =
-			TimeZoneThreadLocal.setWithSafeCloseable(null);
+			TimeZoneThreadLocal.clearDefaultTimeZoneWithSafeCloseable();
 
 		boolean changed = _setCompanyId(companyId, false);
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/LocaleThreadLocal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/LocaleThreadLocal.java
@@ -6,7 +6,6 @@
 package com.liferay.portal.kernel.util;
 
 import com.liferay.petra.lang.CentralizedThreadLocal;
-import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 
@@ -16,10 +15,6 @@ import java.util.Locale;
  * @author Brian Wing Shun Chan
  */
 public class LocaleThreadLocal {
-
-	public static SafeCloseable clearDefaultLocaleWithSafeCloseable() {
-		return _defaultLocale.setWithSafeCloseable(null);
-	}
 
 	public static Locale getDefaultLocale() {
 		return _defaultLocale.get();
@@ -49,7 +44,7 @@ public class LocaleThreadLocal {
 		_themeDisplayLocale.set(locale);
 	}
 
-	private static final CentralizedThreadLocal<Locale> _defaultLocale =
+	private static final ThreadLocal<Locale> _defaultLocale =
 		new CentralizedThreadLocal<>(
 			LocaleThreadLocal.class + "._defaultLocale",
 			() -> {

--- a/portal-kernel/src/com/liferay/portal/kernel/util/LocaleThreadLocal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/LocaleThreadLocal.java
@@ -17,6 +17,10 @@ import java.util.Locale;
  */
 public class LocaleThreadLocal {
 
+	public static SafeCloseable clearDefaultLocaleWithSafeCloseable() {
+		return _defaultLocale.setWithSafeCloseable(null);
+	}
+
 	public static Locale getDefaultLocale() {
 		return _defaultLocale.get();
 	}
@@ -43,10 +47,6 @@ public class LocaleThreadLocal {
 
 	public static void setThemeDisplayLocale(Locale locale) {
 		_themeDisplayLocale.set(locale);
-	}
-
-	public static SafeCloseable setWithSafeCloseable(Locale locale) {
-		return _defaultLocale.setWithSafeCloseable(locale);
 	}
 
 	private static final CentralizedThreadLocal<Locale> _defaultLocale =

--- a/portal-kernel/src/com/liferay/portal/kernel/util/TimeZoneThreadLocal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/TimeZoneThreadLocal.java
@@ -6,7 +6,6 @@
 package com.liferay.portal.kernel.util;
 
 import com.liferay.petra.lang.CentralizedThreadLocal;
-import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 
@@ -16,10 +15,6 @@ import java.util.TimeZone;
  * @author Brian Wing Shun Chan
  */
 public class TimeZoneThreadLocal {
-
-	public static SafeCloseable clearDefaultTimeZoneWithSafeCloseable() {
-		return _defaultTimeZone.setWithSafeCloseable(null);
-	}
 
 	public static TimeZone getDefaultTimeZone() {
 		return _defaultTimeZone.get();
@@ -41,7 +36,7 @@ public class TimeZoneThreadLocal {
 		_themeDisplayTimeZone.set(timeZone);
 	}
 
-	private static final CentralizedThreadLocal<TimeZone> _defaultTimeZone =
+	private static final ThreadLocal<TimeZone> _defaultTimeZone =
 		new CentralizedThreadLocal<>(
 			TimeZoneThreadLocal.class + "._defaultTimeZone",
 			() -> {

--- a/portal-kernel/src/com/liferay/portal/kernel/util/TimeZoneThreadLocal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/TimeZoneThreadLocal.java
@@ -17,6 +17,10 @@ import java.util.TimeZone;
  */
 public class TimeZoneThreadLocal {
 
+	public static SafeCloseable clearDefaultTimeZoneWithSafeCloseable() {
+		return _defaultTimeZone.setWithSafeCloseable(null);
+	}
+
 	public static TimeZone getDefaultTimeZone() {
 		return _defaultTimeZone.get();
 	}
@@ -35,10 +39,6 @@ public class TimeZoneThreadLocal {
 
 	public static void setThemeDisplayTimeZone(TimeZone timeZone) {
 		_themeDisplayTimeZone.set(timeZone);
-	}
-
-	public static SafeCloseable setWithSafeCloseable(TimeZone timeZone) {
-		return _defaultTimeZone.setWithSafeCloseable(timeZone);
 	}
 
 	private static final CentralizedThreadLocal<TimeZone> _defaultTimeZone =

--- a/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 73.0.0
+version 74.0.0

--- a/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 73.1.0
+version 73.0.0

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/security/auth/CompanyThreadLocalTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/security/auth/CompanyThreadLocalTest.java
@@ -53,10 +53,9 @@ public class CompanyThreadLocalTest {
 
 	@Test
 	public void testUserThreadLocalsWithSetWithSafeCloseable() {
-		LocaleThreadLocal.setDefaultLocale(LocaleUtil.GERMAN);
-
 		TimeZone pstTimeZone = TimeZone.getTimeZone("PST");
 
+		LocaleThreadLocal.setDefaultLocale(LocaleUtil.GERMAN);
 		TimeZoneThreadLocal.setDefaultTimeZone(pstTimeZone);
 
 		try (SafeCloseable safeCloseable =


### PR DESCRIPTION
@brianchandotcom Hi Brian,
Please see the issue here: https://liferay.atlassian.net/browse/LPD-17763
I tested this on U112 with company.default.locale=es_ES to portal-ext.properties and start portal

With LPD-1721 commits, home page fails to load properly
Without them, home page is good

We will revert it first and fix the original issue: https://liferay.atlassian.net/browse/LPD-1721

Note that this also reverted some semver commmits:
[ebf64ee](https://github.com/brianchandotcom/liferay-portal/pull/147199/commits/ebf64ee11c1f2471556ef5ed471632d044dcc8c0)
and contain new semver commit:
[4308cc5](https://github.com/brianchandotcom/liferay-portal/pull/147199/commits/4308cc5bd0ace4731be721231df04809a7aaa312)



cc. @shuyangzhou @marianoalvarosaiz