### PR TITLE
LPD-16002

### DIFF
--- a/modules/apps/portal-security-audit/portal-security-audit-storage-api/bnd.bnd
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Security Audit Storage API
 Bundle-SymbolicName: com.liferay.portal.security.audit.storage.api
-Bundle-Version: 8.0.2
+Bundle-Version: 8.1.0
 Export-Package:\
 	com.liferay.portal.security.audit.storage.comparator,\
 	com.liferay.portal.security.audit.storage.exception,\

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/service/AuditEventService.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/service/AuditEventService.java
@@ -45,6 +45,9 @@ public interface AuditEventService extends BaseService {
 	 * Never modify this interface directly. Add custom service methods to <code>com.liferay.portal.security.audit.storage.service.impl.AuditEventServiceImpl</code> and rerun ServiceBuilder to automatically copy the method declarations to this interface. Consume the audit event remote service via injection or a <code>org.osgi.util.tracker.ServiceTracker</code>. Use {@link AuditEventServiceUtil} if injection and service tracking are not available.
 	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public AuditEvent getAuditEvent(long auditEventId) throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<AuditEvent> getAuditEvents(long companyId, int start, int end)
 		throws PortalException;
 

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/service/AuditEventServiceUtil.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/service/AuditEventServiceUtil.java
@@ -30,6 +30,12 @@ public class AuditEventServiceUtil {
 	 *
 	 * Never modify this class directly. Add custom service methods to <code>com.liferay.portal.security.audit.storage.service.impl.AuditEventServiceImpl</code> and rerun ServiceBuilder to regenerate this class.
 	 */
+	public static AuditEvent getAuditEvent(long auditEventId)
+		throws PortalException {
+
+		return getService().getAuditEvent(auditEventId);
+	}
+
 	public static List<AuditEvent> getAuditEvents(
 			long companyId, int start, int end)
 		throws PortalException {

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/service/AuditEventServiceWrapper.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/service/AuditEventServiceWrapper.java
@@ -26,6 +26,14 @@ public class AuditEventServiceWrapper
 	}
 
 	@Override
+	public com.liferay.portal.security.audit.storage.model.AuditEvent
+			getAuditEvent(long auditEventId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _auditEventService.getAuditEvent(auditEventId);
+	}
+
+	@Override
 	public java.util.List
 		<com.liferay.portal.security.audit.storage.model.AuditEvent>
 				getAuditEvents(long companyId, int start, int end)

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/resources/com/liferay/portal/security/audit/storage/service/packageinfo
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/resources/com/liferay/portal/security/audit/storage/service/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/service/http/AuditEventServiceHttp.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/service/http/AuditEventServiceHttp.java
@@ -41,6 +41,47 @@ import com.liferay.portal.security.audit.storage.service.AuditEventServiceUtil;
  */
 public class AuditEventServiceHttp {
 
+	public static com.liferay.portal.security.audit.storage.model.AuditEvent
+			getAuditEvent(HttpPrincipal httpPrincipal, long auditEventId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				AuditEventServiceUtil.class, "getAuditEvent",
+				_getAuditEventParameterTypes0);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, auditEventId);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.portal.security.audit.storage.model.AuditEvent)
+				returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
 	public static java.util.List
 		<com.liferay.portal.security.audit.storage.model.AuditEvent>
 				getAuditEvents(
@@ -51,7 +92,7 @@ public class AuditEventServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				AuditEventServiceUtil.class, "getAuditEvents",
-				_getAuditEventsParameterTypes0);
+				_getAuditEventsParameterTypes1);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, start, end);
@@ -99,7 +140,7 @@ public class AuditEventServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				AuditEventServiceUtil.class, "getAuditEvents",
-				_getAuditEventsParameterTypes1);
+				_getAuditEventsParameterTypes2);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, start, end, orderByComparator);
@@ -148,7 +189,7 @@ public class AuditEventServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				AuditEventServiceUtil.class, "getAuditEvents",
-				_getAuditEventsParameterTypes2);
+				_getAuditEventsParameterTypes3);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, groupId, userId, userName, createDateGT,
@@ -203,7 +244,7 @@ public class AuditEventServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				AuditEventServiceUtil.class, "getAuditEvents",
-				_getAuditEventsParameterTypes3);
+				_getAuditEventsParameterTypes4);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, groupId, userId, userName, createDateGT,
@@ -248,7 +289,7 @@ public class AuditEventServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				AuditEventServiceUtil.class, "getAuditEventsCount",
-				_getAuditEventsCountParameterTypes4);
+				_getAuditEventsCountParameterTypes5);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId);
@@ -293,7 +334,7 @@ public class AuditEventServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				AuditEventServiceUtil.class, "getAuditEventsCount",
-				_getAuditEventsCountParameterTypes5);
+				_getAuditEventsCountParameterTypes6);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, groupId, userId, userName, createDateGT,
@@ -331,20 +372,14 @@ public class AuditEventServiceHttp {
 	private static Log _log = LogFactoryUtil.getLog(
 		AuditEventServiceHttp.class);
 
-	private static final Class<?>[] _getAuditEventsParameterTypes0 =
-		new Class[] {long.class, int.class, int.class};
+	private static final Class<?>[] _getAuditEventParameterTypes0 =
+		new Class[] {long.class};
 	private static final Class<?>[] _getAuditEventsParameterTypes1 =
+		new Class[] {long.class, int.class, int.class};
+	private static final Class<?>[] _getAuditEventsParameterTypes2 =
 		new Class[] {
 			long.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
-		};
-	private static final Class<?>[] _getAuditEventsParameterTypes2 =
-		new Class[] {
-			long.class, long.class, long.class, String.class,
-			java.util.Date.class, java.util.Date.class, String.class,
-			String.class, String.class, String.class, String.class,
-			String.class, int.class, String.class, boolean.class, int.class,
-			int.class
 		};
 	private static final Class<?>[] _getAuditEventsParameterTypes3 =
 		new Class[] {
@@ -352,11 +387,19 @@ public class AuditEventServiceHttp {
 			java.util.Date.class, java.util.Date.class, String.class,
 			String.class, String.class, String.class, String.class,
 			String.class, int.class, String.class, boolean.class, int.class,
+			int.class
+		};
+	private static final Class<?>[] _getAuditEventsParameterTypes4 =
+		new Class[] {
+			long.class, long.class, long.class, String.class,
+			java.util.Date.class, java.util.Date.class, String.class,
+			String.class, String.class, String.class, String.class,
+			String.class, int.class, String.class, boolean.class, int.class,
 			int.class, com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getAuditEventsCountParameterTypes4 =
-		new Class[] {long.class};
 	private static final Class<?>[] _getAuditEventsCountParameterTypes5 =
+		new Class[] {long.class};
+	private static final Class<?>[] _getAuditEventsCountParameterTypes6 =
 		new Class[] {
 			long.class, long.class, long.class, String.class,
 			java.util.Date.class, java.util.Date.class, String.class,

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/service/impl/AuditEventServiceImpl.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/service/impl/AuditEventServiceImpl.java
@@ -44,7 +44,8 @@ public class AuditEventServiceImpl extends AuditEventServiceBaseImpl {
 		if (!(permissionChecker.isCompanyAdmin() ||
 			  _userLocalService.hasRoleUser(
 				  companyId, RoleConstants.ANALYTICS_ADMINISTRATOR,
-				  permissionChecker.getUserId(), true))) {
+				  permissionChecker.getUserId(), true)) ||
+			(permissionChecker.getCompanyId() != companyId)) {
 
 			throw new PrincipalException();
 		}
@@ -63,7 +64,8 @@ public class AuditEventServiceImpl extends AuditEventServiceBaseImpl {
 		if (!(permissionChecker.isCompanyAdmin() ||
 			  _userLocalService.hasRoleUser(
 				  companyId, RoleConstants.ANALYTICS_ADMINISTRATOR,
-				  permissionChecker.getUserId(), true))) {
+				  permissionChecker.getUserId(), true)) ||
+			(permissionChecker.getCompanyId() != companyId)) {
 
 			throw new PrincipalException();
 		}
@@ -85,7 +87,8 @@ public class AuditEventServiceImpl extends AuditEventServiceBaseImpl {
 		if (!(permissionChecker.isCompanyAdmin() ||
 			  _userLocalService.hasRoleUser(
 				  companyId, RoleConstants.ANALYTICS_ADMINISTRATOR,
-				  permissionChecker.getUserId(), true))) {
+				  permissionChecker.getUserId(), true)) ||
+			(permissionChecker.getCompanyId() != companyId)) {
 
 			throw new PrincipalException();
 		}
@@ -110,7 +113,8 @@ public class AuditEventServiceImpl extends AuditEventServiceBaseImpl {
 		if (!(permissionChecker.isCompanyAdmin() ||
 			  _userLocalService.hasRoleUser(
 				  companyId, RoleConstants.ANALYTICS_ADMINISTRATOR,
-				  permissionChecker.getUserId(), true))) {
+				  permissionChecker.getUserId(), true)) ||
+			(permissionChecker.getCompanyId() != companyId)) {
 
 			throw new PrincipalException();
 		}

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/service/impl/AuditEventServiceImpl.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/service/impl/AuditEventServiceImpl.java
@@ -36,6 +36,26 @@ import org.osgi.service.component.annotations.Reference;
 public class AuditEventServiceImpl extends AuditEventServiceBaseImpl {
 
 	@Override
+	public AuditEvent getAuditEvent(long auditEventId) throws PortalException {
+		PermissionChecker permissionChecker = getPermissionChecker();
+
+		AuditEvent auditEvent = auditEventLocalService.getAuditEvent(
+			auditEventId);
+
+		if (!(permissionChecker.isCompanyAdmin() ||
+			  _userLocalService.hasRoleUser(
+				  permissionChecker.getCompanyId(),
+				  RoleConstants.ANALYTICS_ADMINISTRATOR,
+				  permissionChecker.getUserId(), true)) ||
+			(permissionChecker.getCompanyId() != auditEvent.getCompanyId())) {
+
+			throw new PrincipalException();
+		}
+
+		return auditEvent;
+	}
+
+	@Override
 	public List<AuditEvent> getAuditEvents(long companyId, int start, int end)
 		throws PortalException {
 

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/java/com/liferay/portal/security/audit/web/internal/portlet/AuditPortlet.java
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/java/com/liferay/portal/security/audit/web/internal/portlet/AuditPortlet.java
@@ -9,6 +9,9 @@ import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.security.audit.AuditEvent;
+import com.liferay.portal.security.audit.web.internal.AuditEventManagerUtil;
 import com.liferay.portal.security.audit.web.internal.constants.AuditPortletKeys;
 
 import java.io.IOException;
@@ -17,6 +20,7 @@ import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
 import javax.portlet.Portlet;
 import javax.portlet.PortletException;
+import javax.portlet.PortletRequest;
 import javax.portlet.RenderRequest;
 import javax.portlet.RenderResponse;
 import javax.portlet.ResourceRequest;
@@ -51,7 +55,7 @@ public class AuditPortlet extends MVCPortlet {
 			ActionRequest actionRequest, ActionResponse actionResponse)
 		throws IOException, PortletException {
 
-		_checkCompanyAdmin();
+		_checkCompanyAdmin(actionRequest);
 
 		super.processAction(actionRequest, actionResponse);
 	}
@@ -61,7 +65,7 @@ public class AuditPortlet extends MVCPortlet {
 			RenderRequest renderRequest, RenderResponse renderResponse)
 		throws IOException, PortletException {
 
-		_checkCompanyAdmin();
+		_checkCompanyAdmin(renderRequest);
 
 		super.render(renderRequest, renderResponse);
 	}
@@ -71,14 +75,28 @@ public class AuditPortlet extends MVCPortlet {
 			ResourceRequest resourceRequest, ResourceResponse resourceResponse)
 		throws IOException, PortletException {
 
-		_checkCompanyAdmin();
+		_checkCompanyAdmin(resourceRequest);
 
 		super.serveResource(resourceRequest, resourceResponse);
 	}
 
-	private void _checkCompanyAdmin() throws PortletException {
+	private void _checkCompanyAdmin(PortletRequest portletRequest)
+		throws PortletException {
+
 		PermissionChecker permissionChecker =
 			PermissionThreadLocal.getPermissionChecker();
+
+		long auditEventId = ParamUtil.getLong(portletRequest, "auditEventId");
+
+		if (auditEventId > 0) {
+			AuditEvent auditEvent = AuditEventManagerUtil.fetchAuditEvent(
+				auditEventId);
+
+			if (permissionChecker.getCompanyId() != auditEvent.getCompanyId()) {
+				throw new PortletException(
+					"This event does not belong to this company");
+			}
+		}
 
 		if (!permissionChecker.isCompanyAdmin()) {
 			PrincipalException principalException =

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/java/com/liferay/portal/security/audit/web/internal/portlet/AuditPortlet.java
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/java/com/liferay/portal/security/audit/web/internal/portlet/AuditPortlet.java
@@ -8,16 +8,7 @@ package com.liferay.portal.security.audit.web.internal.portlet;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
 import com.liferay.portal.security.audit.web.internal.constants.AuditPortletKeys;
 
-import java.io.IOException;
-
-import javax.portlet.ActionRequest;
-import javax.portlet.ActionResponse;
 import javax.portlet.Portlet;
-import javax.portlet.PortletException;
-import javax.portlet.RenderRequest;
-import javax.portlet.RenderResponse;
-import javax.portlet.ResourceRequest;
-import javax.portlet.ResourceResponse;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -42,29 +33,4 @@ import org.osgi.service.component.annotations.Component;
 	service = Portlet.class
 )
 public class AuditPortlet extends MVCPortlet {
-
-	@Override
-	public void processAction(
-			ActionRequest actionRequest, ActionResponse actionResponse)
-		throws IOException, PortletException {
-
-		super.processAction(actionRequest, actionResponse);
-	}
-
-	@Override
-	public void render(
-			RenderRequest renderRequest, RenderResponse renderResponse)
-		throws IOException, PortletException {
-
-		super.render(renderRequest, renderResponse);
-	}
-
-	@Override
-	public void serveResource(
-			ResourceRequest resourceRequest, ResourceResponse resourceResponse)
-		throws IOException, PortletException {
-
-		super.serveResource(resourceRequest, resourceResponse);
-	}
-
 }

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/java/com/liferay/portal/security/audit/web/internal/portlet/AuditPortlet.java
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/java/com/liferay/portal/security/audit/web/internal/portlet/AuditPortlet.java
@@ -6,12 +6,6 @@
 package com.liferay.portal.security.audit.web.internal.portlet;
 
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
-import com.liferay.portal.kernel.security.auth.PrincipalException;
-import com.liferay.portal.kernel.security.permission.PermissionChecker;
-import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
-import com.liferay.portal.kernel.util.ParamUtil;
-import com.liferay.portal.security.audit.AuditEvent;
-import com.liferay.portal.security.audit.web.internal.AuditEventManagerUtil;
 import com.liferay.portal.security.audit.web.internal.constants.AuditPortletKeys;
 
 import java.io.IOException;
@@ -20,7 +14,6 @@ import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
 import javax.portlet.Portlet;
 import javax.portlet.PortletException;
-import javax.portlet.PortletRequest;
 import javax.portlet.RenderRequest;
 import javax.portlet.RenderResponse;
 import javax.portlet.ResourceRequest;
@@ -55,8 +48,6 @@ public class AuditPortlet extends MVCPortlet {
 			ActionRequest actionRequest, ActionResponse actionResponse)
 		throws IOException, PortletException {
 
-		_checkCompanyAdmin(actionRequest);
-
 		super.processAction(actionRequest, actionResponse);
 	}
 
@@ -64,8 +55,6 @@ public class AuditPortlet extends MVCPortlet {
 	public void render(
 			RenderRequest renderRequest, RenderResponse renderResponse)
 		throws IOException, PortletException {
-
-		_checkCompanyAdmin(renderRequest);
 
 		super.render(renderRequest, renderResponse);
 	}
@@ -75,36 +64,7 @@ public class AuditPortlet extends MVCPortlet {
 			ResourceRequest resourceRequest, ResourceResponse resourceResponse)
 		throws IOException, PortletException {
 
-		_checkCompanyAdmin(resourceRequest);
-
 		super.serveResource(resourceRequest, resourceResponse);
-	}
-
-	private void _checkCompanyAdmin(PortletRequest portletRequest)
-		throws PortletException {
-
-		PermissionChecker permissionChecker =
-			PermissionThreadLocal.getPermissionChecker();
-
-		long auditEventId = ParamUtil.getLong(portletRequest, "auditEventId");
-
-		if (auditEventId > 0) {
-			AuditEvent auditEvent = AuditEventManagerUtil.fetchAuditEvent(
-				auditEventId);
-
-			if (permissionChecker.getCompanyId() != auditEvent.getCompanyId()) {
-				throw new PortletException(
-					"This event does not belong to this company");
-			}
-		}
-
-		if (!permissionChecker.isCompanyAdmin()) {
-			PrincipalException principalException =
-				new PrincipalException.MustBeCompanyAdmin(
-					permissionChecker.getUserId());
-
-			throw new PortletException(principalException);
-		}
 	}
 
 }

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/resources/META-INF/resources/init.jsp
@@ -26,8 +26,8 @@ page import="com.liferay.portal.kernel.util.ParamUtil" %><%@
 page import="com.liferay.portal.kernel.util.PortalClassInvoker" %><%@
 page import="com.liferay.portal.kernel.util.PortalClassLoaderUtil" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %><%@
-page import="com.liferay.portal.security.audit.AuditEvent" %><%@
-page import="com.liferay.portal.security.audit.web.internal.AuditEventManagerUtil" %><%@
+page import="com.liferay.portal.security.audit.storage.model.AuditEvent" %><%@
+page import="com.liferay.portal.security.audit.storage.service.AuditEventServiceUtil" %><%@
 page import="com.liferay.portal.security.audit.web.internal.display.context.AuditDisplayContext" %>
 
 <%@ page import="java.text.Format" %>

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/resources/META-INF/resources/view_audit_event.jsp
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/resources/META-INF/resources/view_audit_event.jsp
@@ -15,7 +15,7 @@ AuditEvent auditEvent = null;
 String eventTypeAction = StringPool.BLANK;
 
 if (auditEventId > 0) {
-	auditEvent = AuditEventManagerUtil.fetchAuditEvent(auditEventId);
+	auditEvent = AuditEventServiceUtil.getAuditEvent(auditEventId);
 
 	if (auditEvent != null) {
 		auditEvent = auditEvent.toEscapedModel();


### PR DESCRIPTION
Previous PR: https://github.com/brianchandotcom/liferay-portal/pull/147499
Hello Brian, re sending this directly as the only change was removing those methods.
About your previous comments:
Re. 1): Indeed those methods were not needed.
Re. 2): The if here is checking three different things, if the user is an admin for a given company, if the user is an analytics administrator and I added the check for if the user companyId is the same as the one passed in the parameter. This is to prevent an user of some company from seeing the audit event from another company. The isCompanyAdmin method just checks if the user is an admin, so if the user is an admin they could see another company's audit event if they have its ID, thats why this new check is necessary. Also, because this is a remote endpoint, clients can provide any companyId, so its important to check this in the service layer in these other methods.