### PR TITLE
LPD-20366: Enable to delete multiple job scheduler triggers created

### DIFF
--- a/modules/apps/dispatch/dispatch-web/src/main/java/com/liferay/dispatch/web/internal/display/context/DispatchTriggerDisplayContext.java
+++ b/modules/apps/dispatch/dispatch-web/src/main/java/com/liferay/dispatch/web/internal/display/context/DispatchTriggerDisplayContext.java
@@ -200,6 +200,12 @@ public class DispatchTriggerDisplayContext extends BaseDisplayContext {
 		return _searchContainer;
 	}
 
+	public int getTotalItems() {
+		SearchContainer<DispatchTrigger> searchContainer = getSearchContainer();
+
+		return searchContainer.getTotal();
+	}
+
 	public ViewTypeItemList getViewTypeItems() {
 		return new ViewTypeItemList(getPortletURL(), "list") {
 			{

--- a/modules/apps/dispatch/dispatch-web/src/main/java/com/liferay/dispatch/web/internal/portlet/action/EditDispatchTriggerMVCActionCommand.java
+++ b/modules/apps/dispatch/dispatch-web/src/main/java/com/liferay/dispatch/web/internal/portlet/action/EditDispatchTriggerMVCActionCommand.java
@@ -31,7 +31,6 @@ import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -122,8 +121,8 @@ public class EditDispatchTriggerMVCActionCommand extends BaseMVCActionCommand {
 			deleteDispatchTriggerIds = new long[] {dispatchTriggerId};
 		}
 		else {
-			deleteDispatchTriggerIds = StringUtil.split(
-				ParamUtil.getString(actionRequest, "rowIds"), 0L);
+			deleteDispatchTriggerIds = ParamUtil.getLongValues(
+				actionRequest, "rowIds");
 		}
 
 		for (long deleteDispatchTriggerId : deleteDispatchTriggerIds) {

--- a/modules/apps/dispatch/dispatch-web/src/main/resources/META-INF/resources/dispatch_trigger_toolbar.jsp
+++ b/modules/apps/dispatch/dispatch-web/src/main/resources/META-INF/resources/dispatch_trigger_toolbar.jsp
@@ -25,6 +25,7 @@ DispatchTriggerDisplayContext dispatchTriggerDisplayContext = (DispatchTriggerDi
 		).build()
 	%>'
 	creationMenu="<%= dispatchTriggerDisplayContext.getCreationMenu() %>"
+	itemsTotal="<%= dispatchTriggerDisplayContext.getTotalItems() %>"
 	propsTransformer="{DispatchTriggerManagementToolbarPropsTransformer} from dispatch-web"
 	searchContainerId='<%= ParamUtil.getString(request, "searchContainerId", "dispatchTrigger") %>'
 	showSearch="<%= false %>"

--- a/modules/test/playwright/pages/product-navigation-applications-menu/ApplicationsMenuPage.ts
+++ b/modules/test/playwright/pages/product-navigation-applications-menu/ApplicationsMenuPage.ts
@@ -22,6 +22,7 @@ export class ApplicationsMenuPage {
 	private readonly gogoShellItem: Locator;
 	private readonly homePage: HomePage;
 	private readonly instanceSettingsMenuItem: Locator;
+	private readonly jobSchedulerMenuItem: Locator;
 	private readonly oAuth2Administration: Locator;
 	private readonly objectsMenuItem: Locator;
 	readonly page: Page;
@@ -72,6 +73,10 @@ export class ApplicationsMenuPage {
 		this.instanceSettingsMenuItem = page.getByRole('menuitem', {
 			exact: true,
 			name: 'Instance Settings',
+		});
+		this.jobSchedulerMenuItem = page.getByRole('menuitem', {
+			exact: true,
+			name: 'Job Scheduler',
 		});
 		this.oAuth2Administration = page.getByRole('menuitem', {
 			exact: true,
@@ -167,6 +172,11 @@ export class ApplicationsMenuPage {
 	async goToInstanceSettings() {
 		await this.goToControlPanel();
 		await this.instanceSettingsMenuItem.click();
+	}
+
+	async goToJobScheduler() {
+		await this.goToControlPanel();
+		await this.jobSchedulerMenuItem.click();
 	}
 
 	async goToCommerceChannels() {

--- a/modules/test/playwright/playwright.config.ts
+++ b/modules/test/playwright/playwright.config.ts
@@ -10,6 +10,7 @@ import {config as announcementsWebConfig} from './tests/announcements-web/config
 import {config as batchPlannerConfig} from './tests/batch-planner/config';
 import {config as clientExtensionWebConfig} from './tests/client-extension-web/config';
 import {config as commerceConfig} from './tests/commerce/config';
+import {config as dispatchWebConfig} from './tests/dispatch-web/config';
 import {config as documentLibraryWebConfig} from './tests/document-library-web/config';
 import {config as exportImportWebConfig} from './tests/export-import-web/config';
 import {config as frontendDataSetViewsWebConfig} from './tests/frontend-data-set-views-web/config';
@@ -39,6 +40,7 @@ export default defineConfig({
 		batchPlannerConfig,
 		clientExtensionWebConfig,
 		commerceConfig,
+		dispatchWebConfig,
 		documentLibraryWebConfig,
 		exportImportWebConfig,
 		frontendDataSetViewsWebConfig,

--- a/modules/test/playwright/tests/dispatch-web/config.ts
+++ b/modules/test/playwright/tests/dispatch-web/config.ts
@@ -1,0 +1,15 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {devices} from '@playwright/test';
+
+export const config = {
+	name: 'dispatch-web',
+	testDir: 'tests/dispatch-web',
+	use: {
+		...devices['Desktop Chrome'],
+		testIdAttribute: 'data-qa-id',
+	},
+};

--- a/modules/test/playwright/tests/dispatch-web/fixtures/jobSchedulerPagesTest.ts
+++ b/modules/test/playwright/tests/dispatch-web/fixtures/jobSchedulerPagesTest.ts
@@ -1,0 +1,18 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {test} from '@playwright/test';
+
+import {JobSchedulerPage} from '../pages/JobSchedulerPage';
+
+const jobSchedulerPagesTest = test.extend<{
+	jobSchedulerPage: JobSchedulerPage;
+}>({
+	jobSchedulerPage: async ({page}, use) => {
+		await use(new JobSchedulerPage(page));
+	},
+});
+
+export {jobSchedulerPagesTest};

--- a/modules/test/playwright/tests/dispatch-web/jobScheduler.spec.ts
+++ b/modules/test/playwright/tests/dispatch-web/jobScheduler.spec.ts
@@ -1,0 +1,39 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {loginTest} from '../../fixtures/loginTest';
+import {jobSchedulerPagesTest} from './fixtures/jobSchedulerPagesTest';
+
+export const test = mergeTests(loginTest(), jobSchedulerPagesTest);
+
+test('can create two job triggers and can delete them', async ({
+	jobSchedulerPage,
+	page,
+}) => {
+	await jobSchedulerPage.goTo();
+
+	await jobSchedulerPage.createNewJobSchedulerTrigger('Job Trigger 1');
+	await jobSchedulerPage.createNewJobSchedulerTrigger('Job Trigger 2');
+
+	await page.getByTestId('row').nth(0).getByRole('checkbox').check();
+	await page.getByTestId('row').nth(1).getByRole('checkbox').check();
+
+	await expect(page.getByText('2 of 6 Items Selected')).toBeVisible();
+
+	page.on('dialog', async (dialogWindow) => {
+		await dialogWindow.accept();
+	});
+
+	await page.getByRole('button', {name: 'Delete'}).click();
+
+	await expect(page.getByRole('link', {name: 'Job Trigger 1'})).toHaveCount(
+		0
+	);
+	await expect(page.getByRole('link', {name: 'Job Trigger 2'})).toHaveCount(
+		0
+	);
+});

--- a/modules/test/playwright/tests/dispatch-web/pages/JobSchedulerPage.ts
+++ b/modules/test/playwright/tests/dispatch-web/pages/JobSchedulerPage.ts
@@ -1,0 +1,42 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Locator, Page} from '@playwright/test';
+
+import {ApplicationsMenuPage} from '../../../pages/product-navigation-applications-menu/ApplicationsMenuPage';
+
+export class JobSchedulerPage {
+	readonly applicationsMenuPage: ApplicationsMenuPage;
+	readonly exportAnalyticsDxpEntitiesItem: Locator;
+	readonly newJobSchedulerTriggerButton: Locator;
+	readonly newJobSchedulerTriggerTitleBox: Locator;
+	readonly page: Page;
+
+	constructor(page: Page) {
+		this.applicationsMenuPage = new ApplicationsMenuPage(page);
+		this.exportAnalyticsDxpEntitiesItem = page.getByRole('menuitem', {
+			name: 'export-analytics-dxp-entities',
+		});
+		this.newJobSchedulerTriggerButton = page.getByRole('button', {
+			name: 'New',
+		});
+		this.newJobSchedulerTriggerTitleBox = page.locator(
+			'//*[@id="_com_liferay_dispatch_web_internal_portlet_DispatchPortlet_name"]'
+		);
+		this.page = page;
+	}
+
+	async goTo() {
+		await this.applicationsMenuPage.goToJobScheduler();
+	}
+
+	async createNewJobSchedulerTrigger(jobSchedulerTriggerName: string) {
+		await this.newJobSchedulerTriggerButton.click();
+		await this.exportAnalyticsDxpEntitiesItem.click();
+		await this.newJobSchedulerTriggerTitleBox.fill(jobSchedulerTriggerName);
+
+		await this.page.getByRole('button', {name: 'Save'}).click();
+	}
+}


### PR DESCRIPTION
## Motivation
The idea of this PR is to fix the management toolbar logic where an user can delete several job schedulers created and it can show all the total job schedulers triggers when a job scheduler is selected.

**What is new?**
- Get all selected `dispatchTriggersIds` from a Long Array instead of getting all the parameter as String and split it because it will always return the first one.
- Fix `management toolbar` total numbers of Job Schedulers created.
- Add new module in `playwright` to test these two cases.

**JIRA Related Ticket**
https://liferay.atlassian.net/browse/LPD-20366 