### PR TITLE
LPD-16337 Daylight saving for recurring events

### DIFF
--- a/modules/apps/calendar/calendar-api/src/main/java/com/liferay/calendar/util/CalendarBookingIterator.java
+++ b/modules/apps/calendar/calendar-api/src/main/java/com/liferay/calendar/util/CalendarBookingIterator.java
@@ -97,6 +97,10 @@ public class CalendarBookingIterator implements Iterator<CalendarBooking> {
 			jCalendar.get(Calendar.SECOND), jCalendar.get(Calendar.MILLISECOND),
 			_getTimeZone(_calendarBooking));
 
+		if (_calendarBooking.isRecurring()) {
+			return startTimeJCalendar;
+		}
+
 		int shift = JCalendarUtil.getDSTShift(
 			jCalendar, startTimeJCalendar,
 			_calendarBooking.isAllDay() ? TimeZone.getTimeZone(StringPool.UTC) :

--- a/modules/apps/calendar/calendar-service/src/test/java/com/liferay/calendar/util/RecurrenceUtilTest.java
+++ b/modules/apps/calendar/calendar-service/src/test/java/com/liferay/calendar/util/RecurrenceUtilTest.java
@@ -38,6 +38,65 @@ public class RecurrenceUtilTest {
 		LiferayUnitTestRule.INSTANCE;
 
 	@Test
+	public void testExpandCalendarBooking() {
+
+		// Daylight savings, calendar timezone PST, display timezone PST
+
+		Calendar startTimeJCalendar = JCalendarUtil.getJCalendar(
+			2024, Calendar.MARCH, 9, 13, 0, 0, 0, _losAngelesTimeZone);
+
+		CalendarBooking calendarBooking = mockCalendarBooking(
+			startTimeJCalendar, "RRULE:FREQ=DAILY;COUNT=2;INTERVAL=1",
+			_losAngelesTimeZone);
+
+		List<CalendarBooking> expandedCalendarBookings =
+			RecurrenceUtil.expandCalendarBooking(
+				calendarBooking, startTimeJCalendar.getTimeInMillis(),
+				startTimeJCalendar.getTimeInMillis() + Time.DAY + Time.HOUR,
+				_losAngelesTimeZone, 0);
+
+		CalendarBooking expandedCalendarBooking = expandedCalendarBookings.get(
+			0);
+
+		Calendar calendar = JCalendarUtil.getJCalendar(
+			expandedCalendarBooking.getStartTime(), _losAngelesTimeZone);
+
+		Assert.assertEquals(9, calendar.get(Calendar.DAY_OF_MONTH));
+		Assert.assertEquals(13, calendar.get(Calendar.HOUR_OF_DAY));
+
+		expandedCalendarBooking = expandedCalendarBookings.get(1);
+
+		calendar = JCalendarUtil.getJCalendar(
+			expandedCalendarBooking.getStartTime(), _losAngelesTimeZone);
+
+		Assert.assertEquals(10, calendar.get(Calendar.DAY_OF_MONTH));
+		Assert.assertEquals(13, calendar.get(Calendar.HOUR_OF_DAY));
+
+		// Daylight savings, calendar timezone PST, display timezone UTC
+
+		expandedCalendarBookings = RecurrenceUtil.expandCalendarBooking(
+			calendarBooking, startTimeJCalendar.getTimeInMillis(),
+			startTimeJCalendar.getTimeInMillis() + Time.DAY + Time.HOUR,
+			_utcTimeZone, 0);
+
+		expandedCalendarBooking = expandedCalendarBookings.get(0);
+
+		calendar = JCalendarUtil.getJCalendar(
+			expandedCalendarBooking.getStartTime(), _utcTimeZone);
+
+		Assert.assertEquals(9, calendar.get(Calendar.DAY_OF_MONTH));
+		Assert.assertEquals(21, calendar.get(Calendar.HOUR_OF_DAY));
+
+		expandedCalendarBooking = expandedCalendarBookings.get(1);
+
+		calendar = JCalendarUtil.getJCalendar(
+			expandedCalendarBooking.getStartTime(), _utcTimeZone);
+
+		Assert.assertEquals(10, calendar.get(Calendar.DAY_OF_MONTH));
+		Assert.assertEquals(20, calendar.get(Calendar.HOUR_OF_DAY));
+	}
+
+	@Test
 	public void testGetLastCalendarBookingInstance() {
 		Calendar lastInstanceStartTimeJCalendar = getJan2016Calendar(23);
 
@@ -384,6 +443,12 @@ public class RecurrenceUtilTest {
 	protected List<CalendarBooking> getRecurringCalendarBookings(
 		Object... objects) {
 
+		return getRecurringCalendarBookings(_utcTimeZone, objects);
+	}
+
+	protected List<CalendarBooking> getRecurringCalendarBookings(
+		TimeZone timeZone, Object... objects) {
+
 		List<CalendarBooking> calendarBookings = new ArrayList<>();
 
 		for (int i = 0; i < objects.length; i += 2) {
@@ -391,7 +456,7 @@ public class RecurrenceUtilTest {
 			String recurrence = (String)objects[i + 1];
 
 			CalendarBooking calendarBooking = mockCalendarBooking(
-				startTimeJCalendar, recurrence);
+				startTimeJCalendar, recurrence, timeZone);
 
 			calendarBookings.add(calendarBooking);
 		}
@@ -400,7 +465,7 @@ public class RecurrenceUtilTest {
 	}
 
 	protected CalendarBooking mockCalendarBooking(
-		Calendar startTimeJCalendar, String recurrence) {
+		Calendar startTimeJCalendar, String recurrence, TimeZone timeZone) {
 
 		CalendarBooking calendarBooking = Mockito.mock(
 			CalendarBookingImpl.class, Mockito.CALLS_REAL_METHODS);
@@ -411,7 +476,7 @@ public class RecurrenceUtilTest {
 		calendarBooking.setRecurrence(recurrence);
 
 		Mockito.doReturn(
-			_utcTimeZone
+			timeZone
 		).when(
 			calendarBooking
 		).getTimeZone();

--- a/modules/apps/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/util/test/CalendarUtilTest.java
+++ b/modules/apps/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/util/test/CalendarUtilTest.java
@@ -116,7 +116,7 @@ public class CalendarUtilTest {
 		throws Exception {
 
 		CalendarBooking calendarBookingInstance =
-			getCalendarBookingChildAllFollowingInstnace();
+			getCalendarBookingChildAllFollowingInstance();
 
 		Method method = _calendarUtilClass.getMethod(
 			"toCalendarBookingJSONObject", ThemeDisplay.class,
@@ -138,7 +138,7 @@ public class CalendarUtilTest {
 		throws Exception {
 
 		CalendarBooking calendarBookingInstance =
-			getCalendarBookingChildAllFollowingInstnace();
+			getCalendarBookingChildAllFollowingInstance();
 
 		CalendarBooking calendarBooking =
 			_calendarBookingLocalService.fetchCalendarBooking(
@@ -301,14 +301,14 @@ public class CalendarUtilTest {
 
 		Set<Long> actualCalendarBookingIds = getCalendarBookingIds(jsonArray);
 
-		Set<Long> excpectedCalendarBookingIds = getCalendarBookingIds(
+		Set<Long> expectedCalendarBookingIds = getCalendarBookingIds(
 			calendarBookings);
 
-		excpectedCalendarBookingIds.remove(
+		expectedCalendarBookingIds.remove(
 			anotherUserDraft.getCalendarBookingId());
 
 		Assert.assertEquals(
-			excpectedCalendarBookingIds, actualCalendarBookingIds);
+			expectedCalendarBookingIds, actualCalendarBookingIds);
 	}
 
 	@Test
@@ -381,7 +381,7 @@ public class CalendarUtilTest {
 		return themeDisplay;
 	}
 
-	protected CalendarBooking getCalendarBookingChildAllFollowingInstnace()
+	protected CalendarBooking getCalendarBookingChildAllFollowingInstance()
 		throws PortalException {
 
 		ServiceContext serviceContext = createServiceContext();


### PR DESCRIPTION
Suppose you do business with a company in New York (Eastern Time which does acknowledge DST), but you live in Arizona (which does not change for DST at all). This company has a weekly conference call every Wednesday at 10am EST...and this conference call is on a shared calendar that you and they both have access to. For you, this call will normally occur at 8am. However, when New York changes their clocks for DST, you do not. So during this time (from March to November), you are experiencing this conference call at 7am while they still experience the same call at 10am like they always have. You will see this reflected on your calendar as well - if you are in Arizona, all occurrences of this event outside of DST will show as being at 8am. However, during the date range from March to November while New York changes for DST, your calendar will show these event occurrences happening at 7am just like you'd expect. For everyone in New York, their calendars will all show the same event always occurring at 10am.

This all works because calendars use the creation time zone's rules for DST.

https://webis.helpshift.com/hc/en/3-pocket-informant/faq/177-recurring-events-and-daylight-saving-time-1634048685/