### PR TITLE
LPD-2835 ElasticsearchStatusException occurs when there are more than 65536 inactive groups & LPD-23550 Create test to ensure that an ElasticsearchStatusException will not be thrown even if the number of terms exceeded the allowed maximum

### DIFF
--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/filter/groupid/GroupIdQueryPreFilterContributorTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/filter/groupid/GroupIdQueryPreFilterContributorTest.java
@@ -10,8 +10,11 @@ import com.liferay.portal.search.test.util.filter.groupid.BaseGroupIdQueryPreFil
 import com.liferay.portal.search.test.util.indexing.IndexingFixture;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
+
+import org.mockito.Mockito;
 
 /**
  * @author Tibor Lipusz
@@ -23,6 +26,18 @@ public class GroupIdQueryPreFilterContributorTest
 	@Rule
 	public static final LiferayUnitTestRule liferayUnitTestRule =
 		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+
+		Mockito.doReturn(
+			"Elasticsearch"
+		).when(
+			searchEngine
+		).getVendor();
+	}
 
 	@Override
 	protected IndexingFixture createIndexingFixture() throws Exception {

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/filter/groupid/GroupIdQueryPreFilterContributorTest.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/filter/groupid/GroupIdQueryPreFilterContributorTest.java
@@ -11,7 +11,10 @@ import com.liferay.portal.search.test.util.filter.groupid.BaseGroupIdQueryPreFil
 import com.liferay.portal.search.test.util.indexing.IndexingFixture;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
+import org.junit.Before;
 import org.junit.ClassRule;
+
+import org.mockito.Mockito;
 
 /**
  * @author Tibor Lipusz
@@ -26,6 +29,18 @@ public class GroupIdQueryPreFilterContributorTest
 	@ClassRule
 	public static final OpenSearchTestRule openSearchTestRule =
 		OpenSearchTestRule.INSTANCE;
+
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+
+		Mockito.doReturn(
+			"OpenSearch"
+		).when(
+			searchEngine
+		).getVendor();
+	}
 
 	@Override
 	protected IndexingFixture createIndexingFixture() throws Exception {

--- a/modules/apps/portal-search-solr8/portal-search-solr8-impl/src/test/java/com/liferay/portal/search/solr8/internal/filter/GroupIdQueryPreFilterContributorTest.java
+++ b/modules/apps/portal-search-solr8/portal-search-solr8-impl/src/test/java/com/liferay/portal/search/solr8/internal/filter/GroupIdQueryPreFilterContributorTest.java
@@ -29,6 +29,12 @@ public class GroupIdQueryPreFilterContributorTest
 	@Ignore
 	@Override
 	@Test
+	public void testNumberOfTermsGreaterThanTheMaximumAllowed() {
+	}
+
+	@Ignore
+	@Override
+	@Test
 	public void testScopeEverythingWithInactiveGroups() {
 	}
 

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/filter/groupid/BaseGroupIdQueryPreFilterContributorTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/filter/groupid/BaseGroupIdQueryPreFilterContributorTestCase.java
@@ -9,6 +9,7 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.search.BooleanClause;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.search.SearchEngine;
 import com.liferay.portal.kernel.search.filter.BooleanFilter;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.service.GroupLocalService;
@@ -49,6 +50,12 @@ public abstract class BaseGroupIdQueryPreFilterContributorTestCase
 
 		_groupIdQueryPreFilterContributor =
 			new GroupIdQueryPreFilterContributor();
+
+		ReflectionTestUtil.setFieldValue(
+			_groupIdQueryPreFilterContributor, "_groupLocalService",
+			groupLocalService);
+		ReflectionTestUtil.setFieldValue(
+			_groupIdQueryPreFilterContributor, "_searchEngine", searchEngine);
 	}
 
 	@Test
@@ -206,10 +213,6 @@ public abstract class BaseGroupIdQueryPreFilterContributorTestCase
 	}
 
 	protected Filter createFilter(SearchContext searchContext) {
-		ReflectionTestUtil.setFieldValue(
-			_groupIdQueryPreFilterContributor, "_groupLocalService",
-			groupLocalService);
-
 		BooleanFilter booleanFilter = new BooleanFilter();
 
 		_groupIdQueryPreFilterContributor.contribute(
@@ -230,6 +233,7 @@ public abstract class BaseGroupIdQueryPreFilterContributorTestCase
 
 	protected GroupLocalService groupLocalService = Mockito.mock(
 		GroupLocalService.class);
+	protected SearchEngine searchEngine = Mockito.mock(SearchEngine.class);
 
 	private GroupIdQueryPreFilterContributor _groupIdQueryPreFilterContributor;
 

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/filter/groupid/BaseGroupIdQueryPreFilterContributorTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/filter/groupid/BaseGroupIdQueryPreFilterContributorTestCase.java
@@ -13,6 +13,7 @@ import com.liferay.portal.kernel.search.filter.BooleanFilter;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.search.internal.spi.model.query.contributor.GroupIdQueryPreFilterContributor;
 import com.liferay.portal.search.test.util.DocumentsAssert;
 import com.liferay.portal.search.test.util.indexing.BaseIndexingTestCase;
@@ -45,6 +46,9 @@ public abstract class BaseGroupIdQueryPreFilterContributorTestCase
 		).getGroupIds(
 			Mockito.anyLong(), Mockito.eq(false)
 		);
+
+		_groupIdQueryPreFilterContributor =
+			new GroupIdQueryPreFilterContributor();
 	}
 
 	@Test
@@ -82,6 +86,33 @@ public abstract class BaseGroupIdQueryPreFilterContributorTestCase
 						booleanFilter.getMustNotBooleanClauses());
 					assertEmptyClauses(booleanFilter.getShouldBooleanClauses());
 				}));
+	}
+
+	@Test
+	public void testNumberOfTermsGreaterThanTheMaximumAllowed() {
+		long[] inactiveGroupIds = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+
+		addDocuments(inactiveGroupIds);
+
+		Mockito.doReturn(
+			ListUtil.fromArray(inactiveGroupIds)
+		).when(
+			groupLocalService
+		).getGroupIds(
+			Mockito.anyLong(), Mockito.eq(false)
+		);
+
+		setMaxTermsCount(10);
+
+		assertNumberOfMustNotBooleanClauses(1);
+
+		setMaxTermsCount(5);
+
+		assertNumberOfMustNotBooleanClauses(2);
+
+		setMaxTermsCount(3);
+
+		assertNumberOfMustNotBooleanClauses(4);
 	}
 
 	@Test
@@ -136,6 +167,22 @@ public abstract class BaseGroupIdQueryPreFilterContributorTestCase
 		Assert.assertEquals(clauses.toString(), 0, clauses.size());
 	}
 
+	protected void assertNumberOfMustNotBooleanClauses(int expected) {
+		assertSearch(
+			indexingTestHelper -> indexingTestHelper.define(
+				searchContext -> {
+					searchContext.setGroupIds(new long[] {0});
+
+					BooleanFilter booleanFilter = (BooleanFilter)createFilter(
+						searchContext);
+
+					Assert.assertEquals(
+						expected,
+						booleanFilter.getMustNotBooleanClauses(
+						).size());
+				}));
+	}
+
 	protected void assertSearch(long scopeGroupId, String expected) {
 		assertSearch(
 			indexingTestHelper -> {
@@ -159,17 +206,22 @@ public abstract class BaseGroupIdQueryPreFilterContributorTestCase
 	}
 
 	protected Filter createFilter(SearchContext searchContext) {
-		GroupIdQueryPreFilterContributor contributor =
-			new GroupIdQueryPreFilterContributor();
-
 		ReflectionTestUtil.setFieldValue(
-			contributor, "_groupLocalService", groupLocalService);
+			_groupIdQueryPreFilterContributor, "_groupLocalService",
+			groupLocalService);
 
 		BooleanFilter booleanFilter = new BooleanFilter();
 
-		contributor.contribute(booleanFilter, searchContext);
+		_groupIdQueryPreFilterContributor.contribute(
+			booleanFilter, searchContext);
 
 		return booleanFilter;
+	}
+
+	protected void setMaxTermsCount(int maxTermsCount) {
+		ReflectionTestUtil.setFieldValue(
+			_groupIdQueryPreFilterContributor, "_MAX_TERMS_COUNT",
+			maxTermsCount);
 	}
 
 	protected static final long INACTIVE_GROUP_ID1 = 4L;
@@ -178,5 +230,7 @@ public abstract class BaseGroupIdQueryPreFilterContributorTestCase
 
 	protected GroupLocalService groupLocalService = Mockito.mock(
 		GroupLocalService.class);
+
+	private GroupIdQueryPreFilterContributor _groupIdQueryPreFilterContributor;
 
 }

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/filter/groupid/BaseGroupIdQueryPreFilterContributorTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/filter/groupid/BaseGroupIdQueryPreFilterContributorTestCase.java
@@ -41,9 +41,9 @@ public abstract class BaseGroupIdQueryPreFilterContributorTestCase
 		super.setUp();
 
 		Mockito.doReturn(
-			Arrays.asList(INACTIVE_GROUP_ID1, INACTIVE_GROUP_ID2)
+			Arrays.asList(_INACTIVE_GROUP_ID1, _INACTIVE_GROUP_ID2)
 		).when(
-			groupLocalService
+			_groupLocalService
 		).getGroupIds(
 			Mockito.anyLong(), Mockito.eq(false)
 		);
@@ -53,7 +53,7 @@ public abstract class BaseGroupIdQueryPreFilterContributorTestCase
 
 		ReflectionTestUtil.setFieldValue(
 			_groupIdQueryPreFilterContributor, "_groupLocalService",
-			groupLocalService);
+			_groupLocalService);
 		ReflectionTestUtil.setFieldValue(
 			_groupIdQueryPreFilterContributor, "_searchEngine", searchEngine);
 	}
@@ -67,7 +67,7 @@ public abstract class BaseGroupIdQueryPreFilterContributorTestCase
 		Mockito.doReturn(
 			group
 		).when(
-			groupLocalService
+			_groupLocalService
 		).getGroup(
 			groupId
 		);
@@ -75,7 +75,7 @@ public abstract class BaseGroupIdQueryPreFilterContributorTestCase
 		Mockito.doReturn(
 			false
 		).when(
-			groupLocalService
+			_groupLocalService
 		).isLiveGroupActive(
 			group
 		);
@@ -85,13 +85,14 @@ public abstract class BaseGroupIdQueryPreFilterContributorTestCase
 				searchContext -> {
 					searchContext.setGroupIds(new long[] {groupId});
 
-					BooleanFilter booleanFilter = (BooleanFilter)createFilter(
+					BooleanFilter booleanFilter = (BooleanFilter)_createFilter(
 						searchContext);
 
-					assertEmptyClauses(booleanFilter.getMustBooleanClauses());
-					assertEmptyClauses(
+					_assertEmptyClauses(booleanFilter.getMustBooleanClauses());
+					_assertEmptyClauses(
 						booleanFilter.getMustNotBooleanClauses());
-					assertEmptyClauses(booleanFilter.getShouldBooleanClauses());
+					_assertEmptyClauses(
+						booleanFilter.getShouldBooleanClauses());
 				}));
 	}
 
@@ -99,37 +100,37 @@ public abstract class BaseGroupIdQueryPreFilterContributorTestCase
 	public void testNumberOfTermsGreaterThanTheMaximumAllowed() {
 		long[] inactiveGroupIds = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-		addDocuments(inactiveGroupIds);
+		_addDocuments(inactiveGroupIds);
 
 		Mockito.doReturn(
 			ListUtil.fromArray(inactiveGroupIds)
 		).when(
-			groupLocalService
+			_groupLocalService
 		).getGroupIds(
 			Mockito.anyLong(), Mockito.eq(false)
 		);
 
-		setMaxTermsCount(10);
+		_setMaxTermsCount(10);
 
-		assertNumberOfMustNotBooleanClauses(1);
+		_assertNumberOfMustNotBooleanClauses(1);
 
-		setMaxTermsCount(5);
+		_setMaxTermsCount(5);
 
-		assertNumberOfMustNotBooleanClauses(2);
+		_assertNumberOfMustNotBooleanClauses(2);
 
-		setMaxTermsCount(3);
+		_setMaxTermsCount(3);
 
-		assertNumberOfMustNotBooleanClauses(4);
+		_assertNumberOfMustNotBooleanClauses(4);
 	}
 
 	@Test
 	public void testScopeEverythingWithInactiveGroups() {
-		addDocuments(1, 2, 3, INACTIVE_GROUP_ID1, INACTIVE_GROUP_ID2);
+		_addDocuments(1, 2, 3, _INACTIVE_GROUP_ID1, _INACTIVE_GROUP_ID2);
 
-		assertSearch(0, "[1, 2, 3]");
+		_assertSearch(0, "[1, 2, 3]");
 
 		Mockito.verify(
-			groupLocalService, Mockito.never()
+			_groupLocalService, Mockito.never()
 		).getActiveGroups(
 			Mockito.anyLong(), Mockito.anyBoolean()
 		);
@@ -142,7 +143,7 @@ public abstract class BaseGroupIdQueryPreFilterContributorTestCase
 		Mockito.doReturn(
 			group
 		).when(
-			groupLocalService
+			_groupLocalService
 		).getGroup(
 			2
 		);
@@ -150,17 +151,19 @@ public abstract class BaseGroupIdQueryPreFilterContributorTestCase
 		Mockito.doReturn(
 			true
 		).when(
-			groupLocalService
+			_groupLocalService
 		).isLiveGroupActive(
 			group
 		);
 
-		addDocuments(1, 2, 3, INACTIVE_GROUP_ID1, INACTIVE_GROUP_ID2);
+		_addDocuments(1, 2, 3, _INACTIVE_GROUP_ID1, _INACTIVE_GROUP_ID2);
 
-		assertSearch(2, "[2]");
+		_assertSearch(2, "[2]");
 	}
 
-	protected void addDocuments(long... groupIds) {
+	protected SearchEngine searchEngine = Mockito.mock(SearchEngine.class);
+
+	private void _addDocuments(long... groupIds) {
 		for (long groupId : groupIds) {
 			addDocument(
 				document -> {
@@ -170,17 +173,17 @@ public abstract class BaseGroupIdQueryPreFilterContributorTestCase
 		}
 	}
 
-	protected void assertEmptyClauses(List<BooleanClause<Filter>> clauses) {
+	private void _assertEmptyClauses(List<BooleanClause<Filter>> clauses) {
 		Assert.assertEquals(clauses.toString(), 0, clauses.size());
 	}
 
-	protected void assertNumberOfMustNotBooleanClauses(int expected) {
+	private void _assertNumberOfMustNotBooleanClauses(int expected) {
 		assertSearch(
 			indexingTestHelper -> indexingTestHelper.define(
 				searchContext -> {
 					searchContext.setGroupIds(new long[] {0});
 
-					BooleanFilter booleanFilter = (BooleanFilter)createFilter(
+					BooleanFilter booleanFilter = (BooleanFilter)_createFilter(
 						searchContext);
 
 					Assert.assertEquals(
@@ -190,7 +193,7 @@ public abstract class BaseGroupIdQueryPreFilterContributorTestCase
 				}));
 	}
 
-	protected void assertSearch(long scopeGroupId, String expected) {
+	private void _assertSearch(long scopeGroupId, String expected) {
 		assertSearch(
 			indexingTestHelper -> {
 				indexingTestHelper.define(
@@ -198,7 +201,7 @@ public abstract class BaseGroupIdQueryPreFilterContributorTestCase
 						searchContext.setGroupIds(new long[] {scopeGroupId});
 
 						indexingTestHelper.setFilter(
-							createFilter(searchContext));
+							_createFilter(searchContext));
 					});
 
 				indexingTestHelper.search();
@@ -212,7 +215,7 @@ public abstract class BaseGroupIdQueryPreFilterContributorTestCase
 			});
 	}
 
-	protected Filter createFilter(SearchContext searchContext) {
+	private Filter _createFilter(SearchContext searchContext) {
 		BooleanFilter booleanFilter = new BooleanFilter();
 
 		_groupIdQueryPreFilterContributor.contribute(
@@ -221,20 +224,18 @@ public abstract class BaseGroupIdQueryPreFilterContributorTestCase
 		return booleanFilter;
 	}
 
-	protected void setMaxTermsCount(int maxTermsCount) {
+	private void _setMaxTermsCount(int maxTermsCount) {
 		ReflectionTestUtil.setFieldValue(
 			_groupIdQueryPreFilterContributor, "_MAX_TERMS_COUNT",
 			maxTermsCount);
 	}
 
-	protected static final long INACTIVE_GROUP_ID1 = 4L;
+	private static final long _INACTIVE_GROUP_ID1 = 4L;
 
-	protected static final long INACTIVE_GROUP_ID2 = 5L;
-
-	protected GroupLocalService groupLocalService = Mockito.mock(
-		GroupLocalService.class);
-	protected SearchEngine searchEngine = Mockito.mock(SearchEngine.class);
+	private static final long _INACTIVE_GROUP_ID2 = 5L;
 
 	private GroupIdQueryPreFilterContributor _groupIdQueryPreFilterContributor;
+	private final GroupLocalService _groupLocalService = Mockito.mock(
+		GroupLocalService.class);
 
 }

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/indexing/BaseIndexingTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/indexing/BaseIndexingTestCase.java
@@ -115,7 +115,7 @@ public abstract class BaseIndexingTestCase {
 
 	@Before
 	public void setUp() throws Exception {
-		setUpIndexingFixture();
+		_setUpIndexingFixture();
 
 		Class<?> clazz = getClass();
 
@@ -165,7 +165,7 @@ public abstract class BaseIndexingTestCase {
 
 	protected void addDocument(DocumentCreationHelper documentCreationHelper) {
 		Document document = DocumentFixture.newDocument(
-			getCompanyId(), GROUP_ID, _entryClassName);
+			getCompanyId(), _GROUP_ID, _entryClassName);
 
 		documentCreationHelper.populate(document);
 
@@ -211,7 +211,7 @@ public abstract class BaseIndexingTestCase {
 		SearchContext searchContext = new SearchContext();
 
 		searchContext.setCompanyId(getCompanyId());
-		searchContext.setGroupIds(new long[] {GROUP_ID});
+		searchContext.setGroupIds(new long[] {_GROUP_ID});
 
 		QueryConfig queryConfig = searchContext.getQueryConfig();
 
@@ -247,7 +247,7 @@ public abstract class BaseIndexingTestCase {
 	}
 
 	protected long getGroupId() {
-		return GROUP_ID;
+		return _GROUP_ID;
 	}
 
 	protected IndexSearcher getIndexSearcher() {
@@ -263,7 +263,7 @@ public abstract class BaseIndexingTestCase {
 	}
 
 	protected DocumentBuilder newDocumentBuilder() {
-		return documentBuilderFactory.builder(
+		return _documentBuilderFactory.builder(
 		).setLong(
 			Field.COMPANY_ID, getCompanyId()
 		).setString(
@@ -307,30 +307,12 @@ public abstract class BaseIndexingTestCase {
 		query.setPreBooleanFilter(booleanFilter);
 	}
 
-	protected void setUpIndexingFixture() throws Exception {
-		if (_indexingFixture != null) {
-			Assume.assumeTrue(_indexingFixture.isSearchEngineAvailable());
-
-			return;
-		}
-
-		_indexingFixture = createIndexingFixture();
-
-		Assume.assumeTrue(_indexingFixture.isSearchEngineAvailable());
-
-		_indexingFixture.setUp();
-	}
-
-	protected static final long GROUP_ID = RandomTestUtil.randomLong();
-
 	protected final AggregationFixture aggregationFixture =
 		new AggregationFixture();
 	protected final Aggregations aggregations = new AggregationsImpl();
 	protected final ComplexQueryPartBuilderFactory
 		complexQueryPartBuilderFactory =
 			new ComplexQueryPartBuilderFactoryImpl();
-	protected DocumentBuilderFactory documentBuilderFactory =
-		new DocumentBuilderFactoryImpl();
 	protected final FieldConfigBuilderFactory fieldConfigBuilderFactory =
 		new FieldConfigBuilderFactoryImpl();
 	protected final GeoBuilders geoBuilders = new GeoBuildersImpl();
@@ -381,13 +363,13 @@ public abstract class BaseIndexingTestCase {
 		public <AR extends AggregationResult> AR getAggregationResult(
 			Aggregation aggregation) {
 
-			return getAggregationResult(aggregation.getName());
+			return _getAggregationResult(aggregation.getName());
 		}
 
 		public <AR extends AggregationResult> AR getAggregationResult(
 			PipelineAggregation pipelineAggregation) {
 
-			return getAggregationResult(pipelineAggregation.getName());
+			return _getAggregationResult(pipelineAggregation.getName());
 		}
 
 		public <AR extends AggregationResult> AR getChildAggregationResult(
@@ -414,7 +396,7 @@ public abstract class BaseIndexingTestCase {
 
 		public void search() {
 			_hits = BaseIndexingTestCase.this.search(
-				_searchContext, getQuery());
+				_searchContext, _getQuery());
 
 			SearchResponseBuilder searchResponseBuilder =
 				new SearchResponseBuilderImpl(_searchContext);
@@ -424,7 +406,7 @@ public abstract class BaseIndexingTestCase {
 
 		public long searchCount() {
 			long count = BaseIndexingTestCase.this.searchCount(
-				_searchContext, getQuery());
+				_searchContext, _getQuery());
 
 			SearchResponseBuilder searchResponseBuilder =
 				new SearchResponseBuilderImpl(_searchContext);
@@ -470,7 +452,7 @@ public abstract class BaseIndexingTestCase {
 			searchResponseConsumer.accept(_searchResponse);
 		}
 
-		protected <AR extends AggregationResult> AR getAggregationResult(
+		private <AR extends AggregationResult> AR _getAggregationResult(
 			String name) {
 
 			AggregationResult aggregationResult =
@@ -481,7 +463,7 @@ public abstract class BaseIndexingTestCase {
 			return (AR)aggregationResult;
 		}
 
-		protected Query getQuery() {
+		private Query _getQuery() {
 			Query query = _query;
 
 			if (query == null) {
@@ -526,10 +508,28 @@ public abstract class BaseIndexingTestCase {
 		}
 	}
 
+	private void _setUpIndexingFixture() throws Exception {
+		if (_indexingFixture != null) {
+			Assume.assumeTrue(_indexingFixture.isSearchEngineAvailable());
+
+			return;
+		}
+
+		_indexingFixture = createIndexingFixture();
+
+		Assume.assumeTrue(_indexingFixture.isSearchEngineAvailable());
+
+		_indexingFixture.setUp();
+	}
+
+	private static final long _GROUP_ID = RandomTestUtil.randomLong();
+
 	private static final DocumentFixture _documentFixture =
 		new DocumentFixture();
 	private static IndexingFixture _indexingFixture;
 
+	private final DocumentBuilderFactory _documentBuilderFactory =
+		new DocumentBuilderFactoryImpl();
 	private String _entryClassName;
 	private IndexSearcher _indexSearcher;
 	private IndexWriter _indexWriter;

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/spi/model/query/contributor/GroupIdQueryPreFilterContributor.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/spi/model/query/contributor/GroupIdQueryPreFilterContributor.java
@@ -109,14 +109,12 @@ public class GroupIdQueryPreFilterContributor
 
 		TermsFilter groupIdTermsFilter = new TermsFilter(Field.GROUP_ID);
 
-		int maxTermsCount = 65536;
-
-		if ((inactiveGroupIds.size() > maxTermsCount) && !_isSolr()) {
+		if ((inactiveGroupIds.size() > _MAX_TERMS_COUNT) && !_isSolr()) {
 			for (int i = 0; i < inactiveGroupIds.size(); i++) {
 				groupIdTermsFilter.addValue(
 					String.valueOf(inactiveGroupIds.get(i)));
 
-				if (((i + 1) % maxTermsCount) == 0) {
+				if (((i + 1) % _MAX_TERMS_COUNT) == 0) {
 					booleanFilter.add(
 						groupIdTermsFilter, BooleanClauseOccur.MUST_NOT);
 
@@ -156,6 +154,8 @@ public class GroupIdQueryPreFilterContributor
 	private boolean _isSolr() {
 		return Objects.equals(_searchEngine.getVendor(), "Solr");
 	}
+
+	private static final Integer _MAX_TERMS_COUNT = 65536;
 
 	@Reference
 	private GroupLocalService _groupLocalService;

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/spi/model/query/contributor/GroupIdQueryPreFilterContributor.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/spi/model/query/contributor/GroupIdQueryPreFilterContributor.java
@@ -107,10 +107,29 @@ public class GroupIdQueryPreFilterContributor
 
 		TermsFilter groupIdTermsFilter = new TermsFilter(Field.GROUP_ID);
 
-		groupIdTermsFilter.addValues(
-			ArrayUtil.toStringArray(inactiveGroupIds.toArray(new Long[0])));
+		int maxTermsCount = 65536; //Could be set by a config
 
-		booleanFilter.add(groupIdTermsFilter, BooleanClauseOccur.MUST_NOT);
+		if (inactiveGroupIds.size() <= maxTermsCount) {
+			groupIdTermsFilter.addValues(
+				ArrayUtil.toStringArray(inactiveGroupIds.toArray(new Long[0])));
+		}
+		else {
+			for (int i = 0; i < inactiveGroupIds.size(); i++) {
+				groupIdTermsFilter.addValue(
+					String.valueOf(inactiveGroupIds.get(i)));
+
+				if (((i + 1) % maxTermsCount) == 0) {
+					booleanFilter.add(
+						groupIdTermsFilter, BooleanClauseOccur.MUST_NOT);
+
+					groupIdTermsFilter = new TermsFilter(Field.GROUP_ID);
+				}
+			}
+		}
+
+		if (!groupIdTermsFilter.isEmpty()) {
+			booleanFilter.add(groupIdTermsFilter, BooleanClauseOccur.MUST_NOT);
+		}
 	}
 
 	private void _addOwnerBooleanFilter(

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/spi/model/query/contributor/GroupIdQueryPreFilterContributor.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/spi/model/query/contributor/GroupIdQueryPreFilterContributor.java
@@ -11,6 +11,7 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.search.SearchEngine;
 import com.liferay.portal.kernel.search.filter.BooleanFilter;
 import com.liferay.portal.kernel.search.filter.TermsFilter;
 import com.liferay.portal.kernel.service.GroupLocalService;
@@ -19,6 +20,7 @@ import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.search.spi.model.query.contributor.QueryPreFilterContributor;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -107,13 +109,9 @@ public class GroupIdQueryPreFilterContributor
 
 		TermsFilter groupIdTermsFilter = new TermsFilter(Field.GROUP_ID);
 
-		int maxTermsCount = 65536; //Could be set by a config
+		int maxTermsCount = 65536;
 
-		if (inactiveGroupIds.size() <= maxTermsCount) {
-			groupIdTermsFilter.addValues(
-				ArrayUtil.toStringArray(inactiveGroupIds.toArray(new Long[0])));
-		}
-		else {
+		if ((inactiveGroupIds.size() > maxTermsCount) && !_isSolr()) {
 			for (int i = 0; i < inactiveGroupIds.size(); i++) {
 				groupIdTermsFilter.addValue(
 					String.valueOf(inactiveGroupIds.get(i)));
@@ -125,6 +123,10 @@ public class GroupIdQueryPreFilterContributor
 					groupIdTermsFilter = new TermsFilter(Field.GROUP_ID);
 				}
 			}
+		}
+		else {
+			groupIdTermsFilter.addValues(
+				ArrayUtil.toStringArray(inactiveGroupIds.toArray(new Long[0])));
 		}
 
 		if (!groupIdTermsFilter.isEmpty()) {
@@ -151,7 +153,14 @@ public class GroupIdQueryPreFilterContributor
 		}
 	}
 
+	private boolean _isSolr() {
+		return Objects.equals(_searchEngine.getVendor(), "Solr");
+	}
+
 	@Reference
 	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private SearchEngine _searchEngine;
 
 }


### PR DESCRIPTION
## Previous PR: https://github.com/brianchandotcom/liferay-portal/pull/149498

### This PR contains the changes asked here: https://github.com/brianchandotcom/liferay-portal/pull/149498#issuecomment-2069431558

https://liferay.atlassian.net/browse/LPD-2835

https://liferay.atlassian.net/browse/LPD-23550