### PR TITLE
cx stabilization

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/configuration/BaseConfigurationFactory.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/configuration/BaseConfigurationFactory.java
@@ -62,27 +62,27 @@ public abstract class BaseConfigurationFactory {
 				oAuth2ApplicationLocalService.deleteOAuth2Application(
 					oAuth2Application);
 
-				if (Validator.isNotNull(_configMapName)) {
-					PortalK8sConfigMapModifier portalK8sConfigMapModifier =
-						_portalK8sConfigMapModifierSnapshot.get();
-
-					portalK8sConfigMapModifier.modifyConfigMap(
-						configMapModel -> {
-							_extensionProperties.forEach(
-								configMapModel.data()::remove);
-
-							Map<String, String> labels =
-								configMapModel.labels();
-
-							labels.put(
-								"dxp.lxc.liferay.com/virtualInstanceId",
-								_virtualInstanceId);
-							labels.put(
-								"ext.lxc.liferay.com/projectName",
-								_projectName);
-						},
-						_configMapName);
+				if (Validator.isNull(_configMapName)) {
+					return;
 				}
+
+				PortalK8sConfigMapModifier portalK8sConfigMapModifier =
+					_portalK8sConfigMapModifierSnapshot.get();
+
+				portalK8sConfigMapModifier.modifyConfigMap(
+					configMapModel -> {
+						_extensionProperties.forEach(
+							configMapModel.data()::remove);
+
+						Map<String, String> labels = configMapModel.labels();
+
+						labels.put(
+							"dxp.lxc.liferay.com/virtualInstanceId",
+							_virtualInstanceId);
+						labels.put(
+							"ext.lxc.liferay.com/projectName", _projectName);
+					},
+					_configMapName);
 			});
 	}
 

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/configuration/BaseConfigurationFactory.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/configuration/BaseConfigurationFactory.java
@@ -6,7 +6,10 @@
 package com.liferay.oauth2.provider.internal.configuration;
 
 import com.liferay.oauth2.provider.model.OAuth2Application;
+import com.liferay.oauth2.provider.model.OAuth2ApplicationScopeAliases;
+import com.liferay.oauth2.provider.scope.liferay.ScopeLocator;
 import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
+import com.liferay.oauth2.provider.service.OAuth2ApplicationScopeAliasesLocalService;
 import com.liferay.osgi.util.configuration.ConfigurationFactoryUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -24,6 +27,7 @@ import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
 import javax.ws.rs.core.Application;
@@ -177,6 +181,44 @@ public abstract class BaseConfigurationFactory {
 			_configMapName);
 	}
 
+	protected void updateScopes(
+			OAuth2Application oAuth2Application, List<String> scopeAliasesList)
+		throws Exception {
+
+		boolean update = true;
+
+		OAuth2ApplicationScopeAliases oAuth2ApplicationScopeAliases =
+			oAuth2ApplicationScopeAliasesLocalService.
+				fetchOAuth2ApplicationScopeAliases(
+					oAuth2Application.getOAuth2ApplicationId(),
+					scopeAliasesList);
+
+		if (oAuth2ApplicationScopeAliases != null) {
+			List<String> currentScopeAliasesList =
+				oAuth2ApplicationScopeAliasesLocalService.getScopeAliasesList(
+					oAuth2ApplicationScopeAliases.
+						getOAuth2ApplicationScopeAliasesId());
+
+			if (currentScopeAliasesList.containsAll(scopeAliasesList) &&
+				(currentScopeAliasesList.size() == scopeAliasesList.size())) {
+
+				update = false;
+			}
+		}
+
+		if (update) {
+
+			// Make sure all scopes are registered
+
+			scopeLocator.getLiferayOAuth2Scopes(
+				oAuth2Application.getCompanyId());
+
+			oAuth2ApplicationLocalService.updateScopeAliases(
+				oAuth2Application.getUserId(), oAuth2Application.getUserName(),
+				oAuth2Application.getOAuth2ApplicationId(), scopeAliasesList);
+		}
+	}
+
 	@Reference(policyOption = ReferencePolicyOption.GREEDY)
 	protected Collection<Application> applications;
 
