### PR TITLE
LPD-17248 Use the expected hexadecimal representation when testing/as…

### DIFF
--- a/portal-kernel/test/unit/com/liferay/portal/kernel/util/HtmlUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/util/HtmlUtilTest.java
@@ -12,10 +12,6 @@ import com.liferay.petra.string.StringPool;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import javax.script.ScriptEngine;
-import javax.script.ScriptEngineManager;
-import javax.script.ScriptException;
-
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -147,23 +143,14 @@ public class HtmlUtilTest {
 	}
 
 	@Test
-	public void testEscapeJS() throws ScriptException {
-		ScriptEngineManager scriptEngineManager = new ScriptEngineManager();
-
-		ScriptEngine scriptEngine = scriptEngineManager.getEngineByName(
-			"JavaScript");
-
-		String[] stringLiterals = {
-			"'", "\"", "\\", "\n", "\r", "\u2028", "\u2029"
-		};
-
-		for (String stringLiteral : stringLiterals) {
-			String escaped = HtmlUtil.escapeJS(stringLiteral);
-
-			scriptEngine.eval(String.format("var result = '%1$s';", escaped));
-
-			Assert.assertEquals(stringLiteral, scriptEngine.get("result"));
-		}
+	public void testEscapeJS() {
+		Assert.assertEquals("\\x27", HtmlUtil.escapeJS("'"));
+		Assert.assertEquals("\\x22", HtmlUtil.escapeJS("\""));
+		Assert.assertEquals("\\x5c", HtmlUtil.escapeJS("\\"));
+		Assert.assertEquals("\\x0a", HtmlUtil.escapeJS("\n"));
+		Assert.assertEquals("\\x0d", HtmlUtil.escapeJS("\r"));
+		Assert.assertEquals("\\u2028", HtmlUtil.escapeJS("\u2028"));
+		Assert.assertEquals("\\u2029", HtmlUtil.escapeJS("\u2029"));
 	}
 
 	@Test


### PR DESCRIPTION
…serting the result of HtmlUtil#escapeJS method to avoid NPE when running the test case HtmlUtilTest#testEscapeJS on JDK17/JDK21. It is required because since the JDK15 there is no Javascript ScriptEngine implementation available on JDK due to the removal of the Nashorn implementation, see https://openjdk.org/jeps/372 and https://bugs.openjdk.org/browse/JDK-8236933