### PR TITLE
LPD-24555 Replace deprecated CreateIndexRequest

### DIFF
--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/index/CompanyIndexFactoryHelper.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/index/CompanyIndexFactoryHelper.java
@@ -32,11 +32,11 @@ import java.io.IOException;
 import java.util.List;
 
 import org.elasticsearch.action.ActionResponse;
-import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.client.IndicesClient;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.client.indices.CreateIndexRequest;
 import org.elasticsearch.client.indices.GetIndexRequest;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.xcontent.XContentType;

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/index/LiferayDocumentTypeFactory.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/index/LiferayDocumentTypeFactory.java
@@ -25,9 +25,9 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.elasticsearch.action.ActionResponse;
-import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.client.IndicesClient;
 import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.indices.CreateIndexRequest;
 import org.elasticsearch.client.indices.GetMappingsRequest;
 import org.elasticsearch.client.indices.GetMappingsResponse;
 import org.elasticsearch.client.indices.PutMappingRequest;
@@ -81,7 +81,7 @@ public class LiferayDocumentTypeFactory
 		}
 
 		createIndexRequest.mapping(
-			"_doc", mappingsJSONObject.toString(), XContentType.JSON);
+			mappingsJSONObject.toString(), XContentType.JSON);
 	}
 
 	public void createOptionalDefaultTypeMappings(String indexName) {

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/index/CreateIndexRequestExecutorImpl.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/index/CreateIndexRequestExecutorImpl.java
@@ -34,11 +34,11 @@ public class CreateIndexRequestExecutorImpl
 
 	@Override
 	public CreateIndexResponse execute(CreateIndexRequest createIndexRequest) {
-		org.elasticsearch.action.admin.indices.create.CreateIndexRequest
+		org.elasticsearch.client.indices.CreateIndexRequest
 			elasticsearchCreateIndexRequest = createCreateIndexRequest(
 				createIndexRequest);
 
-		org.elasticsearch.action.admin.indices.create.CreateIndexResponse
+		org.elasticsearch.client.indices.CreateIndexResponse
 			elasticsearchCreateIndexResponse = _getCreateIndexResponse(
 				elasticsearchCreateIndexRequest, createIndexRequest);
 
@@ -50,19 +50,18 @@ public class CreateIndexRequestExecutorImpl
 			elasticsearchCreateIndexResponse.index());
 	}
 
-	protected org.elasticsearch.action.admin.indices.create.CreateIndexRequest
+	protected org.elasticsearch.client.indices.CreateIndexRequest
 		createCreateIndexRequest(CreateIndexRequest createIndexRequest) {
 
-		org.elasticsearch.action.admin.indices.create.CreateIndexRequest
+		org.elasticsearch.client.indices.CreateIndexRequest
 			elasticsearchCreateIndexRequest =
-				new org.elasticsearch.action.admin.indices.create.
-					CreateIndexRequest(createIndexRequest.getIndexName());
+				new org.elasticsearch.client.indices.CreateIndexRequest(
+					createIndexRequest.getIndexName());
 
 		if (createIndexRequest.getMappings() != null) {
 			ClassLoaderUtil.getWithContextClassLoader(
 				() -> elasticsearchCreateIndexRequest.mapping(
-					"_doc", createIndexRequest.getMappings(),
-					XContentType.JSON),
+					createIndexRequest.getMappings(), XContentType.JSON),
 				getClass());
 		}
 
@@ -83,9 +82,9 @@ public class CreateIndexRequestExecutorImpl
 		return elasticsearchCreateIndexRequest;
 	}
 
-	private org.elasticsearch.action.admin.indices.create.CreateIndexResponse
+	private org.elasticsearch.client.indices.CreateIndexResponse
 		_getCreateIndexResponse(
-			org.elasticsearch.action.admin.indices.create.CreateIndexRequest
+			org.elasticsearch.client.indices.CreateIndexRequest
 				elasticsearchCreateIndexRequest,
 			CreateIndexRequest createIndexRequest) {
 

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/background/task/ReindexSingleIndexerBackgroundTaskExecutorTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/background/task/ReindexSingleIndexerBackgroundTaskExecutorTest.java
@@ -7,7 +7,6 @@ package com.liferay.portal.search.elasticsearch7.internal.background.task;
 
 import com.liferay.portal.search.elasticsearch7.internal.connection.ElasticsearchConnectionFixture;
 import com.liferay.portal.search.elasticsearch7.internal.index.FieldMappingAssert;
-import com.liferay.portal.search.elasticsearch7.internal.index.constants.LiferayTypeMappingsConstants;
 import com.liferay.portal.search.elasticsearch7.internal.search.engine.ElasticsearchSearchEngineFixture;
 import com.liferay.portal.search.test.util.background.task.BaseReindexSingleIndexerBackgroundTaskExecutorTestCase;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
@@ -53,8 +52,7 @@ public class ReindexSingleIndexerBackgroundTaskExecutorTest
 			_elasticsearchConnectionFixture.getRestHighLevelClient();
 
 		FieldMappingAssert.assertType(
-			fieldType, fieldName,
-			LiferayTypeMappingsConstants.LIFERAY_DOCUMENT_TYPE, getIndexName(),
+			fieldType, fieldName, getIndexName(),
 			restHighLevelClient.indices());
 	}
 

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/connection/IndexCreator.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/connection/IndexCreator.java
@@ -10,12 +10,12 @@ import com.liferay.portal.search.elasticsearch7.internal.connection.helper.Lifer
 
 import java.io.IOException;
 
