### PR TITLE
LPD-25505 Don't apply SF rule to upgrade tests

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaBaseUpgradeCallableCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaBaseUpgradeCallableCheck.java
@@ -48,16 +48,16 @@ public class JavaBaseUpgradeCallableCheck extends BaseJavaTermCheck {
 			return javaTerm.getContent();
 		}
 
-		Matcher runnablematcher = _runnablePattern.matcher(fileContent);
+		Matcher runnableMatcher = _runnablePattern.matcher(fileContent);
 
-		if (runnablematcher.find()) {
+		if (runnableMatcher.find()) {
 			addMessage(
 				fileName,
 				StringBundler.concat(
 					"Do not use 'java.lang.Runnable' in '",
 					packageNameMatcher.group(2),
 					"' classes, use 'BaseUpgradeCallable' instead."),
-				getLineNumber(fileContent, runnablematcher.start()));
+				getLineNumber(fileContent, runnableMatcher.start()));
 		}
 
 		List<String> importNames = javaClass.getImportNames();

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaBaseUpgradeCallableCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaBaseUpgradeCallableCheck.java
@@ -30,6 +30,12 @@ public class JavaBaseUpgradeCallableCheck extends BaseJavaTermCheck {
 
 		JavaClass javaClass = (JavaClass)javaTerm;
 
+		String name = javaClass.getName();
+
+		if (name.endsWith("Test")) {
+			return javaTerm.getContent();
+		}
+
 		String packageName = javaClass.getPackageName();
 
 		if (packageName == null) {


### PR DESCRIPTION
@adolfopa

> # What is this trying to solve?
> 
> https://liferay.atlassian.net/browse/LPD-25505
> 
> There's an SF rule that forces the use of `BaseUpgradeCallable` instead of the `Runnable` interface.  The issue is that the criteria to apply this rule is too broad. The rule should only apply to upgrade classes, but right now it affects integration tests too (which live under similarly named packages).
> 
> The changes in https://github.com/liferay-content-management/liferay-portal/pull/5438 depend on this rule ignoring tests.
> 
> # How am I fixing it?
> 
> By explicitly ignoring classes that end in `*Test`.