### PR TITLE
LPD-2835 ElasticsearchStatusException occurs when there are more than 65536 inactive groups & LPD-23550 Create test to ensure that an ElasticsearchStatusException will not be thrown even if the number of terms exceeded the allowed maximum

### DIFF
--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/filter/groupid/GroupIdQueryPreFilterContributorTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/filter/groupid/GroupIdQueryPreFilterContributorTest.java
@@ -10,8 +10,11 @@ import com.liferay.portal.search.test.util.filter.groupid.BaseGroupIdQueryPreFil
 import com.liferay.portal.search.test.util.indexing.IndexingFixture;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
+
+import org.mockito.Mockito;
 
 /**
  * @author Tibor Lipusz
@@ -23,6 +26,18 @@ public class GroupIdQueryPreFilterContributorTest
 	@Rule
 	public static final LiferayUnitTestRule liferayUnitTestRule =
 		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+
+		Mockito.doReturn(
+			"Elasticsearch"
+		).when(
+			searchEngine
+		).getVendor();
+	}
 
 	@Override
 	protected IndexingFixture createIndexingFixture() throws Exception {

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/filter/groupid/GroupIdQueryPreFilterContributorTest.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/filter/groupid/GroupIdQueryPreFilterContributorTest.java
@@ -11,7 +11,10 @@ import com.liferay.portal.search.test.util.filter.groupid.BaseGroupIdQueryPreFil
 import com.liferay.portal.search.test.util.indexing.IndexingFixture;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
+import org.junit.Before;
 import org.junit.ClassRule;
+
+import org.mockito.Mockito;
 
 /**
  * @author Tibor Lipusz
@@ -26,6 +29,18 @@ public class GroupIdQueryPreFilterContributorTest
 	@ClassRule
 	public static final OpenSearchTestRule openSearchTestRule =
 		OpenSearchTestRule.INSTANCE;
+
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+
+		Mockito.doReturn(
+			"OpenSearch"
+		).when(
+			searchEngine
+		).getVendor();
+	}
 
 	@Override
 	protected IndexingFixture createIndexingFixture() throws Exception {

--- a/modules/apps/portal-search-solr8/portal-search-solr8-impl/src/test/java/com/liferay/portal/search/solr8/internal/filter/GroupIdQueryPreFilterContributorTest.java
+++ b/modules/apps/portal-search-solr8/portal-search-solr8-impl/src/test/java/com/liferay/portal/search/solr8/internal/filter/GroupIdQueryPreFilterContributorTest.java
@@ -29,6 +29,12 @@ public class GroupIdQueryPreFilterContributorTest
 	@Ignore
 	@Override
 	@Test
+	public void testNumberOfTermsGreaterThanTheMaximumAllowed() {
+	}
+
+	@Ignore
+	@Override
+	@Test
 	public void testScopeEverythingWithInactiveGroups() {
 	}
 

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/filter/groupid/BaseGroupIdQueryPreFilterContributorTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/filter/groupid/BaseGroupIdQueryPreFilterContributorTestCase.java
@@ -13,6 +13,7 @@ import com.liferay.portal.kernel.search.filter.BooleanFilter;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.search.internal.spi.model.query.contributor.GroupIdQueryPreFilterContributor;
 import com.liferay.portal.search.test.util.DocumentsAssert;
 import com.liferay.portal.search.test.util.indexing.BaseIndexingTestCase;
@@ -45,6 +46,9 @@ public abstract class BaseGroupIdQueryPreFilterContributorTestCase
 		).getGroupIds(
 			Mockito.anyLong(), Mockito.eq(false)
 		);
+
+		_groupIdQueryPreFilterContributor =
+			new GroupIdQueryPreFilterContributor();
 	}
 
 	@Test
@@ -82,6 +86,33 @@ public abstract class BaseGroupIdQueryPreFilterContributorTestCase
 						booleanFilter.getMustNotBooleanClauses());
 					assertEmptyClauses(booleanFilter.getShouldBooleanClauses());
 				}));
+	}
+
+	@Test
+	public void testNumberOfTermsGreaterThanTheMaximumAllowed() {
+		long[] inactiveGroupIds = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+
+		addDocuments(inactiveGroupIds);
+
+		Mockito.doReturn(
+			ListUtil.fromArray(inactiveGroupIds)
+		).when(
+			groupLocalService
+		).getGroupIds(
+			Mockito.anyLong(), Mockito.eq(false)
+		);
+
+		setMaxTermsCount(10);
+
+		assertNumberOfMustNotBooleanClauses(1);
+
+		setMaxTermsCount(5);
+
+		assertNumberOfMustNotBooleanClauses(2);
+
+		setMaxTermsCount(3);
+
+		assertNumberOfMustNotBooleanClauses(4);
 	}
 
 	@Test
@@ -136,6 +167,22 @@ public abstract class BaseGroupIdQueryPreFilterContributorTestCase
 		Assert.assertEquals(clauses.toString(), 0, clauses.size());
 	}
 
+	protected void assertNumberOfMustNotBooleanClauses(int expected) {
+		assertSearch(
+			indexingTestHelper -> indexingTestHelper.define(
+				searchContext -> {
+					searchContext.setGroupIds(new long[] {0});
+
+					BooleanFilter booleanFilter = (BooleanFilter)createFilter(
+						searchContext);
+
+					Assert.assertEquals(
+						expected,
+						booleanFilter.getMustNotBooleanClauses(
+						).size());
+				}));
+	}
+
 	protected void assertSearch(long scopeGroupId, String expected) {
 		assertSearch(
 			indexingTestHelper -> {
@@ -159,17 +206,22 @@ public abstract class BaseGroupIdQueryPreFilterContributorTestCase
 	}
 
 	protected Filter createFilter(SearchContext searchContext) {
-		GroupIdQueryPreFilterContributor contributor =
-			new GroupIdQueryPreFilterContributor();
-
 		ReflectionTestUtil.setFieldValue(
-			contributor, "_groupLocalService", groupLocalService);
+			_groupIdQueryPreFilterContributor, "_groupLocalService",
+			groupLocalService);
 
 		BooleanFilter booleanFilter = new BooleanFilter();
 
-		contributor.contribute(booleanFilter, searchContext);
+		_groupIdQueryPreFilterContributor.contribute(
+			booleanFilter, searchContext);
 
 		return booleanFilter;
+	}
+
+	protected void setMaxTermsCount(int maxTermsCount) {
+		ReflectionTestUtil.setFieldValue(
+			_groupIdQueryPreFilterContributor, "_MAX_TERMS_COUNT",
+			maxTermsCount);
 	}
 
 	protected static final long INACTIVE_GROUP_ID1 = 4L;
@@ -178,5 +230,7 @@ public abstract class BaseGroupIdQueryPreFilterContributorTestCase
 
 	protected GroupLocalService groupLocalService = Mockito.mock(
 		GroupLocalService.class);
+
+	private GroupIdQueryPreFilterContributor _groupIdQueryPreFilterContributor;
 
 }

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/filter/groupid/BaseGroupIdQueryPreFilterContributorTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/filter/groupid/BaseGroupIdQueryPreFilterContributorTestCase.java
@@ -9,6 +9,7 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.search.BooleanClause;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.search.SearchEngine;
 import com.liferay.portal.kernel.search.filter.BooleanFilter;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.service.GroupLocalService;
@@ -209,6 +210,8 @@ public abstract class BaseGroupIdQueryPreFilterContributorTestCase
 		ReflectionTestUtil.setFieldValue(
 			_groupIdQueryPreFilterContributor, "_groupLocalService",
 			groupLocalService);
+		ReflectionTestUtil.setFieldValue(
+			_groupIdQueryPreFilterContributor, "_searchEngine", searchEngine);
 
 		BooleanFilter booleanFilter = new BooleanFilter();
 
@@ -230,6 +233,7 @@ public abstract class BaseGroupIdQueryPreFilterContributorTestCase
 
 	protected GroupLocalService groupLocalService = Mockito.mock(
 		GroupLocalService.class);
+	protected SearchEngine searchEngine = Mockito.mock(SearchEngine.class);
 
 	private GroupIdQueryPreFilterContributor _groupIdQueryPreFilterContributor;
 

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/spi/model/query/contributor/GroupIdQueryPreFilterContributor.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/spi/model/query/contributor/GroupIdQueryPreFilterContributor.java
@@ -109,14 +109,12 @@ public class GroupIdQueryPreFilterContributor
 
 		TermsFilter groupIdTermsFilter = new TermsFilter(Field.GROUP_ID);
 
-		int maxTermsCount = 65536;
-
-		if ((inactiveGroupIds.size() > maxTermsCount) && !_isSolr()) {
+		if ((inactiveGroupIds.size() > _MAX_TERMS_COUNT) && !_isSolr()) {
 			for (int i = 0; i < inactiveGroupIds.size(); i++) {
 				groupIdTermsFilter.addValue(
 					String.valueOf(inactiveGroupIds.get(i)));
 
-				if (((i + 1) % maxTermsCount) == 0) {
+				if (((i + 1) % _MAX_TERMS_COUNT) == 0) {
 					booleanFilter.add(
 						groupIdTermsFilter, BooleanClauseOccur.MUST_NOT);
 
@@ -156,6 +154,8 @@ public class GroupIdQueryPreFilterContributor
 	private boolean _isSolr() {
 		return Objects.equals(_searchEngine.getVendor(), "Solr");
 	}
+
+	private static final Integer _MAX_TERMS_COUNT = 65536;
 
 	@Reference
 	private GroupLocalService _groupLocalService;

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/spi/model/query/contributor/GroupIdQueryPreFilterContributor.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/spi/model/query/contributor/GroupIdQueryPreFilterContributor.java
@@ -107,10 +107,29 @@ public class GroupIdQueryPreFilterContributor
 
 		TermsFilter groupIdTermsFilter = new TermsFilter(Field.GROUP_ID);
 
-		groupIdTermsFilter.addValues(
-			ArrayUtil.toStringArray(inactiveGroupIds.toArray(new Long[0])));
+		int maxTermsCount = 65536; //Could be set by a config
 
-		booleanFilter.add(groupIdTermsFilter, BooleanClauseOccur.MUST_NOT);
+		if (inactiveGroupIds.size() <= maxTermsCount) {
+			groupIdTermsFilter.addValues(
+				ArrayUtil.toStringArray(inactiveGroupIds.toArray(new Long[0])));
+		}
+		else {
+			for (int i = 0; i < inactiveGroupIds.size(); i++) {
+				groupIdTermsFilter.addValue(
+					String.valueOf(inactiveGroupIds.get(i)));
+
+				if (((i + 1) % maxTermsCount) == 0) {
+					booleanFilter.add(
+						groupIdTermsFilter, BooleanClauseOccur.MUST_NOT);
+
+					groupIdTermsFilter = new TermsFilter(Field.GROUP_ID);
+				}
+			}
+		}
+
+		if (!groupIdTermsFilter.isEmpty()) {
+			booleanFilter.add(groupIdTermsFilter, BooleanClauseOccur.MUST_NOT);
+		}
 	}
 
 	private void _addOwnerBooleanFilter(

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/spi/model/query/contributor/GroupIdQueryPreFilterContributor.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/spi/model/query/contributor/GroupIdQueryPreFilterContributor.java
@@ -11,6 +11,7 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.search.SearchEngine;
 import com.liferay.portal.kernel.search.filter.BooleanFilter;
 import com.liferay.portal.kernel.search.filter.TermsFilter;
 import com.liferay.portal.kernel.service.GroupLocalService;
@@ -19,6 +20,7 @@ import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.search.spi.model.query.contributor.QueryPreFilterContributor;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -107,13 +109,9 @@ public class GroupIdQueryPreFilterContributor
 
 		TermsFilter groupIdTermsFilter = new TermsFilter(Field.GROUP_ID);
 
-		int maxTermsCount = 65536; //Could be set by a config
+		int maxTermsCount = 65536;
 
-		if (inactiveGroupIds.size() <= maxTermsCount) {
-			groupIdTermsFilter.addValues(
-				ArrayUtil.toStringArray(inactiveGroupIds.toArray(new Long[0])));
-		}
-		else {
+		if ((inactiveGroupIds.size() > maxTermsCount) && !_isSolr()) {
 			for (int i = 0; i < inactiveGroupIds.size(); i++) {
 				groupIdTermsFilter.addValue(
 					String.valueOf(inactiveGroupIds.get(i)));
@@ -125,6 +123,10 @@ public class GroupIdQueryPreFilterContributor
 					groupIdTermsFilter = new TermsFilter(Field.GROUP_ID);
 				}
 			}
+		}
+		else {
+			groupIdTermsFilter.addValues(
+				ArrayUtil.toStringArray(inactiveGroupIds.toArray(new Long[0])));
 		}
 
 		if (!groupIdTermsFilter.isEmpty()) {
@@ -151,7 +153,14 @@ public class GroupIdQueryPreFilterContributor
 		}
 	}
 
+	private boolean _isSolr() {
+		return Objects.equals(_searchEngine.getVendor(), "Solr");
+	}
+
 	@Reference
 	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private SearchEngine _searchEngine;
 
 }


### PR DESCRIPTION
## Previous PR: https://github.com/brianchandotcom/liferay-portal/pull/149498

### This PR contains the changes asked here: https://github.com/brianchandotcom/liferay-portal/pull/149498#issuecomment-2069431558

https://liferay.atlassian.net/browse/LPD-2835

https://liferay.atlassian.net/browse/LPD-23550

