### PR TITLE
Lpd 15909

### DIFF
--- a/modules/apps/commerce/commerce-payment-service/build.gradle
+++ b/modules/apps/commerce/commerce-payment-service/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.1"
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly group: "org.osgi", name: "org.osgi.annotation.versioning", version: "1.1.0"
+	compileOnly group: "org.osgi", name: "org.osgi.service.cm", version: "1.6.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:commerce:commerce-api")

--- a/modules/apps/commerce/commerce-payment-service/src/main/java/com/liferay/commerce/payment/internal/entry/CommercePaymentEntryRefundTypeRegistryImpl.java
+++ b/modules/apps/commerce/commerce-payment-service/src/main/java/com/liferay/commerce/payment/internal/entry/CommercePaymentEntryRefundTypeRegistryImpl.java
@@ -25,7 +25,6 @@ import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
-import org.osgi.service.component.annotations.Modified;
 
 /**
  * @author Alessio Antonio Rendina
@@ -93,7 +92,6 @@ public class CommercePaymentEntryRefundTypeRegistryImpl
 	}
 
 	@Activate
-	@Modified
 	protected void activate(BundleContext bundleContext) {
 		_serviceTrackerMap = ServiceTrackerMapFactory.openSingleValueMap(
 			bundleContext, CommercePaymentEntryRefundType.class, null,
@@ -123,7 +121,7 @@ public class CommercePaymentEntryRefundTypeRegistryImpl
 	private final Comparator<CommercePaymentEntryRefundType>
 		_commercePaymentEntryRefundTypeOrderComparator =
 			new CommercePaymentEntryRefundTypeOrderComparator();
-	private volatile ServiceTrackerMap<String, CommercePaymentEntryRefundType>
+	private ServiceTrackerMap<String, CommercePaymentEntryRefundType>
 		_serviceTrackerMap;
 
 }

--- a/modules/apps/commerce/commerce-payment-service/src/main/java/com/liferay/commerce/payment/internal/entry/CommercePaymentEntryRefundTypeRegistryImpl.java
+++ b/modules/apps/commerce/commerce-payment-service/src/main/java/com/liferay/commerce/payment/internal/entry/CommercePaymentEntryRefundTypeRegistryImpl.java
@@ -8,9 +8,9 @@ package com.liferay.commerce.payment.internal.entry;
 import com.liferay.commerce.payment.entry.CommercePaymentEntryRefundType;
 import com.liferay.commerce.payment.entry.CommercePaymentEntryRefundTypeRegistry;
 import com.liferay.commerce.payment.internal.entry.comparator.CommercePaymentEntryRefundTypeOrderComparator;
+import com.liferay.osgi.service.tracker.collections.map.PropertyServiceReferenceMapper;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
-import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -66,27 +66,10 @@ public class CommercePaymentEntryRefundTypeRegistryImpl
 		}
 
 		List<CommercePaymentEntryRefundType> commercePaymentEntryRefundTypes =
-			new ArrayList<>();
+			new ArrayList<>(_serviceTrackerMap.values());
 
-		try {
-			commercePaymentEntryRefundTypes = TransformUtil.transform(
-				_serviceTrackerMap.values(),
-				commercePaymentEntryRefundType -> {
-					if (commercePaymentEntryRefundType.isEnabled()) {
-						return commercePaymentEntryRefundType;
-					}
-
-					return null;
-				});
-
-			commercePaymentEntryRefundTypes.sort(
-				_commercePaymentEntryRefundTypeOrderComparator);
-		}
-		catch (Exception exception) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(exception);
-			}
-		}
+		commercePaymentEntryRefundTypes.sort(
+			_commercePaymentEntryRefundTypeOrderComparator);
 
 		return Collections.unmodifiableList(commercePaymentEntryRefundTypes);
 	}
@@ -94,20 +77,8 @@ public class CommercePaymentEntryRefundTypeRegistryImpl
 	@Activate
 	protected void activate(BundleContext bundleContext) {
 		_serviceTrackerMap = ServiceTrackerMapFactory.openSingleValueMap(
-			bundleContext, CommercePaymentEntryRefundType.class, null,
-			(serviceReference, emitter) -> {
-				CommercePaymentEntryRefundType commercePaymentEntryRefundType =
-					bundleContext.getService(serviceReference);
-
-				try {
-					if (commercePaymentEntryRefundType.getKey() != null) {
-						emitter.emit(commercePaymentEntryRefundType.getKey());
-					}
-				}
-				finally {
-					bundleContext.ungetService(serviceReference);
-				}
-			});
+			bundleContext, CommercePaymentEntryRefundType.class,
+			"(enabled=true)", new PropertyServiceReferenceMapper<>("key"));
 	}
 
 	@Deactivate

--- a/modules/apps/commerce/commerce-payment-service/src/main/java/com/liferay/commerce/payment/internal/feature/flag/DefaultCommercePaymentEntryRefundTypeFeatureFlagListener.java
+++ b/modules/apps/commerce/commerce-payment-service/src/main/java/com/liferay/commerce/payment/internal/feature/flag/DefaultCommercePaymentEntryRefundTypeFeatureFlagListener.java
@@ -1,0 +1,100 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.commerce.payment.internal.feature.flag;
+
+import com.liferay.commerce.payment.configuration.CommercePaymentEntryRefundTypeConfiguration;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
+import com.liferay.portal.kernel.exception.ModelListenerException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagListener;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+
+import java.io.IOException;
+
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Shuyang Zhou
+ */
+@Component(
+	property = "featureFlagKey=COMMERCE-12754",
+	service = FeatureFlagListener.class
+)
+public class DefaultCommercePaymentEntryRefundTypeFeatureFlagListener
+	implements FeatureFlagListener {
+
+	@Override
+	public void onValue(
+		long companyId, String featureFlagKey, boolean enabled) {
+
+		if (!enabled) {
+			return;
+		}
+
+		try {
+			Configuration[] configurations =
+				_configurationAdmin.listConfigurations(
+					StringBundler.concat(
+						"(&(companyId=", companyId, ")(service.pid=",
+						CommercePaymentEntryRefundTypeConfiguration.class.
+							getName(),
+						"*))"));
+
+			if (!ArrayUtil.isEmpty(configurations)) {
+				return;
+			}
+
+			_createFactoryConfiguration(
+				_configurationAdmin.createFactoryConfiguration(
+					CommercePaymentEntryRefundTypeConfiguration.class.getName(),
+					StringPool.QUESTION),
+				CommercePaymentEntryRefundTypeConfiguration.class.getName(),
+				"damaged-in-transit", "Damaged in Transit", companyId);
+			_createFactoryConfiguration(
+				_configurationAdmin.createFactoryConfiguration(
+					CommercePaymentEntryRefundTypeConfiguration.class.getName(),
+					StringPool.QUESTION),
+				CommercePaymentEntryRefundTypeConfiguration.class.getName(),
+				"product-defect", "Product Defect", companyId);
+		}
+		catch (Exception exception) {
+			throw new ModelListenerException(exception);
+		}
+	}
+
+	private void _createFactoryConfiguration(
+			Configuration configuration, String factoryPid, String key,
+			String name, long companyId)
+		throws IOException {
+
+		configuration.update(
+			HashMapDictionaryBuilder.<String, Object>put(
+				ConfigurationAdmin.SERVICE_FACTORYPID, factoryPid
+			).put(
+				"enabled", true
+			).put(
+				"key", key
+			).put(
+				"name", name
+			).put(
+				"priority", "0"
+			).put(
+				ExtendedObjectClassDefinition.Scope.COMPANY.getPropertyKey(),
+				companyId
+			).put(
+				"configuration.cleaner.ignore", "true"
+			).build());
+	}
+
+	@Reference
+	private ConfigurationAdmin _configurationAdmin;
+
+}

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/instance/lifecycle/CommerceServicePortalInstanceLifecycleListener.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/instance/lifecycle/CommerceServicePortalInstanceLifecycleListener.java
@@ -6,24 +6,12 @@
 package com.liferay.commerce.internal.instance.lifecycle;
 
 import com.liferay.commerce.helper.CommerceSAPHelper;
