### PR TITLE
LPD-25370 InvokerFilterHelper.destroy() is only invoked by InvokerFil…

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/filters/invoker/InvokerFilterHelper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/filters/invoker/InvokerFilterHelper.java
@@ -76,8 +76,6 @@ public class InvokerFilterHelper {
 
 		_filterMappingsMap.clear();
 		_filterNames.clear();
-
-		clearFilterChainsCache();
 	}
 
 	public void init(FilterConfig filterConfig) throws ServletException {


### PR DESCRIPTION
…ter.destroy(). InvokerFilter.destroy() is already removing its own PortalCache instance, there is no point of letting InvokerFilterHelper.destroy() doing the cache clearing before the cache removing.

@victorhcunha another shutdown time file related optimization, needs the same thing as https://github.com/brianchandotcom/liferay-portal/pull/150069#issuecomment-2100970655, but wait until the benchmark tool profile support issue is solved by @tinatian @dantewang.