### PR TITLE
LPD-26171 This nested tx for retry visibility solution does not fit w…

### DIFF
--- a/portal-impl/src/com/liferay/portlet/social/service/impl/SocialActivityCounterLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/social/service/impl/SocialActivityCounterLocalServiceImpl.java
@@ -20,8 +20,6 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.persistence.GroupPersistence;
 import com.liferay.portal.kernel.service.persistence.UserPersistence;
-import com.liferay.portal.kernel.transaction.Propagation;
-import com.liferay.portal.kernel.transaction.Transactional;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Tuple;
@@ -99,7 +97,6 @@ public class SocialActivityCounterLocalServiceImpl
 	 * @return the added activity counter
 	 */
 	@Override
-	@Transactional(propagation = Propagation.REQUIRES_NEW)
 	public SocialActivityCounter addActivityCounter(
 			long groupId, long classNameId, long classPK, String name,
 			int ownerType, int totalValue, long previousActivityCounterId,

--- a/portal-kernel/src/com/liferay/social/kernel/service/SocialActivityCounterLocalService.java
+++ b/portal-kernel/src/com/liferay/social/kernel/service/SocialActivityCounterLocalService.java
@@ -98,7 +98,6 @@ public interface SocialActivityCounterLocalService
 	 {@link SocialActivityCounterConstants}.
 	 * @return the added activity counter
 	 */
-	@Transactional(propagation = Propagation.REQUIRES_NEW)
 	public SocialActivityCounter addActivityCounter(
 			long groupId, long classNameId, long classPK, String name,
 			int ownerType, int totalValue, long previousActivityCounterId,

--- a/portal-kernel/src/com/liferay/social/kernel/service/packageinfo
+++ b/portal-kernel/src/com/liferay/social/kernel/service/packageinfo
@@ -1,1 +1,1 @@
-version 3.4.0
+version 3.4.1


### PR DESCRIPTION
…ith change tracking, which leads to deadlock. With CT in place, the best way is to just let "duplicated" concurrent creation fail with unique index violation failure, to force upper logic (or user) to retry, rather than trying to resolve it within the scope of this service call.