### PR TITLE
LPD-25577 When the current live group is already at HEAD, no need to …

### DIFF
--- a/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/manager/RecentGroupManagerImpl.java
+++ b/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/manager/RecentGroupManagerImpl.java
@@ -74,6 +74,10 @@ public class RecentGroupManagerImpl implements RecentGroupManager {
 		List<Long> groupIds = ListUtil.fromArray(
 			ArrayUtil.toLongArray(StringUtil.split(value, 0L)));
 
+		if (!groupIds.isEmpty() && (groupIds.get(0) == liveGroupId)) {
+			return;
+		}
+
 		groupIds.remove(liveGroupId);
 
 		groupIds.add(0, liveGroupId);


### PR DESCRIPTION
…save the same PortalPreferences value back to DB, it is purely a waste of time.

@tinatian @vicnate5 backport is needed for LXC, thanks!

@slnn this should drop DB usages on all test cases, please guide @victorhcunha to run through a runtime performance compare on all test cases, thanks!