### PR TITLE
LPD-25509 When bundle blacklist is used. We see "new" bundles on ever…

### DIFF
--- a/modules/apps/static/portal-file-install/portal-file-install-impl/src/main/java/com/liferay/portal/file/install/internal/DirectoryWatcher.java
+++ b/modules/apps/static/portal-file-install/portal-file-install-impl/src/main/java/com/liferay/portal/file/install/internal/DirectoryWatcher.java
@@ -100,6 +100,16 @@ public class DirectoryWatcher extends Thread implements BundleListener {
 				index += 16;
 			}
 
+			List<Long> currentBundleIds = new ArrayList<>();
+
+			for (Bundle currentBundle : bundleContext.getBundles()) {
+				currentBundleIds.add(currentBundle.getBundleId());
+			}
+
+			Set<Long> checksumBundleIds = _bundleChecksums.keySet();
+
+			checksumBundleIds.retainAll(currentBundleIds);
+
 			int actualEntryCount = _bundleChecksums.size();
 
 			if (actualEntryCount < entryCount) {

--- a/modules/core/portal-bootstrap/src/main/java/com/liferay/portal/bootstrap/ModuleFrameworkImpl.java
+++ b/modules/core/portal-bootstrap/src/main/java/com/liferay/portal/bootstrap/ModuleFrameworkImpl.java
@@ -1317,7 +1317,7 @@ public class ModuleFrameworkImpl implements ModuleFramework {
 		}
 
 		try (OutputStream outputStream = new FileOutputStream(
-				bundleContext.getDataFile("bundles.checksum"))) {
+				bundleContext.getDataFile("bundles.checksum"), true)) {
 
 			outputStream.write(bytes);
 		}


### PR DESCRIPTION
…y startup. Change ModuleFrameworkImpl dynamic bundle checksum registering to append mode to avoid losing older checksums. In DirectoryWatcher we need to add a scrubbing protection to remove those blacklisted bundles from checksum file, this is necessary because they come back on every startup with different bundleIds, without a proper srcubbing, the checksum file will grow upon restart with trash data.