-import com.liferay.commerce.payment.configuration.CommercePaymentEntryRefundTypeConfiguration;
-import com.liferay.petra.string.StringBundler;
-import com.liferay.petra.string.StringPool;
-import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
 import com.liferay.portal.instance.lifecycle.BasePortalInstanceLifecycleListener;
 import com.liferay.portal.instance.lifecycle.PortalInstanceLifecycleListener;
-import com.liferay.portal.kernel.exception.ModelListenerException;
-import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.UserLocalService;
-import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 
-import java.io.IOException;
-
-import org.osgi.service.cm.Configuration;
-import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
@@ -40,72 +28,10 @@ public class CommerceServicePortalInstanceLifecycleListener
 
 		_commerceSAPHelper.addCommerceDefaultSAPEntries(
 			company.getCompanyId(), user.getUserId());
-
-		if (!FeatureFlagManagerUtil.isEnabled("COMMERCE-12754")) {
-			return;
-		}
-
-		try {
-			Configuration[] configurations =
-				_configurationAdmin.listConfigurations(
-					StringBundler.concat(
-						"(&(companyId=", company.getCompanyId(),
-						")(service.pid=",
-						CommercePaymentEntryRefundTypeConfiguration.class.
-							getName(),
-						"*))"));
-
-			if (!ArrayUtil.isEmpty(configurations)) {
-				return;
-			}
-
-			_createFactoryConfiguration(
-				_configurationAdmin.createFactoryConfiguration(
-					CommercePaymentEntryRefundTypeConfiguration.class.getName(),
-					StringPool.QUESTION),
-				CommercePaymentEntryRefundTypeConfiguration.class.getName(),
-				"damaged-in-transit", "Damaged in Transit", company);
-			_createFactoryConfiguration(
-				_configurationAdmin.createFactoryConfiguration(
-					CommercePaymentEntryRefundTypeConfiguration.class.getName(),
-					StringPool.QUESTION),
-				CommercePaymentEntryRefundTypeConfiguration.class.getName(),
-				"product-defect", "Product Defect", company);
-		}
-		catch (Exception exception) {
-			throw new ModelListenerException(exception);
-		}
-	}
-
-	private void _createFactoryConfiguration(
-			Configuration configuration, String factoryPid, String key,
-			String name, Company company)
-		throws IOException {
-
-		configuration.update(
-			HashMapDictionaryBuilder.<String, Object>put(
-				ConfigurationAdmin.SERVICE_FACTORYPID, factoryPid
-			).put(
-				"enabled", true
-			).put(
-				"key", key
-			).put(
-				"name", name
-			).put(
-				"priority", "0"
-			).put(
-				ExtendedObjectClassDefinition.Scope.COMPANY.getPropertyKey(),
-				company.getCompanyId()
-			).put(
-				"configuration.cleaner.ignore", "true"
-			).build());
 	}
 
 	@Reference
 	private CommerceSAPHelper _commerceSAPHelper;
