### PR TITLE
LPD-17718 app.server.lib.global.dir is no longer the ext folder, it i…

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -16,9 +16,6 @@
 						includes="*-ext/**,*-ext.war/**,*-hook/**,*-hook.war/**,*-layouttpl/**,*-layouttpl.war/**,*-portlet/**,*-portlet.war/**,*-theme/**,*-theme.war/**,*-web/**,*-web.war/**"
 					/>
 					<fileset
-						dir="${app.server.lib.global.dir}"
-					/>
-					<fileset
 						dir="${liferay.home}"
 						includes=".liferay-home"
 					/>


### PR DESCRIPTION
…s the real app server global dir. We don't deploy anything there, it should not be deleted.