### PR TITLE
LPD-18888 Use the LocaleUtil.BRAZIL instead of LocaleUtil.PORTUGAL as…

### DIFF
--- a/portal-kernel/test/unit/com/liferay/portal/kernel/util/GetterUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/util/GetterUtilTest.java
@@ -78,7 +78,7 @@ public class GetterUtilTest {
 		// Locale aware
 
 		Assert.assertEquals(
-			4.7, GetterUtil.getDouble("4,7", LocaleUtil.PORTUGAL),
+			4.7, GetterUtil.getDouble("4,7", LocaleUtil.BRAZIL),
 			GetterUtil.DEFAULT_DOUBLE);
 
 		Assert.assertEquals(


### PR DESCRIPTION
… they share the same number format to avoid a known issue on JDK8 with some Portuguese locales, see https://bugs.openjdk.org/browse/JDK-8187711 and https://bugs.openjdk.org/browse/JDK-8178872. With that JDK bug and with CLDR configured as the default locale provider, It requires that the decimal separator for the Locale("pt", "PT") be "$" instead of "," as described in the ticket mentioned early