### PR TITLE
LRCI-4031 Remove get_absolute_dir because used before declared

### DIFF
--- a/modules/test/playwright/env/common.sh
+++ b/modules/test/playwright/env/common.sh
@@ -2,8 +2,8 @@
 
 PLAYWRIGHT_ENV_DIR=$(dirname ${BASH_SOURCE[0]})
 
-export PLAYWRIGHT_BASE_DIR=$(get_absolute_dir ${PLAYWRIGHT_ENV_DIR}/../..)
-export PORTAL_PROJECT_DIR=$(get_absolute_dir ${PLAYWRIGHT_ENV_DIR}/../../../../..)
+export PLAYWRIGHT_BASE_DIR=$(cd -- $(dirname -- ${PLAYWRIGHT_ENV_DIR}/../..) &> /dev/null && pwd)
+export PORTAL_PROJECT_DIR=$(cd -- $(dirname -- ${PLAYWRIGHT_ENV_DIR}/../../../../..) &> /dev/null && pwd)
 
 if [[ "${LIFERAY_HOME}" == "" ]]
 then
@@ -180,10 +180,6 @@ function deploy_project_osgi_modules() {
 	then
 		deploy_osgi_modules $(cat ${playwright_project_dir}/env/osgi-modules.list)
 	fi
-}
-
-function get_absolute_dir() {
-	echo $(cd -- $(dirname -- $1) &> /dev/null && pwd)
 }
 
 function get_gradlew() {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-4031

@brianchandotcom - I'm not sure which way to go with this, but the function needed to be declared before it could be used.  So either we can move it back to the end, or we can do what I had put.

It was throwing an error like this:
```
./env/common.sh: line 5: get_absolute_dir: command not found
./env/common.sh: line 6: get_absolute_dir: command not found
```