@@ -190,6 +232,13 @@ public abstract class BaseConfigurationFactory {
 
 	@Reference
 	protected OAuth2ApplicationLocalService oAuth2ApplicationLocalService;
+
+	@Reference
+	protected OAuth2ApplicationScopeAliasesLocalService
+		oAuth2ApplicationScopeAliasesLocalService;
+
+	@Reference
+	protected ScopeLocator scopeLocator;
 
 	@Reference
 	protected UserLocalService userLocalService;

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/configuration/BaseConfigurationFactory.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/configuration/BaseConfigurationFactory.java
@@ -7,6 +7,7 @@ package com.liferay.oauth2.provider.internal.configuration;
 
 import com.liferay.oauth2.provider.model.OAuth2Application;
 import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
+import com.liferay.osgi.util.configuration.ConfigurationFactoryUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.k8s.agent.PortalK8sConfigMapModifier;
@@ -18,6 +19,7 @@ import com.liferay.portal.kernel.module.service.Snapshot;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -51,26 +53,37 @@ public abstract class BaseConfigurationFactory {
 			log.debug("Deactivating " + oAuth2Application);
 		}
 
-		oAuth2ApplicationLocalService.deleteOAuth2Application(
-			oAuth2Application);
+		ConfigurationFactoryUtil.executeAsCompany(
+			companyLocalService,
+			HashMapBuilder.<String, Object>put(
+				"companyId", oAuth2Application.getCompanyId()
+			).build(),
+			companyId -> {
+				oAuth2ApplicationLocalService.deleteOAuth2Application(
+					oAuth2Application);
 
-		if (Validator.isNotNull(_configMapName)) {
-			PortalK8sConfigMapModifier portalK8sConfigMapModifier =
-				_portalK8sConfigMapModifierSnapshot.get();
+				if (Validator.isNotNull(_configMapName)) {
+					PortalK8sConfigMapModifier portalK8sConfigMapModifier =
+						_portalK8sConfigMapModifierSnapshot.get();
 
-			portalK8sConfigMapModifier.modifyConfigMap(
-				configMapModel -> {
-					_extensionProperties.forEach(configMapModel.data()::remove);
+					portalK8sConfigMapModifier.modifyConfigMap(
+						configMapModel -> {
+							_extensionProperties.forEach(
+								configMapModel.data()::remove);
 
-					Map<String, String> labels = configMapModel.labels();
+							Map<String, String> labels =
+								configMapModel.labels();
 
-					labels.put(
-						"dxp.lxc.liferay.com/virtualInstanceId",
-						_virtualInstanceId);
-					labels.put("ext.lxc.liferay.com/projectName", _projectName);
-				},
-				_configMapName);
-		}
+							labels.put(
+								"dxp.lxc.liferay.com/virtualInstanceId",
+								_virtualInstanceId);
+							labels.put(
+								"ext.lxc.liferay.com/projectName",
+								_projectName);
+						},
+						_configMapName);
+				}
+			});
 	}
 
 	protected String getHomePageURL(String homePageURL, String baseURL) {

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/configuration/OAuth2ProviderApplicationHeadlessServerConfigurationFactory.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/configuration/OAuth2ProviderApplicationHeadlessServerConfigurationFactory.java
@@ -168,9 +168,7 @@ public class OAuth2ProviderApplicationHeadlessServerConfigurationFactory
 				Collections.emptyList(), false, true, null,
 				new ServiceContext());
 
