### PR TITLE
LPD-1721 CentralizedThreadLocal needs to be able to restore value upo…

### DIFF
--- a/modules/core/petra/petra-lang/src/main/java/com/liferay/petra/lang/CentralizedThreadLocal.java
+++ b/modules/core/petra/petra-lang/src/main/java/com/liferay/petra/lang/CentralizedThreadLocal.java
@@ -179,7 +179,7 @@ public class CentralizedThreadLocal<T> extends ThreadLocal<T> {
 
 		entry._value = value;
 
-		return () -> entry._value = originalValue;
+		return () -> threadLocalMap.putEntry(this, originalValue);
 	}
 
 	public SafeCloseable setWithSafeCloseable(T value) {
@@ -197,7 +197,7 @@ public class CentralizedThreadLocal<T> extends ThreadLocal<T> {
 
 		entry._value = value;
 
-		return () -> entry._value = originalValue;
+		return () -> threadLocalMap.putEntry(this, originalValue);
 	}
 
 	@Override

--- a/modules/core/petra/petra-lang/src/test/java/com/liferay/petra/lang/CentralizedThreadLocalTest.java
+++ b/modules/core/petra/petra-lang/src/test/java/com/liferay/petra/lang/CentralizedThreadLocalTest.java
@@ -291,6 +291,18 @@ public class CentralizedThreadLocalTest {
 
 		Assert.assertSame(initialValue, centralizedThreadLocal.get());
 
+		try (SafeCloseable safeCloseable =
+				centralizedThreadLocal.setWithSafeCloseable(value1)) {
+
+			Assert.assertSame(value1, centralizedThreadLocal.get());
+
+			centralizedThreadLocal.remove();
+
+			Assert.assertSame(initialValue, centralizedThreadLocal.get());
+		}
+
+		Assert.assertSame(initialValue, centralizedThreadLocal.get());
+
 		String value2 = "value2";
 
 		try (SafeCloseable safeCloseable1 =
@@ -300,6 +312,18 @@ public class CentralizedThreadLocalTest {
 					centralizedThreadLocal.setWithSafeCloseable(value2)) {
 
 				Assert.assertSame(value2, centralizedThreadLocal.get());
+			}
+
+			Assert.assertSame(value1, centralizedThreadLocal.get());
+
+			try (SafeCloseable safeCloseable3 =
+					centralizedThreadLocal.setWithSafeCloseable(value2)) {
+
+				Assert.assertSame(value2, centralizedThreadLocal.get());
+
+				centralizedThreadLocal.remove();
+
+				Assert.assertSame(initialValue, centralizedThreadLocal.get());
 			}
 
 			Assert.assertSame(value1, centralizedThreadLocal.get());


### PR DESCRIPTION
…n closing SafeCloseable from setWithSafeCloseable(), even ThreadLocal value has been removed.