### PR TITLE
LPD-22652 Change order back so threads are started and executed concurrently

### DIFF
--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectActionLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectActionLocalServiceTest.java
@@ -1753,10 +1753,6 @@ public class ObjectActionLocalServiceTest {
 					}
 				});
 
-			thread1.start();
-
-			thread1.join();
-
 			Thread thread2 = new Thread(
 				() -> {
 					try {
@@ -1772,8 +1768,10 @@ public class ObjectActionLocalServiceTest {
 					}
 				});
 
+			thread1.start();
 			thread2.start();
 
+			thread1.join();
 			thread2.join();
 
 			Assert.assertEquals(


### PR DESCRIPTION
Follow up on: https://github.com/brianchandotcom/liferay-portal/pull/149449

We need to start both threads together and then join them. 
Or else, as mentioned, the test will pass even without the fix its intended to cover. 