### PR TITLE
LPD-25582 No matter how you paginate it, an empty result is always ju…

### DIFF
--- a/modules/apps/portal-cache/portal-cache-impl/src/main/java/com/liferay/portal/cache/internal/dao/orm/EmptyResult.java
+++ b/modules/apps/portal-cache/portal-cache-impl/src/main/java/com/liferay/portal/cache/internal/dao/orm/EmptyResult.java
@@ -5,11 +5,15 @@
 
 package com.liferay.portal.cache.internal.dao.orm;
 
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.util.OrderByComparator;
+
 import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 
+import java.util.Arrays;
 import java.util.Objects;
 
 /**
@@ -21,10 +25,12 @@ public class EmptyResult implements Externalizable {
 	}
 
 	public EmptyResult(Object[] args) {
-		_args = args;
+		_args = _stripPagination(args);
 	}
 
 	public boolean matches(Object[] args) {
+		args = _stripPagination(args);
+
 		if (args.length != _args.length) {
 			return false;
 		}
@@ -48,6 +54,33 @@ public class EmptyResult implements Externalizable {
 	@Override
 	public void writeExternal(ObjectOutput objectOutput) throws IOException {
 		objectOutput.writeObject(_args);
+	}
+
+	private Object[] _stripPagination(Object[] args) {
+		if ((args.length >= 3) &&
+			(args[args.length - 1] instanceof OrderByComparator) &&
+			(args[args.length - 2] instanceof Integer) &&
+			(args[args.length - 3] instanceof Integer)) {
+
+			int start = (Integer)args[args.length - 3];
+			int end = (Integer)args[args.length - 2];
+
+			if ((start == end) && (start != QueryUtil.ALL_POS)) {
+
+				// Defense for on purpose empty page.
+
+				args = Arrays.copyOf(args, args.length - 1);
+
+				args[args.length - 1] = 0;
+				args[args.length - 2] = 0;
+
+				return args;
+			}
+
+			return Arrays.copyOf(args, args.length - 3);
+		}
+
+		return args;
 	}
 
 	private Object[] _args;

--- a/modules/apps/portal-cache/portal-cache-impl/src/test/java/com/liferay/portal/cache/internal/dao/orm/EmptyResultTest.java
+++ b/modules/apps/portal-cache/portal-cache-impl/src/test/java/com/liferay/portal/cache/internal/dao/orm/EmptyResultTest.java
@@ -1,0 +1,288 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.cache.internal.dao.orm;
+
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.CodeCoverageAssertor;
+import com.liferay.portal.kernel.util.OrderByComparator;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+import java.util.Arrays;
+import java.util.Date;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class EmptyResultTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			CodeCoverageAssertor.INSTANCE, LiferayUnitTestRule.INSTANCE);
+
+	@Test
+	public void testEmptyConstructor() {
+		new EmptyResult();
+	}
+
+	@Test
+	public void testPlainMatch() {
+
+		// 3 args and last is not OrderByComparator
+
+		Object[] args = {1, "test", new Date()};
+
+		EmptyResult emptyResult = new EmptyResult(args);
+
+		Assert.assertTrue(emptyResult.matches(args));
+
+		Assert.assertFalse(emptyResult.matches(Arrays.copyOf(args, 2)));
+
+		args = Arrays.copyOf(args, args.length);
+
+		args[0] = 2;
+
+		Assert.assertFalse(emptyResult.matches(args));
+
+		// 2 args
+
+		args = new Object[] {1, "test"};
+
+		emptyResult = new EmptyResult(args);
+
+		Assert.assertTrue(emptyResult.matches(args));
+
+		args = Arrays.copyOf(args, args.length);
+
+		args[0] = 2;
+
+		Assert.assertFalse(emptyResult.matches(args));
+
+		// start is not int
+
+		args = new Object[] {
+			1, "test", 1L, 2,
+			new OrderByComparator<Object>() {
+
+				@Override
+				public int compare(Object object1, Object object2) {
+					return 0;
+				}
+
+			}
+		};
+
+		emptyResult = new EmptyResult(args);
+
+		Object[] savedArgs = ReflectionTestUtil.getFieldValue(
+			emptyResult, "_args");
+
+		Assert.assertEquals(Arrays.toString(savedArgs), 5, savedArgs.length);
+
+		Assert.assertTrue(emptyResult.matches(args));
+
+		// end is not int
+
+		args = new Object[] {
+			1, "test", 1, 2L,
+			new OrderByComparator<Object>() {
+
+				@Override
+				public int compare(Object object1, Object object2) {
+					return 0;
+				}
+
+			}
+		};
+
+		emptyResult = new EmptyResult(args);
+
+		savedArgs = ReflectionTestUtil.getFieldValue(emptyResult, "_args");
+
+		Assert.assertEquals(Arrays.toString(savedArgs), 5, savedArgs.length);
+
+		Assert.assertTrue(emptyResult.matches(args));
+	}
+
+	@Test
+	public void testSerialization() throws Exception {
+		Object[] args = {
+			1, "test", new Date(), 1, 2,
+			new OrderByComparator<Object>() {
+
+				@Override
+				public int compare(Object object1, Object object2) {
+					return 0;
+				}
+
+			}
+		};
+
+		EmptyResult emptyResult = new EmptyResult(args);
+
+		ByteArrayOutputStream byteArrayOutputStream =
+			new ByteArrayOutputStream();
+
+		try (ObjectOutputStream objectOutputStream = new ObjectOutputStream(
+				byteArrayOutputStream)) {
+
+			objectOutputStream.writeObject(emptyResult);
+		}
+
+		ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(
+			byteArrayOutputStream.toByteArray());
+
+		try (ObjectInputStream objectInputStream = new ObjectInputStream(
+				byteArrayInputStream)) {
+
+			EmptyResult deserializedEmptyResult =
+				(EmptyResult)objectInputStream.readObject();
+
+			Assert.assertTrue(deserializedEmptyResult.matches(args));
+			Assert.assertTrue(
+				deserializedEmptyResult.matches(Arrays.copyOf(args, 3)));
+		}
+	}
+
+	@Test
+	public void testStripPaginationDefenseEmptyPageMatch() {
+
+		// start = 2 and end = 2 is stripped to start = 0 and end = 0
+
+		Object[] args = {
+			1, "test", new Date(), 2, 2,
+			new OrderByComparator<Object>() {
+
+				@Override
+				public int compare(Object object1, Object object2) {
+					return 0;
+				}
+
+			}
+		};
+
+		EmptyResult emptyResult = new EmptyResult(args);
+
+		Object[] savedArgs = ReflectionTestUtil.getFieldValue(
+			emptyResult, "_args");
+
+		Assert.assertEquals(Arrays.toString(savedArgs), 5, savedArgs.length);
+		Assert.assertEquals(0, savedArgs[3]);
+		Assert.assertEquals(0, savedArgs[4]);
+
+		Assert.assertTrue(emptyResult.matches(args));
+
+		// Match with start = 5 and end = 5
+
+		args = Arrays.copyOf(args, args.length);
+
+		args[3] = 5;
+		args[4] = 5;
+
+		Assert.assertTrue(emptyResult.matches(args));
+
+		// Not match with no start/end
+
+		Assert.assertFalse(emptyResult.matches(Arrays.copyOf(args, 3)));
+	}
+
+	@Test
+	public void testStripPaginationMatch() {
+
+		// Strip away pagination parameters
+
+		Object[] args = {
+			1, "test", new Date(), 1, 2,
+			new OrderByComparator<Object>() {
+
+				@Override
+				public int compare(Object object1, Object object2) {
+					return 0;
+				}
+
+			}
+		};
+
+		EmptyResult emptyResult = new EmptyResult(args);
+
+		Object[] savedArgs = ReflectionTestUtil.getFieldValue(
+			emptyResult, "_args");
+
+		Assert.assertEquals(Arrays.toString(savedArgs), 3, savedArgs.length);
+
+		Assert.assertTrue(emptyResult.matches(args));
+
+		// Match with different OrderByComparator
+
+		args = Arrays.copyOf(args, args.length);
+
+		args[5] = new OrderByComparator<Object>() {
+
+			@Override
+			public int compare(Object object1, Object object2) {
+				return 0;
+			}
+
+		};
+
+		Assert.assertTrue(emptyResult.matches(args));
+
+		// Match with start = 3 and end = 5
+
+		args[4] = 5;
+		args[3] = 3;
+
+		Assert.assertTrue(emptyResult.matches(args));
+
+		// Not match with diffent 1st parameter
+
+		args[0] = 2;
+
+		Assert.assertFalse(emptyResult.matches(args));
+
+		// Match with no pagination args
+
+		args[0] = 1;
+
+		Assert.assertTrue(emptyResult.matches(Arrays.copyOf(args, 3)));
+
+		// start = QueryUtil.ALL_POS and end = QueryUtil.ALL_POS is stripped
+
+		args = new Object[] {
+			1, "test", new Date(), QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+			new OrderByComparator<Object>() {
+
+				@Override
+				public int compare(Object object1, Object object2) {
+					return 0;
+				}
+
+			}
+		};
+
+		emptyResult = new EmptyResult(args);
+
+		savedArgs = ReflectionTestUtil.getFieldValue(emptyResult, "_args");
+
+		Assert.assertEquals(Arrays.toString(savedArgs), 3, savedArgs.length);
+
+		Assert.assertTrue(emptyResult.matches(args));
+	}
+
+}


### PR DESCRIPTION
…st an empty result.

@tiantian @vicnate5 backport is needed for LXC, this is an important cache fix, please advise them to apply it asap. Thanks!

@victorhcunha this affects all test cases, and it should drop DB usages, please check.

CC @dantewang 