### PR TITLE
Lpd 19944 21146 revised

### DIFF
--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderLocalService.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderLocalService.java
@@ -206,7 +206,8 @@ public interface CommerceOrderLocalService
 	public void deleteCommerceOrders(long userId, Date date, int status);
 
 	public void deleteCommerceOrdersByAccountId(
-		long commerceAccountId, Date date, int status);
+			long commerceAccountId, Date date, int status)
+		throws PortalException;
 
 	/**
 	 * @throws PortalException

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderLocalServiceUtil.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderLocalServiceUtil.java
@@ -246,7 +246,8 @@ public class CommerceOrderLocalServiceUtil {
 	}
 
 	public static void deleteCommerceOrdersByAccountId(
-		long commerceAccountId, java.util.Date date, int status) {
+			long commerceAccountId, java.util.Date date, int status)
+		throws PortalException {
 
 		getService().deleteCommerceOrdersByAccountId(
 			commerceAccountId, date, status);

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderLocalServiceWrapper.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderLocalServiceWrapper.java
@@ -258,7 +258,8 @@ public class CommerceOrderLocalServiceWrapper
 
 	@Override
 	public void deleteCommerceOrdersByAccountId(
-		long commerceAccountId, java.util.Date date, int status) {
+			long commerceAccountId, java.util.Date date, int status)
+		throws com.liferay.portal.kernel.exception.PortalException {
 
 		_commerceOrderLocalService.deleteCommerceOrdersByAccountId(
 			commerceAccountId, date, status);

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderLocalServiceImpl.java
@@ -92,8 +92,8 @@ import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.SortFactoryUtil;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.UserLocalService;
-import com.liferay.portal.kernel.service.UserService;
 import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
 import com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalService;
 import com.liferay.portal.kernel.settings.GroupServiceSettingsLocator;
@@ -481,10 +481,8 @@ public class CommerceOrderLocalServiceImpl
 
 			// Commerce order items
 
-			User user = _userService.getCurrentUser();
-
 			_commerceOrderItemLocalService.deleteCommerceOrderItems(
-				user.getUserId(), commerceOrder.getCommerceOrderId());
+				_getUserId(commerceOrder), commerceOrder.getCommerceOrderId());
 
 			// Commerce order notes
 
@@ -2334,6 +2332,21 @@ public class CommerceOrderLocalServiceImpl
 			serviceContext);
 	}
 
+	private long _getUserId(CommerceOrder commerceOrder) {
+		ServiceContext serviceContext =
+			ServiceContextThreadLocal.getServiceContext();
+
+		if (serviceContext != null) {
+			User user = _userLocalService.fetchUser(serviceContext.getUserId());
+
+			if (user != null) {
+				return user.getUserId();
+			}
+		}
+
+		return commerceOrder.getUserId();
+	}
+
 	private boolean _hasWorkflowDefinition(long groupId, long typePK)
 		throws PortalException {
 
@@ -2916,9 +2929,6 @@ public class CommerceOrderLocalServiceImpl
 
 	@Reference
 	private UserLocalService _userLocalService;
-
-	@Reference
-	private UserService _userService;
 
 	@Reference
 	private WorkflowDefinitionLinkLocalService

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderLocalServiceImpl.java
@@ -556,10 +556,17 @@ public class CommerceOrderLocalServiceImpl
 
 	@Override
 	public void deleteCommerceOrdersByAccountId(
-		long commerceAccountId, Date date, int status) {
+			long commerceAccountId, Date date, int status)
+		throws PortalException {
 
-		commerceOrderPersistence.removeByC_LtC_O(
-			date, commerceAccountId, status);
+		List<CommerceOrder> commerceOrderList =
+			commerceOrderPersistence.findByC_LtC_O(
+				date, commerceAccountId, status, QueryUtil.ALL_POS,
+				QueryUtil.ALL_POS, null);
+
+		for (CommerceOrder commerceOrder : commerceOrderList) {
+			commerceOrderLocalService.deleteCommerceOrder(commerceOrder);
+		}
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderLocalServiceImpl.java
@@ -93,6 +93,7 @@ import com.liferay.portal.kernel.search.SortFactoryUtil;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.service.UserService;
 import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
 import com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalService;
 import com.liferay.portal.kernel.settings.GroupServiceSettingsLocator;
@@ -480,8 +481,10 @@ public class CommerceOrderLocalServiceImpl
 
 			// Commerce order items
 
+			User user = _userService.getCurrentUser();
+
 			_commerceOrderItemLocalService.deleteCommerceOrderItems(
-				commerceOrder.getUserId(), commerceOrder.getCommerceOrderId());
+				user.getUserId(), commerceOrder.getCommerceOrderId());
 
 			// Commerce order notes
 
@@ -2906,6 +2909,9 @@ public class CommerceOrderLocalServiceImpl
 
 	@Reference
 	private UserLocalService _userLocalService;
+
+	@Reference
+	private UserService _userService;
 
 	@Reference
 	private WorkflowDefinitionLinkLocalService

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/internal/order/test/CommerceOrderHttpHelperImplTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/internal/order/test/CommerceOrderHttpHelperImplTest.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -86,6 +87,8 @@ public class CommerceOrderHttpHelperImplTest {
 		_group = GroupTestUtil.addGroup();
 
 		_user = UserTestUtil.addUser();
+
+		_permissionChecker = PermissionThreadLocal.getPermissionChecker();
 
 		PermissionThreadLocal.setPermissionChecker(
 			PermissionCheckerFactoryUtil.create(_user));
@@ -145,11 +148,12 @@ public class CommerceOrderHttpHelperImplTest {
 
 	@After
 	public void tearDown() throws PortalException {
-		CentralizedThreadLocal.clearShortLivedThreadLocals();
-
 		for (CommerceOrder commerceOrder : _commerceOrders) {
 			_commerceOrderLocalService.deleteCommerceOrder(commerceOrder);
 		}
+
+		PermissionThreadLocal.setPermissionChecker(_permissionChecker);
+		CentralizedThreadLocal.clearShortLivedThreadLocals();
 	}
 
 	@Test
@@ -255,6 +259,7 @@ public class CommerceOrderHttpHelperImplTest {
 	private final List<CommerceOrder> _commerceOrders = new ArrayList<>();
 	private Group _group;
 	private HttpServletRequest _httpServletRequest;
+	private PermissionChecker _permissionChecker;
 	private ThemeDisplay _themeDisplay;
 
 }

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/order/engine/test/CommerceOrderEngineTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/order/engine/test/CommerceOrderEngineTest.java
@@ -51,6 +51,7 @@ import com.liferay.portal.kernel.security.RandomUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -110,6 +111,8 @@ public class CommerceOrderEngineTest {
 
 		_user = UserTestUtil.addUser();
 
+		_permissionChecker = PermissionThreadLocal.getPermissionChecker();
+
 		PrincipalThreadLocal.setName(_user.getUserId());
 
 		PermissionThreadLocal.setPermissionChecker(
@@ -154,6 +157,9 @@ public class CommerceOrderEngineTest {
 	@After
 	public void tearDown() throws PortalException {
 		_commerceOrderLocalService.deleteCommerceOrder(_commerceOrder);
+
+		PermissionThreadLocal.setPermissionChecker(_permissionChecker);
+		CentralizedThreadLocal.clearShortLivedThreadLocals();
 
 		CompanyThreadLocal.setCompanyId(_originalCompanyId);
 	}
@@ -856,8 +862,6 @@ public class CommerceOrderEngineTest {
 			CommerceOrderConstants.ORDER_STATUS_COMPLETED,
 			_commerceOrder.getOrderStatus());
 
-		CentralizedThreadLocal.clearShortLivedThreadLocals();
-
 		for (ComponentDescriptionDTO componentDescriptionDTO :
 				componentDescriptionDTOs) {
 
@@ -1119,6 +1123,7 @@ public class CommerceOrderEngineTest {
 
 	private Group _group;
 	private long _originalCompanyId;
+	private PermissionChecker _permissionChecker;
 
 	@Inject
 	private ServiceComponentRuntime _serviceComponentRuntime;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/dto/v1_0/converter/OrderDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/dto/v1_0/converter/OrderDTOConverter.java
@@ -24,6 +24,7 @@ import com.liferay.commerce.service.CommerceOrderTypeService;
 import com.liferay.expando.kernel.model.ExpandoBridge;
 import com.liferay.headless.commerce.admin.order.dto.v1_0.Order;
 import com.liferay.headless.commerce.admin.order.dto.v1_0.Status;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.UserLocalService;
@@ -96,8 +97,12 @@ public class OrderDTOConverter implements DTOConverter<CommerceOrder, Order> {
 				setCreateDate(commerceOrder::getCreateDate);
 				setCreatorEmailAddress(
 					() -> {
-						User user = _userLocalService.getUser(
+						User user = _userLocalService.fetchUser(
 							commerceOrder.getUserId());
+
+						if (user == null) {
+							return StringPool.BLANK;
+						}
 
 						return user.getEmailAddress();
 					});

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/AddressResourceTest.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/AddressResourceTest.java
@@ -25,14 +25,19 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.CountryLocalService;
 import com.liferay.portal.kernel.service.RegionLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.runner.RunWith;
 
 /**
@@ -40,6 +45,13 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 public class AddressResourceTest extends BaseAddressResourceTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
 
 	@Before
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/CartResourceTest.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/CartResourceTest.java
@@ -20,19 +20,24 @@ import com.liferay.headless.commerce.delivery.cart.client.dto.v1_0.CouponCode;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
 import java.util.List;
 
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -41,6 +46,13 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 public class CartResourceTest extends BaseCartResourceTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
 
 	@Before
 	@Override


### PR DESCRIPTION
Resent from:

https://github.com/brianchandotcom/liferay-portal/pull/148613

due to

https://github.com/brianchandotcom/liferay-portal/pull/148613#issuecomment-2026430892

https://liferay.atlassian.net/browse/LPD-19944
https://liferay.atlassian.net/browse/LPD-21146

@brianchandotcom ,

My understanding of your issue with the previous PR was how we were handling the exceptions in getting the user since `getCurrentUser()` was not a fetch call. I revised this to use the `serviceContext` instead. Please note that the commit is absolutely necessary due to how commerceOrder auditing works for BookedQuantities.

https://github.com/brianchandotcom/liferay-portal/commit/ed0c52f83bcba027ccf3f01feacbe4331aeeaaae