### PR TITLE
LPD-5235 Set maxThreads for tomcat which aims to specify the maximum …

### DIFF
--- a/build-dist.xml
+++ b/build-dist.xml
@@ -1203,6 +1203,13 @@ org.apache.level=WARNING]]>
 		</replace>
 
 		<replace
+			file="${app.server.tomcat.dir}/conf/server.xml"
+		>
+			<replacetoken><![CDATA[<Connector port="8080" protocol="HTTP/1.1"]]></replacetoken>
+			<replacevalue><![CDATA[<Connector maxThreads="75" port="8080" protocol="HTTP/1.1"]]></replacevalue>
+		</replace>
+
+		<replace
 			file="${app.server.tomcat.dir}/conf/web.xml"
 		>
 			<replacetoken><![CDATA[<web-app]]></replacetoken>


### PR DESCRIPTION
…number of request processing threads to be created by this Connector, which therefore determines the maximum number of simultaneous requests that can be handled, the number of maxThreads should not bigger than the value of jdbc.default.maximumPoolSize, otherwise, DB side can not support so hight pressure, the default value of jdbc.default.maximumPoolSize is 100, but tomcat's default value of maxThreads is 200, use 75 as maxThreads for portal according to benchmark test configuration