-		oAuth2Application = oAuth2ApplicationLocalService.updateScopeAliases(
-			oAuth2Application.getUserId(), oAuth2Application.getUserName(),
-			oAuth2Application.getOAuth2ApplicationId(), scopeAliasesList);
+		updateScopes(oAuth2Application, scopeAliasesList);
 
 		if (_log.isInfoEnabled()) {
 			_log.info(

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/configuration/OAuth2ProviderApplicationUserAgentConfigurationFactory.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/configuration/OAuth2ProviderApplicationUserAgentConfigurationFactory.java
@@ -164,9 +164,7 @@ public class OAuth2ProviderApplicationUserAgentConfigurationFactory
 					privacyPolicyURL(),
 				redirectURIsList, false, true, null, new ServiceContext());
 
-		oAuth2Application = oAuth2ApplicationLocalService.updateScopeAliases(
-			oAuth2Application.getUserId(), oAuth2Application.getUserName(),
-			oAuth2Application.getOAuth2ApplicationId(), scopeAliasesList);
+		updateScopes(oAuth2Application, scopeAliasesList);
 
 		if (_log.isInfoEnabled()) {
 			_log.info(

--- a/modules/apps/portal-instances/portal-instances-service/source-formatter-suppressions.xml
+++ b/modules/apps/portal-instances/portal-instances-service/source-formatter-suppressions.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+
+<suppressions>
+	<source-check>
+		<suppress checks="JavaComponentAnnotationsCheck" files="src/main/java/com/liferay/portal/instances/internal/configuration/PortalInstancesExecutor\.java" />
+	</source-check>
+</suppressions>

--- a/modules/apps/portal-instances/portal-instances-service/src/main/java/com/liferay/portal/instances/internal/configuration/PortalInstancesConfiguration.java
+++ b/modules/apps/portal-instances/portal-instances-service/src/main/java/com/liferay/portal/instances/internal/configuration/PortalInstancesConfiguration.java
@@ -22,6 +22,27 @@ public interface PortalInstancesConfiguration {
 	@Meta.AD(deflt = "true", required = false, type = Meta.Type.Boolean)
 	public boolean active();
 
+	@Meta.AD(required = false, type = Meta.Type.String)
+	public String defaultAdminPassword();
+
+	@Meta.AD(required = false, type = Meta.Type.String)
+	public String defaultAdminScreenName();
+
+	@Meta.AD(required = false, type = Meta.Type.String)
+	public String defaultAdminEmailAddress();
+
+	@Meta.AD(required = false, type = Meta.Type.String)
+	public String defaultAdminFirstName();
+
+	@Meta.AD(required = false, type = Meta.Type.String)
+	public String defaultAdminMiddleName();
+
+	@Meta.AD(required = false, type = Meta.Type.String)
+	public String defaultAdminLastName();
+
+	@Meta.AD(deflt = "10", required = false, type = Meta.Type.Long)
+	public long delay();
+
 	@Meta.AD(required = false, type = Meta.Type.Integer)
 	public int maxUsers();
 

--- a/modules/apps/portal-instances/portal-instances-service/src/main/java/com/liferay/portal/instances/internal/configuration/PortalInstancesConfigurationFactory.java
+++ b/modules/apps/portal-instances/portal-instances-service/src/main/java/com/liferay/portal/instances/internal/configuration/PortalInstancesConfigurationFactory.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.osgi.framework.Constants;
 import org.osgi.service.component.annotations.Activate;
@@ -36,14 +37,30 @@ import org.osgi.service.component.annotations.Reference;
 public class PortalInstancesConfigurationFactory {
 
 	@Activate
-	protected void activate(Map<String, Object> properties)
-		throws PortalException {
-
+	protected void activate(Map<String, Object> properties) {
 		PortalInstancesConfiguration portalInstancesConfiguration =
 			ConfigurableUtil.createConfigurable(
 				PortalInstancesConfiguration.class, properties);
 
 		String webId = _getWebId(properties);
+
+		_portalInstancesExecutor.schedule(
+			() -> {
+				try {
+					_addInstance(portalInstancesConfiguration, webId);
+				}
+				catch (PortalException portalException) {
+					throw new RuntimeException(portalException);
+				}
+			},
+			portalInstancesConfiguration.delay(), TimeUnit.SECONDS);
+	}
+
+	private void _addInstance(
+			PortalInstancesConfiguration portalInstancesConfiguration,
+			String webId)
+		throws PortalException {
+
 		String virtualHostname = portalInstancesConfiguration.virtualHostname();
 		String mx = portalInstancesConfiguration.mx();
 		int maxUsers = portalInstancesConfiguration.maxUsers();
@@ -62,8 +79,13 @@ public class PortalInstancesConfigurationFactory {
 
 		if (company == null) {
 			company = _companyLocalService.addCompany(
-				null, webId, virtualHostname, mx, maxUsers, active, null, null,
-				null, null, null, null);
+				null, webId, virtualHostname, mx, maxUsers, active,
+				portalInstancesConfiguration.defaultAdminPassword(),
+				portalInstancesConfiguration.defaultAdminScreenName(),
+				portalInstancesConfiguration.defaultAdminEmailAddress(),
+				portalInstancesConfiguration.defaultAdminFirstName(),
+				portalInstancesConfiguration.defaultAdminMiddleName(),
+				portalInstancesConfiguration.defaultAdminLastName());
 
 			try (SafeCloseable safeCloseable =
 					CompanyThreadLocal.setWithSafeCloseable(
@@ -109,6 +131,9 @@ public class PortalInstancesConfigurationFactory {
 
 	@Reference(target = ModuleServiceLifecycle.PORTLETS_INITIALIZED)
 	private ModuleServiceLifecycle _moduleServiceLifecycle;
+
+	@Reference
+	private PortalInstancesExecutor _portalInstancesExecutor;
 
 	@Reference
 	private PortalInstancesLocalService _portalInstancesLocalService;

--- a/modules/apps/portal-instances/portal-instances-service/src/main/java/com/liferay/portal/instances/internal/configuration/PortalInstancesExecutor.java
+++ b/modules/apps/portal-instances/portal-instances-service/src/main/java/com/liferay/portal/instances/internal/configuration/PortalInstancesExecutor.java
@@ -1,0 +1,42 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.instances.internal.configuration;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+
+/**
+ * @author Raymond Augé
+ */
+@Component(service = PortalInstancesExecutor.class)
+public class PortalInstancesExecutor {
+
+	@Activate
+	public PortalInstancesExecutor() {
+		_scheduledExecutorService =
+			Executors.newSingleThreadScheduledExecutor();
+	}
+
+	public ScheduledFuture<?> schedule(
+		Runnable runnable, long delay, TimeUnit unit) {
+
+		return _scheduledExecutorService.schedule(runnable, delay, unit);
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		_scheduledExecutorService.shutdown();
+	}
+
+	private final ScheduledExecutorService _scheduledExecutorService;
+
+}

--- a/modules/apps/portal-instances/portal-instances-test/build.gradle
+++ b/modules/apps/portal-instances/portal-instances-test/build.gradle
@@ -5,6 +5,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")
 	testIntegrationImplementation project(":apps:portal-instances:portal-instances-api")
 	testIntegrationImplementation project(":apps:portal-instances:portal-instances-service")
+	testIntegrationImplementation project(":apps:portal:portal-instance-lifecycle-api")
 	testIntegrationImplementation project(":core:osgi-service-tracker-collections")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/portal-instances/portal-instances-test/src/testIntegration/java/com/liferay/portal/instances/internal/configuration/test/PortalInstancesConfigurationFactoryTest.java
+++ b/modules/apps/portal-instances/portal-instances-test/src/testIntegration/java/com/liferay/portal/instances/internal/configuration/test/PortalInstancesConfigurationFactoryTest.java
@@ -8,22 +8,35 @@ package com.liferay.portal.instances.internal.configuration.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.test.util.ConfigurationTestUtil;
+import com.liferay.portal.instance.lifecycle.BasePortalInstanceLifecycleListener;
+import com.liferay.portal.instance.lifecycle.PortalInstanceLifecycleListener;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
-import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.rule.DataGuardTestRuleUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.SynchronousMailTestRule;
 
+import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
 
@@ -39,32 +52,77 @@ public class PortalInstancesConfigurationFactoryTest {
 		new AggregateTestRule(
 			new LiferayIntegrationTestRule(), SynchronousMailTestRule.INSTANCE);
 
-	@Test
-	public void test() throws Exception {
-		String webId = RandomTestUtil.randomString();
+	@Before
+	public void setUp() {
+		Bundle bundle = FrameworkUtil.getBundle(
+			PortalInstancesConfigurationFactoryTest.class);
 
-		Configuration configuration =
-			_configurationAdmin.getFactoryConfiguration(
-				"com.liferay.portal.instances.internal.configuration." +
-					"PortalInstancesConfiguration",
-				webId, StringPool.QUESTION);
-
-		ConfigurationTestUtil.saveConfiguration(
-			configuration,
-			HashMapDictionaryBuilder.<String, Object>put(
-				"mx", webId.concat(".foo.bar")
-			).put(
-				"virtualHostname", webId.concat(".foo.bar")
-			).build());
-
-		_company = _companyLocalService.getCompanyByWebId(webId);
-
-		Assert.assertNotNull(_company);
-
-		ConfigurationTestUtil.deleteConfiguration(configuration);
+		_bundleContext = bundle.getBundleContext();
 	}
 
-	@DeleteAfterTestRun
+	@Test
+	public void test() throws Exception {
+		try (LogCapture logCapture1 = LoggerTestUtil.configureLog4JLogger(
+				"org.hibernate.engine.jdbc.spi.SqlExceptionHelper",
+				LoggerTestUtil.ERROR);
+			LogCapture logCapture2 = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.portal.instance.lifecycle.internal." +
+					"PortalInstanceLifecycleListenerManagerImpl",
+				LoggerTestUtil.WARN)) {
+
+			String webId = RandomTestUtil.randomString();
+			CountDownLatch countDownLatch = new CountDownLatch(1);
+
+			ServiceRegistration<PortalInstanceLifecycleListener>
+				serviceRegistration = _bundleContext.registerService(
+					PortalInstanceLifecycleListener.class,
+					new BasePortalInstanceLifecycleListener() {
+
+						@Override
+						public void portalInstanceRegistered(Company company)
+							throws Exception {
+
+							if (Objects.equals(company.getWebId(), webId)) {
+								countDownLatch.countDown();
+							}
+						}
+
+					},
+					null);
+
+			Configuration configuration =
+				_configurationAdmin.getFactoryConfiguration(
+					"com.liferay.portal.instances.internal.configuration." +
+						"PortalInstancesConfiguration",
+					webId, StringPool.QUESTION);
+
+			try {
+				ConfigurationTestUtil.saveConfiguration(
+					configuration,
+					HashMapDictionaryBuilder.<String, Object>put(
+						"mx", webId.concat(".foo.bar")
+					).put(
+						"virtualHostname", webId.concat(".foo.bar")
+					).build());
+
+				countDownLatch.await(60, TimeUnit.SECONDS);
+
+				_company = _companyLocalService.getCompanyByWebId(webId);
+
+				Assert.assertNotNull(_company);
+			}
+			finally {
+				ConfigurationTestUtil.deleteConfiguration(configuration);
+
+				serviceRegistration.unregister();
+
+				DataGuardTestRuleUtil.smartDelete(
+					_companyLocalService, Company.class, _company);
+			}
+		}
+	}
+
+	private BundleContext _bundleContext;
 	private Company _company;
 
 	@Inject

--- a/modules/apps/static/portal-k8s-agent/portal-k8s-agent-impl/src/main/java/com/liferay/portal/k8s/agent/internal/AgentPortalK8sConfigMapModifier.java
+++ b/modules/apps/static/portal-k8s-agent/portal-k8s-agent-impl/src/main/java/com/liferay/portal/k8s/agent/internal/AgentPortalK8sConfigMapModifier.java
@@ -711,7 +711,7 @@ public class AgentPortalK8sConfigMapModifier
 				TimeUnit.MILLISECONDS);
 		}
 		else {
-			if (_log.isDebugEnabled()) {
+			if ((localClusterNode != null) && _log.isDebugEnabled()) {
 				_log.debug(
 					"Execute on master node " +
 						localClusterNode.getClusterNodeId());

--- a/modules/apps/static/portal-k8s-agent/portal-k8s-agent-impl/src/main/java/com/liferay/portal/k8s/agent/internal/AgentPortalK8sConfigMapModifier.java
+++ b/modules/apps/static/portal-k8s-agent/portal-k8s-agent-impl/src/main/java/com/liferay/portal/k8s/agent/internal/AgentPortalK8sConfigMapModifier.java
@@ -528,7 +528,7 @@ public class AgentPortalK8sConfigMapModifier
 			ObjectMeta objectMeta)
 		throws Exception {
 
-		Map<String, String> labels = objectMeta.getLabels();
+		Map<String, String> labels = _getMap(objectMeta.getLabels());
 
 		String virtualInstanceId = labels.get(
 			"dxp.lxc.liferay.com/virtualInstanceId");
@@ -589,6 +589,9 @@ public class AgentPortalK8sConfigMapModifier
 					Configuration.ConfigurationAttribute.READ_ONLY);
 			}
 
+			Map<String, String> annotations = _getMap(
+				objectMeta.getAnnotations());
+
 			Dictionary<String, Object> properties = config.getProperties();
 
 			for (PortalK8sConfigurationPropertiesMutator
@@ -597,7 +600,7 @@ public class AgentPortalK8sConfigMapModifier
 
 				portalK8sConfigurationPropertiesMutator.
 					mutateConfigurationProperties(
-						objectMeta.getAnnotations(), labels, properties);
+						annotations, labels, properties);
 			}
 
 			properties.put(".k8s.config.key", virtualInstancePid);

--- a/modules/apps/static/portal-k8s-agent/portal-k8s-agent-impl/src/main/java/com/liferay/portal/k8s/agent/internal/mutator/BaseURLPortalK8sConfigurationPropertiesMutator.java
+++ b/modules/apps/static/portal-k8s-agent/portal-k8s-agent-impl/src/main/java/com/liferay/portal/k8s/agent/internal/mutator/BaseURLPortalK8sConfigurationPropertiesMutator.java
@@ -6,7 +6,11 @@
 package com.liferay.portal.k8s.agent.internal.mutator;
 
 import com.liferay.portal.k8s.agent.mutator.PortalK8sConfigurationPropertiesMutator;
-import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -14,6 +18,7 @@ import java.util.Dictionary;
 import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.propertytypes.ServiceRanking;
 
 /**
@@ -29,8 +34,7 @@ public class BaseURLPortalK8sConfigurationPropertiesMutator
 		Map<String, String> annotations, Map<String, String> labels,
 		Dictionary<String, Object> properties) {
 
-		String mainDomain = GetterUtil.getString(
-			annotations.get("ext.lxc.liferay.com/mainDomain"));
+		String mainDomain = _getMainDomain(annotations, labels);
 
 		if (Validator.isNotNull(mainDomain)) {
 			properties.put(
@@ -39,5 +43,38 @@ public class BaseURLPortalK8sConfigurationPropertiesMutator
 			properties.put(".serviceScheme", Http.HTTPS);
 		}
 	}
+
+	private String _getMainDomain(
+		Map<String, String> annotations, Map<String, String> labels) {
+
+		String mainDomain = annotations.get("ext.lxc.liferay.com/mainDomain");
+
+		if (Validator.isNotNull(mainDomain)) {
+			return mainDomain;
+		}
+
+		String virtualInstanceId = labels.get(
+			"dxp.lxc.liferay.com/virtualInstanceId");
+
+		if (Validator.isNotNull(virtualInstanceId)) {
+			try {
+				Company company = _companyLocalService.getCompanyByWebId(
+					virtualInstanceId);
+
+				return company.getVirtualHostname();
+			}
+			catch (PortalException portalException) {
+				_log.error(portalException);
+			}
+		}
+
+		return null;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		BaseURLPortalK8sConfigurationPropertiesMutator.class);
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
 
 }


### PR DESCRIPTION
- **LPD-23619 Deleting OAuth2Applications through `com.liferay.oauth2.provider.internal.configuration.BaseConfigurationFactory` is not DB partition aware**
- **LPD-23619 buy space**
- **LPD-23697 Scopes assigned to a CX OAuth2Application are lost after a server restart**
- **LPD-23789 Error when using PortalInstancesConfiguration to create new instances on startup**
- **LPD-23041 OAuth2ProviderApplicationHeadlessServerConfigurationFactory does not detect a reasonable value for `Website URL` (the `homePageURL` field)**
- **LPD-23041 ensure maps are never null**
- **LPD-23041 prevent NPE**
