### PR TITLE
LRCI-4163 Add property to work with new jenkins-ee validation

### DIFF
--- a/ci.properties
+++ b/ci.properties
@@ -232,6 +232,8 @@ ci.test.available.suites=\
     workflow-metrics,\
     workflow-opensearch2
 
+ci.test.available.suites[test-portal-release]=${ci.release.test.suites.whitelist}
+
 ci.test.relevant.bypass.file.path.patterns=\
     .*/(ci|test).properties$,\
     .*/liferay-portal[^/]*/.github/.*,\


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-4163
This is just to keep release testing working for both ways of validating the CI suite. Upstream master will be solely on the new way for future releases