-
-	@Reference
-	private ConfigurationAdmin _configurationAdmin;
 
 	@Reference
 	private UserLocalService _userLocalService;


### PR DESCRIPTION
@brianchandotcom statistically speaking, whenever a new PortalInstanceLifecycleListener is added or existing ones being modified with if condition (like in this case https://github.com/liferay/liferay-portal/commit/c4e3fa9c8311d12c8d0d029558ec5c3096a74948#diff-9a6a47bc6dc1f5601da9c131c422466b5cfcc896477e74363c25f68d39554a33R44), it is very likely to have some logical issues there. Please be more strict on reviewing those changes.

@CrescenzoRegaLF there are still 2 issues you need to deal with after my fix.

1) Everytime a new company enables "COMMERCE-12754" feature flag, its 2 default configurations are created, which leads to 2 instances of CommercePaymentEntryRefundTypeImpl being activated. They will then be collected by CommercePaymentEntryRefundTypeRegistryImpl's ServiceTrackerMap. Due it is a single value ServiceTrackerMap and all default configurations have the same key. The ServiceTrackerMap always just returns the very first 2 configurations it collected, ignoring all following ones. If no one changes the default configurations, they all have the same content, it would not be a problem (other than wasting memory). But if a later company changes its default configurations, CommercePaymentEntryRefundTypeRegistryImpl is not going to see the change. Depending on how you use this CommercePaymentEntryRefundTypeRegistryImpl, this could be a serious bug.

Fundamentally this issue is, you made the CommercePaymentEntryRefundTypeConfiguration company scope, which also means CommercePaymentEntryRefundTypeImpl is company scope. But CommercePaymentEntryRefundTypeRegistryImpl is still system scope, this is logically self conflicting.


2) In the original logic, you only dealt with default configuration creation when feature flag is enabled. So I kept the same thing in the DefaultCommercePaymentEntryRefundTypeFeatureFlagListener. But what is the expected behavior when user disables the feature flag later? Right now it just left the created default configuration alone. Don't you want to clean them up to restore to the original state before enabling the feature flag? If so, please add a follow up cleaning logic in DefaultCommercePaymentEntryRefundTypeFeatureFlagListener when the feature flag is disabled.

Please send your followup pulls through core-infra.

CC @vicnate5 @brunofalc unplanned work.