### PR TITLE
LPD-2835 ElasticsearchStatusException "The number of terms exceeded the allowed maximum" (defined in index.max_terms_count) occurs on Elasticsearch 7 when there are more than 65536 inactive groups (users or sites) & LPD-23550 Create test to ensure that an ElasticsearchStatusException will not be thrown even if the number of terms exceeded the allowed maximum

### DIFF
--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/query/TermsQueryTranslatorImpl.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/query/TermsQueryTranslatorImpl.java
@@ -11,7 +11,7 @@ import java.util.ArrayList;
 
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.TermsQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -28,7 +28,7 @@ public class TermsQueryTranslatorImpl implements TermsQueryTranslator {
 		String[] terms = termsQuery.getValues();
 
 		if (terms.length <= maxTermsCount) {
-			return new TermsQueryBuilder(field, terms);
+			return QueryBuilders.termsQuery(field, terms);
 		}
 
 		ArrayList<String> termsList = new ArrayList<>();
@@ -39,7 +39,7 @@ public class TermsQueryTranslatorImpl implements TermsQueryTranslator {
 
 			if (termsList.size() == maxTermsCount) {
 				boolQueryBuilder.should(
-					new TermsQueryBuilder(
+					QueryBuilders.termsQuery(
 						field, termsList.toArray(new String[0])));
 
 				termsList.clear();
@@ -48,7 +48,8 @@ public class TermsQueryTranslatorImpl implements TermsQueryTranslator {
 
 		if (!termsList.isEmpty()) {
 			boolQueryBuilder.should(
-				new TermsQueryBuilder(field, termsList.toArray(new String[0])));
+				QueryBuilders.termsQuery(
+					field, termsList.toArray(new String[0])));
 		}
 
 		return boolQueryBuilder;

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/query/TermsQueryTranslatorImpl.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/query/TermsQueryTranslatorImpl.java
@@ -32,7 +32,7 @@ public class TermsQueryTranslatorImpl implements TermsQueryTranslator {
 		}
 
 		ArrayList<String> termsList = new ArrayList<>();
-		BoolQueryBuilder boolQueryBuilder = new BoolQueryBuilder();
+		BoolQueryBuilder boolQueryBuilder = QueryBuilders.boolQuery();
 
 		for (String term : terms) {
 			termsList.add(term);

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/query/TermsQueryTranslatorImpl.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/query/TermsQueryTranslatorImpl.java
@@ -24,10 +24,9 @@ public class TermsQueryTranslatorImpl implements TermsQueryTranslator {
 	@Override
 	public QueryBuilder translate(TermsQuery termsQuery) {
 		String field = termsQuery.getField();
-		int maxTermsCount = 65536;
 		String[] terms = termsQuery.getValues();
 
-		if (terms.length <= maxTermsCount) {
+		if (terms.length <= _MAX_TERMS_COUNT) {
 			return QueryBuilders.termsQuery(field, terms);
 		}
 
@@ -37,7 +36,7 @@ public class TermsQueryTranslatorImpl implements TermsQueryTranslator {
 		for (String term : terms) {
 			termsList.add(term);
 
-			if (termsList.size() == maxTermsCount) {
+			if (termsList.size() == _MAX_TERMS_COUNT) {
 				boolQueryBuilder.should(
 					QueryBuilders.termsQuery(
 						field, termsList.toArray(new String[0])));
@@ -54,5 +53,7 @@ public class TermsQueryTranslatorImpl implements TermsQueryTranslator {
 
 		return boolQueryBuilder;
 	}
+
+	private static final Integer _MAX_TERMS_COUNT = 65536;
 
 }

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/query/TermsQueryTranslatorImpl.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/query/TermsQueryTranslatorImpl.java
@@ -7,8 +7,11 @@ package com.liferay.portal.search.elasticsearch7.internal.query;
 
 import com.liferay.portal.search.query.TermsQuery;
 
+import java.util.ArrayList;
+
+import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.query.TermsQueryBuilder;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -20,8 +23,35 @@ public class TermsQueryTranslatorImpl implements TermsQueryTranslator {
 
 	@Override
 	public QueryBuilder translate(TermsQuery termsQuery) {
-		return QueryBuilders.termsQuery(
-			termsQuery.getField(), termsQuery.getValues());
+		String field = termsQuery.getField();
+		int maxTermsCount = 65536;
+		String[] terms = termsQuery.getValues();
+
+		if (terms.length <= maxTermsCount) {
+			return new TermsQueryBuilder(field, terms);
+		}
+
+		ArrayList<String> termsList = new ArrayList<>();
+		BoolQueryBuilder boolQueryBuilder = new BoolQueryBuilder();
+
+		for (String term : terms) {
+			termsList.add(term);
+
+			if (termsList.size() == maxTermsCount) {
+				boolQueryBuilder.should(
+					new TermsQueryBuilder(
+						field, termsList.toArray(new String[0])));
+
+				termsList.clear();
+			}
+		}
+
+		if (!termsList.isEmpty()) {
+			boolQueryBuilder.should(
+				new TermsQueryBuilder(field, termsList.toArray(new String[0])));
+		}
+
+		return boolQueryBuilder;
 	}
 
 }

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/query/ElasticsearchQueryTranslatorTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/query/ElasticsearchQueryTranslatorTest.java
@@ -5,15 +5,19 @@
 
 package com.liferay.portal.search.elasticsearch7.internal.query;
 
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.search.internal.query.BooleanQueryImpl;
 import com.liferay.portal.search.internal.query.CommonTermsQueryImpl;
 import com.liferay.portal.search.internal.query.FuzzyQueryImpl;
 import com.liferay.portal.search.internal.query.MatchAllQueryImpl;
 import com.liferay.portal.search.internal.query.MoreLikeThisQueryImpl;
 import com.liferay.portal.search.internal.query.TermQueryImpl;
+import com.liferay.portal.search.internal.query.TermsQueryImpl;
 import com.liferay.portal.search.internal.query.WildcardQueryImpl;
 import com.liferay.portal.search.query.BooleanQuery;
 import com.liferay.portal.search.query.Query;
+import com.liferay.portal.search.query.TermsQuery;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import java.util.Collections;
@@ -104,6 +108,32 @@ public class ElasticsearchQueryTranslatorTest {
 			String.valueOf(innerQueryBuilder.boost()));
 	}
 
+	@Test
+	public void testTranslateTermsQueryExceedingMaxAllowedTerms() {
+		TermsQuery termsQuery = new TermsQueryImpl("groupId");
+
+		TermsQueryTranslator termsQueryTranslator =
+			new TermsQueryTranslatorImpl();
+
+		ReflectionTestUtil.setFieldValue(
+			_elasticsearchQueryTranslator, "_termsQueryTranslator",
+			termsQueryTranslator);
+
+		termsQuery.addValues("0", "1", "2", "3", "4", "5", "6", "7", "8", "9");
+
+		_setMaxTermsCount(10, termsQueryTranslator);
+
+		_assertNumberOfTermsClauses(1, termsQuery);
+
+		_setMaxTermsCount(5, termsQueryTranslator);
+
+		_assertNumberOfTermsClauses(2, termsQuery);
+
+		_setMaxTermsCount(3, termsQueryTranslator);
+
+		_assertNumberOfTermsClauses(4, termsQuery);
+	}
+
 	private void _assertBoost(Query query) {
 		query.setBoost(_BOOST);
 
@@ -113,6 +143,24 @@ public class ElasticsearchQueryTranslatorTest {
 		Assert.assertEquals(
 			queryBuilder.toString(), String.valueOf(_BOOST),
 			String.valueOf(queryBuilder.boost()));
+	}
+
+	private void _assertNumberOfTermsClauses(
+		int expected, TermsQuery termsQuery) {
+
+		String queryString = _elasticsearchQueryTranslator.translate(
+			termsQuery
+		).toString();
+
+		Assert.assertEquals(
+			queryString, expected, StringUtil.count(queryString, "terms"));
+	}
+
+	private void _setMaxTermsCount(
+		int maxTermsCount, TermsQueryTranslator termsQueryTranslator) {
+
+		ReflectionTestUtil.setFieldValue(
+			termsQueryTranslator, "_MAX_TERMS_COUNT", maxTermsCount);
 	}
 
 	private static final Float _BOOST = 1.5F;

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/query/OpenSearchQueryTranslator.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/query/OpenSearchQueryTranslator.java
@@ -992,20 +992,36 @@ public class OpenSearchQueryTranslator
 
 	@Override
 	public QueryVariant visit(TermsQuery termsQuery) {
-		org.opensearch.client.opensearch._types.query_dsl.TermsQuery.Builder
-			builder = QueryBuilders.terms();
+		String field = termsQuery.getField();
+		int maxTermsCount = 65536;
+		String[] terms = termsQuery.getValues();
 
-		SetterUtil.setNotNullFloat(builder::boost, termsQuery.getBoost());
+		if (terms.length <= maxTermsCount) {
+			return _getTermsQuery(termsQuery, field, terms);
+		}
 
-		builder.field(termsQuery.getField());
+		ArrayList<String> termsList = new ArrayList<>();
+		BoolQuery.Builder builder = QueryBuilders.bool();
 
-		List<FieldValue> fieldValues = new ArrayList<>();
+		for (String term : terms) {
+			termsList.add(term);
 
-		ListUtil.isNotEmptyForEach(
-			Arrays.asList(termsQuery.getValues()),
-			value -> fieldValues.add(FieldValue.of(value)));
+			if (termsList.size() == maxTermsCount) {
+				builder.should(
+					_getTermsQuery(
+						termsQuery, field, termsList.toArray(new String[0])
+					)._toQuery());
 
-		builder.terms(termsQueryField -> termsQueryField.value(fieldValues));
+				termsList.clear();
+			}
+		}
+
+		if (!termsList.isEmpty()) {
+			builder.should(
+				_getTermsQuery(
+					termsQuery, field, termsList.toArray(new String[0])
+				)._toQuery());
+		}
 
 		return builder.build();
 	}
@@ -1132,6 +1148,30 @@ public class OpenSearchQueryTranslator
 			"Invalid multi match query type " + type);
 	}
 
+	private org.opensearch.client.opensearch._types.query_dsl.TermsQuery
+		_getTermsQuery(TermsQuery termsQuery, String field, String[] values) {
+
+		org.opensearch.client.opensearch._types.query_dsl.TermsQuery.Builder
+			builder = QueryBuilders.terms();
+
+		SetterUtil.setNotNullFloat(builder::boost, termsQuery.getBoost());
+
+		builder.field(field);
+
+		builder.terms(
+			termsQueryField -> {
+				List<FieldValue> fieldValues = new ArrayList<>();
+
+				ListUtil.isNotEmptyForEach(
+					Arrays.asList(values),
+					value -> fieldValues.add(FieldValue.of(value)));
+
+				return termsQueryField.value(fieldValues);
+			});
+
+		return builder.build();
+	}
+
 	private void _processBooleanQueryClauses(
 		List<Query> queryClauses,
 		Consumer<org.opensearch.client.opensearch._types.query_dsl.Query>
@@ -1181,14 +1221,12 @@ public class OpenSearchQueryTranslator
 
 		documentIdentifiers.forEach(
 			documentIdentifier -> {
-				LikeDocument.Builder likeDocumentBuilder =
-					new LikeDocument.Builder();
+				LikeDocument.Builder builder = new LikeDocument.Builder();
 
-				likeDocumentBuilder.id(documentIdentifier.getId());
-				likeDocumentBuilder.index(documentIdentifier.getIndex());
+				builder.id(documentIdentifier.getId());
+				builder.index(documentIdentifier.getIndex());
 
-				likes.add(
-					Like.of(l -> l.document(likeDocumentBuilder.build())));
+				likes.add(Like.of(l -> l.document(builder.build())));
 			});
 
 		return likes;

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/query/OpenSearchQueryTranslator.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/query/OpenSearchQueryTranslator.java
@@ -991,10 +991,9 @@ public class OpenSearchQueryTranslator
 	@Override
 	public QueryVariant visit(TermsQuery termsQuery) {
 		String field = termsQuery.getField();
-		int maxTermsCount = 65536;
 		String[] terms = termsQuery.getValues();
 
-		if (terms.length <= maxTermsCount) {
+		if (terms.length <= _MAX_TERMS_COUNT) {
 			return _getTermsQuery(termsQuery, field, terms);
 		}
 
@@ -1004,7 +1003,7 @@ public class OpenSearchQueryTranslator
 		for (String term : terms) {
 			termsList.add(term);
 
-			if (termsList.size() == maxTermsCount) {
+			if (termsList.size() == _MAX_TERMS_COUNT) {
 				builder.should(
 					_getTermsQuery(
 						termsQuery, field, termsList.toArray(new String[0])
@@ -1420,6 +1419,8 @@ public class OpenSearchQueryTranslator
 		throw new IllegalArgumentException(
 			"Invalid shape relation " + shapeRelation);
 	}
+
+	private static final Integer _MAX_TERMS_COUNT = 65536;
 
 	private final GeoTranslator _geoTranslator = new GeoTranslator();
 	private final OpenSearchScoreFunctionTranslator

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/query/OpenSearchQueryTranslator.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/query/OpenSearchQueryTranslator.java
@@ -608,7 +608,6 @@ public class OpenSearchQueryTranslator
 
 	@Override
 	public QueryVariant visit(MatchQuery matchQuery) {
-		String field = matchQuery.getField();
 		MatchQuery.Type type = matchQuery.getType();
 		Object value = matchQuery.getValue();
 
@@ -628,17 +627,16 @@ public class OpenSearchQueryTranslator
 			}
 
 			if (type == MatchQuery.Type.PHRASE) {
-				return _translateMatchPhraseQuery(
-					field, matchQuery, stringValue);
+				return _translateMatchPhraseQuery(matchQuery, stringValue);
 			}
 			else if (type == MatchQuery.Type.PHRASE_PREFIX) {
 				return _translateMatchPhrasePrefixQuery(
-					field, matchQuery, stringValue);
+					matchQuery, stringValue);
 			}
 		}
 
 		if ((type == null) || (type == MatchQuery.Type.BOOLEAN)) {
-			return _translateMatchQuery(field, matchQuery, value);
+			return _translateMatchQuery(matchQuery, value);
 		}
 
 		throw new IllegalArgumentException("Invalid match query type " + type);
@@ -1233,7 +1231,7 @@ public class OpenSearchQueryTranslator
 	}
 
 	private QueryVariant _translateMatchPhrasePrefixQuery(
-		String field, MatchQuery matchQuery, String value) {
+		MatchQuery matchQuery, String value) {
 
 		org.opensearch.client.opensearch._types.query_dsl.
 			MatchPhrasePrefixQuery.Builder builder =
@@ -1256,7 +1254,7 @@ public class OpenSearchQueryTranslator
 	}
 
 	private QueryVariant _translateMatchPhraseQuery(
-		String field, MatchQuery matchQuery, String value) {
+		MatchQuery matchQuery, String value) {
 
 		org.opensearch.client.opensearch._types.query_dsl.MatchPhraseQuery.
 			Builder builder = QueryBuilders.matchPhrase();
@@ -1274,7 +1272,7 @@ public class OpenSearchQueryTranslator
 	}
 
 	private QueryVariant _translateMatchQuery(
-		String field, MatchQuery matchQuery, Object value) {
+		MatchQuery matchQuery, Object value) {
 
 		org.opensearch.client.opensearch._types.query_dsl.MatchQuery.Builder
 			builder = QueryBuilders.match();

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/query/OpenSearchQueryTranslatorTest.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/query/OpenSearchQueryTranslatorTest.java
@@ -5,6 +5,8 @@
 
 package com.liferay.portal.search.opensearch2.internal.query;
 
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.search.internal.query.BooleanQueryImpl;
 import com.liferay.portal.search.internal.query.CommonTermsQueryImpl;
 import com.liferay.portal.search.internal.query.FuzzyQueryImpl;
@@ -12,11 +14,13 @@ import com.liferay.portal.search.internal.query.MatchAllQueryImpl;
 import com.liferay.portal.search.internal.query.MoreLikeThisQueryImpl;
 import com.liferay.portal.search.internal.query.MultiMatchQueryImpl;
 import com.liferay.portal.search.internal.query.TermQueryImpl;
+import com.liferay.portal.search.internal.query.TermsQueryImpl;
 import com.liferay.portal.search.internal.query.WildcardQueryImpl;
 import com.liferay.portal.search.opensearch2.internal.OpenSearchTestRule;
 import com.liferay.portal.search.opensearch2.internal.util.JsonpUtil;
 import com.liferay.portal.search.query.BooleanQuery;
 import com.liferay.portal.search.query.Query;
+import com.liferay.portal.search.query.TermsQuery;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import java.util.Collections;
@@ -118,19 +122,56 @@ public class OpenSearchQueryTranslatorTest {
 			queryString.contains("\"boost\":" + String.valueOf(_BOOST)));
 	}
 
+	@Test
+	public void testTranslateTermsQueryExceedingMaxAllowedTerms() {
+		TermsQuery termsQuery = new TermsQueryImpl("groupId");
+
+		termsQuery.addValues("0", "1", "2", "3", "4", "5", "6", "7", "8", "9");
+
+		_setMaxTermsCount(10);
+
+		_assertNumberOfTermsClauses(1, termsQuery);
+
+		_setMaxTermsCount(5);
+
+		_assertNumberOfTermsClauses(2, termsQuery);
+
+		_setMaxTermsCount(3);
+
+		_assertNumberOfTermsClauses(4, termsQuery);
+	}
+
 	private void _assertBoost(Query query) {
 		query.setBoost(_BOOST);
 
+		String queryString = _getTranslatedQueryString(query);
+
+		Assert.assertTrue(
+			queryString,
+			queryString.contains("\"boost\":" + String.valueOf(_BOOST)));
+	}
+
+	private void _assertNumberOfTermsClauses(
+		int expected, TermsQuery termsQuery) {
+
+		String queryString = _getTranslatedQueryString(termsQuery);
+
+		Assert.assertEquals(
+			queryString, expected, StringUtil.count(queryString, "terms"));
+	}
+
+	private String _getTranslatedQueryString(Query query) {
 		org.opensearch.client.opensearch._types.query_dsl.Query
 			openSearchQuery =
 				new org.opensearch.client.opensearch._types.query_dsl.Query(
 					_openSearchQueryTranslator.translate(query));
 
-		String queryString = JsonpUtil.toString(openSearchQuery);
+		return JsonpUtil.toString(openSearchQuery);
+	}
 
-		Assert.assertTrue(
-			queryString,
-			queryString.contains("\"boost\":" + String.valueOf(_BOOST)));
+	private void _setMaxTermsCount(int maxTermsCount) {
+		ReflectionTestUtil.setFieldValue(
+			_openSearchQueryTranslator, "_MAX_TERMS_COUNT", maxTermsCount);
 	}
 
 	private static final Float _BOOST = 1.5F;


### PR DESCRIPTION
### Forwarded from: https://github.com/liferay-search/liferay-portal/pull/1334

https://liferay.atlassian.net/browse/LPD-2835
https://liferay.atlassian.net/browse/LPD-23550