### PR TITLE
LPD-18879-LPD-18880

### DIFF
--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/UserAccountResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/UserAccountResourceImpl.java
@@ -983,7 +983,7 @@ public class UserAccountResourceImpl extends BaseUserAccountResourceImpl {
 			serviceContext);
 
 		user = _userService.updateExternalReferenceCode(
-			userAccountId,
+			user,
 			GetterUtil.getString(
 				userAccount.getExternalReferenceCode(),
 				user.getExternalReferenceCode()));


### PR DESCRIPTION
Hey @brianchandotcom, update from #147863 because one of your changes broke the putUserAccount.

The updateExternalReferenceCode which has userId as a param needs to be called before updateUser otherwise a `org.hibernate.StaleObjectStateException: Row was updated or deleted by another transaction (or unsaved-value mapping was incorrect)` occurs.

If we want to call it after the updateUser, we need to use the new updateExternalReferenceCode which has the user as a param