### PR TITLE
LPD-18073 EnityCache must be replicated to cluster and corresponding …

### DIFF
--- a/modules/apps/view-count/view-count-service/src/main/java/com/liferay/view/count/service/persistence/impl/ViewCountEntryFinderImpl.java
+++ b/modules/apps/view-count/view-count-service/src/main/java/com/liferay/view/count/service/persistence/impl/ViewCountEntryFinderImpl.java
@@ -57,7 +57,7 @@ public class ViewCountEntryFinderImpl
 			}
 
 			_entityCache.putResult(
-				ViewCountEntryImpl.class, viewCountEntryPK, viewCountEntry);
+				ViewCountEntryImpl.class, viewCountEntry, false, true);
 		}
 		finally {
 			closeSession(session);


### PR DESCRIPTION
…finder cache must be updated too when an entity is updated, must not be replicated when loading an entity from database for reading to avoid unnecessary resetting of cache and cluster communication.