-import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.IndicesClient;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.client.indices.CreateIndexRequest;
 import org.elasticsearch.common.settings.Settings;
 
 import org.mockito.Mockito;

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/connection/helper/IndexCreationHelper.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/connection/helper/IndexCreationHelper.java
@@ -5,7 +5,7 @@
 
 package com.liferay.portal.search.elasticsearch7.internal.connection.helper;
 
-import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
+import org.elasticsearch.client.indices.CreateIndexRequest;
 import org.elasticsearch.common.settings.Settings;
 
 /**

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/connection/helper/LiferayIndexCreationHelper.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/connection/helper/LiferayIndexCreationHelper.java
@@ -9,8 +9,8 @@ import com.liferay.portal.json.JSONFactoryImpl;
 import com.liferay.portal.search.elasticsearch7.internal.connection.ElasticsearchClientResolver;
 import com.liferay.portal.search.elasticsearch7.internal.index.LiferayDocumentTypeFactory;
 
-import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.client.indices.CreateIndexRequest;
 import org.elasticsearch.common.settings.Settings;
 
 /**

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/document/GeoLocationPointFieldTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/document/GeoLocationPointFieldTest.java
@@ -19,10 +19,10 @@ import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import java.io.IOException;
 
-import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.client.IndicesClient;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.client.indices.CreateIndexRequest;
 import org.elasticsearch.client.indices.PutMappingRequest;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.xcontent.XContentType;

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/document/SingleFieldFixture.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/document/SingleFieldFixture.java
@@ -23,11 +23,9 @@ import org.elasticsearch.index.query.QueryBuilder;
 public class SingleFieldFixture {
 
 	public SingleFieldFixture(
-		RestHighLevelClient restHighLevelClient, IndexName indexName,
-		String type) {
+		RestHighLevelClient restHighLevelClient, IndexName indexName) {
 
 		_restHighLevelClient = restHighLevelClient;
-		_type = type;
 
 		_index = indexName.getName();
 	}
@@ -73,6 +71,5 @@ public class SingleFieldFixture {
 	private final String _index;
 	private QueryBuilderFactory _queryBuilderFactory;
 	private final RestHighLevelClient _restHighLevelClient;
-	private final String _type;
 
 }

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/index/CompanyIndexFactoryTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/index/CompanyIndexFactoryTest.java
@@ -17,7 +17,6 @@ import com.liferay.portal.search.elasticsearch7.internal.configuration.Elasticse
 import com.liferay.portal.search.elasticsearch7.internal.connection.ElasticsearchFixture;
 import com.liferay.portal.search.elasticsearch7.internal.connection.IndexName;
 import com.liferay.portal.search.elasticsearch7.internal.document.SingleFieldFixture;
-import com.liferay.portal.search.elasticsearch7.internal.index.constants.LiferayTypeMappingsConstants;
 import com.liferay.portal.search.elasticsearch7.internal.query.QueryBuilderFactories;
 import com.liferay.portal.search.elasticsearch7.internal.util.ResourceUtil;
 import com.liferay.portal.search.spi.model.index.contributor.IndexContributor;
@@ -122,8 +121,7 @@ public class CompanyIndexFactoryTest {
 
 		_singleFieldFixture = new SingleFieldFixture(
 			_elasticsearchFixture.getRestHighLevelClient(),
-			new IndexName(_companyIndexFactoryFixture.getIndexName()),
-			LiferayTypeMappingsConstants.LIFERAY_DOCUMENT_TYPE);
+			new IndexName(_companyIndexFactoryFixture.getIndexName()));
 
 		_singleFieldFixture.setQueryBuilderFactory(QueryBuilderFactories.MATCH);
 	}
@@ -551,8 +549,7 @@ public class CompanyIndexFactoryTest {
 			_elasticsearchFixture.getRestHighLevelClient();
 
 		FieldMappingAssert.assertAnalyzer(
-			analyzer, field, LiferayTypeMappingsConstants.LIFERAY_DOCUMENT_TYPE,
-			_companyIndexFactoryFixture.getIndexName(),
+			analyzer, field, _companyIndexFactoryFixture.getIndexName(),
 			restHighLevelClient.indices());
 	}
 
@@ -561,8 +558,7 @@ public class CompanyIndexFactoryTest {
 			_elasticsearchFixture.getRestHighLevelClient();
 
 		FieldMappingAssert.assertType(
-			type, field, LiferayTypeMappingsConstants.LIFERAY_DOCUMENT_TYPE,
-			_companyIndexFactoryFixture.getIndexName(),
+			type, field, _companyIndexFactoryFixture.getIndexName(),
 			restHighLevelClient.indices());
 	}
 

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/index/FieldMappingAssert.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/index/FieldMappingAssert.java
@@ -27,17 +27,17 @@ import org.junit.Assert;
 public class FieldMappingAssert {
 
 	public static void assertAnalyzer(
-			String expectedValue, String field, String type, String index,
+			String expectedValue, String field, String index,
 			IndicesClient indicesClient)
 		throws Exception {
 
 		assertFieldMappingMetadata(
-			expectedValue, "analyzer", field, type, index, indicesClient);
+			expectedValue, "analyzer", field, index, indicesClient);
 	}
 
 	public static void assertFieldMappingMetadata(
-			String expectedValue, String key, String field, String type,
-			String index, IndicesClient indicesClient)
+			String expectedValue, String key, String field, String index,
+			IndicesClient indicesClient)
 		throws Exception {
 
 		IdempotentRetryAssert.retryAssert(
@@ -47,12 +47,12 @@ public class FieldMappingAssert {
 	}
 
 	public static void assertType(
-			String expectedValue, String field, String type, String index,
+			String expectedValue, String field, String index,
 			IndicesClient indicesClient)
 		throws Exception {
 
 		assertFieldMappingMetadata(
-			expectedValue, "type", field, type, index, indicesClient);
+			expectedValue, "type", field, index, indicesClient);
 	}
 
 	private static void _assertFieldMappingMetadata(

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/index/LiferayIndexFixture.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/index/LiferayIndexFixture.java
@@ -8,7 +8,6 @@ package com.liferay.portal.search.elasticsearch7.internal.index;
 import com.liferay.portal.search.elasticsearch7.internal.connection.ElasticsearchFixture;
 import com.liferay.portal.search.elasticsearch7.internal.connection.IndexCreator;
 import com.liferay.portal.search.elasticsearch7.internal.connection.IndexName;
-import com.liferay.portal.search.elasticsearch7.internal.index.constants.LiferayTypeMappingsConstants;
 
 import java.io.IOException;
 
@@ -43,16 +42,15 @@ public class LiferayIndexFixture {
 		RestHighLevelClient restHighLevelClient = getRestHighLevelClient();
 
 		FieldMappingAssert.assertAnalyzer(
-			analyzer, field, LiferayTypeMappingsConstants.LIFERAY_DOCUMENT_TYPE,
-			_indexName.getName(), restHighLevelClient.indices());
+			analyzer, field, _indexName.getName(),
+			restHighLevelClient.indices());
 	}
 
 	public void assertType(String field, String type) throws Exception {
 		RestHighLevelClient restHighLevelClient = getRestHighLevelClient();
 
 		FieldMappingAssert.assertType(
-			type, field, LiferayTypeMappingsConstants.LIFERAY_DOCUMENT_TYPE,
-			_indexName.getName(), restHighLevelClient.indices());
+			type, field, _indexName.getName(), restHighLevelClient.indices());
 	}
 
 	public RestHighLevelClient getRestHighLevelClient() {

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/index/LiferayTypeMappingsJapaneseTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/index/LiferayTypeMappingsJapaneseTest.java
@@ -7,7 +7,6 @@ package com.liferay.portal.search.elasticsearch7.internal.index;
 
 import com.liferay.portal.search.elasticsearch7.internal.connection.IndexName;
 import com.liferay.portal.search.elasticsearch7.internal.document.SingleFieldFixture;
-import com.liferay.portal.search.elasticsearch7.internal.index.constants.LiferayTypeMappingsConstants;
 import com.liferay.portal.search.elasticsearch7.internal.query.QueryBuilderFactories;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
@@ -36,8 +35,7 @@ public class LiferayTypeMappingsJapaneseTest {
 		_liferayIndexFixture.setUp();
 
 		_singleFieldFixture = new SingleFieldFixture(
-			_liferayIndexFixture.getRestHighLevelClient(), indexName,
-			LiferayTypeMappingsConstants.LIFERAY_DOCUMENT_TYPE);
+			_liferayIndexFixture.getRestHighLevelClient(), indexName);
 
 		_singleFieldFixture.setField(_PREFIX + "_ja");
 		_singleFieldFixture.setQueryBuilderFactory(QueryBuilderFactories.MATCH);

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/index/LiferayTypeMappingsPrefixPerLanguageTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/index/LiferayTypeMappingsPrefixPerLanguageTest.java
@@ -7,7 +7,6 @@ package com.liferay.portal.search.elasticsearch7.internal.index;
 
 import com.liferay.portal.search.elasticsearch7.internal.connection.IndexName;
 import com.liferay.portal.search.elasticsearch7.internal.document.SingleFieldFixture;
-import com.liferay.portal.search.elasticsearch7.internal.index.constants.LiferayTypeMappingsConstants;
 import com.liferay.portal.search.elasticsearch7.internal.query.QueryBuilderFactories;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
@@ -36,8 +35,7 @@ public class LiferayTypeMappingsPrefixPerLanguageTest {
 		_liferayIndexFixture.setUp();
 
 		_singleFieldFixture = new SingleFieldFixture(
-			_liferayIndexFixture.getRestHighLevelClient(), indexName,
-			LiferayTypeMappingsConstants.LIFERAY_DOCUMENT_TYPE);
+			_liferayIndexFixture.getRestHighLevelClient(), indexName);
 
 		_singleFieldFixture.setQueryBuilderFactory(
 			QueryBuilderFactories.MATCH_PHRASE_PREFIX);

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/ElasticsearchSearchEngineAdapterDocumentRequestTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/ElasticsearchSearchEngineAdapterDocumentRequestTest.java
@@ -17,6 +17,7 @@ import com.liferay.portal.search.elasticsearch7.internal.connection.Elasticsearc
 import com.liferay.portal.search.elasticsearch7.internal.connection.ElasticsearchFixture;
 import com.liferay.portal.search.elasticsearch7.internal.document.DefaultElasticsearchDocumentFactory;
 import com.liferay.portal.search.elasticsearch7.internal.document.ElasticsearchDocumentFactory;
+import com.liferay.portal.search.elasticsearch7.internal.index.constants.LiferayTypeMappingsConstants;
 import com.liferay.portal.search.elasticsearch7.internal.search.engine.adapter.document.DocumentRequestExecutorFixture;
 import com.liferay.portal.search.engine.adapter.SearchEngineAdapter;
 import com.liferay.portal.search.engine.adapter.document.BulkDocumentItemResponse;
@@ -116,7 +117,8 @@ public class ElasticsearchSearchEngineAdapterDocumentRequestTest {
 		IndexDocumentRequest indexDocumentRequest1 = new IndexDocumentRequest(
 			_INDEX_NAME, document1);
 
-		indexDocumentRequest1.setType(_MAPPING_NAME);
+		indexDocumentRequest1.setType(
+			LiferayTypeMappingsConstants.LIFERAY_DOCUMENT_TYPE);
 
 		BulkDocumentRequest bulkDocumentRequest1 = new BulkDocumentRequest();
 
@@ -130,7 +132,8 @@ public class ElasticsearchSearchEngineAdapterDocumentRequestTest {
 		IndexDocumentRequest indexDocumentRequest2 = new IndexDocumentRequest(
 			_INDEX_NAME, document2);
 
-		indexDocumentRequest2.setType(_MAPPING_NAME);
+		indexDocumentRequest2.setType(
+			LiferayTypeMappingsConstants.LIFERAY_DOCUMENT_TYPE);
 
 		bulkDocumentRequest1.addBulkableDocumentRequest(indexDocumentRequest2);
 
@@ -159,7 +162,8 @@ public class ElasticsearchSearchEngineAdapterDocumentRequestTest {
 		DeleteDocumentRequest deleteDocumentRequest = new DeleteDocumentRequest(
 			_INDEX_NAME, "1");
 
-		deleteDocumentRequest.setType(_MAPPING_NAME);
+		deleteDocumentRequest.setType(
+			LiferayTypeMappingsConstants.LIFERAY_DOCUMENT_TYPE);
 
 		BulkDocumentRequest bulkDocumentRequest2 = new BulkDocumentRequest();
 
@@ -173,7 +177,8 @@ public class ElasticsearchSearchEngineAdapterDocumentRequestTest {
 		UpdateDocumentRequest updateDocumentRequest = new UpdateDocumentRequest(
 			_INDEX_NAME, "2", document2Update);
 
-		updateDocumentRequest.setType(_MAPPING_NAME);
+		updateDocumentRequest.setType(
+			LiferayTypeMappingsConstants.LIFERAY_DOCUMENT_TYPE);
 
 		bulkDocumentRequest2.addBulkableDocumentRequest(updateDocumentRequest);
 
@@ -221,7 +226,8 @@ public class ElasticsearchSearchEngineAdapterDocumentRequestTest {
 		IndexDocumentRequest indexDocumentRequest1 = new IndexDocumentRequest(
 			_INDEX_NAME, document1);
 
-		indexDocumentRequest1.setType(_MAPPING_NAME);
+		indexDocumentRequest1.setType(
+			LiferayTypeMappingsConstants.LIFERAY_DOCUMENT_TYPE);
 
 		BulkDocumentRequest bulkDocumentRequest1 = new BulkDocumentRequest();
 
@@ -234,7 +240,8 @@ public class ElasticsearchSearchEngineAdapterDocumentRequestTest {
 		IndexDocumentRequest indexDocumentRequest2 = new IndexDocumentRequest(
 			_INDEX_NAME, document2);
 
-		indexDocumentRequest2.setType(_MAPPING_NAME);
+		indexDocumentRequest2.setType(
+			LiferayTypeMappingsConstants.LIFERAY_DOCUMENT_TYPE);
 
 		bulkDocumentRequest1.addBulkableDocumentRequest(indexDocumentRequest2);
 
@@ -265,7 +272,8 @@ public class ElasticsearchSearchEngineAdapterDocumentRequestTest {
 		DeleteDocumentRequest deleteDocumentRequest = new DeleteDocumentRequest(
 			_INDEX_NAME, bulkDocumentItemResponse1.getId());
 
-		deleteDocumentRequest.setType(_MAPPING_NAME);
+		deleteDocumentRequest.setType(
+			LiferayTypeMappingsConstants.LIFERAY_DOCUMENT_TYPE);
 
 		BulkDocumentRequest bulkDocumentRequest2 = new BulkDocumentRequest();
 
@@ -280,7 +288,8 @@ public class ElasticsearchSearchEngineAdapterDocumentRequestTest {
 		UpdateDocumentRequest updateDocumentRequest = new UpdateDocumentRequest(
 			_INDEX_NAME, bulkDocumentItemResponse2.getId(), document2Update);
 
-		updateDocumentRequest.setType(_MAPPING_NAME);
+		updateDocumentRequest.setType(
+			LiferayTypeMappingsConstants.LIFERAY_DOCUMENT_TYPE);
 
 		bulkDocumentRequest2.addBulkableDocumentRequest(updateDocumentRequest);
 
@@ -360,7 +369,8 @@ public class ElasticsearchSearchEngineAdapterDocumentRequestTest {
 		DeleteDocumentRequest deleteDocumentRequest = new DeleteDocumentRequest(
 			_INDEX_NAME, id);
 
-		deleteDocumentRequest.setType(_MAPPING_NAME);
+		deleteDocumentRequest.setType(
+			LiferayTypeMappingsConstants.LIFERAY_DOCUMENT_TYPE);
 
 		DeleteDocumentResponse deleteDocumentResponse =
 			_searchEngineAdapter.execute(deleteDocumentRequest);
@@ -668,7 +678,7 @@ public class ElasticsearchSearchEngineAdapterDocumentRequestTest {
 		indexRequest.id(id);
 		indexRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
 		indexRequest.source(documentSource, XContentType.JSON);
-		indexRequest.type(_MAPPING_NAME);
+		indexRequest.type(LiferayTypeMappingsConstants.LIFERAY_DOCUMENT_TYPE);
 
 		try {
 			_restHighLevelClient.index(indexRequest, RequestOptions.DEFAULT);
@@ -684,7 +694,8 @@ public class ElasticsearchSearchEngineAdapterDocumentRequestTest {
 		IndexDocumentRequest indexDocumentRequest = new IndexDocumentRequest(
 			_INDEX_NAME, uid, document);
 
-		indexDocumentRequest.setType(_MAPPING_NAME);
+		indexDocumentRequest.setType(
+			LiferayTypeMappingsConstants.LIFERAY_DOCUMENT_TYPE);
 
 		return _searchEngineAdapter.execute(indexDocumentRequest);
 	}
@@ -695,7 +706,8 @@ public class ElasticsearchSearchEngineAdapterDocumentRequestTest {
 		UpdateDocumentRequest updateDocumentRequest = new UpdateDocumentRequest(
 			_INDEX_NAME, uid, document);
 
-		updateDocumentRequest.setType(_MAPPING_NAME);
+		updateDocumentRequest.setType(
+			LiferayTypeMappingsConstants.LIFERAY_DOCUMENT_TYPE);
 
 		return _searchEngineAdapter.execute(updateDocumentRequest);
 	}
@@ -707,7 +719,8 @@ public class ElasticsearchSearchEngineAdapterDocumentRequestTest {
 			_INDEX_NAME, uid, script);
 
 		updateDocumentRequest.setScriptedUpsert(scriptedUpsert);
-		updateDocumentRequest.setType(_MAPPING_NAME);
+		updateDocumentRequest.setType(
+			LiferayTypeMappingsConstants.LIFERAY_DOCUMENT_TYPE);
 
 		return _searchEngineAdapter.execute(updateDocumentRequest);
 	}
@@ -715,8 +728,6 @@ public class ElasticsearchSearchEngineAdapterDocumentRequestTest {
 	private static final String _FIELD_NAME = "matchDocument";
 
 	private static final String _INDEX_NAME = "test_request_index";
-
-	private static final String _MAPPING_NAME = "testDocumentMapping";
 
 	private static final String _MAPPING_SOURCE =
 		"{\"properties\":{\"matchDocument\":{\"type\":\"boolean\"}}}";

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/ElasticsearchSearchEngineAdapterDocumentRequestTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/ElasticsearchSearchEngineAdapterDocumentRequestTest.java
@@ -44,7 +44,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.action.get.GetRequest;
 import org.elasticsearch.action.get.GetResponse;
@@ -53,6 +52,7 @@ import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.client.IndicesClient;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.client.indices.CreateIndexRequest;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xcontent.XContentType;
 
@@ -626,8 +626,7 @@ public class ElasticsearchSearchEngineAdapterDocumentRequestTest {
 		CreateIndexRequest createIndexRequest = new CreateIndexRequest(
 			_INDEX_NAME);
 
-		createIndexRequest.mapping(
-			_MAPPING_NAME, _MAPPING_SOURCE, XContentType.JSON);
+		createIndexRequest.mapping(_MAPPING_SOURCE, XContentType.JSON);
 
 		try {
 			_indicesClient.create(createIndexRequest, RequestOptions.DEFAULT);

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/ElasticsearchSearchEngineAdapterIndexRequestTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/ElasticsearchSearchEngineAdapterIndexRequestTest.java
@@ -306,12 +306,10 @@ public class ElasticsearchSearchEngineAdapterIndexRequestTest {
 			StringBundler.concat(
 				"{\n", "    \"settings\": {\n",
 				"        \"number_of_shards\": 1\n", "    },\n",
-				"    \"mappings\": {\n", "        \"type1\": {\n",
-				"            \"properties\": {\n",
+				"    \"mappings\": {\n", "            \"properties\": {\n",
 				"                \"field1\": {\n",
 				"                    \"type\": \"text\"\n",
-				"                }\n", "            }\n", "        }\n",
-				"    }\n", "}"));
+				"                }\n", "            }\n", "    }\n", "}"));
 
 		CreateIndexResponse createIndexResponse = _searchEngineAdapter.execute(
 			createIndexRequest);

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/ElasticsearchSearchEngineAdapterSearchRequestTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/ElasticsearchSearchEngineAdapterSearchRequestTest.java
@@ -46,7 +46,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.action.get.GetRequest;
 import org.elasticsearch.action.get.GetResponse;
@@ -55,6 +54,7 @@ import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.client.IndicesClient;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.client.indices.CreateIndexRequest;
 import org.elasticsearch.client.indices.PutMappingRequest;
 import org.elasticsearch.xcontent.XContentType;
 

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/ElasticsearchSearchEngineAdapterSnapshotRequestTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/ElasticsearchSearchEngineAdapterSnapshotRequestTest.java
@@ -37,13 +37,13 @@ import org.elasticsearch.action.admin.cluster.repositories.get.GetRepositoriesRe
 import org.elasticsearch.action.admin.cluster.repositories.get.GetRepositoriesResponse;
 import org.elasticsearch.action.admin.cluster.repositories.put.PutRepositoryRequest;
 import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsResponse;
-import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
 import org.elasticsearch.client.IndicesClient;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.client.SnapshotClient;
+import org.elasticsearch.client.indices.CreateIndexRequest;
 import org.elasticsearch.cluster.metadata.RepositoryMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.repositories.fs.FsRepository;

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/index/CreateIndexRequestExecutorTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/index/CreateIndexRequestExecutorTest.java
@@ -61,7 +61,7 @@ public class CreateIndexRequestExecutorTest {
 			createIndexRequestExecutorImpl, "_elasticsearchClientResolver",
 			_elasticsearchFixture);
 
-		org.elasticsearch.action.admin.indices.create.CreateIndexRequest
+		org.elasticsearch.client.indices.CreateIndexRequest
 			elasticsearchCreateIndexRequest =
 				createIndexRequestExecutorImpl.createCreateIndexRequest(
 					createIndexRequest);

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/synonym/SynonymFiltersTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/synonym/SynonymFiltersTest.java
@@ -10,7 +10,6 @@ import com.liferay.portal.search.elasticsearch7.internal.connection.Elasticsearc
 import com.liferay.portal.search.elasticsearch7.internal.connection.ElasticsearchFixture;
 import com.liferay.portal.search.elasticsearch7.internal.connection.IndexName;
 import com.liferay.portal.search.elasticsearch7.internal.document.SingleFieldFixture;
-import com.liferay.portal.search.elasticsearch7.internal.index.constants.LiferayTypeMappingsConstants;
 import com.liferay.portal.search.elasticsearch7.internal.query.QueryBuilderFactories;
 import com.liferay.portal.search.elasticsearch7.internal.query.SearchAssert;
 import com.liferay.portal.search.elasticsearch7.internal.search.engine.adapter.ElasticsearchSearchEngineAdapterImpl;
@@ -56,8 +55,7 @@ public class SynonymFiltersTest {
 
 		_singleFieldFixture = new SingleFieldFixture(
 			_elasticsearchFixture.getRestHighLevelClient(),
-			new IndexName(_INDEX_NAME),
-			LiferayTypeMappingsConstants.LIFERAY_DOCUMENT_TYPE);
+			new IndexName(_INDEX_NAME));
 
 		_singleFieldFixture.setField(_FIELD_NAME);
 		_singleFieldFixture.setQueryBuilderFactory(QueryBuilderFactories.MATCH);

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/resources/com/liferay/portal/search/elasticsearch7/internal/synonym/dependencies/synonym-filters-test-synonym-filter-quoted.json
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/resources/com/liferay/portal/search/elasticsearch7/internal/synonym/dependencies/synonym-filters-test-synonym-filter-quoted.json
@@ -1,13 +1,11 @@
 {
 	"mappings": {
-		"_doc": {
-			"properties": {
-				"content": {
-					"analyzer": "english",
-					"search_analyzer": "english_with_synonym_analyzer",
-					"store": true,
-					"type": "text"
-				}
+		"properties": {
+			"content": {
+				"analyzer": "english",
+				"search_analyzer": "english_with_synonym_analyzer",
+				"store": true,
+				"type": "text"
 			}
 		}
 	},

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/resources/com/liferay/portal/search/elasticsearch7/internal/synonym/dependencies/synonym-filters-test-synonym-filter-spaced.json
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/resources/com/liferay/portal/search/elasticsearch7/internal/synonym/dependencies/synonym-filters-test-synonym-filter-spaced.json
@@ -1,13 +1,11 @@
 {
 	"mappings": {
-		"_doc": {
-			"properties": {
-				"content": {
-					"analyzer": "english",
-					"search_analyzer": "english_with_synonym_analyzer",
-					"store": true,
-					"type": "text"
-				}
+		"properties": {
+			"content": {
+				"analyzer": "english",
+				"search_analyzer": "english_with_synonym_analyzer",
+				"store": true,
+				"type": "text"
 			}
 		}
 	},

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/resources/com/liferay/portal/search/elasticsearch7/internal/synonym/dependencies/synonym-filters-test-synonym-filter-unquoted.json
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/resources/com/liferay/portal/search/elasticsearch7/internal/synonym/dependencies/synonym-filters-test-synonym-filter-unquoted.json
@@ -1,13 +1,11 @@
 {
 	"mappings": {
-		"_doc": {
-			"properties": {
-				"content": {
-					"analyzer": "english",
-					"search_analyzer": "english_with_synonym_analyzer",
-					"store": true,
-					"type": "text"
-				}
+		"properties": {
+			"content": {
+				"analyzer": "english",
+				"search_analyzer": "english_with_synonym_analyzer",
+				"store": true,
+				"type": "text"
 			}
 		}
 	},

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/resources/com/liferay/portal/search/elasticsearch7/internal/synonym/dependencies/synonym-filters-test-synonym-graph-filter-quoted.json
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/resources/com/liferay/portal/search/elasticsearch7/internal/synonym/dependencies/synonym-filters-test-synonym-graph-filter-quoted.json
@@ -1,13 +1,11 @@
 {
 	"mappings": {
-		"_doc": {
-			"properties": {
-				"content": {
-					"analyzer": "english",
-					"search_analyzer": "english_with_synonym_analyzer",
-					"store": true,
-					"type": "text"
-				}
+		"properties": {
+			"content": {
+				"analyzer": "english",
+				"search_analyzer": "english_with_synonym_analyzer",
+				"store": true,
+				"type": "text"
 			}
 		}
 	},

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/resources/com/liferay/portal/search/elasticsearch7/internal/synonym/dependencies/synonym-filters-test-synonym-graph-filter-spaced.json
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/resources/com/liferay/portal/search/elasticsearch7/internal/synonym/dependencies/synonym-filters-test-synonym-graph-filter-spaced.json
@@ -1,13 +1,11 @@
 {
 	"mappings": {
-		"_doc": {
-			"properties": {
-				"content": {
-					"analyzer": "english",
-					"search_analyzer": "english_with_synonym_analyzer",
-					"store": true,
-					"type": "text"
-				}
+		"properties": {
+			"content": {
+				"analyzer": "english",
+				"search_analyzer": "english_with_synonym_analyzer",
+				"store": true,
+				"type": "text"
 			}
 		}
 	},

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/resources/com/liferay/portal/search/elasticsearch7/internal/synonym/dependencies/synonym-filters-test-synonym-graph-filter-unquoted.json
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/resources/com/liferay/portal/search/elasticsearch7/internal/synonym/dependencies/synonym-filters-test-synonym-graph-filter-unquoted.json
@@ -1,13 +1,11 @@
 {
 	"mappings": {
-		"_doc": {
-			"properties": {
-				"content": {
-					"analyzer": "english",
-					"search_analyzer": "english_with_synonym_analyzer",
-					"store": true,
-					"type": "text"
-				}
+		"properties": {
+			"content": {
+				"analyzer": "english",
+				"search_analyzer": "english_with_synonym_analyzer",
+				"store": true,
+				"type": "text"
 			}
 		}
 	},

--- a/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/query/MoreLikeThisQuery.java
+++ b/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/query/MoreLikeThisQuery.java
@@ -69,6 +69,10 @@ public interface MoreLikeThisQuery extends Query {
 
 	public Float getTermBoost();
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+	 */
+	@Deprecated
 	public String getType();
 
 	public boolean isDocumentUIDsEmpty();
