### PR TITLE
LPD-17648 LPD-18566 LPD-18715: Forward headless search and suggestions to a new baseURI. Introduce scope parameter

### DIFF
--- a/modules/apps/portal-search/portal-search-rest-api/bnd.bnd
+++ b/modules/apps/portal-search/portal-search-rest-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Search REST API
 Bundle-SymbolicName: com.liferay.portal.search.rest.api
-Bundle-Version: 4.2.2
+Bundle-Version: 5.0.0
 Export-Package:\
 	com.liferay.portal.search.rest.configuration,\
 	com.liferay.portal.search.rest.dto.v1_0,\

--- a/modules/apps/portal-search/portal-search-rest-api/src/main/java/com/liferay/portal/search/rest/resource/v1_0/SearchResultResource.java
+++ b/modules/apps/portal-search/portal-search-rest-api/src/main/java/com/liferay/portal/search/rest/resource/v1_0/SearchResultResource.java
@@ -39,7 +39,7 @@ import org.osgi.annotation.versioning.ProviderType;
 /**
  * To access this resource, run:
  *
- *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/portal-search-rest/v1.0
+ *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/search/v1.0
  *
  * @author Petteri Karttunen
  * @generated
@@ -49,7 +49,7 @@ import org.osgi.annotation.versioning.ProviderType;
 public interface SearchResultResource {
 
 	public Page<SearchResult> postSearchPage(
-			String entryClassNames, String search, Filter filter,
+			String entryClassNames, String scope, String search, Filter filter,
 			Pagination pagination, Sort[] sorts,
 			SearchRequestBody searchRequestBody)
 		throws Exception;

--- a/modules/apps/portal-search/portal-search-rest-api/src/main/java/com/liferay/portal/search/rest/resource/v1_0/SuggestionResource.java
+++ b/modules/apps/portal-search/portal-search-rest-api/src/main/java/com/liferay/portal/search/rest/resource/v1_0/SuggestionResource.java
@@ -36,7 +36,7 @@ import org.osgi.annotation.versioning.ProviderType;
 /**
  * To access this resource, run:
  *
- *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/portal-search-rest/v1.0
+ *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/search/v1.0
  *
  * @author Petteri Karttunen
  * @generated

--- a/modules/apps/portal-search/portal-search-rest-api/src/main/resources/com/liferay/portal/search/rest/resource/v1_0/packageinfo
+++ b/modules/apps/portal-search/portal-search-rest-api/src/main/resources/com/liferay/portal/search/rest/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 4.1.0
+version 5.0.0

--- a/modules/apps/portal-search/portal-search-rest-client/src/main/java/com/liferay/portal/search/rest/client/resource/v1_0/SearchResultResource.java
+++ b/modules/apps/portal-search/portal-search-rest-client/src/main/java/com/liferay/portal/search/rest/client/resource/v1_0/SearchResultResource.java
@@ -36,14 +36,14 @@ public interface SearchResultResource {
 	}
 
 	public Page<SearchResult> postSearchPage(
-			String entryClassNames, String search, String filterString,
-			Pagination pagination, String sortString,
+			String entryClassNames, String scope, String search,
+			String filterString, Pagination pagination, String sortString,
 			SearchRequestBody searchRequestBody)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse postSearchPageHttpResponse(
-			String entryClassNames, String search, String filterString,
-			Pagination pagination, String sortString,
+			String entryClassNames, String scope, String search,
+			String filterString, Pagination pagination, String sortString,
 			SearchRequestBody searchRequestBody)
 		throws Exception;
 
@@ -157,14 +157,14 @@ public interface SearchResultResource {
 		implements SearchResultResource {
 
 		public Page<SearchResult> postSearchPage(
-				String entryClassNames, String search, String filterString,
-				Pagination pagination, String sortString,
+				String entryClassNames, String scope, String search,
+				String filterString, Pagination pagination, String sortString,
 				SearchRequestBody searchRequestBody)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse = postSearchPageHttpResponse(
-				entryClassNames, search, filterString, pagination, sortString,
-				searchRequestBody);
+				entryClassNames, scope, search, filterString, pagination,
+				sortString, searchRequestBody);
 
 			String content = httpResponse.getContent();
 
@@ -226,8 +226,8 @@ public interface SearchResultResource {
 		}
 
 		public HttpInvoker.HttpResponse postSearchPageHttpResponse(
-				String entryClassNames, String search, String filterString,
-				Pagination pagination, String sortString,
+				String entryClassNames, String scope, String search,
+				String filterString, Pagination pagination, String sortString,
 				SearchRequestBody searchRequestBody)
 			throws Exception {
 
@@ -259,6 +259,10 @@ public interface SearchResultResource {
 					"entryClassNames", String.valueOf(entryClassNames));
 			}
 
+			if (scope != null) {
+				httpInvoker.parameter("scope", String.valueOf(scope));
+			}
+
 			if (search != null) {
 				httpInvoker.parameter("search", String.valueOf(search));
 			}
@@ -281,7 +285,7 @@ public interface SearchResultResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/portal-search-rest/v1.0/search");
+						"/o/search/v1.0/search");
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);

--- a/modules/apps/portal-search/portal-search-rest-client/src/main/java/com/liferay/portal/search/rest/client/resource/v1_0/SuggestionResource.java
+++ b/modules/apps/portal-search/portal-search-rest-client/src/main/java/com/liferay/portal/search/rest/client/resource/v1_0/SuggestionResource.java
@@ -310,7 +310,7 @@ public interface SuggestionResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/portal-search-rest/v1.0/suggestions");
+						"/o/search/v1.0/suggestions");
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);

--- a/modules/apps/portal-search/portal-search-rest-impl/rest-config.yaml
+++ b/modules/apps/portal-search/portal-search-rest-impl/rest-config.yaml
@@ -1,7 +1,7 @@
 apiDir: "../portal-search-rest-api/src/main/java"
 apiPackagePath: "com.liferay.portal.search.rest"
 application:
-    baseURI: "/portal-search-rest"
+    baseURI: "/search"
     className: "PortalSearchRESTApplication"
     name: "Liferay.Portal.Search.REST"
 author: "Petteri Karttunen"

--- a/modules/apps/portal-search/portal-search-rest-impl/rest-openapi.yaml
+++ b/modules/apps/portal-search/portal-search-rest-impl/rest-openapi.yaml
@@ -194,6 +194,9 @@ paths:
                   schema:
                       type: string
                 - in: query
+                  deprecated: true
+                  description:
+                      Deprecated as of Cavanaugh (7.4.x), replaced by scope
                   name: groupId
                   schema:
                       format: int64

--- a/modules/apps/portal-search/portal-search-rest-impl/rest-openapi.yaml
+++ b/modules/apps/portal-search/portal-search-rest-impl/rest-openapi.yaml
@@ -152,6 +152,10 @@ paths:
                   schema:
                       type: string
                 - in: query
+                  name: scope
+                  schema:
+                      type: string
+                - in: query
                   name: search
                   schema:
                       type: string

--- a/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/graphql/mutation/v1_0/Mutation.java
@@ -64,6 +64,7 @@ public class Mutation {
 	)
 	public java.util.Collection<SearchResult> createSearchPage(
 			@GraphQLName("entryClassNames") String entryClassNames,
+			@GraphQLName("scope") String scope,
 			@GraphQLName("search") String search,
 			@GraphQLName("filter") String filterString,
 			@GraphQLName("pageSize") int pageSize,
@@ -78,7 +79,7 @@ public class Mutation {
 			this::_populateResourceContext,
 			searchResultResource -> {
 				Page paginationPage = searchResultResource.postSearchPage(
-					entryClassNames, search,
+					entryClassNames, scope, search,
 					_filterBiFunction.apply(searchResultResource, filterString),
 					Pagination.of(page, pageSize),
 					_sortsBiFunction.apply(searchResultResource, sortsString),

--- a/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -53,7 +53,7 @@ public class ServletDataImpl implements ServletData {
 
 	@Override
 	public String getPath() {
-		return "/portal-search-rest-graphql/v1_0";
+		return "/search-graphql/v1_0";
 	}
 
 	@Override

--- a/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/jaxrs/application/PortalSearchRESTApplication.java
+++ b/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/jaxrs/application/PortalSearchRESTApplication.java
@@ -17,8 +17,7 @@ import org.osgi.service.component.annotations.Component;
  */
 @Component(
 	property = {
-		"liferay.jackson=false",
-		"osgi.jaxrs.application.base=/portal-search-rest",
+		"liferay.jackson=false", "osgi.jaxrs.application.base=/search",
 		"osgi.jaxrs.extension.select=(osgi.jaxrs.name=Liferay.Vulcan)",
 		"osgi.jaxrs.name=Liferay.Portal.Search.REST"
 	},

--- a/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/jaxrs/exception/mapper/IllegalScopeParameterExceptionMapper.java
+++ b/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/jaxrs/exception/mapper/IllegalScopeParameterExceptionMapper.java
@@ -1,0 +1,39 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.rest.internal.jaxrs.exception.mapper;
+
+import com.liferay.portal.search.rest.internal.resource.exception.IllegalScopeParameterException;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.BaseExceptionMapper;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.Problem;
+
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Petteri Karttunen
+ */
+@Component(
+	property = {
+		"osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Portal.Search.REST)",
+		"osgi.jaxrs.extension=true",
+		"osgi.jaxrs.name=Liferay.Portal.Search.REST.IllegalScopeParameterExceptionMapper"
+	},
+	service = ExceptionMapper.class
+)
+@Provider
+public class IllegalScopeParameterExceptionMapper
+	extends BaseExceptionMapper<IllegalScopeParameterException> {
+
+	@Override
+	protected Problem getProblem(
+		IllegalScopeParameterException illegalScopeParameterException) {
+
+		return new Problem(illegalScopeParameterException);
+	}
+
+}

--- a/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/resource/exception/IllegalScopeParameterException.java
+++ b/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/resource/exception/IllegalScopeParameterException.java
@@ -1,0 +1,32 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.rest.internal.resource.exception;
+
+import com.liferay.portal.kernel.exception.SystemException;
+
+/**
+ * @author Petteri Karttunen
+ */
+public class IllegalScopeParameterException extends SystemException {
+
+	public IllegalScopeParameterException() {
+	}
+
+	public IllegalScopeParameterException(String msg) {
+		super(msg);
+	}
+
+	public IllegalScopeParameterException(String msg, Throwable throwable) {
+		super(msg, throwable);
+	}
+
+	public IllegalScopeParameterException(Throwable throwable) {
+		super(throwable);
+	}
+
+	private static final long serialVersionUID = 1L;
+
+}

--- a/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/resource/v1_0/BaseSearchResultResourceImpl.java
+++ b/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/resource/v1_0/BaseSearchResultResourceImpl.java
@@ -70,7 +70,7 @@ public abstract class BaseSearchResultResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/portal-search-rest/v1.0/search' -d $'{"attributes": ___, "facetConfigurations": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/search/v1.0/search' -d $'{"attributes": ___, "facetConfigurations": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Search the company index for matching content. This endpoint is beta and requires setting the portal property 'feature.flag.LPS-179669' to true or enabling via Instance Settings > Feature Flags: Beta."
@@ -107,6 +107,10 @@ public abstract class BaseSearchResultResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "scope"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "search"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
@@ -127,6 +131,9 @@ public abstract class BaseSearchResultResourceImpl
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@javax.ws.rs.QueryParam("entryClassNames")
 			String entryClassNames,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("scope")
+			String scope,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@javax.ws.rs.QueryParam("search")
 			String search,

--- a/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/resource/v1_0/BaseSuggestionResourceImpl.java
+++ b/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/resource/v1_0/BaseSuggestionResourceImpl.java
@@ -47,7 +47,7 @@ public abstract class BaseSuggestionResourceImpl implements SuggestionResource {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/portal-search-rest/v1.0/suggestions'  -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/search/v1.0/suggestions'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -60,6 +60,7 @@ public abstract class BaseSuggestionResourceImpl implements SuggestionResource {
 				name = "destinationFriendlyURL"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
+				deprecated = true,
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "groupId"
 			),
@@ -96,7 +97,7 @@ public abstract class BaseSuggestionResourceImpl implements SuggestionResource {
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@javax.ws.rs.QueryParam("destinationFriendlyURL")
 			String destinationFriendlyURL,
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@Deprecated @io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@javax.ws.rs.QueryParam("groupId")
 			Long groupId,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)

--- a/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/resource/v1_0/SearchResultResourceImpl.java
+++ b/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/resource/v1_0/SearchResultResourceImpl.java
@@ -51,6 +51,8 @@ import com.liferay.portal.search.rest.dto.v1_0.SearchResult;
 import com.liferay.portal.search.rest.internal.facet.FacetRequestContributor;
 import com.liferay.portal.search.rest.internal.facet.FacetResponseProcessor;
 import com.liferay.portal.search.rest.internal.odata.entity.v1_0.SearchResultEntityModel;
+import com.liferay.portal.search.rest.internal.util.ScopeUtil;
+import com.liferay.portal.search.rest.internal.util.ValueUtil;
 import com.liferay.portal.search.rest.pagination.SearchPage;
 import com.liferay.portal.search.rest.resource.v1_0.SearchResultResource;
 import com.liferay.portal.search.searcher.SearchRequestBuilder;
@@ -99,7 +101,7 @@ public class SearchResultResourceImpl extends BaseSearchResultResourceImpl {
 
 	@Override
 	public Page<SearchResult> postSearchPage(
-			String entryClassNames, String search, Filter filter,
+			String entryClassNames, String scope, String search, Filter filter,
 			Pagination pagination, Sort[] sorts,
 			SearchRequestBody searchRequestBody)
 		throws Exception {
@@ -127,12 +129,12 @@ public class SearchResultResourceImpl extends BaseSearchResultResourceImpl {
 			).size(
 				pagination.getPageSize()
 			).withSearchContext(
-				searchContext -> _addSearchContextAttributes(
-					searchRequestBody.getAttributes(), filter, search,
+				searchContext -> _populateSearchContext(
+					searchRequestBody.getAttributes(), filter, scope, search,
 					searchContext, sorts)
 			);
 
-		String[] entryClassNamesArray = _toArray(entryClassNames);
+		String[] entryClassNamesArray = ValueUtil.toArray(entryClassNames);
 
 		if (!ArrayUtil.isEmpty(entryClassNamesArray)) {
 			searchRequestBuilder.entryClassNames(entryClassNamesArray);
@@ -154,49 +156,6 @@ public class SearchResultResourceImpl extends BaseSearchResultResourceImpl {
 			Arrays.asList(
 				ParamUtil.getStringValues(contextHttpServletRequest, "fields")),
 			pagination, _searcher.search(searchRequestBuilder.build()));
-	}
-
-	private void _addSearchContextAttributes(
-		Map<String, Object> attributes, Filter filter, String search,
-		SearchContext searchContext, Sort[] sorts) {
-
-		MapUtil.isNotEmptyForEach(
-			attributes,
-			(key, value) -> {
-				if (_isAllowedSearchContextAttribute(key) && (value != null) &&
-					(value instanceof Serializable)) {
-
-					searchContext.setAttribute(key, (Serializable)value);
-				}
-			});
-
-		if (searchContext.getAttribute("search.experiences.ip.address") ==
-				null) {
-
-			searchContext.setAttribute(
-				"search.experiences.ip.address",
-				contextHttpServletRequest.getRemoteAddr());
-		}
-
-		if (filter != null) {
-			searchContext.setBooleanClauses(
-				new BooleanClause[] {
-					_getBooleanClause(
-						booleanQuery -> {
-						},
-						filter)
-				});
-		}
-
-		searchContext.setKeywords(search);
-		searchContext.setLocale(contextAcceptLanguage.getPreferredLocale());
-
-		if (!ArrayUtil.isEmpty(sorts)) {
-			searchContext.setSorts(sorts);
-		}
-
-		searchContext.setTimeZone(contextUser.getTimeZone());
-		searchContext.setUserId(contextUser.getUserId());
 	}
 
 	private Object _fetchObject(String entryClassName, Long entryClassPK) {
@@ -393,6 +352,51 @@ public class SearchResultResourceImpl extends BaseSearchResultResourceImpl {
 		}
 	}
 
+	private void _populateSearchContext(
+		Map<String, Object> attributes, Filter filter, String scope,
+		String search, SearchContext searchContext, Sort[] sorts) {
+
+		MapUtil.isNotEmptyForEach(
+			attributes,
+			(key, value) -> {
+				if (_isAllowedSearchContextAttribute(key) && (value != null) &&
+					(value instanceof Serializable)) {
+
+					searchContext.setAttribute(key, (Serializable)value);
+				}
+			});
+
+		if (searchContext.getAttribute("search.experiences.ip.address") ==
+				null) {
+
+			searchContext.setAttribute(
+				"search.experiences.ip.address",
+				contextHttpServletRequest.getRemoteAddr());
+		}
+
+		if (filter != null) {
+			searchContext.setBooleanClauses(
+				new BooleanClause[] {
+					_getBooleanClause(
+						booleanQuery -> {
+						},
+						filter)
+				});
+		}
+
+		searchContext.setGroupIds(
+			ScopeUtil.parseGroupIds(contextCompany.getCompanyId(), scope));
+		searchContext.setKeywords(search);
+		searchContext.setLocale(contextAcceptLanguage.getPreferredLocale());
+
+		if (!ArrayUtil.isEmpty(sorts)) {
+			searchContext.setSorts(sorts);
+		}
+
+		searchContext.setTimeZone(contextUser.getTimeZone());
+		searchContext.setUserId(contextUser.getUserId());
+	}
+
 	private void _setDateModified(
 		Document document, List<String> fields, SearchResult searchResult) {
 
@@ -556,16 +560,6 @@ public class SearchResultResourceImpl extends BaseSearchResultResourceImpl {
 		}
 
 		return aggregations;
-	}
-
-	private String[] _toArray(String csvString) {
-		if (Validator.isBlank(csvString)) {
-			return new String[0];
-		}
-
-		csvString = StringUtil.trim(csvString);
-
-		return csvString.split("\\s*,\\s*");
 	}
 
 	private SearchPage<SearchResult> _toSearchPage(

--- a/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/resource/v1_0/SuggestionResourceImpl.java
+++ b/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/resource/v1_0/SuggestionResourceImpl.java
@@ -8,7 +8,6 @@ package com.liferay.portal.search.rest.internal.resource.v1_0;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
-import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.Portlet;
@@ -22,12 +21,14 @@ import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.search.constants.SearchContextAttributes;
 import com.liferay.portal.search.rest.configuration.SearchSuggestionsCompanyConfiguration;
 import com.liferay.portal.search.rest.dto.v1_0.Suggestion;
 import com.liferay.portal.search.rest.dto.v1_0.SuggestionsContributorConfiguration;
 import com.liferay.portal.search.rest.dto.v1_0.SuggestionsContributorResults;
+import com.liferay.portal.search.rest.internal.util.ScopeUtil;
 import com.liferay.portal.search.rest.resource.v1_0.SuggestionResource;
 import com.liferay.portal.search.suggestions.SuggestionsRetriever;
 import com.liferay.portal.search.web.constants.SearchBarPortletKeys;
@@ -75,8 +76,12 @@ public class SuggestionResourceImpl extends BaseSuggestionResourceImpl {
 			return Page.of(Collections.emptyList());
 		}
 
+		Layout layout = _layoutLocalService.getLayout(plid);
+
+		ThemeDisplay themeDisplay = _createThemeDisplay(currentURL, layout);
+
 		LiferayRenderRequest liferayRenderRequest = _createLiferayRenderRequest(
-			currentURL, plid);
+			layout, themeDisplay);
 
 		if (!StringUtil.startsWith(destinationFriendlyURL, CharPool.SLASH)) {
 			destinationFriendlyURL = StringPool.SLASH.concat(
@@ -90,9 +95,9 @@ public class SuggestionResourceImpl extends BaseSuggestionResourceImpl {
 					RenderResponseFactory.create(
 						contextHttpServletResponse, liferayRenderRequest),
 					_createSearchContext(
-						destinationFriendlyURL, _getGroupId(groupId),
-						keywordsParameterName, scope, search,
-						suggestionsContributorConfigurations)),
+						destinationFriendlyURL, groupId, keywordsParameterName,
+						scope, search, suggestionsContributorConfigurations,
+						themeDisplay)),
 				suggestionsContributorResult ->
 					new SuggestionsContributorResults() {
 						{
@@ -130,13 +135,11 @@ public class SuggestionResourceImpl extends BaseSuggestionResourceImpl {
 	}
 
 	private LiferayRenderRequest _createLiferayRenderRequest(
-			String currentURL, long plid)
+			Layout layout, ThemeDisplay themeDisplay)
 		throws Exception {
 
-		Layout layout = _layoutLocalService.getLayout(plid);
-
 		contextHttpServletRequest.setAttribute(
-			WebKeys.THEME_DISPLAY, _createThemeDisplay(currentURL, layout));
+			WebKeys.THEME_DISPLAY, themeDisplay);
 
 		Portlet portlet = _portletLocalService.getPortletById(
 			SearchBarPortletKeys.SEARCH_BAR);
@@ -164,10 +167,11 @@ public class SuggestionResourceImpl extends BaseSuggestionResourceImpl {
 	}
 
 	private SearchContext _createSearchContext(
-			String destinationFriendlyURL, long groupId,
+			String destinationFriendlyURL, Long groupId,
 			String keywordsParameterName, String scope, String search,
 			SuggestionsContributorConfiguration[]
-				suggestionsContributorConfigurations)
+				suggestionsContributorConfigurations,
+			ThemeDisplay themeDisplay)
 		throws Exception {
 
 		SearchContext searchContext = new SearchContext();
@@ -178,8 +182,6 @@ public class SuggestionResourceImpl extends BaseSuggestionResourceImpl {
 			"search.experiences.ip.address",
 			contextHttpServletRequest.getRemoteAddr());
 		searchContext.setAttribute(
-			"search.experiences.scope.group.id", groupId);
-		searchContext.setAttribute(
 			"search.suggestions.contributor.configurations",
 			suggestionsContributorConfigurations);
 		searchContext.setAttribute(
@@ -188,16 +190,20 @@ public class SuggestionResourceImpl extends BaseSuggestionResourceImpl {
 		searchContext.setAttribute(
 			"search.suggestions.keywords.parameter.name",
 			keywordsParameterName);
-		searchContext.setCompanyId(contextCompany.getCompanyId());
 
-		if (!StringUtil.equals(scope, "everything")) {
-			searchContext.setGroupIds(new long[] {groupId});
+		if (themeDisplay != null) {
+			searchContext.setAttribute(
+				"search.experiences.scope.group.id",
+				themeDisplay.getScopeGroupId());
 		}
 
+		searchContext.setCompanyId(contextCompany.getCompanyId());
 		searchContext.setKeywords(search);
 		searchContext.setLocale(contextAcceptLanguage.getPreferredLocale());
 		searchContext.setTimeZone(contextUser.getTimeZone());
 		searchContext.setUserId(contextUser.getUserId());
+
+		_setScope(groupId, scope, searchContext);
 
 		return searchContext;
 	}
@@ -223,17 +229,22 @@ public class SuggestionResourceImpl extends BaseSuggestionResourceImpl {
 		return themeDisplay;
 	}
 
-	private long _getGroupId(Long groupId) {
-		if (groupId != null) {
-			return groupId;
+	private void _setScope(
+		Long groupId, String scope, SearchContext searchContext) {
+
+		if (StringUtil.equals(scope, "everything") ||
+			(Validator.isBlank(scope) && (groupId == null))) {
+
+			return;
+		}
+		else if (StringUtil.equals(scope, "this-site") && (groupId != null)) {
+			searchContext.setGroupIds(new long[] {groupId});
+
+			return;
 		}
 
-		try {
-			return contextCompany.getGroupId();
-		}
-		catch (PortalException portalException) {
-			throw new RuntimeException(portalException);
-		}
+		searchContext.setGroupIds(
+			ScopeUtil.parseGroupIds(contextCompany.getCompanyId(), scope));
 	}
 
 	@Reference

--- a/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/resource/v1_0/factory/SearchResultResourceFactoryImpl.java
+++ b/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/resource/v1_0/factory/SearchResultResourceFactoryImpl.java
@@ -55,7 +55,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	property = "resource.locator.key=/portal-search-rest/v1.0/SearchResult",
+	property = "resource.locator.key=/search/v1.0/SearchResult",
 	service = SearchResultResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/resource/v1_0/factory/SuggestionResourceFactoryImpl.java
+++ b/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/resource/v1_0/factory/SuggestionResourceFactoryImpl.java
@@ -55,7 +55,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	property = "resource.locator.key=/portal-search-rest/v1.0/Suggestion",
+	property = "resource.locator.key=/search/v1.0/Suggestion",
 	service = SuggestionResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/util/ScopeUtil.java
+++ b/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/util/ScopeUtil.java
@@ -1,0 +1,52 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.rest.internal.util;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.search.rest.internal.resource.exception.IllegalScopeParameterException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Petteri Karttunen
+ */
+public class ScopeUtil {
+
+	public static long[] parseGroupIds(long companyId, String scope) {
+		List<Long> groupIds = new ArrayList<>();
+
+		String[] scopes = ValueUtil.toArray(scope);
+
+		for (String s : scopes) {
+			Group group =
+				GroupLocalServiceUtil.fetchGroupByExternalReferenceCode(
+					s, companyId);
+
+			if (group != null) {
+				groupIds.add(group.getGroupId());
+
+				continue;
+			}
+
+			try {
+				groupIds.add(Long.parseLong(s));
+			}
+			catch (NumberFormatException numberFormatException) {
+				throw new IllegalScopeParameterException(
+					StringBundler.concat(
+						"Invalid group external reference code or ID ", s, ". ",
+						numberFormatException));
+			}
+		}
+
+		return ArrayUtil.toLongArray(groupIds);
+	}
+
+}

--- a/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/util/ValueUtil.java
+++ b/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/util/ValueUtil.java
@@ -1,0 +1,26 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.rest.internal.util;
+
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+
+/**
+ * @author Petteri Karttunen
+ */
+public class ValueUtil {
+
+	public static String[] toArray(String csvString) {
+		if (Validator.isBlank(csvString)) {
+			return new String[0];
+		}
+
+		csvString = StringUtil.trim(csvString);
+
+		return csvString.split("\\s*,\\s*");
+	}
+
+}

--- a/modules/apps/portal-search/portal-search-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/openapi.properties
+++ b/modules/apps/portal-search/portal-search-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/openapi.properties
@@ -4,6 +4,6 @@
 
 api.version=v1.0
 openapi.resource=true
-openapi.resource.path=/portal-search-rest
+openapi.resource.path=/search
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Portal.Search.REST)
 osgi.jaxrs.resource=true

--- a/modules/apps/portal-search/portal-search-rest-test/src/testIntegration/java/com/liferay/portal/search/rest/resource/v1_0/test/SearchResultResourceTest.java
+++ b/modules/apps/portal-search/portal-search-rest-test/src/testIntegration/java/com/liferay/portal/search/rest/resource/v1_0/test/SearchResultResourceTest.java
@@ -32,12 +32,14 @@ import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.SearchEngine;
 import com.liferay.portal.kernel.search.SearchEngineHelper;
 import com.liferay.portal.kernel.search.highlight.HighlightUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.HTTPTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
@@ -97,6 +99,8 @@ public class SearchResultResourceTest extends BaseSearchResultResourceTestCase {
 	public void setUp() throws Exception {
 		super.setUp();
 
+		_baseURI = "search";
+
 		_locale = LocaleUtil.getSiteDefault();
 
 		_ddmStructure = _addJournalArticleDDMStructure(_locale);
@@ -118,18 +122,20 @@ public class SearchResultResourceTest extends BaseSearchResultResourceTestCase {
 	@Override
 	@Test
 	public void testPostSearchPage() throws Exception {
-		SearchPage<SearchResult> searchPage = _postSearchPage(
-			_journalArticle.getArticleId());
-
-		Assert.assertEquals(1L, searchPage.getPage());
-		Assert.assertEquals(1L, searchPage.getTotalCount());
-
 		_testPostSearchPageWithCategoryTreeFacetConfiguration();
 		_testPostSearchPageWithCustomFacetConfiguration();
 		_testPostSearchPageWithDateRangeFacetConfiguration();
 		_testPostSearchPageWithEmbeddedNestedFields();
+		_testPostSearchPageWithEmptyScope();
+		_testPostSearchPageWithFaultyScope();
+		_testPostSearchPageWithFilter();
 		_testPostSearchPageWithFolderFacetConfiguration();
+		_testPostSearchPageWithGroupERCAndIdScope();
+		_testPostSearchPageWithGroupERCScope();
+		_testPostSearchPageWithGroupIdScope();
 		_testPostSearchPageWithHighlightConfiguration();
+		_testPostSearchPageWithKeywords();
+		_testPostSearchPageWithMultipleGroupIdsScope();
 		_testPostSearchPageWithNestedFacetConfiguration();
 		_testPostSearchPageWithSiteFacetConfiguration();
 		_testPostSearchPageWithTagFacetConfiguration();
@@ -137,6 +143,13 @@ public class SearchResultResourceTest extends BaseSearchResultResourceTestCase {
 		_testPostSearchPageWithUserFacetConfiguration();
 		_testPostSearchPageWithoutHighlightConfiguration();
 		_testPostSearchPageZeroResults();
+	}
+
+	@Test
+	public void testSearchEndpointRedirect() throws Exception {
+		_baseURI = "portal-search-rest";
+
+		_testPostSearchPageWithKeywords();
 	}
 
 	private AssetCategory _addAssetCategory(
@@ -301,6 +314,26 @@ public class SearchResultResourceTest extends BaseSearchResultResourceTestCase {
 		return searchPage;
 	}
 
+	private void _assertSearchResultTitles(
+		SearchPage<SearchResult> searchPage, String... expectedValues) {
+
+		List<SearchResult> searchResults = ListUtil.fromCollection(
+			searchPage.getItems());
+
+		List<String> titles = new ArrayList<>();
+
+		for (SearchResult searchResult : searchResults) {
+			titles.add(searchResult.getTitle());
+		}
+
+		Arrays.sort(expectedValues);
+
+		Collections.sort(titles);
+
+		Assert.assertEquals(
+			Arrays.toString(expectedValues), String.valueOf(titles));
+	}
+
 	private JSONObject _createSXPBlueprintHighlightConfigurationJSON() {
 		return JSONUtil.put(
 			"fields",
@@ -330,10 +363,10 @@ public class SearchResultResourceTest extends BaseSearchResultResourceTestCase {
 
 	private String _getEndpoint(
 			String entryClassNames, String filterString, String keywords,
-			String nestedFields)
+			String nestedFields, String scope)
 		throws Exception {
 
-		String endpoint = "portal-search-rest/v1.0/search?";
+		String endpoint = _baseURI + "/v1.0/search?";
 
 		if (!Validator.isBlank(entryClassNames)) {
 			endpoint +=
@@ -350,6 +383,10 @@ public class SearchResultResourceTest extends BaseSearchResultResourceTestCase {
 			endpoint +=
 				"&nestedFields=" +
 					URLEncoder.encode(nestedFields, StringPool.UTF8);
+		}
+
+		if (!Validator.isBlank(scope)) {
+			endpoint += "&scope=" + URLEncoder.encode(scope, StringPool.UTF8);
 		}
 
 		if (!Validator.isBlank(keywords)) {
@@ -393,20 +430,30 @@ public class SearchResultResourceTest extends BaseSearchResultResourceTestCase {
 		throws Exception {
 
 		return _postSearchPage(
-			null, "groupIds/any(g:g eq " + testGroup.getGroupId() + ")",
-			keywords, null, new SearchRequestBody());
+			null, null, keywords, null, String.valueOf(testGroup.getGroupId()),
+			new SearchRequestBody());
+	}
+
+	private SearchPage<SearchResult> _postSearchPage(
+			String keywords, String scope)
+		throws Exception {
+
+		return _postSearchPage(
+			null, null, keywords, null, scope, new SearchRequestBody());
 	}
 
 	private SearchPage<SearchResult> _postSearchPage(
 			String entryClassNames, String filterString, String keywords,
-			String nestedFields, SearchRequestBody searchRequestBody)
+			String nestedFields, String scope,
+			SearchRequestBody searchRequestBody)
 		throws Exception {
 
 		return _toSearchPage(
 			HTTPTestUtil.invokeToJSONObject(
 				searchRequestBody.toString(),
 				_getEndpoint(
-					entryClassNames, filterString, keywords, nestedFields),
+					entryClassNames, filterString, keywords, nestedFields,
+					scope),
 				Http.Method.POST));
 	}
 
@@ -427,9 +474,8 @@ public class SearchResultResourceTest extends BaseSearchResultResourceTestCase {
 		};
 
 		return _postSearchPage(
-			entryClassNames,
-			"groupIds/any(g:g eq " + testGroup.getGroupId() + ")", null, null,
-			searchRequestBody);
+			entryClassNames, null, null, null,
+			String.valueOf(testGroup.getGroupId()), searchRequestBody);
 	}
 
 	private SearchPage<SearchResult>
@@ -448,7 +494,7 @@ public class SearchResultResourceTest extends BaseSearchResultResourceTestCase {
 		};
 
 		return _postSearchPage(
-			entryClassNames, null, keywords, null, searchRequestBody);
+			entryClassNames, null, keywords, null, null, searchRequestBody);
 	}
 
 	private void _testPostSearchPageWithCategoryTreeFacetConfiguration()
@@ -544,7 +590,7 @@ public class SearchResultResourceTest extends BaseSearchResultResourceTestCase {
 
 		SearchPage<SearchResult> searchPage = _postSearchPage(
 			objectDefinition.getClassName(), null,
-			objectDefinition.getUserName(), "embedded",
+			objectDefinition.getUserName(), "embedded", null,
 			new SearchRequestBody());
 
 		Collection<SearchResult> searchResults = searchPage.getItems();
@@ -556,12 +602,89 @@ public class SearchResultResourceTest extends BaseSearchResultResourceTestCase {
 		}
 	}
 
+	private void _testPostSearchPageWithEmptyScope() throws Exception {
+		Group testGroup2 = GroupTestUtil.addGroup();
+
+		JournalArticle journalArticle = JournalTestUtil.addArticle(
+			testGroup2.getGroupId(), StringUtil.randomString(),
+			StringUtil.randomString());
+
+		SearchPage<SearchResult> searchPage = _postSearchPage(
+			StringBundler.concat(
+				_journalArticle.getTitle(_locale), StringPool.SPACE,
+				journalArticle.getTitle(_locale)),
+			null);
+
+		_assertSearchResultTitles(
+			searchPage, _journalArticle.getTitle(_locale),
+			journalArticle.getTitle(_locale));
+
+		GroupTestUtil.deleteGroup(testGroup2);
+	}
+
+	private void _testPostSearchPageWithFaultyScope() throws Exception {
+		SearchPage<SearchResult> searchPage = _postSearchPage(
+			_journalArticle.getArticleId(), "notexistingscope");
+
+		_assertSearchResultTitles(searchPage, new String[0]);
+	}
+
+	private void _testPostSearchPageWithFilter() throws Exception {
+		SearchPage<SearchResult> searchPage = _postSearchPage(
+			null, "groupIds/any(g:g eq " + testGroup.getGroupId() + ")",
+			_journalArticle.getArticleId(), null, null,
+			new SearchRequestBody());
+
+		_assertSearchResultTitles(
+			searchPage, _journalArticle.getTitle(_locale));
+	}
+
 	private void _testPostSearchPageWithFolderFacetConfiguration()
 		throws Exception {
 
 		_assertFacetConfiguration(
 			false, null, null, "folder", _journalArticle.getFolderId(),
 			String.valueOf(_journalArticle.getFolderId()));
+	}
+
+	private void _testPostSearchPageWithGroupERCAndIdScope() throws Exception {
+		Group testGroup2 = GroupTestUtil.addGroup();
+
+		JournalArticle journalArticle = JournalTestUtil.addArticle(
+			testGroup2.getGroupId(), StringUtil.randomString(),
+			StringUtil.randomString());
+
+		SearchPage<SearchResult> searchPage = _postSearchPage(
+			StringBundler.concat(
+				_journalArticle.getTitle(_locale), StringPool.SPACE,
+				journalArticle.getTitle(_locale)),
+			StringBundler.concat(
+				testGroup.getGroupId(), StringPool.COMMA,
+				testGroup2.getExternalReferenceCode()));
+
+		_assertSearchResultTitles(
+			searchPage, _journalArticle.getTitle(_locale),
+			journalArticle.getTitle(_locale));
+
+		GroupTestUtil.deleteGroup(testGroup2);
+	}
+
+	private void _testPostSearchPageWithGroupERCScope() throws Exception {
+		SearchPage<SearchResult> searchPage = _postSearchPage(
+			_journalArticle.getArticleId(),
+			String.valueOf(testGroup.getExternalReferenceCode()));
+
+		_assertSearchResultTitles(
+			searchPage, _journalArticle.getTitle(_locale));
+	}
+
+	private void _testPostSearchPageWithGroupIdScope() throws Exception {
+		SearchPage<SearchResult> searchPage = _postSearchPage(
+			_journalArticle.getArticleId(),
+			String.valueOf(testGroup.getGroupId()));
+
+		_assertSearchResultTitles(
+			searchPage, _journalArticle.getTitle(_locale));
 	}
 
 	private void _testPostSearchPageWithHighlightConfiguration()
@@ -582,6 +705,38 @@ public class SearchResultResourceTest extends BaseSearchResultResourceTestCase {
 				searchResult -> Objects.equals(
 					searchResult.getTitle(), _getUserHighlightedFullName())) >=
 						1);
+	}
+
+	private void _testPostSearchPageWithKeywords() throws Exception {
+		SearchPage<SearchResult> searchPage = _postSearchPage(
+			_journalArticle.getArticleId());
+
+		Assert.assertEquals(1L, searchPage.getPage());
+		Assert.assertEquals(1L, searchPage.getTotalCount());
+	}
+
+	private void _testPostSearchPageWithMultipleGroupIdsScope()
+		throws Exception {
+
+		Group testGroup2 = GroupTestUtil.addGroup();
+
+		JournalArticle journalArticle = JournalTestUtil.addArticle(
+			testGroup2.getGroupId(), StringUtil.randomString(),
+			StringUtil.randomString());
+
+		SearchPage<SearchResult> searchPage = _postSearchPage(
+			StringBundler.concat(
+				_journalArticle.getTitle(_locale), StringPool.SPACE,
+				journalArticle.getTitle(_locale)),
+			StringBundler.concat(
+				testGroup.getGroupId(), StringPool.COMMA,
+				testGroup2.getGroupId()));
+
+		_assertSearchResultTitles(
+			searchPage, _journalArticle.getTitle(_locale),
+			journalArticle.getTitle(_locale));
+
+		GroupTestUtil.deleteGroup(testGroup2);
 	}
 
 	private void _testPostSearchPageWithNestedFacetConfiguration()
@@ -707,6 +862,7 @@ public class SearchResultResourceTest extends BaseSearchResultResourceTestCase {
 	@Inject
 	private AssetVocabularyLocalService _assetVocabularyLocalService;
 
+	private String _baseURI;
 	private DDMStructure _ddmStructure;
 	private JournalArticle _journalArticle;
 

--- a/modules/apps/portal-search/portal-search-rest-test/src/testIntegration/java/com/liferay/portal/search/rest/resource/v1_0/test/SuggestionResourceTest.java
+++ b/modules/apps/portal-search/portal-search-rest-test/src/testIntegration/java/com/liferay/portal/search/rest/resource/v1_0/test/SuggestionResourceTest.java
@@ -6,16 +6,38 @@
 package com.liferay.portal.search.rest.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.test.util.JournalTestUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.search.rest.client.dto.v1_0.Suggestion;
 import com.liferay.portal.search.rest.client.dto.v1_0.SuggestionsContributorConfiguration;
 import com.liferay.portal.search.rest.client.dto.v1_0.SuggestionsContributorResults;
 import com.liferay.portal.search.rest.client.pagination.Page;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.search.experiences.model.SXPBlueprint;
+import com.liferay.search.experiences.service.SXPBlueprintLocalService;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -25,21 +47,210 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 public class SuggestionResourceTest extends BaseSuggestionResourceTestCase {
 
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+
+		_journalArticle = JournalTestUtil.addArticle(
+			testGroup.getGroupId(), StringUtil.randomString(),
+			StringUtil.randomString());
+
+		_layout = LayoutTestUtil.addTypePortletLayout(testGroup);
+
+		_locale = LocaleUtil.getSiteDefault();
+	}
+
 	@Override
 	@Test
 	public void testPostSuggestionsPage() throws Exception {
-		String title = "Document Title";
+		_testPostSuggestionsPageWithBasicSuggestionsContributor();
+		_testPostSuggestionsPageWithBasicSuggestionsContributorWithAssetSearchSummary();
+		_testPostSuggestionsPageWithBasicSuggestionsContributorWithEverythingScope();
+		_testPostSuggestionsPageWithBasicSuggestionsContributorWithGroupERCScope();
+		_testPostSuggestionsPageWithBasicSuggestionsContributorWithThisSiteScope();
+		_testPostSuggestionsPageWithSXPBlueprintSuggestionsContributor();
+		_testPostSuggestionsPageWithSXPBlueprintSuggestionsContributorWithGroupERCScope();
+	}
 
-		JournalTestUtil.addArticle(testGroup.getGroupId(), title, "");
+	private void _assertSuggestionContributorResults(
+			String displayGroupName,
+			Page<SuggestionsContributorResults> suggestionPage,
+			String... expectedTexts)
+		throws Exception {
+
+		SuggestionsContributorResults suggestionsContributorResults1 = null;
+
+		for (SuggestionsContributorResults suggestionsContributorResults2 :
+				suggestionPage.getItems()) {
+
+			if (!StringUtil.equals(
+					suggestionsContributorResults2.getDisplayGroupName(),
+					displayGroupName)) {
+
+				continue;
+			}
+
+			suggestionsContributorResults1 = suggestionsContributorResults2;
+		}
+
+		Assert.assertTrue(
+			"Display group not found", suggestionsContributorResults1 != null);
+
+		Suggestion[] suggestions =
+			suggestionsContributorResults1.getSuggestions();
+
+		Assert.assertEquals(
+			Arrays.toString(suggestions), expectedTexts.length,
+			suggestions.length);
+
+		_assertSuggestionTexts(suggestionsContributorResults1, expectedTexts);
+	}
+
+	private void _assertSuggestionTexts(
+			SuggestionsContributorResults suggestionsContributorResults,
+			String... expectedTexts)
+		throws Exception {
+
+		Suggestion[] suggestions =
+			suggestionsContributorResults.getSuggestions();
+
+		List<String> texts = new ArrayList<>();
+
+		for (Suggestion suggestion : suggestions) {
+			texts.add(suggestion.getText());
+		}
+
+		Arrays.sort(expectedTexts);
+
+		Collections.sort(texts);
+
+		Assert.assertEquals(
+			Arrays.toString(expectedTexts), String.valueOf(texts));
+	}
+
+	private Page<SuggestionsContributorResults> _postSuggestionsPage(
+			String currentURL, String destinationFriendlyURL, Long groupId,
+			String keywordsParameterName, Long plid, String scope,
+			String search,
+			SuggestionsContributorConfiguration[]
+				suggestionsContributorConfigurations)
+		throws Exception {
+
+		return suggestionResource.postSuggestionsPage(
+			currentURL, destinationFriendlyURL, groupId, keywordsParameterName,
+			plid, scope, search, suggestionsContributorConfigurations);
+	}
+
+	private Page<SuggestionsContributorResults>
+			_postSuggestionsPageWithBasicSuggestionsContributor(
+				String scope, String search,
+				String suggestionsDisplayGroupGroupName)
+		throws Exception {
+
+		return _postSuggestionsPage(
+			"http://localhost:8080/web/guest/home", "/search", null, "q",
+			_layout.getPlid(), scope, search,
+			new SuggestionsContributorConfiguration[] {
+				new SuggestionsContributorConfiguration() {
+					{
+						contributorName = "basic";
+						displayGroupName = suggestionsDisplayGroupGroupName;
+					}
+				}
+			});
+	}
+
+	private void _testPostSuggestionsPageWithBasicSuggestionsContributor()
+		throws Exception {
+
+		String displayGroupName = "Suggestions";
+
+		Page<SuggestionsContributorResults> suggestionsPage =
+			_postSuggestionsPageWithBasicSuggestionsContributor(
+				null, _journalArticle.getArticleId(), displayGroupName);
+
+		_assertSuggestionContributorResults(
+			displayGroupName, suggestionsPage,
+			_journalArticle.getTitle(_locale));
+	}
+
+	private void _testPostSuggestionsPageWithBasicSuggestionsContributorWithAssetSearchSummary()
+		throws Exception {
+
+		Page<SuggestionsContributorResults> suggestionsPage =
+			_postSuggestionsPageWithBasicSuggestionsContributor(
+				null, _journalArticle.getArticleId(), "Suggestions");
+
+		SuggestionsContributorResults suggestionsContributorResults =
+			suggestionsPage.fetchFirstItem();
+
+		Suggestion[] suggestions =
+			suggestionsContributorResults.getSuggestions();
+
+		Suggestion suggestion = suggestions[0];
+
+		JSONObject suggestionAttributesJSONObject =
+			JSONFactoryUtil.createJSONObject(
+				String.valueOf(suggestion.getAttributes()));
+
+		Assert.assertEquals(
+			_journalArticle.getDescription(_locale),
+			suggestionAttributesJSONObject.get("assetSearchSummary"));
+	}
+
+	private void _testPostSuggestionsPageWithBasicSuggestionsContributorWithEverythingScope()
+		throws Exception {
+
+		Group testGroup2 = GroupTestUtil.addGroup();
+
+		JournalArticle journalArticle = JournalTestUtil.addArticle(
+			testGroup2.getGroupId(), StringUtil.randomString(),
+			StringUtil.randomString());
 
 		Page<SuggestionsContributorResults> suggestionPage =
-			suggestionResource.postSuggestionsPage(
-				"http://localhost:8080/web/guest/home", "%2Fsearch",
-				testGroup.getGroupId(), "q",
-				LayoutTestUtil.addTypePortletLayout(
-					testGroup
-				).getPlid(),
-				"everything", "Document",
+			_postSuggestionsPageWithBasicSuggestionsContributor(
+				"everything",
+				StringBundler.concat(
+					_journalArticle.getTitle(_locale), StringPool.SPACE,
+					journalArticle.getTitle(_locale)),
+				"Suggestions");
+
+		_assertSuggestionTexts(
+			suggestionPage.fetchFirstItem(), _journalArticle.getTitle(_locale),
+			journalArticle.getTitle(_locale));
+
+		GroupTestUtil.deleteGroup(testGroup2);
+	}
+
+	private void _testPostSuggestionsPageWithBasicSuggestionsContributorWithGroupERCScope()
+		throws Exception {
+
+		Page<SuggestionsContributorResults> suggestionPage =
+			_postSuggestionsPageWithBasicSuggestionsContributor(
+				testGroup.getExternalReferenceCode(),
+				_journalArticle.getArticleId(), "Suggestions");
+
+		_assertSuggestionTexts(
+			suggestionPage.fetchFirstItem(), _journalArticle.getTitle(_locale));
+	}
+
+	private void _testPostSuggestionsPageWithBasicSuggestionsContributorWithThisSiteScope()
+		throws Exception {
+
+		Group testGroup2 = GroupTestUtil.addGroup();
+
+		JournalArticle journalArticle = JournalTestUtil.addArticle(
+			testGroup2.getGroupId(), StringUtil.randomString(),
+			StringUtil.randomString());
+
+		Page<SuggestionsContributorResults> suggestionPage =
+			_postSuggestionsPage(
+				"http://localhost:8080/web/guest/home", "/search",
+				testGroup.getGroupId(), "q", _layout.getPlid(), "this-site",
+				StringBundler.concat(
+					_journalArticle.getTitle(_locale), StringPool.SPACE,
+					journalArticle.getTitle(_locale)),
 				new SuggestionsContributorConfiguration[] {
 					new SuggestionsContributorConfiguration() {
 						{
@@ -49,27 +260,87 @@ public class SuggestionResourceTest extends BaseSuggestionResourceTestCase {
 					}
 				});
 
-		Assert.assertEquals(1, suggestionPage.getTotalCount());
+		_assertSuggestionTexts(
+			suggestionPage.fetchFirstItem(), _journalArticle.getTitle(_locale));
 
-		SuggestionsContributorResults suggestionsContributorResults =
-			suggestionPage.fetchFirstItem();
-
-		Assert.assertEquals(
-			"Suggestions", suggestionsContributorResults.getDisplayGroupName());
-
-		Suggestion[] suggestions =
-			suggestionsContributorResults.getSuggestions();
-
-		Suggestion suggestion = suggestions[0];
-
-		Assert.assertEquals(title, suggestion.getText());
-
-		JSONObject suggestionAttributesJSONObject =
-			JSONFactoryUtil.createJSONObject(
-				String.valueOf(suggestion.getAttributes()));
-
-		Assert.assertEquals(
-			title, suggestionAttributesJSONObject.get("assetSearchSummary"));
+		GroupTestUtil.deleteGroup(testGroup2);
 	}
+
+	private void _testPostSuggestionsPageWithSXPBlueprintSuggestionsContributor()
+		throws Exception {
+
+		String suggestionsDisplayGroupGroupName = "Suggestions";
+
+		SXPBlueprint sxpBlueprint = _sxpBlueprintLocalService.addSXPBlueprint(
+			null, TestPropsValues.getUserId(), "{}",
+			Collections.singletonMap(LocaleUtil.US, ""), null, "",
+			Collections.singletonMap(
+				LocaleUtil.US, RandomTestUtil.randomString()),
+			ServiceContextTestUtil.getServiceContext(
+				testGroup, TestPropsValues.getUserId()));
+
+		Page<SuggestionsContributorResults> suggestionPage =
+			_postSuggestionsPage(
+				"http://localhost:8080/web/guest/home", "/search",
+				testGroup.getGroupId(), "q", _layout.getPlid(), null,
+				_journalArticle.getArticleId(),
+				new SuggestionsContributorConfiguration[] {
+					new SuggestionsContributorConfiguration() {
+						{
+							attributes = JSONUtil.put(
+								"sxpBlueprintExternalReferenceCode",
+								sxpBlueprint.getExternalReferenceCode());
+							contributorName = "sxpBlueprint";
+							displayGroupName = suggestionsDisplayGroupGroupName;
+						}
+					}
+				});
+
+		_assertSuggestionContributorResults(
+			suggestionsDisplayGroupGroupName, suggestionPage,
+			_journalArticle.getTitle(_locale));
+	}
+
+	private void _testPostSuggestionsPageWithSXPBlueprintSuggestionsContributorWithGroupERCScope()
+		throws Exception {
+
+		SXPBlueprint sxpBlueprint = _sxpBlueprintLocalService.addSXPBlueprint(
+			null, TestPropsValues.getUserId(), "{}",
+			Collections.singletonMap(LocaleUtil.US, ""), null, "",
+			Collections.singletonMap(
+				LocaleUtil.US, RandomTestUtil.randomString()),
+			ServiceContextTestUtil.getServiceContext(
+				testGroup, TestPropsValues.getUserId()));
+
+		String suggestionsDisplayGroupGroupName = "Suggestions";
+
+		Page<SuggestionsContributorResults> suggestionPage =
+			_postSuggestionsPage(
+				"http://localhost:8080/web/guest/home", "/search", null, "q",
+				_layout.getPlid(), testGroup.getExternalReferenceCode(),
+				_journalArticle.getArticleId(),
+				new SuggestionsContributorConfiguration[] {
+					new SuggestionsContributorConfiguration() {
+						{
+							attributes = JSONUtil.put(
+								"sxpBlueprintExternalReferenceCode",
+								sxpBlueprint.getExternalReferenceCode());
+							contributorName = "sxpBlueprint";
+							displayGroupName = suggestionsDisplayGroupGroupName;
+						}
+					}
+				});
+
+		_assertSuggestionContributorResults(
+			suggestionsDisplayGroupGroupName, suggestionPage,
+			_journalArticle.getTitle(_locale));
+	}
+
+	private JournalArticle _journalArticle;
+	private Layout _layout;
+	private Locale _locale;
+
+	@Inject
+	private SXPBlueprintLocalService _sxpBlueprintLocalService;
 
 }

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactory.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactory.java
@@ -209,7 +209,7 @@ public class SearchBarPortletDisplayContextFactory {
 			searchBarPortletDisplayContext.setSuggestionsEnabled(
 				searchBarPortletPreferences.isSuggestionsEnabled());
 			searchBarPortletDisplayContext.setSuggestionsURL(
-				"/o/portal-search-rest/v1.0/suggestions");
+				"/o/search/v1.0/suggestions");
 		}
 
 		searchBarPortletDisplayContext.setSuggestionsEndpointEnabled(

--- a/modules/apps/portal/portal-url-rewrite-filter/src/main/resources/com/liferay/portal/url/rewrite/filter/internal/dependencies/urlrewrite.xml
+++ b/modules/apps/portal/portal-url-rewrite-filter/src/main/resources/com/liferay/portal/url/rewrite/filter/internal/dependencies/urlrewrite.xml
@@ -3,14 +3,6 @@
 
 <urlrewrite>
 	<rule>
-		<from>^/api/webdav(.{0,2000})</from>
-		<to type="redirect">%{context-path}/webdav$1</to>
-	</rule>
-	<rule>
-		<from>^/favicon.ico$</from>
-		<to type="redirect">/o/favicon/</to>
-	</rule>
-	<rule>
 		<from>^/(.{1,1000}/)?blog/blogs/rss(.{0,1000})</from>
 		<to type="permanent-redirect">%{context-path}/html/common/referer_jsp.jsp?referer=${escape:/$1blog/-/blogs/rss$2}</to>
 	</rule>
@@ -21,6 +13,18 @@
 	<rule>
 		<from>^/(.{1,1000}/)?tunnel-web(.{0,1000})</from>
 		<to type="permanent-redirect">%{context-path}/html/common/referer_jsp.jsp?referer=${escape:/$1api$2}</to>
+	</rule>
+	<rule>
+		<from>^/api/webdav(.{0,2000})</from>
+		<to type="redirect">%{context-path}/webdav$1</to>
+	</rule>
+	<rule>
+		<from>^/favicon.ico$</from>
+		<to type="redirect">/o/favicon/</to>
+	</rule>
+	<rule>
+		<from>^/o/portal-search-rest/(.*)</from>
+		<to type="forward">%{context-path}/o/search/$1</to>
 	</rule>
 	<rule>
 		<from>^/web/guest/community/forums/message_boards(.{0,2000})$</from>


### PR DESCRIPTION
- https://liferay.atlassian.net/browse/LPD-17648
- https://liferay.atlassian.net/browse/LPD-18566
- https://liferay.atlassian.net/browse/LPD-18715

This PR covers renaming the baseURI for both search and suggestions endpoint as well as introducing the new 'scope' parameter, supporting both ERCs and group IDs, for both of the endpoints.

See https://github.com/brianchandotcom/liferay-portal/pull/150274#issuecomment-2109942562