### PR TITLE
LPD-6870 Sign In Utility Page - rename 2nd struts action (resent after rebase)

### DIFF
--- a/modules/apps/layout/layout-utility-page/layout-utility-page-login/src/main/java/com/liferay/layout/utility/page/login/internal/struts/LoginUtilityPageStrutsAction.java
+++ b/modules/apps/layout/layout-utility-page/layout-utility-page-login/src/main/java/com/liferay/layout/utility/page/login/internal/struts/LoginUtilityPageStrutsAction.java
@@ -46,12 +46,6 @@ public class LoginUtilityPageStrutsAction implements StrutsAction {
 		LayoutSet layoutSet = _layoutSetLocalService.getLayoutSet(
 			themeDisplay.getScopeGroupId(), false);
 
-		themeDisplay.setLayoutSet(layoutSet);
-		themeDisplay.setLookAndFeel(
-			layoutSet.getTheme(), layoutSet.getColorScheme());
-
-		httpServletRequest.setAttribute(WebKeys.THEME_DISPLAY, themeDisplay);
-
 		RequestDispatcher requestDispatcher =
 			_servletContext.getRequestDispatcher("/login.jsp");
 

--- a/modules/apps/layout/layout-utility-page/layout-utility-page-login/src/main/java/com/liferay/layout/utility/page/login/internal/struts/LoginUtilityPageStrutsAction.java
+++ b/modules/apps/layout/layout-utility-page/layout-utility-page-login/src/main/java/com/liferay/layout/utility/page/login/internal/struts/LoginUtilityPageStrutsAction.java
@@ -30,8 +30,8 @@ import org.osgi.service.component.annotations.Reference;
 /**
  * @author Olivér Kecskeméty
  */
-@Component(property = "path=/portal/sign_in", service = StrutsAction.class)
-public class SignInStrutsAction implements StrutsAction {
+@Component(property = "path=/portal/login_up", service = StrutsAction.class)
+public class LoginUtilityPageStrutsAction implements StrutsAction {
 
 	@Override
 	public String execute(

--- a/modules/apps/layout/layout-utility-page/layout-utility-page-login/src/main/java/com/liferay/layout/utility/page/login/internal/struts/SignInStrutsAction.java
+++ b/modules/apps/layout/layout-utility-page/layout-utility-page-login/src/main/java/com/liferay/layout/utility/page/login/internal/struts/SignInStrutsAction.java
@@ -13,9 +13,6 @@ import com.liferay.portal.kernel.servlet.ServletResponseUtil;
 import com.liferay.portal.kernel.struts.StrutsAction;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.theme.ThemeUtil;
-import com.liferay.portal.kernel.util.ParamUtil;
-import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import javax.servlet.RequestDispatcher;
@@ -45,20 +42,6 @@ public class SignInStrutsAction implements StrutsAction {
 		ThemeDisplay themeDisplay =
 			(ThemeDisplay)httpServletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
-
-		long groupId = ParamUtil.getLong(httpServletRequest, "groupId");
-
-		if (groupId != 0) {
-			themeDisplay.setScopeGroupId(groupId);
-
-			String portletId = ParamUtil.getString(
-				httpServletRequest, "p_p_id");
-
-			if (Validator.isNotNull(portletId)) {
-				themeDisplay.setPlid(
-					_portal.getPlidFromPortletId(groupId, portletId));
-			}
-		}
 
 		LayoutSet layoutSet = _layoutSetLocalService.getLayoutSet(
 			themeDisplay.getScopeGroupId(), false);
@@ -96,9 +79,6 @@ public class SignInStrutsAction implements StrutsAction {
 
 	@Reference
 	private LayoutSetLocalService _layoutSetLocalService;
-
-	@Reference
-	private Portal _portal;
 
 	@Reference(
 		target = "(osgi.web.symbolicname=com.liferay.layout.utility.page.login)"

--- a/modules/apps/layout/layout-utility-page/layout-utility-page-login/src/main/java/com/liferay/layout/utility/page/login/internal/struts/SignInStrutsAction.java
+++ b/modules/apps/layout/layout-utility-page/layout-utility-page-login/src/main/java/com/liferay/layout/utility/page/login/internal/struts/SignInStrutsAction.java
@@ -1,0 +1,88 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.utility.page.login.internal.struts;
+
+import com.liferay.petra.io.unsync.UnsyncStringWriter;
+import com.liferay.portal.kernel.model.LayoutSet;
+import com.liferay.portal.kernel.service.LayoutSetLocalService;
+import com.liferay.portal.kernel.servlet.PipingServletResponse;
+import com.liferay.portal.kernel.servlet.ServletResponseUtil;
+import com.liferay.portal.kernel.struts.StrutsAction;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.theme.ThemeUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Olivér Kecskeméty
+ */
+@Component(property = "path=/portal/sign_in", service = StrutsAction.class)
+public class SignInStrutsAction implements StrutsAction {
+
+	@Override
+	public String execute(
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse)
+		throws Exception {
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		LayoutSet layoutSet = _layoutSetLocalService.getLayoutSet(
+			themeDisplay.getScopeGroupId(), false);
+
+		themeDisplay.setLayoutSet(layoutSet);
+		themeDisplay.setLookAndFeel(
+			layoutSet.getTheme(), layoutSet.getColorScheme());
+
+		httpServletRequest.setAttribute(WebKeys.THEME_DISPLAY, themeDisplay);
+
+		RequestDispatcher requestDispatcher =
+			_servletContext.getRequestDispatcher("/login.jsp");
+
+		UnsyncStringWriter unsyncStringWriter = new UnsyncStringWriter();
+
+		PipingServletResponse pipingServletResponse = new PipingServletResponse(
+			httpServletResponse, unsyncStringWriter);
+
+		requestDispatcher.include(httpServletRequest, pipingServletResponse);
+
+		Document document = Jsoup.parse(
+			ThemeUtil.include(
+				httpServletRequest.getServletContext(), httpServletRequest,
+				httpServletResponse, "portal_normal.ftl", layoutSet.getTheme(),
+				false));
+
+		Element contentElement = document.getElementById("content");
+
+		contentElement.html(unsyncStringWriter.toString());
+
+		ServletResponseUtil.write(httpServletResponse, document.html());
+
+		return null;
+	}
+
+	@Reference
+	private LayoutSetLocalService _layoutSetLocalService;
+
+	@Reference(
+		target = "(osgi.web.symbolicname=com.liferay.layout.utility.page.login)"
+	)
+	private ServletContext _servletContext;
+
+}

--- a/modules/apps/layout/layout-utility-page/layout-utility-page-login/src/main/java/com/liferay/layout/utility/page/login/internal/struts/SignInStrutsAction.java
+++ b/modules/apps/layout/layout-utility-page/layout-utility-page-login/src/main/java/com/liferay/layout/utility/page/login/internal/struts/SignInStrutsAction.java
@@ -13,6 +13,9 @@ import com.liferay.portal.kernel.servlet.ServletResponseUtil;
 import com.liferay.portal.kernel.struts.StrutsAction;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.theme.ThemeUtil;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import javax.servlet.RequestDispatcher;
@@ -42,6 +45,20 @@ public class SignInStrutsAction implements StrutsAction {
 		ThemeDisplay themeDisplay =
 			(ThemeDisplay)httpServletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
+
+		long groupId = ParamUtil.getLong(httpServletRequest, "groupId");
+
+		if (groupId != 0) {
+			themeDisplay.setScopeGroupId(groupId);
+
+			String portletId = ParamUtil.getString(
+				httpServletRequest, "p_p_id");
+
+			if (Validator.isNotNull(portletId)) {
+				themeDisplay.setPlid(
+					_portal.getPlidFromPortletId(groupId, portletId));
+			}
+		}
 
 		LayoutSet layoutSet = _layoutSetLocalService.getLayoutSet(
 			themeDisplay.getScopeGroupId(), false);
@@ -79,6 +96,9 @@ public class SignInStrutsAction implements StrutsAction {
 
 	@Reference
 	private LayoutSetLocalService _layoutSetLocalService;
+
+	@Reference
+	private Portal _portal;
 
 	@Reference(
 		target = "(osgi.web.symbolicname=com.liferay.layout.utility.page.login)"

--- a/modules/apps/layout/layout-utility-page/layout-utility-page-login/src/main/resources/META-INF/resources/init-ext.jsp
+++ b/modules/apps/layout/layout-utility-page/layout-utility-page-login/src/main/resources/META-INF/resources/init-ext.jsp
@@ -1,0 +1,6 @@
+<%--
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+--%>

--- a/modules/apps/layout/layout-utility-page/layout-utility-page-login/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/layout/layout-utility-page/layout-utility-page-login/src/main/resources/META-INF/resources/init.jsp
@@ -1,0 +1,15 @@
+<%--
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+--%>
+
+<%@ taglib uri="http://liferay.com/tld/layout" prefix="liferay-layout" %><%@
+taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
+
+<%@ page import="com.liferay.layout.utility.page.kernel.constants.LayoutUtilityPageEntryConstants" %>
+
+<liferay-theme:defineObjects />
+
+<%@ include file="/init-ext.jsp" %>

--- a/modules/apps/layout/layout-utility-page/layout-utility-page-login/src/main/resources/META-INF/resources/login.jsp
+++ b/modules/apps/layout/layout-utility-page/layout-utility-page-login/src/main/resources/META-INF/resources/login.jsp
@@ -1,0 +1,12 @@
+<%--
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+--%>
+
+<%@ include file="/init.jsp" %>
+
+<liferay-layout:render-layout-utility-page-entry
+	type="<%= LayoutUtilityPageEntryConstants.TYPE_LOGIN %>"
+/>

--- a/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/portlet/action/LoginMVCActionCommand.java
+++ b/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/portlet/action/LoginMVCActionCommand.java
@@ -247,13 +247,13 @@ public class LoginMVCActionCommand extends BaseMVCActionCommand {
 
 		Layout layout = (Layout)actionRequest.getAttribute(WebKeys.LAYOUT);
 
-		Layout utilityPage =
+		Layout signInUtilityPage =
 			LayoutUtilityPageEntryLayoutProviderUtil.
 				getDefaultLayoutUtilityPageEntryLayout(
 					layout.getGroupId(),
 					LayoutUtilityPageEntryConstants.TYPE_LOGIN);
 
-		if (utilityPage != null) {
+		if (signInUtilityPage != null) {
 			actionResponse.sendRedirect(Portal.PATH_MAIN + "/portal/sign_in");
 
 			return;

--- a/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/portlet/action/LoginMVCActionCommand.java
+++ b/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/portlet/action/LoginMVCActionCommand.java
@@ -259,7 +259,7 @@ public class LoginMVCActionCommand extends BaseMVCActionCommand {
 			redirect = Portal.PATH_MAIN + "/portal/sign_in";
 
 			redirect = HttpComponentsUtil.setParameter(
-				redirect, "groupId", layout.getGroupId());
+				redirect, "p_l_id", layout.getPlid());
 		}
 
 		if (Validator.isNull(redirect)) {

--- a/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/portlet/action/LoginMVCActionCommand.java
+++ b/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/portlet/action/LoginMVCActionCommand.java
@@ -5,6 +5,8 @@
 
 package com.liferay.login.web.internal.portlet.action;
 
+import com.liferay.layout.utility.page.kernel.constants.LayoutUtilityPageEntryConstants;
+import com.liferay.layout.utility.page.kernel.provider.util.LayoutUtilityPageEntryLayoutProviderUtil;
 import com.liferay.login.web.constants.LoginPortletKeys;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.CompanyMaxUsersException;
@@ -243,12 +245,24 @@ public class LoginMVCActionCommand extends BaseMVCActionCommand {
 			ActionRequest actionRequest, ActionResponse actionResponse)
 		throws Exception {
 
+		Layout layout = (Layout)actionRequest.getAttribute(WebKeys.LAYOUT);
+
+		Layout utilityPage =
+			LayoutUtilityPageEntryLayoutProviderUtil.
+				getDefaultLayoutUtilityPageEntryLayout(
+					layout.getGroupId(),
+					LayoutUtilityPageEntryConstants.TYPE_LOGIN);
+
+		if (utilityPage != null) {
+			actionResponse.sendRedirect(Portal.PATH_MAIN + "/portal/sign_in");
+
+			return;
+		}
+
 		LiferayPortletRequest liferayPortletRequest =
 			_portal.getLiferayPortletRequest(actionRequest);
 
 		String portletName = liferayPortletRequest.getPortletName();
-
-		Layout layout = (Layout)actionRequest.getAttribute(WebKeys.LAYOUT);
 
 		PortletURL portletURL = PortletURLBuilder.create(
 			PortletURLFactoryUtil.create(

--- a/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/portlet/action/LoginMVCActionCommand.java
+++ b/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/portlet/action/LoginMVCActionCommand.java
@@ -247,6 +247,8 @@ public class LoginMVCActionCommand extends BaseMVCActionCommand {
 
 		Layout layout = (Layout)actionRequest.getAttribute(WebKeys.LAYOUT);
 
+		String redirect = null;
+
 		Layout signInUtilityPage =
 			LayoutUtilityPageEntryLayoutProviderUtil.
 				getDefaultLayoutUtilityPageEntryLayout(
@@ -254,34 +256,32 @@ public class LoginMVCActionCommand extends BaseMVCActionCommand {
 					LayoutUtilityPageEntryConstants.TYPE_LOGIN);
 
 		if (signInUtilityPage != null) {
-			actionResponse.sendRedirect(Portal.PATH_MAIN + "/portal/sign_in");
-
-			return;
+			redirect = Portal.PATH_MAIN + "/portal/sign_in";
 		}
 
-		LiferayPortletRequest liferayPortletRequest =
-			_portal.getLiferayPortletRequest(actionRequest);
+		if (Validator.isNull(redirect)) {
+			LiferayPortletRequest liferayPortletRequest =
+				_portal.getLiferayPortletRequest(actionRequest);
 
-		String portletName = liferayPortletRequest.getPortletName();
+			String portletName = liferayPortletRequest.getPortletName();
 
-		PortletURL portletURL = PortletURLBuilder.create(
-			PortletURLFactoryUtil.create(
-				actionRequest, liferayPortletRequest.getPortlet(), layout,
-				PortletRequest.RENDER_PHASE)
-		).setRedirect(
-			() -> {
-				String redirect = ParamUtil.getString(
-					actionRequest, "redirect");
+			PortletURL portletURL = PortletURLBuilder.create(
+				PortletURLFactoryUtil.create(
+					actionRequest, liferayPortletRequest.getPortlet(), layout,
+					PortletRequest.RENDER_PHASE)
+			).setParameter(
+				"saveLastPath", false
+			).buildPortletURL();
 
-				if (Validator.isNotNull(redirect)) {
-					return redirect;
-				}
-
-				return null;
+			if (portletName.equals(LoginPortletKeys.LOGIN)) {
+				portletURL.setWindowState(WindowState.MAXIMIZED);
 			}
-		).setParameter(
-			"saveLastPath", false
-		).buildPortletURL();
+			else {
+				portletURL.setWindowState(actionRequest.getWindowState());
+			}
+
+			redirect = portletURL.toString();
+		}
 
 		String login = ParamUtil.getString(actionRequest, "login");
 
@@ -289,14 +289,23 @@ public class LoginMVCActionCommand extends BaseMVCActionCommand {
 			SessionErrors.add(actionRequest, "login", login);
 		}
 
-		if (portletName.equals(LoginPortletKeys.LOGIN)) {
-			portletURL.setWindowState(WindowState.MAXIMIZED);
-		}
-		else {
-			portletURL.setWindowState(actionRequest.getWindowState());
+		String loginRedirect = ParamUtil.getString(actionRequest, "redirect");
+
+		if (Validator.isNotNull(loginRedirect)) {
+			String loginPortletNamespace = _portal.getPortletNamespace(
+				PropsValues.AUTH_LOGIN_PORTLET_NAME);
+
+			String loginRedirectParameter = loginPortletNamespace + "redirect";
+
+			redirect = HttpComponentsUtil.setParameter(
+				redirect, "p_p_id", PropsValues.AUTH_LOGIN_PORTLET_NAME);
+			redirect = HttpComponentsUtil.setParameter(
+				redirect, "p_p_lifecycle", "0");
+			redirect = HttpComponentsUtil.setParameter(
+				redirect, loginRedirectParameter, loginRedirect);
 		}
 
-		actionResponse.sendRedirect(portletURL.toString());
+		actionResponse.sendRedirect(redirect);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/portlet/action/LoginMVCActionCommand.java
+++ b/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/portlet/action/LoginMVCActionCommand.java
@@ -253,14 +253,14 @@ public class LoginMVCActionCommand extends BaseMVCActionCommand {
 
 		Layout layout = (Layout)actionRequest.getAttribute(WebKeys.LAYOUT);
 
-		Layout signInUtilityPage =
+		Layout loginUtilityPage =
 			LayoutUtilityPageEntryLayoutProviderUtil.
 				getDefaultLayoutUtilityPageEntryLayout(
 					layout.getGroupId(),
 					LayoutUtilityPageEntryConstants.TYPE_LOGIN);
 
-		if (signInUtilityPage != null) {
-			String redirect = Portal.PATH_MAIN + "/portal/sign_in";
+		if (loginUtilityPage != null) {
+			String redirect = Portal.PATH_MAIN + "/portal/login_up";
 
 			redirect = HttpComponentsUtil.setParameter(
 				redirect, "p_l_id", layout.getPlid());

--- a/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/portlet/action/LoginMVCActionCommand.java
+++ b/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/portlet/action/LoginMVCActionCommand.java
@@ -245,9 +245,13 @@ public class LoginMVCActionCommand extends BaseMVCActionCommand {
 			ActionRequest actionRequest, ActionResponse actionResponse)
 		throws Exception {
 
-		Layout layout = (Layout)actionRequest.getAttribute(WebKeys.LAYOUT);
+		String login = ParamUtil.getString(actionRequest, "login");
 
-		String redirect = null;
+		if (Validator.isNotNull(login)) {
+			SessionErrors.add(actionRequest, "login", login);
+		}
+
+		Layout layout = (Layout)actionRequest.getAttribute(WebKeys.LAYOUT);
 
 		Layout signInUtilityPage =
 			LayoutUtilityPageEntryLayoutProviderUtil.
@@ -256,59 +260,64 @@ public class LoginMVCActionCommand extends BaseMVCActionCommand {
 					LayoutUtilityPageEntryConstants.TYPE_LOGIN);
 
 		if (signInUtilityPage != null) {
-			redirect = Portal.PATH_MAIN + "/portal/sign_in";
+			String redirect = Portal.PATH_MAIN + "/portal/sign_in";
 
 			redirect = HttpComponentsUtil.setParameter(
 				redirect, "p_l_id", layout.getPlid());
-		}
 
-		if (Validator.isNull(redirect)) {
-			LiferayPortletRequest liferayPortletRequest =
-				_portal.getLiferayPortletRequest(actionRequest);
+			String loginRedirect = ParamUtil.getString(
+				actionRequest, "redirect");
 
-			String portletName = liferayPortletRequest.getPortletName();
+			if (Validator.isNotNull(loginRedirect)) {
+				String loginPortletNamespace = _portal.getPortletNamespace(
+					PropsValues.AUTH_LOGIN_PORTLET_NAME);
 
-			PortletURL portletURL = PortletURLBuilder.create(
-				PortletURLFactoryUtil.create(
-					actionRequest, liferayPortletRequest.getPortlet(), layout,
-					PortletRequest.RENDER_PHASE)
-			).setParameter(
-				"saveLastPath", false
-			).buildPortletURL();
-
-			if (portletName.equals(LoginPortletKeys.LOGIN)) {
-				portletURL.setWindowState(WindowState.MAXIMIZED);
-			}
-			else {
-				portletURL.setWindowState(actionRequest.getWindowState());
+				redirect = HttpComponentsUtil.setParameter(
+					redirect, "p_p_id", PropsValues.AUTH_LOGIN_PORTLET_NAME);
+				redirect = HttpComponentsUtil.setParameter(
+					redirect, "p_p_lifecycle", "0");
+				redirect = HttpComponentsUtil.setParameter(
+					redirect, loginPortletNamespace + "redirect",
+					loginRedirect);
 			}
 
-			redirect = portletURL.toString();
+			actionResponse.sendRedirect(redirect);
+
+			return;
 		}
 
-		String login = ParamUtil.getString(actionRequest, "login");
+		LiferayPortletRequest liferayPortletRequest =
+			_portal.getLiferayPortletRequest(actionRequest);
 
-		if (Validator.isNotNull(login)) {
-			SessionErrors.add(actionRequest, "login", login);
+		PortletURL portletURL = PortletURLBuilder.create(
+			PortletURLFactoryUtil.create(
+				actionRequest, liferayPortletRequest.getPortlet(), layout,
+				PortletRequest.RENDER_PHASE)
+		).setRedirect(
+			() -> {
+				String redirect = ParamUtil.getString(
+					actionRequest, "redirect");
+
+				if (Validator.isNotNull(redirect)) {
+					return redirect;
+				}
+
+				return null;
+			}
+		).setParameter(
+			"saveLastPath", false
+		).buildPortletURL();
+
+		String portletName = liferayPortletRequest.getPortletName();
+
+		if (portletName.equals(LoginPortletKeys.LOGIN)) {
+			portletURL.setWindowState(WindowState.MAXIMIZED);
+		}
+		else {
+			portletURL.setWindowState(actionRequest.getWindowState());
 		}
 
-		String loginRedirect = ParamUtil.getString(actionRequest, "redirect");
-
-		if (Validator.isNotNull(loginRedirect)) {
-			String loginPortletNamespace = _portal.getPortletNamespace(
-				PropsValues.AUTH_LOGIN_PORTLET_NAME);
-
-			String loginRedirectParameter = loginPortletNamespace + "redirect";
-
-			redirect = HttpComponentsUtil.setParameter(
-				redirect, "p_p_id", PropsValues.AUTH_LOGIN_PORTLET_NAME);
-			redirect = HttpComponentsUtil.setParameter(
-				redirect, "p_p_lifecycle", "0");
-			redirect = HttpComponentsUtil.setParameter(
-				redirect, loginRedirectParameter, loginRedirect);
-		}
-
-		actionResponse.sendRedirect(redirect);
+		actionResponse.sendRedirect(portletURL.toString());
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/portlet/action/LoginMVCActionCommand.java
+++ b/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/portlet/action/LoginMVCActionCommand.java
@@ -257,6 +257,9 @@ public class LoginMVCActionCommand extends BaseMVCActionCommand {
 
 		if (signInUtilityPage != null) {
 			redirect = Portal.PATH_MAIN + "/portal/sign_in";
+
+			redirect = HttpComponentsUtil.setParameter(
+				redirect, "groupId", layout.getGroupId());
 		}
 
 		if (Validator.isNull(redirect)) {

--- a/portal-impl/src/com/liferay/portal/action/LoginAction.java
+++ b/portal-impl/src/com/liferay/portal/action/LoginAction.java
@@ -115,18 +115,18 @@ public class LoginAction implements Action {
 
 		String redirect = PortalUtil.getSiteLoginURL(themeDisplay);
 
-		Layout signInUtilityPage =
+		Layout loginUtilityPage =
 			LayoutUtilityPageEntryLayoutProviderUtil.
 				getDefaultLayoutUtilityPageEntryLayout(
 					themeDisplay.getScopeGroupId(),
 					LayoutUtilityPageEntryConstants.TYPE_LOGIN);
 
-		if ((signInUtilityPage != null) &&
+		if ((loginUtilityPage != null) &&
 			!Objects.equals(
 				getWindowState(httpServletRequest),
 				LiferayWindowState.EXCLUSIVE)) {
 
-			redirect = Portal.PATH_MAIN + "/portal/sign_in";
+			redirect = Portal.PATH_MAIN + "/portal/login_up";
 
 			redirect = HttpComponentsUtil.setParameter(
 				redirect, "p_l_id", themeDisplay.getPlid());

--- a/portal-impl/src/com/liferay/portal/action/LoginAction.java
+++ b/portal-impl/src/com/liferay/portal/action/LoginAction.java
@@ -5,8 +5,6 @@
 
 package com.liferay.portal.action;
 
-import com.liferay.layout.utility.page.kernel.LayoutUtilityPageEntryViewRenderer;
-import com.liferay.layout.utility.page.kernel.LayoutUtilityPageEntryViewRendererRegistryUtil;
 import com.liferay.layout.utility.page.kernel.constants.LayoutUtilityPageEntryConstants;
 import com.liferay.layout.utility.page.kernel.provider.util.LayoutUtilityPageEntryLayoutProviderUtil;
 import com.liferay.petra.string.CharPool;
@@ -123,26 +121,12 @@ public class LoginAction implements Action {
 					themeDisplay.getScopeGroupId(),
 					LayoutUtilityPageEntryConstants.TYPE_LOGIN);
 
-		if (utilityPage != null) {
+		if ((utilityPage != null) &&
+			!Objects.equals(
+				getWindowState(httpServletRequest),
+				LiferayWindowState.EXCLUSIVE)) {
+
 			redirect = Portal.PATH_MAIN + "/portal/sign_in";
-
-			if (Objects.equals(
-					getWindowState(httpServletRequest),
-					LiferayWindowState.EXCLUSIVE)) {
-
-				LayoutUtilityPageEntryViewRenderer
-					layoutUtilityPageEntryViewRenderer =
-						LayoutUtilityPageEntryViewRendererRegistryUtil.
-							getLayoutUtilityPageEntryViewRenderer(
-								LayoutUtilityPageEntryConstants.TYPE_SIGN_IN);
-
-				if (layoutUtilityPageEntryViewRenderer != null) {
-					layoutUtilityPageEntryViewRenderer.renderHTML(
-						httpServletRequest, httpServletResponse);
-
-					return null;
-				}
-			}
 		}
 
 		if (Validator.isNull(redirect)) {

--- a/portal-impl/src/com/liferay/portal/action/LoginAction.java
+++ b/portal-impl/src/com/liferay/portal/action/LoginAction.java
@@ -127,6 +127,9 @@ public class LoginAction implements Action {
 				LiferayWindowState.EXCLUSIVE)) {
 
 			redirect = Portal.PATH_MAIN + "/portal/sign_in";
+
+			redirect = HttpComponentsUtil.setParameter(
+				redirect, "groupId", themeDisplay.getScopeGroupId());
 		}
 
 		if (Validator.isNull(redirect)) {

--- a/portal-impl/src/com/liferay/portal/action/LoginAction.java
+++ b/portal-impl/src/com/liferay/portal/action/LoginAction.java
@@ -129,7 +129,7 @@ public class LoginAction implements Action {
 			redirect = Portal.PATH_MAIN + "/portal/sign_in";
 
 			redirect = HttpComponentsUtil.setParameter(
-				redirect, "groupId", themeDisplay.getScopeGroupId());
+				redirect, "p_l_id", themeDisplay.getPlid());
 		}
 
 		if (Validator.isNull(redirect)) {

--- a/portal-impl/src/com/liferay/portal/action/LoginAction.java
+++ b/portal-impl/src/com/liferay/portal/action/LoginAction.java
@@ -115,13 +115,13 @@ public class LoginAction implements Action {
 
 		String redirect = PortalUtil.getSiteLoginURL(themeDisplay);
 
-		Layout utilityPage =
+		Layout signInUtilityPage =
 			LayoutUtilityPageEntryLayoutProviderUtil.
 				getDefaultLayoutUtilityPageEntryLayout(
 					themeDisplay.getScopeGroupId(),
 					LayoutUtilityPageEntryConstants.TYPE_LOGIN);
 
-		if ((utilityPage != null) &&
+		if ((signInUtilityPage != null) &&
 			!Objects.equals(
 				getWindowState(httpServletRequest),
 				LiferayWindowState.EXCLUSIVE)) {

--- a/portal-impl/src/com/liferay/portal/action/LoginAction.java
+++ b/portal-impl/src/com/liferay/portal/action/LoginAction.java
@@ -5,7 +5,13 @@
 
 package com.liferay.portal.action;
 
+import com.liferay.layout.utility.page.kernel.LayoutUtilityPageEntryViewRenderer;
+import com.liferay.layout.utility.page.kernel.LayoutUtilityPageEntryViewRendererRegistryUtil;
+import com.liferay.layout.utility.page.kernel.constants.LayoutUtilityPageEntryConstants;
+import com.liferay.layout.utility.page.kernel.provider.util.LayoutUtilityPageEntryLayoutProviderUtil;
 import com.liferay.petra.string.CharPool;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.portlet.LiferayWindowState;
 import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
 import com.liferay.portal.kernel.portlet.WindowStateFactory;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
@@ -13,6 +19,7 @@ import com.liferay.portal.kernel.security.auth.AuthTokenUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.Validator;
@@ -23,6 +30,8 @@ import com.liferay.portal.struts.Action;
 import com.liferay.portal.struts.model.ActionForward;
 import com.liferay.portal.struts.model.ActionMapping;
 import com.liferay.portal.util.PropsValues;
+
+import java.util.Objects;
 
 import javax.portlet.PortletMode;
 import javax.portlet.PortletRequest;
@@ -107,6 +116,34 @@ public class LoginAction implements Action {
 		}
 
 		String redirect = PortalUtil.getSiteLoginURL(themeDisplay);
+
+		Layout utilityPage =
+			LayoutUtilityPageEntryLayoutProviderUtil.
+				getDefaultLayoutUtilityPageEntryLayout(
+					themeDisplay.getScopeGroupId(),
+					LayoutUtilityPageEntryConstants.TYPE_LOGIN);
+
+		if (utilityPage != null) {
+			redirect = Portal.PATH_MAIN + "/portal/sign_in";
+
+			if (Objects.equals(
+					getWindowState(httpServletRequest),
+					LiferayWindowState.EXCLUSIVE)) {
+
+				LayoutUtilityPageEntryViewRenderer
+					layoutUtilityPageEntryViewRenderer =
+						LayoutUtilityPageEntryViewRendererRegistryUtil.
+							getLayoutUtilityPageEntryViewRenderer(
+								LayoutUtilityPageEntryConstants.TYPE_SIGN_IN);
+
+				if (layoutUtilityPageEntryViewRenderer != null) {
+					layoutUtilityPageEntryViewRenderer.renderHTML(
+						httpServletRequest, httpServletResponse);
+
+					return null;
+				}
+			}
+		}
 
 		if (Validator.isNull(redirect)) {
 			redirect = PropsValues.AUTH_LOGIN_URL;

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -3584,6 +3584,7 @@
         /portal/extend_session_confirm,\
         /portal/json_service,\
         /portal/license,\
+        /portal/login_up,\
         /portal/logout,\
         /portal/open_id_request,\
         /portal/open_id_response,\
@@ -3591,7 +3592,6 @@
         /portal/robots,\
         /portal/session_click,\
         /portal/session_tree_js_click,\
-        /portal/sign_in,\
         /portal/sitemap,\
         /portal/status
 
@@ -9336,13 +9336,13 @@
         /c/portal/json_service,\
         /c/portal/layout,\
         /c/portal/login,\
+        /c/portal/login_up,\
         /c/portal/logout,\
         /c/portal/portlet_url,\
         /c/portal/progress_poller,\
         /c/portal/render_portlet,\
         /c/portal/reverse_ajax,\
         /c/portal/session_tree_js_click,\
-        /c/portal/sign_in,\
         /c/portal/status,\
         /c/portal/update_layout,\
         /c/portal/update_terms_of_use

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -3591,6 +3591,7 @@
         /portal/robots,\
         /portal/session_click,\
         /portal/session_tree_js_click,\
+        /portal/sign_in,\
         /portal/sitemap,\
         /portal/status
 
@@ -9341,6 +9342,7 @@
         /c/portal/render_portlet,\
         /c/portal/reverse_ajax,\
         /c/portal/session_tree_js_click,\
+        /c/portal/sign_in,\
         /c/portal/status,\
         /c/portal/update_layout,\
         /c/portal/update_terms_of_use

--- a/portal-web/docroot/WEB-INF/struts-config.xml
+++ b/portal-web/docroot/WEB-INF/struts-config.xml
@@ -56,6 +56,7 @@
 			<forward name="portal.setup_wizard" path="portal.setup_wizard" />
 		</action>
 
+		<action forward="portal.sign.in" path="/portal/sign_in" />
 		<action forward="portal.status" path="/portal/status" />
 
 		<!--<action path="/portal/test" type="com.liferay.portal.action.TestAction">

--- a/portal-web/docroot/WEB-INF/struts-config.xml
+++ b/portal-web/docroot/WEB-INF/struts-config.xml
@@ -40,6 +40,7 @@
 
 		<action path="/portal/login" type="com.liferay.portal.action.LoginAction" />
 		<action forward="portal.login_disabled" path="/portal/login_disabled" />
+		<action forward="portal.login_up" path="/portal/login_up" />
 		<action path="/portal/logout" type="com.liferay.portal.action.LogoutAction" />
 		<action forward="portal.progress_poller" path="/portal/progress_poller" />
 		<action forward="/portal/protected.jsp" path="/portal/protected" />
@@ -56,7 +57,6 @@
 			<forward name="portal.setup_wizard" path="portal.setup_wizard" />
 		</action>
 
-		<action forward="portal.sign.in" path="/portal/sign_in" />
 		<action forward="portal.status" path="/portal/status" />
 
 		<!--<action path="/portal/test" type="com.liferay.portal.action.TestAction">


### PR DESCRIPTION
Hi Brian. Following up on https://github.com/brianchandotcom/liferay-portal/pull/148291#issuecomment-2005899965

"login_up" stands for login utility page. I didn't want to make the path too long so used the abbreviation.
I had hoped to not need a 2nd struts action at all, but because we need to inject the portlet namespace to the parameter it became necessary. After discussing a proposal for this with Echo team last week, we had to return to this struts based approach.