@@ -97,6 +101,10 @@ public interface MoreLikeThisQuery extends Query {
 
 	public void setTermBoost(Float termBoost);
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+	 */
+	@Deprecated
 	public void setType(String type);
 
 	public interface DocumentIdentifier {
@@ -105,6 +113,10 @@ public interface MoreLikeThisQuery extends Query {
 
 		public String getIndex();
 
+		/**
+		 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+		 */
+		@Deprecated
 		public String getType();
 
 	}

--- a/modules/apps/portal-search/portal-search-engine-adapter-api/src/main/java/com/liferay/portal/search/engine/adapter/document/DeleteDocumentRequest.java
+++ b/modules/apps/portal-search/portal-search-engine-adapter-api/src/main/java/com/liferay/portal/search/engine/adapter/document/DeleteDocumentRequest.java
@@ -38,6 +38,10 @@ public class DeleteDocumentRequest
 		return _indexName;
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+	 */
+	@Deprecated
 	public String getType() {
 		return _type;
 	}
@@ -54,6 +58,10 @@ public class DeleteDocumentRequest
 		_refresh = refresh;
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+	 */
+	@Deprecated
 	public void setType(String type) {
 		_type = type;
 	}

--- a/modules/apps/portal-search/portal-search-engine-adapter-api/src/main/java/com/liferay/portal/search/engine/adapter/document/IndexDocumentRequest.java
+++ b/modules/apps/portal-search/portal-search-engine-adapter-api/src/main/java/com/liferay/portal/search/engine/adapter/document/IndexDocumentRequest.java
@@ -88,6 +88,10 @@ public class IndexDocumentRequest
 		return _indexName;
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+	 */
+	@Deprecated
 	public String getType() {
 		return _type;
 	}
@@ -104,6 +108,10 @@ public class IndexDocumentRequest
 		_refresh = refresh;
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+	 */
+	@Deprecated
 	public void setType(String type) {
 		_type = type;
 	}

--- a/modules/apps/portal-search/portal-search-engine-adapter-api/src/main/java/com/liferay/portal/search/engine/adapter/document/UpdateDocumentRequest.java
+++ b/modules/apps/portal-search/portal-search-engine-adapter-api/src/main/java/com/liferay/portal/search/engine/adapter/document/UpdateDocumentRequest.java
@@ -87,6 +87,10 @@ public class UpdateDocumentRequest
 		return _script;
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+	 */
+	@Deprecated
 	public String getType() {
 		return _type;
 	}
@@ -119,6 +123,10 @@ public class UpdateDocumentRequest
 		_scriptedUpsert = scriptedUpsert;
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+	 */
+	@Deprecated
 	public void setType(String type) {
 		_type = type;
 	}

--- a/portal-kernel/src/com/liferay/portal/kernel/search/generic/MoreLikeThisQuery.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/generic/MoreLikeThisQuery.java
@@ -122,6 +122,10 @@ public class MoreLikeThisQuery extends BaseQueryImpl {
 		return _termBoost;
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+	 */
+	@Deprecated
 	public String getType() {
 		return _type;
 	}
@@ -182,6 +186,10 @@ public class MoreLikeThisQuery extends BaseQueryImpl {
 		_termBoost = termBoost;
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+	 */
+	@Deprecated
 	public void setType(String type) {
 		_type = type;
 	}


### PR DESCRIPTION
use import org.elasticsearch.client.indices.CreateIndexRequest; instead of import org.elasticsearch.action.admin.indices.create.CreateIndexRequest

reason:

[types removal] Using include_type_name in get mapping requests is deprecated. The parameter will be removed in the next major version of elasticsearch

https://liferay.atlassian.net/browse/LPD-24555

https://www.elastic.co/guide/en/elasticsearch/reference/7.17/removal-of-types.html

Forwarding manually because ci is not working today, but all suit passed on friday [here](https://github.com/liferay-search/liferay-portal/pull/1352)