### PR TITLE
LPD-24820 Escaping the link causes the url to behave incorrectly

### DIFF
--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/views/ChangeTrackingWorkflowView.js
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/views/ChangeTrackingWorkflowView.js
@@ -80,7 +80,7 @@ export default function ChangeTrackingWorkflowView({workflowData}) {
 						</ClayTable.Cell>
 
 						<ClayTable.Cell className="table-cell-expand">
-							<a href={Liferay.Util.escape(workflowData.usages)}>
+							<a href={workflowData.usages}>
 								{Liferay.Language.get('view-usages')}
 							</a>
 						</ClayTable.Cell>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-24820

Tested in https://github.com/liferay-publications/liferay-portal/pull/1169#issuecomment-2092035208, manually forwarding due to rebase error