### PR TITLE
LPD-26308 Improve GraphQL tests

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/GraphQLServletTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/GraphQLServletTest.java
@@ -269,7 +269,7 @@ public class GraphQLServletTest {
 							new GraphQLField("string"),
 							new GraphQLField("version"))),
 					"query"),
-				"JSONObject/data", "JSONObject/testDTO"));
+				"JSONObject/data", "JSONObject/testPath", "JSONObject/testDTO"));
 
 		_assertEqualsV1(
 			true, _testDTOV1,
@@ -283,7 +283,7 @@ public class GraphQLServletTest {
 							new GraphQLField("string"),
 							new GraphQLField("version"))),
 					"query"),
-				"JSONObject/data", "JSONObject/testDTOV1"));
+				"JSONObject/data", "JSONObject/testPath",  "JSONObject/testDTOV1"));
 
 		_assertEqualsV2(
 			true, _testDTOV2,
@@ -297,7 +297,7 @@ public class GraphQLServletTest {
 							new GraphQLField("string"),
 							new GraphQLField("version"))),
 					"query"),
-				"JSONObject/data", "JSONObject/testDTOV2"));
+				"JSONObject/data", "JSONObject/testPath", "JSONObject/testDTOV2"));
 
 		Assert.assertEquals(
 			"Not Found",

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/GraphQLServletTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/GraphQLServletTest.java
@@ -88,24 +88,6 @@ public class GraphQLServletTest {
 
 	@Test
 	public void testMutation() throws Exception {
-		TestDTO testDTO = new TestDTO();
-
-		_assertEquals(
-			false, testDTO,
-			JSONUtil.getValueAsJSONObject(
-				_invoke(
-					new GraphQLField(
-						"createTestDTO",
-						Collections.singletonMap(
-							"testDTO", _toGraphQLString(testDTO)),
-						new GraphQLField("id"), new GraphQLField("map"),
-						new GraphQLField("string")),
-					"mutation"),
-				"JSONObject/data", "JSONObject/createTestDTO"));
-	}
-
-	@Test
-	public void testMutationWithGraphQLNamespace() throws Exception {
 
 		// With namespace
 
@@ -147,6 +129,49 @@ public class GraphQLServletTest {
 
 	@Test
 	public void testQuery() throws Exception {
+
+		// With namespace
+
+		_assertEquals(
+			true, _testDTO,
+			JSONUtil.getValueAsJSONObject(
+				_invoke(
+					new GraphQLField(
+						"testPath_v1_0",
+						new GraphQLField(
+							"testDTO", new GraphQLField("extendedString"),
+							new GraphQLField("id"), new GraphQLField("map"),
+							new GraphQLField("string"))),
+					"query"),
+				"JSONObject/data", "JSONObject/testPath_v1_0",
+				"JSONObject/testDTO"));
+
+		Assert.assertEquals(
+			"Not Found",
+			JSONUtil.getValueAsString(
+				_invoke(
+					new GraphQLField(
+						"testPath_v1_0",
+						new GraphQLField(
+							"testNoPermissionOverDTO", new GraphQLField("id"))),
+					"query"),
+				"JSONArray/errors", "Object/0", "JSONObject/extensions",
+				"Object/code"));
+
+		Assert.assertEquals(
+			"Not Found",
+			JSONUtil.getValueAsString(
+				_invoke(
+					new GraphQLField(
+						"testPath_v1_0",
+						new GraphQLField(
+							"testNotFoundDTO", new GraphQLField("id"))),
+					"query"),
+				"JSONArray/errors", "Object/0", "JSONObject/extensions",
+				"Object/code"));
+
+		// Without namespace (backwards compatibility)
+
 		_assertEquals(
 			true, _testDTO,
 			JSONUtil.getValueAsJSONObject(
@@ -157,6 +182,25 @@ public class GraphQLServletTest {
 						new GraphQLField("string")),
 					"query"),
 				"JSONObject/data", "JSONObject/testDTO"));
+
+		Assert.assertEquals(
+			"Not Found",
+			JSONUtil.getValueAsString(
+				_invoke(
+					new GraphQLField(
+						"testNoPermissionOverDTO", new GraphQLField("id")),
+					"query"),
+				"JSONArray/errors", "Object/0", "JSONObject/extensions",
+				"Object/code"));
+
+		Assert.assertEquals(
+			"Not Found",
+			JSONUtil.getValueAsString(
+				_invoke(
+					new GraphQLField("testNotFoundDTO", new GraphQLField("id")),
+					"query"),
+				"JSONArray/errors", "Object/0", "JSONObject/extensions",
+				"Object/code"));
 	}
 
 	@Test
@@ -326,82 +370,6 @@ public class GraphQLServletTest {
 			0, () -> _test(-1, -1, null, -1));
 		PaginationConfigurationTestUtil.withPageSizeLimit(
 			0, () -> _test(-1, -1, null, 0));
-	}
-
-	@Test
-	public void testQueryWithGraphQLNamespace() throws Exception {
-
-		// With namespace
-
-		_assertEquals(
-			true, _testDTO,
-			JSONUtil.getValueAsJSONObject(
-				_invoke(
-					new GraphQLField(
-						"testPath_v1_0",
-						new GraphQLField(
-							"testDTO", new GraphQLField("extendedString"),
-							new GraphQLField("id"), new GraphQLField("map"),
-							new GraphQLField("string"))),
-					"query"),
-				"JSONObject/data", "JSONObject/testPath_v1_0",
-				"JSONObject/testDTO"));
-
-		Assert.assertEquals(
-			"Not Found",
-			JSONUtil.getValueAsString(
-				_invoke(
-					new GraphQLField(
-						"testPath_v1_0",
-						new GraphQLField(
-							"testNoPermissionOverDTO", new GraphQLField("id"))),
-					"query"),
-				"JSONArray/errors", "Object/0", "JSONObject/extensions",
-				"Object/code"));
-
-		Assert.assertEquals(
-			"Not Found",
-			JSONUtil.getValueAsString(
-				_invoke(
-					new GraphQLField(
-						"testPath_v1_0",
-						new GraphQLField(
-							"testNotFoundDTO", new GraphQLField("id"))),
-					"query"),
-				"JSONArray/errors", "Object/0", "JSONObject/extensions",
-				"Object/code"));
-
-		// Without namespace (backwards compatibility)
-
-		_assertEquals(
-			true, _testDTO,
-			JSONUtil.getValueAsJSONObject(
-				_invoke(
-					new GraphQLField(
-						"testDTO", new GraphQLField("extendedString"),
-						new GraphQLField("id"), new GraphQLField("map"),
-						new GraphQLField("string")),
-					"query"),
-				"JSONObject/data", "JSONObject/testDTO"));
-
-		Assert.assertEquals(
-			"Not Found",
-			JSONUtil.getValueAsString(
-				_invoke(
-					new GraphQLField(
-						"testNoPermissionOverDTO", new GraphQLField("id")),
-					"query"),
-				"JSONArray/errors", "Object/0", "JSONObject/extensions",
-				"Object/code"));
-
-		Assert.assertEquals(
-			"Not Found",
-			JSONUtil.getValueAsString(
-				_invoke(
-					new GraphQLField("testNotFoundDTO", new GraphQLField("id")),
-					"query"),
-				"JSONArray/errors", "Object/0", "JSONObject/extensions",
-				"Object/code"));
 	}
 
 	@Test

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/GraphQLServletTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/GraphQLServletTest.java
@@ -75,22 +75,22 @@ public class GraphQLServletTest {
 
 		_testDTOV1 = new TestDTOV1();
 
-		TestServletDataV1 testServletData = new TestServletDataV1(_testDTOV1);
+		TestServletDataV1 testServletDataV1 = new TestServletDataV1(_testDTOV1);
 
 		_testDTOV2 = new TestDTOV2();
 
 		TestServletDataV2 testServletDataV2 = new TestServletDataV2(_testDTOV2);
 
-		_serviceRegistrationV1 = bundleContext.registerService(
-			ServletData.class, testServletData, null);
-		_serviceRegistrationV2 = bundleContext.registerService(
+		_serviceRegistration1 = bundleContext.registerService(
+			ServletData.class, testServletDataV1, null);
+		_serviceRegistration2 = bundleContext.registerService(
 			ServletData.class, testServletDataV2, null);
 	}
 
 	@After
 	public void tearDown() {
-		_serviceRegistrationV1.unregister();
-		_serviceRegistrationV2.unregister();
+		_serviceRegistration1.unregister();
+		_serviceRegistration2.unregister();
 	}
 
 	@Test
@@ -184,7 +184,8 @@ public class GraphQLServletTest {
 						new GraphQLField(
 							"testDTO", new GraphQLField("extendedString"),
 							new GraphQLField("id"), new GraphQLField("map"),
-							new GraphQLField("string"), new GraphQLField("version"))),
+							new GraphQLField("string"),
+							new GraphQLField("version"))),
 					"query"),
 				"JSONObject/data", "JSONObject/testPath_v1_0",
 				"JSONObject/testDTO"));
@@ -303,7 +304,8 @@ public class GraphQLServletTest {
 					new GraphQLField(
 						"testDTO", new GraphQLField("extendedString"),
 						new GraphQLField("id"), new GraphQLField("map"),
-						new GraphQLField("string"), new GraphQLField("version")),
+						new GraphQLField("string"),
+						new GraphQLField("version")),
 					"query"),
 				"JSONObject/data", "JSONObject/testDTO"));
 
@@ -606,8 +608,6 @@ public class GraphQLServletTest {
 
 	public static class TestDTOV1 {
 
-		final double version = 1.0;
-
 		public TestDTOV1() {
 			this(
 				RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
@@ -644,10 +644,6 @@ public class GraphQLServletTest {
 			return map;
 		}
 
-		public String getOneVersionOnly() {
-			return "1.0 only text";
-		}
-
 		public String getString() {
 			return string;
 		}
@@ -665,13 +661,14 @@ public class GraphQLServletTest {
 		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
 		protected String string;
 
+		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
+		protected int version = 1;
+
 		private String _extendedString;
 
 	}
 
 	public static class TestDTOV2 {
-
-		final double version = 2.0;
 
 		public TestDTOV2() {
 			this(
@@ -713,10 +710,6 @@ public class GraphQLServletTest {
 			return string;
 		}
 
-		public String getTwoVersionOnly() {
-			return "2.0 only text";
-		}
-
 		public double getVersion() {
 			return version;
 		}
@@ -729,6 +722,9 @@ public class GraphQLServletTest {
 
 		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
 		protected String string;
+
+		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
+		protected int version = 2;
 
 		private String _extendedString;
 
@@ -799,11 +795,6 @@ public class GraphQLServletTest {
 				return _testDTO.getExtendedString();
 			}
 
-			@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
-			public String oneVersionOnly() {
-				return _testDTO.getOneVersionOnly();
-			}
-
 			private final TestDTOV1 _testDTO;
 
 		}
@@ -815,13 +806,13 @@ public class GraphQLServletTest {
 
 	public static class TestQueryV2 {
 
-		public TestQueryV2(TestDTOV2 testDTO) {
-			_testDTO = testDTO;
+		public TestQueryV2(TestDTOV2 testDTOV2) {
+			_testDTOV2 = testDTOV2;
 		}
 
 		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
 		public TestDTOV2 testDTO() {
-			return _testDTO;
+			return _testDTOV2;
 		}
 
 		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
@@ -857,17 +848,12 @@ public class GraphQLServletTest {
 				return _testDTO.getExtendedString();
 			}
 
-			@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
-			public String twoVersionOnly() {
-				return _testDTO.getTwoVersionOnly();
-			}
-
 			private final TestDTOV2 _testDTO;
 
 		}
 
-		private static TestDTOV2 _testDTO;
 		private static TestDTOPage _testDTOPage;
+		private static TestDTOV2 _testDTOV2;
 
 	}
 
@@ -931,8 +917,8 @@ public class GraphQLServletTest {
 
 	public class TestServletDataV1 implements ServletData {
 
-		public TestServletDataV1(TestDTOV1 testDTO) {
-			_testQuery = new TestQueryV1(testDTO);
+		public TestServletDataV1(TestDTOV1 testDTOV1) {
+			_testQueryV1 = new TestQueryV1(testDTOV1);
 		}
 
 		@Override
@@ -942,7 +928,7 @@ public class GraphQLServletTest {
 
 		@Override
 		public Object getMutation() {
-			return _testMutation;
+			return _testMutationV1;
 		}
 
 		@Override
@@ -952,7 +938,7 @@ public class GraphQLServletTest {
 
 		@Override
 		public TestQueryV1 getQuery() {
-			return _testQuery;
+			return _testQueryV1;
 		}
 
 		@Override
@@ -960,15 +946,15 @@ public class GraphQLServletTest {
 			return false;
 		}
 
-		private final TestMutationV1 _testMutation = new TestMutationV1();
-		private final TestQueryV1 _testQuery;
+		private final TestMutationV1 _testMutationV1 = new TestMutationV1();
+		private final TestQueryV1 _testQueryV1;
 
 	}
 
 	public class TestServletDataV2 implements ServletData {
 
 		public TestServletDataV2(TestDTOV2 testDTO) {
-			_testQuery = new TestQueryV2(testDTO);
+			_testQueryV2 = new TestQueryV2(testDTO);
 		}
 
 		@Override
@@ -978,7 +964,7 @@ public class GraphQLServletTest {
 
 		@Override
 		public Object getMutation() {
-			return _testMutation;
+			return _testMutationV2;
 		}
 
 		@Override
@@ -988,7 +974,7 @@ public class GraphQLServletTest {
 
 		@Override
 		public TestQueryV2 getQuery() {
-			return _testQuery;
+			return _testQueryV2;
 		}
 
 		@Override
@@ -996,8 +982,8 @@ public class GraphQLServletTest {
 			return false;
 		}
 
-		private final TestMutationV2 _testMutation = new TestMutationV2();
-		private final TestQueryV2 _testQuery;
+		private final TestMutationV2 _testMutationV2 = new TestMutationV2();
+		private final TestQueryV2 _testQueryV2;
 
 	}
 
@@ -1049,6 +1035,7 @@ public class GraphQLServletTest {
 			JSONUtil.toStringMap(jsonObject.getJSONObject("map")));
 		Assert.assertEquals(
 			expectedTestDTO.getString(), jsonObject.get("string"));
+		Assert.assertEquals(1, jsonObject.getInt("version"));
 	}
 
 	private void _assertEqualsV2(
@@ -1067,6 +1054,7 @@ public class GraphQLServletTest {
 			JSONUtil.toStringMap(jsonObject.getJSONObject("map")));
 		Assert.assertEquals(
 			expectedTestDTO.getString(), jsonObject.get("string"));
+		Assert.assertEquals(2, jsonObject.getInt("version"));
 	}
 
 	private void _assertGraphQLSchemaField(
@@ -1165,7 +1153,9 @@ public class GraphQLServletTest {
 	private String _toGraphQLString(Object objectDTO) throws Exception {
 		StringBuilder sb = new StringBuilder("{");
 
-		for (Field field : ReflectionUtil.getDeclaredFields(objectDTO.getClass())) {
+		for (Field field :
+				ReflectionUtil.getDeclaredFields(objectDTO.getClass())) {
+
 			if (ArrayUtil.isEmpty(
 					field.getAnnotationsByType(
 						com.liferay.portal.vulcan.graphql.annotation.
@@ -1192,8 +1182,8 @@ public class GraphQLServletTest {
 	@Inject
 	private ConfigurationAdmin _configurationAdmin;
 
-	private ServiceRegistration<ServletData> _serviceRegistrationV1;
-	private ServiceRegistration<ServletData> _serviceRegistrationV2;
+	private ServiceRegistration<ServletData> _serviceRegistration1;
+	private ServiceRegistration<ServletData> _serviceRegistration2;
 	private TestDTOV1 _testDTOV1;
 	private TestDTOV2 _testDTOV2;
 

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/GraphQLServletTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/GraphQLServletTest.java
@@ -271,6 +271,34 @@ public class GraphQLServletTest {
 					"query"),
 				"JSONObject/data", "JSONObject/testDTO"));
 
+		_assertEqualsV1(
+			true, _testDTOV1,
+			JSONUtil.getValueAsJSONObject(
+				_invoke(
+					new GraphQLField(
+						"testPath",
+						new GraphQLField(
+							"testDTOV1", new GraphQLField("extendedString"),
+							new GraphQLField("id"), new GraphQLField("map"),
+							new GraphQLField("string"),
+							new GraphQLField("version"))),
+					"query"),
+				"JSONObject/data", "JSONObject/testDTOV1"));
+
+		_assertEqualsV2(
+			true, _testDTOV2,
+			JSONUtil.getValueAsJSONObject(
+				_invoke(
+					new GraphQLField(
+						"testPath",
+						new GraphQLField(
+							"testDTOV2", new GraphQLField("extendedString"),
+							new GraphQLField("id"), new GraphQLField("map"),
+							new GraphQLField("string"),
+							new GraphQLField("version"))),
+					"query"),
+				"JSONObject/data", "JSONObject/testDTOV2"));
+
 		Assert.assertEquals(
 			"Not Found",
 			JSONUtil.getValueAsString(
@@ -308,6 +336,30 @@ public class GraphQLServletTest {
 						new GraphQLField("version")),
 					"query"),
 				"JSONObject/data", "JSONObject/testDTO"));
+
+		_assertEqualsV1(
+			true, _testDTOV1,
+			JSONUtil.getValueAsJSONObject(
+				_invoke(
+					new GraphQLField(
+						"testDTOV1", new GraphQLField("extendedString"),
+						new GraphQLField("id"), new GraphQLField("map"),
+						new GraphQLField("string"),
+						new GraphQLField("version")),
+					"query"),
+				"JSONObject/data", "JSONObject/testDTOV1"));
+
+		_assertEqualsV2(
+			true, _testDTOV2,
+			JSONUtil.getValueAsJSONObject(
+				_invoke(
+					new GraphQLField(
+						"testDTOV2", new GraphQLField("extendedString"),
+						new GraphQLField("id"), new GraphQLField("map"),
+						new GraphQLField("string"),
+						new GraphQLField("version")),
+					"query"),
+				"JSONObject/data", "JSONObject/testDTOV2"));
 
 		Assert.assertEquals(
 			"Not Found",

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/GraphQLServletTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/GraphQLServletTest.java
@@ -969,7 +969,7 @@ public class GraphQLServletTest {
 
 		@Override
 		public String getPath() {
-			return "/test-path-graphql/V2_0";
+			return "/test-path-graphql/v2_0";
 		}
 
 		@Override

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/GraphQLServletTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/GraphQLServletTest.java
@@ -12,9 +12,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
-import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.test.util.HTTPTestUtil;
-import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -23,9 +21,9 @@ import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
-import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
-import com.liferay.portal.vulcan.graphql.annotation.GraphQLTypeExtension;
 import com.liferay.portal.vulcan.graphql.servlet.ServletData;
+import com.liferay.portal.vulcan.internal.graphql.servlet.test.v1_0.TestDTO;
+import com.liferay.portal.vulcan.internal.graphql.servlet.test.v1_0.TestServletData;
 import com.liferay.portal.vulcan.internal.test.util.PaginationConfigurationTestUtil;
 
 import java.lang.reflect.Field;
@@ -35,8 +33,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import javax.ws.rs.NotFoundException;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -73,18 +69,22 @@ public class GraphQLServletTest {
 
 		BundleContext bundleContext = bundle.getBundleContext();
 
-		_testDTOV1 = new TestDTOV1();
+		_testDTOV1 = new TestDTO();
 
-		TestServletDataV1 testServletDataV1 = new TestServletDataV1(_testDTOV1);
+		TestServletData servletDataV1 = new TestServletData(_testDTOV1);
 
-		_testDTOV2 = new TestDTOV2();
+		_testDTOV2 =
+			new com.liferay.portal.vulcan.internal.graphql.servlet.test.v2_0.
+				TestDTO();
 
-		TestServletDataV2 testServletDataV2 = new TestServletDataV2(_testDTOV2);
+		ServletData servletDataV2 =
+			new com.liferay.portal.vulcan.internal.graphql.servlet.test.v2_0.
+				TestServletData(_testDTOV2);
 
 		_serviceRegistration1 = bundleContext.registerService(
-			ServletData.class, testServletDataV1, null);
+			ServletData.class, servletDataV1, null);
 		_serviceRegistration2 = bundleContext.registerService(
-			ServletData.class, testServletDataV2, null);
+			ServletData.class, servletDataV2, null);
 	}
 
 	@After
@@ -382,14 +382,15 @@ public class GraphQLServletTest {
 					"queryDepthLimit", 2
 				).build());
 
-			_assertEqualsV1(
-				true, _testDTOV1,
+			_assertEqualsV2(
+				true, _testDTOV2,
 				JSONUtil.getValueAsJSONObject(
 					_invoke(
 						new GraphQLField(
 							"testDTO", new GraphQLField("extendedString"),
 							new GraphQLField("id"), new GraphQLField("map"),
-							new GraphQLField("string")),
+							new GraphQLField("string"),
+							new GraphQLField("version")),
 						"query"),
 					"JSONObject/data", "JSONObject/testDTO"));
 		}
@@ -583,280 +584,6 @@ public class GraphQLServletTest {
 			false, namespacedQueryFieldsJSONArray, false, "testDTOPage");
 	}
 
-	public static class TestDTOPage {
-
-		public TestDTOPage(int page, int pageSize) {
-			this.page = page;
-			this.pageSize = pageSize;
-		}
-
-		public int getPage() {
-			return page;
-		}
-
-		public int getPageSize() {
-			return pageSize;
-		}
-
-		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
-		protected int page;
-
-		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
-		protected int pageSize;
-
-	}
-
-	public static class TestDTOV1 {
-
-		public TestDTOV1() {
-			this(
-				RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
-				HashMapBuilder.put(
-					"a" + RandomTestUtil.randomString(),
-					RandomTestUtil.randomString()
-				).put(
-					"a" + RandomTestUtil.randomString(),
-					RandomTestUtil.randomString()
-				).build(),
-				RandomTestUtil.randomString());
-		}
-
-		public TestDTOV1(
-			String extendedString, long id, Map<String, String> map,
-			String string) {
-
-			_extendedString = extendedString;
-
-			this.id = id;
-			this.map = map;
-			this.string = string;
-		}
-
-		public String getExtendedString() {
-			return _extendedString;
-		}
-
-		public long getId() {
-			return id;
-		}
-
-		public Map<String, String> getMap() {
-			return map;
-		}
-
-		public String getString() {
-			return string;
-		}
-
-		public double getVersion() {
-			return version;
-		}
-
-		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
-		protected long id;
-
-		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
-		protected Map<String, String> map;
-
-		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
-		protected String string;
-
-		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
-		protected int version = 1;
-
-		private String _extendedString;
-
-	}
-
-	public static class TestDTOV2 {
-
-		public TestDTOV2() {
-			this(
-				RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
-				HashMapBuilder.put(
-					"a" + RandomTestUtil.randomString(),
-					RandomTestUtil.randomString()
-				).put(
-					"a" + RandomTestUtil.randomString(),
-					RandomTestUtil.randomString()
-				).build(),
-				RandomTestUtil.randomString());
-		}
-
-		public TestDTOV2(
-			String extendedString, long id, Map<String, String> map,
-			String string) {
-
-			_extendedString = extendedString;
-
-			this.id = id;
-			this.map = map;
-			this.string = string;
-		}
-
-		public String getExtendedString() {
-			return _extendedString;
-		}
-
-		public long getId() {
-			return id;
-		}
-
-		public Map<String, String> getMap() {
-			return map;
-		}
-
-		public String getString() {
-			return string;
-		}
-
-		public double getVersion() {
-			return version;
-		}
-
-		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
-		protected long id;
-
-		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
-		protected Map<String, String> map;
-
-		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
-		protected String string;
-
-		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
-		protected int version = 2;
-
-		private String _extendedString;
-
-	}
-
-	public static class TestMutationV1 {
-
-		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
-		public TestDTOV1 createTestDTO(
-			@GraphQLName("testDTO") TestDTOV1 testDTO) {
-
-			return testDTO;
-		}
-
-	}
-
-	public static class TestMutationV2 {
-
-		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
-		public TestDTOV2 createTestDTO(
-			@GraphQLName("testDTO") TestDTOV2 testDTO) {
-
-			return testDTO;
-		}
-
-	}
-
-	public static class TestQueryV1 {
-
-		public TestQueryV1(TestDTOV1 testDTO) {
-			_testDTO = testDTO;
-		}
-
-		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
-		public TestDTOV1 testDTO() {
-			return _testDTO;
-		}
-
-		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
-		public TestDTOPage testDTOPage(
-			@GraphQLName("page") int page,
-			@GraphQLName("pageSize") int pageSize) {
-
-			return new TestDTOPage(page, pageSize);
-		}
-
-		public TestDTOV1 testNoPermissionOverDTO()
-			throws PrincipalException.MustHavePermission {
-
-			throw new PrincipalException.MustHavePermission(
-				0L, StringUtil.randomString());
-		}
-
-		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
-		public TestDTOV1 testNotFoundDTO() {
-			throw new NotFoundException();
-		}
-
-		@GraphQLTypeExtension(TestDTOV1.class)
-		public class TestGraphQLTypeExtension {
-
-			public TestGraphQLTypeExtension(TestDTOV1 testDTO) {
-				_testDTO = testDTO;
-			}
-
-			@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
-			public String extendedString() {
-				return _testDTO.getExtendedString();
-			}
-
-			private final TestDTOV1 _testDTO;
-
-		}
-
-		private static TestDTOV1 _testDTO;
-		private static TestDTOPage _testDTOPage;
-
-	}
-
-	public static class TestQueryV2 {
-
-		public TestQueryV2(TestDTOV2 testDTOV2) {
-			_testDTOV2 = testDTOV2;
-		}
-
-		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
-		public TestDTOV2 testDTO() {
-			return _testDTOV2;
-		}
-
-		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
-		public TestDTOPage testDTOPage(
-			@GraphQLName("page") int page,
-			@GraphQLName("pageSize") int pageSize) {
-
-			return new TestDTOPage(page, pageSize);
-		}
-
-		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
-		public TestDTOV2 testNoPermissionOverDTO()
-			throws PrincipalException.MustHavePermission {
-
-			throw new PrincipalException.MustHavePermission(
-				0L, StringUtil.randomString());
-		}
-
-		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
-		public TestDTOV2 testNotFoundDTO() {
-			throw new NotFoundException();
-		}
-
-		@GraphQLTypeExtension(TestDTOV2.class)
-		public class TestGraphQLTypeExtension {
-
-			public TestGraphQLTypeExtension(TestDTOV2 testDTO) {
-				_testDTO = testDTO;
-			}
-
-			@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
-			public String extendedString() {
-				return _testDTO.getExtendedString();
-			}
-
-			private final TestDTOV2 _testDTO;
-
-		}
-
-		private static TestDTOPage _testDTOPage;
-		private static TestDTOV2 _testDTOV2;
-
-	}
-
 	public class GraphQLField {
 
 		public GraphQLField(String key, GraphQLField... graphQLFields) {
@@ -915,78 +642,6 @@ public class GraphQLServletTest {
 
 	}
 
-	public class TestServletDataV1 implements ServletData {
-
-		public TestServletDataV1(TestDTOV1 testDTOV1) {
-			_testQueryV1 = new TestQueryV1(testDTOV1);
-		}
-
-		@Override
-		public String getApplicationName() {
-			return "test";
-		}
-
-		@Override
-		public Object getMutation() {
-			return _testMutationV1;
-		}
-
-		@Override
-		public String getPath() {
-			return "/test-path-graphql/v1_0";
-		}
-
-		@Override
-		public TestQueryV1 getQuery() {
-			return _testQueryV1;
-		}
-
-		@Override
-		public boolean isJaxRsResourceInvocation() {
-			return false;
-		}
-
-		private final TestMutationV1 _testMutationV1 = new TestMutationV1();
-		private final TestQueryV1 _testQueryV1;
-
-	}
-
-	public class TestServletDataV2 implements ServletData {
-
-		public TestServletDataV2(TestDTOV2 testDTO) {
-			_testQueryV2 = new TestQueryV2(testDTO);
-		}
-
-		@Override
-		public String getApplicationName() {
-			return "test";
-		}
-
-		@Override
-		public Object getMutation() {
-			return _testMutationV2;
-		}
-
-		@Override
-		public String getPath() {
-			return "/test-path-graphql/v2_0";
-		}
-
-		@Override
-		public TestQueryV2 getQuery() {
-			return _testQueryV2;
-		}
-
-		@Override
-		public boolean isJaxRsResourceInvocation() {
-			return false;
-		}
-
-		private final TestMutationV2 _testMutationV2 = new TestMutationV2();
-		private final TestQueryV2 _testQueryV2;
-
-	}
-
 	private void _appendGraphQLFieldValue(StringBuilder sb, Object value) {
 		if (value instanceof Map) {
 			Map<String, Object> map = (Map)value;
@@ -1020,7 +675,7 @@ public class GraphQLServletTest {
 	}
 
 	private void _assertEqualsV1(
-		boolean assertExtendedProperties, TestDTOV1 expectedTestDTO,
+		boolean assertExtendedProperties, TestDTO expectedTestDTO,
 		JSONObject jsonObject) {
 
 		if (assertExtendedProperties) {
@@ -1039,7 +694,9 @@ public class GraphQLServletTest {
 	}
 
 	private void _assertEqualsV2(
-		boolean assertExtendedProperties, TestDTOV2 expectedTestDTO,
+		boolean assertExtendedProperties,
+		com.liferay.portal.vulcan.internal.graphql.servlet.test.v2_0.TestDTO
+			expectedTestDTO,
 		JSONObject jsonObject) {
 
 		if (assertExtendedProperties) {
@@ -1094,7 +751,7 @@ public class GraphQLServletTest {
 			sb.append("query is available at query/");
 		}
 
-		sb.append("testPath_v1_0/");
+		sb.append("testPath_v2_0/");
 		sb.append(operationName);
 
 		return sb.toString();
@@ -1184,7 +841,8 @@ public class GraphQLServletTest {
 
 	private ServiceRegistration<ServletData> _serviceRegistration1;
 	private ServiceRegistration<ServletData> _serviceRegistration2;
-	private TestDTOV1 _testDTOV1;
-	private TestDTOV2 _testDTOV2;
+	private TestDTO _testDTOV1;
+	private com.liferay.portal.vulcan.internal.graphql.servlet.test.v2_0.TestDTO
+		_testDTOV2;
 
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/GraphQLServletTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/GraphQLServletTest.java
@@ -134,59 +134,6 @@ public class GraphQLServletTest {
 				"JSONObject/data", "JSONObject/testPath_v2_0",
 				"JSONObject/createTestDTO"));
 
-		// With simple namespace (without version)
-
-		_assertEqualsV2(
-			false, _testDTOV2,
-			JSONUtil.getValueAsJSONObject(
-				_invoke(
-					new GraphQLField(
-						"testPath",
-						new GraphQLField(
-							"createTestDTO",
-							Collections.singletonMap(
-								"testDTO", _toGraphQLString(_testDTOV2)),
-							new GraphQLField("id"), new GraphQLField("map"),
-							new GraphQLField("string"),
-							new GraphQLField("version"))),
-					"mutation"),
-				"JSONObject/data", "JSONObject/testPath",
-				"JSONObject/createTestDTO"));
-
-		_assertEqualsV1(
-			false, _testDTOV1,
-			JSONUtil.getValueAsJSONObject(
-				_invoke(
-					new GraphQLField(
-						"testPath",
-						new GraphQLField(
-							"createTestDTOV1",
-							Collections.singletonMap(
-								"testDTO", _toGraphQLString(_testDTOV1)),
-							new GraphQLField("id"), new GraphQLField("map"),
-							new GraphQLField("string"),
-							new GraphQLField("version"))),
-					"mutation"),
-				"JSONObject/data", "JSONObject/testPath",
-				"JSONObject/createTestDTOV1"));
-
-		_assertEqualsV2(
-			false, _testDTOV2,
-			JSONUtil.getValueAsJSONObject(
-				_invoke(
-					new GraphQLField(
-						"testPath",
-						new GraphQLField(
-							"createTestDTOV2",
-							Collections.singletonMap(
-								"testDTO", _toGraphQLString(_testDTOV2)),
-							new GraphQLField("id"), new GraphQLField("map"),
-							new GraphQLField("string"),
-							new GraphQLField("version"))),
-					"mutation"),
-				"JSONObject/data", "JSONObject/testPath",
-				"JSONObject/createTestDTOV2"));
-
 		// Without namespace (backwards compatibility)
 
 		_assertEqualsV2(
@@ -311,77 +258,6 @@ public class GraphQLServletTest {
 				_invoke(
 					new GraphQLField(
 						"testPath_v2_0",
-						new GraphQLField(
-							"testNotFoundDTO", new GraphQLField("id"))),
-					"query"),
-				"JSONArray/errors", "Object/0", "JSONObject/extensions",
-				"Object/code"));
-
-		// With simple namespace (without version)
-
-		_assertEqualsV2(
-			true, _testDTOV2,
-			JSONUtil.getValueAsJSONObject(
-				_invoke(
-					new GraphQLField(
-						"testPath",
-						new GraphQLField(
-							"testDTO", new GraphQLField("extendedString"),
-							new GraphQLField("id"), new GraphQLField("map"),
-							new GraphQLField("string"),
-							new GraphQLField("version"))),
-					"query"),
-				"JSONObject/data", "JSONObject/testPath",
-				"JSONObject/testDTO"));
-
-		_assertEqualsV1(
-			true, _testDTOV1,
-			JSONUtil.getValueAsJSONObject(
-				_invoke(
-					new GraphQLField(
-						"testPath",
-						new GraphQLField(
-							"testDTOV1", new GraphQLField("extendedString"),
-							new GraphQLField("id"), new GraphQLField("map"),
-							new GraphQLField("string"),
-							new GraphQLField("version"))),
-					"query"),
-				"JSONObject/data", "JSONObject/testPath",
-				"JSONObject/testDTOV1"));
-
-		_assertEqualsV2(
-			true, _testDTOV2,
-			JSONUtil.getValueAsJSONObject(
-				_invoke(
-					new GraphQLField(
-						"testPath",
-						new GraphQLField(
-							"testDTOV2", new GraphQLField("extendedString"),
-							new GraphQLField("id"), new GraphQLField("map"),
-							new GraphQLField("string"),
-							new GraphQLField("version"))),
-					"query"),
-				"JSONObject/data", "JSONObject/testPath",
-				"JSONObject/testDTOV2"));
-
-		Assert.assertEquals(
-			"Not Found",
-			JSONUtil.getValueAsString(
-				_invoke(
-					new GraphQLField(
-						"testPath",
-						new GraphQLField(
-							"testNoPermissionOverDTO", new GraphQLField("id"))),
-					"query"),
-				"JSONArray/errors", "Object/0", "JSONObject/extensions",
-				"Object/code"));
-
-		Assert.assertEquals(
-			"Not Found",
-			JSONUtil.getValueAsString(
-				_invoke(
-					new GraphQLField(
-						"testPath",
 						new GraphQLField(
 							"testNotFoundDTO", new GraphQLField("id"))),
 					"query"),

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/GraphQLServletTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/GraphQLServletTest.java
@@ -73,28 +73,33 @@ public class GraphQLServletTest {
 
 		BundleContext bundleContext = bundle.getBundleContext();
 
-		_testDTO = new TestDTO();
+		_testDTOV1 = new TestDTOV1();
 
-		TestServletData testServletData = new TestServletData(_testDTO);
+		TestServletDataV1 testServletData = new TestServletDataV1(_testDTOV1);
 
-		_serviceRegistration = bundleContext.registerService(
+		_testDTOV2 = new TestDTOV2();
+
+		TestServletDataV2 testServletDataV2 = new TestServletDataV2(_testDTOV2);
+
+		_serviceRegistrationV1 = bundleContext.registerService(
 			ServletData.class, testServletData, null);
+		_serviceRegistrationV2 = bundleContext.registerService(
+			ServletData.class, testServletDataV2, null);
 	}
 
 	@After
 	public void tearDown() {
-		_serviceRegistration.unregister();
+		_serviceRegistrationV1.unregister();
+		_serviceRegistrationV2.unregister();
 	}
 
 	@Test
 	public void testMutation() throws Exception {
 
-		// With namespace
+		// With namespace v1
 
-		TestDTO testDTO = new TestDTO();
-
-		_assertEquals(
-			false, testDTO,
+		_assertEqualsV1(
+			false, _testDTOV1,
 			JSONUtil.getValueAsJSONObject(
 				_invoke(
 					new GraphQLField(
@@ -102,27 +107,65 @@ public class GraphQLServletTest {
 						new GraphQLField(
 							"createTestDTO",
 							Collections.singletonMap(
-								"testDTO", _toGraphQLString(testDTO)),
+								"testDTO", _toGraphQLStringV1(_testDTOV1)),
 							new GraphQLField("id"), new GraphQLField("map"),
-							new GraphQLField("string"))),
+							new GraphQLField("string"),
+							new GraphQLField("version"))),
 					"mutation"),
 				"JSONObject/data", "JSONObject/testPath_v1_0",
 				"JSONObject/createTestDTO"));
 
+		// With namespace v2
+
+		_assertEqualsV2(
+			false, _testDTOV2,
+			JSONUtil.getValueAsJSONObject(
+				_invoke(
+					new GraphQLField(
+						"testPath_v2_0",
+						new GraphQLField(
+							"createTestDTO",
+							Collections.singletonMap(
+								"testDTO", _toGraphQLStringV2(_testDTOV2)),
+							new GraphQLField("id"), new GraphQLField("map"),
+							new GraphQLField("string"),
+							new GraphQLField("version"))),
+					"mutation"),
+				"JSONObject/data", "JSONObject/testPath_v2_0",
+				"JSONObject/createTestDTO"));
+
+		// With simple namespace (without version)
+
+		_assertEqualsV2(
+			false, _testDTOV2,
+			JSONUtil.getValueAsJSONObject(
+				_invoke(
+					new GraphQLField(
+						"testPath",
+						new GraphQLField(
+							"createTestDTO",
+							Collections.singletonMap(
+								"testDTO", _toGraphQLStringV2(_testDTOV2)),
+							new GraphQLField("id"), new GraphQLField("map"),
+							new GraphQLField("string"),
+							new GraphQLField("version"))),
+					"mutation"),
+				"JSONObject/data", "JSONObject/testPath",
+				"JSONObject/createTestDTO"));
+
 		// Without namespace (backwards compatibility)
 
-		testDTO = new TestDTO();
-
-		_assertEquals(
-			false, testDTO,
+		_assertEqualsV2(
+			false, _testDTOV2,
 			JSONUtil.getValueAsJSONObject(
 				_invoke(
 					new GraphQLField(
 						"createTestDTO",
 						Collections.singletonMap(
-							"testDTO", _toGraphQLString(testDTO)),
+							"testDTO", _toGraphQLStringV2(_testDTOV2)),
 						new GraphQLField("id"), new GraphQLField("map"),
-						new GraphQLField("string")),
+						new GraphQLField("string"),
+						new GraphQLField("version")),
 					"mutation"),
 				"JSONObject/data", "JSONObject/createTestDTO"));
 	}
@@ -130,10 +173,10 @@ public class GraphQLServletTest {
 	@Test
 	public void testQuery() throws Exception {
 
-		// With namespace
+		// With namespace v1
 
-		_assertEquals(
-			true, _testDTO,
+		_assertEqualsV1(
+			true, _testDTOV1,
 			JSONUtil.getValueAsJSONObject(
 				_invoke(
 					new GraphQLField(
@@ -141,7 +184,7 @@ public class GraphQLServletTest {
 						new GraphQLField(
 							"testDTO", new GraphQLField("extendedString"),
 							new GraphQLField("id"), new GraphQLField("map"),
-							new GraphQLField("string"))),
+							new GraphQLField("string"), new GraphQLField("version"))),
 					"query"),
 				"JSONObject/data", "JSONObject/testPath_v1_0",
 				"JSONObject/testDTO"));
@@ -170,16 +213,97 @@ public class GraphQLServletTest {
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
 
+		// With namespace v2
+
+		_assertEqualsV2(
+			true, _testDTOV2,
+			JSONUtil.getValueAsJSONObject(
+				_invoke(
+					new GraphQLField(
+						"testPath_v2_0",
+						new GraphQLField(
+							"testDTO", new GraphQLField("extendedString"),
+							new GraphQLField("id"), new GraphQLField("map"),
+							new GraphQLField("string"),
+							new GraphQLField("version"))),
+					"query"),
+				"JSONObject/data", "JSONObject/testPath_v2_0",
+				"JSONObject/testDTO"));
+
+		Assert.assertEquals(
+			"Not Found",
+			JSONUtil.getValueAsString(
+				_invoke(
+					new GraphQLField(
+						"testPath_v2_0",
+						new GraphQLField(
+							"testNoPermissionOverDTO", new GraphQLField("id"))),
+					"query"),
+				"JSONArray/errors", "Object/0", "JSONObject/extensions",
+				"Object/code"));
+
+		Assert.assertEquals(
+			"Not Found",
+			JSONUtil.getValueAsString(
+				_invoke(
+					new GraphQLField(
+						"testPath_v2_0",
+						new GraphQLField(
+							"testNotFoundDTO", new GraphQLField("id"))),
+					"query"),
+				"JSONArray/errors", "Object/0", "JSONObject/extensions",
+				"Object/code"));
+
+		// With simple namespace (without version)
+
+		_assertEqualsV2(
+			true, _testDTOV2,
+			JSONUtil.getValueAsJSONObject(
+				_invoke(
+					new GraphQLField(
+						"testPath",
+						new GraphQLField(
+							"testDTO", new GraphQLField("extendedString"),
+							new GraphQLField("id"), new GraphQLField("map"),
+							new GraphQLField("string"),
+							new GraphQLField("version"))),
+					"query"),
+				"JSONObject/data", "JSONObject/testDTO"));
+
+		Assert.assertEquals(
+			"Not Found",
+			JSONUtil.getValueAsString(
+				_invoke(
+					new GraphQLField(
+						"testPath",
+						new GraphQLField(
+							"testNoPermissionOverDTO", new GraphQLField("id"))),
+					"query"),
+				"JSONArray/errors", "Object/0", "JSONObject/extensions",
+				"Object/code"));
+
+		Assert.assertEquals(
+			"Not Found",
+			JSONUtil.getValueAsString(
+				_invoke(
+					new GraphQLField(
+						"testPath",
+						new GraphQLField(
+							"testNotFoundDTO", new GraphQLField("id"))),
+					"query"),
+				"JSONArray/errors", "Object/0", "JSONObject/extensions",
+				"Object/code"));
+
 		// Without namespace (backwards compatibility)
 
-		_assertEquals(
-			true, _testDTO,
+		_assertEqualsV2(
+			true, _testDTOV2,
 			JSONUtil.getValueAsJSONObject(
 				_invoke(
 					new GraphQLField(
 						"testDTO", new GraphQLField("extendedString"),
 						new GraphQLField("id"), new GraphQLField("map"),
-						new GraphQLField("string")),
+						new GraphQLField("string"), new GraphQLField("version")),
 					"query"),
 				"JSONObject/data", "JSONObject/testDTO"));
 
@@ -256,8 +380,8 @@ public class GraphQLServletTest {
 					"queryDepthLimit", 2
 				).build());
 
-			_assertEquals(
-				true, _testDTO,
+			_assertEqualsV1(
+				true, _testDTOV1,
 				JSONUtil.getValueAsJSONObject(
 					_invoke(
 						new GraphQLField(
@@ -410,6 +534,15 @@ public class GraphQLServletTest {
 				"JSONObject/type", "JSONArray/fields"),
 			true, "createTestDTO");
 
+		_assertGraphQLSchemaField(
+			false, mutationFieldsJSONArray, true, "testPath_v2_0");
+		_assertGraphQLSchemaField(
+			false,
+			JSONUtil.getValueAsJSONArray(
+				_getJSONObject(mutationFieldsJSONArray, "testPath_v2_0"),
+				"JSONObject/type", "JSONArray/fields"),
+			true, "createTestDTO");
+
 		// Query fields
 
 		JSONArray queryFieldsJSONArray = JSONUtil.getValueAsJSONArray(
@@ -448,61 +581,6 @@ public class GraphQLServletTest {
 			false, namespacedQueryFieldsJSONArray, false, "testDTOPage");
 	}
 
-	public static class TestDTO {
-
-		public TestDTO() {
-			this(
-				RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
-				HashMapBuilder.put(
-					"a" + RandomTestUtil.randomString(),
-					RandomTestUtil.randomString()
-				).put(
-					"a" + RandomTestUtil.randomString(),
-					RandomTestUtil.randomString()
-				).build(),
-				RandomTestUtil.randomString());
-		}
-
-		public TestDTO(
-			String extendedString, long id, Map<String, String> map,
-			String string) {
-
-			_extendedString = extendedString;
-
-			this.id = id;
-			this.map = map;
-			this.string = string;
-		}
-
-		public String getExtendedString() {
-			return _extendedString;
-		}
-
-		public long getId() {
-			return id;
-		}
-
-		public Map<String, String> getMap() {
-			return map;
-		}
-
-		public String getString() {
-			return string;
-		}
-
-		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
-		protected long id;
-
-		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
-		protected Map<String, String> map;
-
-		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
-		protected String string;
-
-		private String _extendedString;
-
-	}
-
 	public static class TestDTOPage {
 
 		public TestDTOPage(int page, int pageSize) {
@@ -526,26 +604,223 @@ public class GraphQLServletTest {
 
 	}
 
-	public static class TestMutation {
+	public static class TestDTOV1 {
+
+		final double version = 1.0;
+
+		public TestDTOV1() {
+			this(
+				RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
+				HashMapBuilder.put(
+					"a" + RandomTestUtil.randomString(),
+					RandomTestUtil.randomString()
+				).put(
+					"a" + RandomTestUtil.randomString(),
+					RandomTestUtil.randomString()
+				).build(),
+				RandomTestUtil.randomString());
+		}
+
+		public TestDTOV1(
+			String extendedString, long id, Map<String, String> map,
+			String string) {
+
+			_extendedString = extendedString;
+
+			this.id = id;
+			this.map = map;
+			this.string = string;
+		}
+
+		public String getExtendedString() {
+			return _extendedString + " " + version + " version";
+		}
+
+		public long getId() {
+			return id;
+		}
+
+		public Map<String, String> getMap() {
+			return map;
+		}
+
+		public String getOneVersionOnly() {
+			return "1.0 only text";
+		}
+
+		public String getString() {
+			return string;
+		}
+
+		public double getVersion() {
+			return version;
+		}
 
 		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
-		public TestDTO createTestDTO(@GraphQLName("testDTO") TestDTO testDTO) {
+		protected long id;
+
+		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
+		protected Map<String, String> map;
+
+		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
+		protected String string;
+
+		private String _extendedString;
+
+	}
+
+	public static class TestDTOV2 {
+
+		final double version = 2.0;
+
+		public TestDTOV2() {
+			this(
+				RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
+				HashMapBuilder.put(
+					"a" + RandomTestUtil.randomString(),
+					RandomTestUtil.randomString()
+				).put(
+					"a" + RandomTestUtil.randomString(),
+					RandomTestUtil.randomString()
+				).build(),
+				RandomTestUtil.randomString());
+		}
+
+		public TestDTOV2(
+			String extendedString, long id, Map<String, String> map,
+			String string) {
+
+			_extendedString = extendedString;
+
+			this.id = id;
+			this.map = map;
+			this.string = string;
+		}
+
+		public String getExtendedString() {
+			return _extendedString + " " + version +" version";
+		}
+
+		public long getId() {
+			return id;
+		}
+
+		public Map<String, String> getMap() {
+			return map;
+		}
+
+		public String getString() {
+			return string;
+		}
+
+		public String getTwoVersionOnly() {
+			return "2.0 only text";
+		}
+
+		public double getVersion() {
+			return version;
+		}
+
+		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
+		protected long id;
+
+		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
+		protected Map<String, String> map;
+
+		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
+		protected String string;
+
+		private String _extendedString;
+
+	}
+
+	public static class TestMutationV1 {
+
+		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
+		public TestDTOV1 createTestDTO(
+			@GraphQLName("testDTO") TestDTOV1 testDTO) {
+
 			return testDTO;
 		}
 
 	}
 
-	public static class TestQuery {
+	public static class TestMutationV2 {
 
-		public TestQuery() {
+		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
+		public TestDTOV2 createTestDTO(
+			@GraphQLName("testDTO") TestDTOV2 testDTO) {
+
+			return testDTO;
 		}
 
-		public TestQuery(TestDTO testDTO) {
+	}
+
+	public static class TestQueryV1 {
+
+		public TestQueryV1(TestDTOV1 testDTO) {
 			_testDTO = testDTO;
 		}
 
 		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
-		public TestDTO testDTO() {
+		public TestDTOV1 testDTO() {
+			return _testDTO;
+		}
+
+		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
+		public TestDTOPage testDTOPage(
+			@GraphQLName("page") int page,
+			@GraphQLName("pageSize") int pageSize) {
+
+			return new TestDTOPage(page, pageSize);
+		}
+
+		public TestDTOV1 testNoPermissionOverDTO()
+			throws PrincipalException.MustHavePermission {
+
+			throw new PrincipalException.MustHavePermission(
+				0L, StringUtil.randomString());
+		}
+
+		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
+		public TestDTOV1 testNotFoundDTO() {
+			throw new NotFoundException();
+		}
+
+		@GraphQLTypeExtension(TestDTOV1.class)
+		public class TestGraphQLTypeExtension {
+
+			public TestGraphQLTypeExtension(TestDTOV1 testDTO) {
+				_testDTO = testDTO;
+			}
+
+			@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
+			public String extendedString() {
+				return _testDTO.getExtendedString();
+			}
+
+			@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
+			public String oneVersionOnly() {
+				return _testDTO.getOneVersionOnly();
+			}
+
+			private final TestDTOV1 _testDTO;
+
+		}
+
+		private static TestDTOV1 _testDTO;
+		private static TestDTOPage _testDTOPage;
+
+	}
+
+	public static class TestQueryV2 {
+
+		public TestQueryV2(TestDTOV2 testDTO) {
+			_testDTO = testDTO;
+		}
+
+		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
+		public TestDTOV2 testDTO() {
 			return _testDTO;
 		}
 
@@ -558,7 +833,7 @@ public class GraphQLServletTest {
 		}
 
 		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
-		public TestDTO testNoPermissionOverDTO()
+		public TestDTOV2 testNoPermissionOverDTO()
 			throws PrincipalException.MustHavePermission {
 
 			throw new PrincipalException.MustHavePermission(
@@ -566,14 +841,14 @@ public class GraphQLServletTest {
 		}
 
 		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
-		public TestDTO testNotFoundDTO() {
+		public TestDTOV2 testNotFoundDTO() {
 			throw new NotFoundException();
 		}
 
-		@GraphQLTypeExtension(TestDTO.class)
+		@GraphQLTypeExtension(TestDTOV2.class)
 		public class TestGraphQLTypeExtension {
 
-			public TestGraphQLTypeExtension(TestDTO testDTO) {
+			public TestGraphQLTypeExtension(TestDTOV2 testDTO) {
 				_testDTO = testDTO;
 			}
 
@@ -582,11 +857,16 @@ public class GraphQLServletTest {
 				return _testDTO.getExtendedString();
 			}
 
-			private final TestDTO _testDTO;
+			@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
+			public String twoVersionOnly() {
+				return _testDTO.getTwoVersionOnly();
+			}
+
+			private final TestDTOV2 _testDTO;
 
 		}
 
-		private static TestDTO _testDTO;
+		private static TestDTOV2 _testDTO;
 		private static TestDTOPage _testDTOPage;
 
 	}
@@ -649,10 +929,10 @@ public class GraphQLServletTest {
 
 	}
 
-	public class TestServletData implements ServletData {
+	public class TestServletDataV1 implements ServletData {
 
-		public TestServletData(TestDTO testDTO) {
-			_testQuery = new TestQuery(testDTO);
+		public TestServletDataV1(TestDTOV1 testDTO) {
+			_testQuery = new TestQueryV1(testDTO);
 		}
 
 		@Override
@@ -671,7 +951,7 @@ public class GraphQLServletTest {
 		}
 
 		@Override
-		public TestQuery getQuery() {
+		public TestQueryV1 getQuery() {
 			return _testQuery;
 		}
 
@@ -680,8 +960,44 @@ public class GraphQLServletTest {
 			return false;
 		}
 
-		private final TestMutation _testMutation = new TestMutation();
-		private final TestQuery _testQuery;
+		private final TestMutationV1 _testMutation = new TestMutationV1();
+		private final TestQueryV1 _testQuery;
+
+	}
+
+	public class TestServletDataV2 implements ServletData {
+
+		public TestServletDataV2(TestDTOV2 testDTO) {
+			_testQuery = new TestQueryV2(testDTO);
+		}
+
+		@Override
+		public String getApplicationName() {
+			return "test";
+		}
+
+		@Override
+		public Object getMutation() {
+			return _testMutation;
+		}
+
+		@Override
+		public String getPath() {
+			return "/test-path-graphql/V2_0";
+		}
+
+		@Override
+		public TestQueryV2 getQuery() {
+			return _testQuery;
+		}
+
+		@Override
+		public boolean isJaxRsResourceInvocation() {
+			return false;
+		}
+
+		private final TestMutationV2 _testMutation = new TestMutationV2();
+		private final TestQueryV2 _testQuery;
 
 	}
 
@@ -717,8 +1033,26 @@ public class GraphQLServletTest {
 		}
 	}
 
-	private void _assertEquals(
-		boolean assertExtendedProperties, TestDTO expectedTestDTO,
+	private void _assertEqualsV1(
+		boolean assertExtendedProperties, TestDTOV1 expectedTestDTO,
+		JSONObject jsonObject) {
+
+		if (assertExtendedProperties) {
+			Assert.assertEquals(
+				expectedTestDTO.getExtendedString(),
+				jsonObject.get("extendedString"));
+		}
+
+		Assert.assertEquals(expectedTestDTO.getId(), jsonObject.get("id"));
+		Assert.assertEquals(
+			expectedTestDTO.getMap(),
+			JSONUtil.toStringMap(jsonObject.getJSONObject("map")));
+		Assert.assertEquals(
+			expectedTestDTO.getString(), jsonObject.get("string"));
+	}
+
+	private void _assertEqualsV2(
+		boolean assertExtendedProperties, TestDTOV2 expectedTestDTO,
 		JSONObject jsonObject) {
 
 		if (assertExtendedProperties) {
@@ -828,14 +1162,49 @@ public class GraphQLServletTest {
 		Assert.assertEquals(expectedPageSize, jsonObject.getInt("pageSize"));
 	}
 
-	private String _toGraphQLString(TestDTO testDTO) throws Exception {
+	private String _toGraphQLStringV1(TestDTOV1 testDTO) throws Exception {
 		StringBuilder sb = new StringBuilder("{");
 
-		for (Field field : ReflectionUtil.getDeclaredFields(TestDTO.class)) {
+		for (Field field : ReflectionUtil.getDeclaredFields(TestDTOV1.class)) {
 			if (ArrayUtil.isEmpty(
 					field.getAnnotationsByType(
 						com.liferay.portal.vulcan.graphql.annotation.
-							GraphQLField.class))) {
+							GraphQLField.class)) &&
+				!field.getName(
+				).endsWith(
+					"VersionOnly"
+				)) {
+
+				continue;
+			}
+
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append(field.getName());
+			sb.append(": ");
+
+			_appendGraphQLFieldValue(sb, field.get(testDTO));
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private String _toGraphQLStringV2(TestDTOV2 testDTO) throws Exception {
+		StringBuilder sb = new StringBuilder("{");
+
+		for (Field field : ReflectionUtil.getDeclaredFields(TestDTOV2.class)) {
+			if (ArrayUtil.isEmpty(
+					field.getAnnotationsByType(
+						com.liferay.portal.vulcan.graphql.annotation.
+							GraphQLField.class)) &&
+				field.getName(
+				).endsWith(
+					"versionOnly"
+				)) {
 
 				continue;
 			}
@@ -858,7 +1227,9 @@ public class GraphQLServletTest {
 	@Inject
 	private ConfigurationAdmin _configurationAdmin;
 
-	private ServiceRegistration<ServletData> _serviceRegistration;
-	private TestDTO _testDTO;
+	private ServiceRegistration<ServletData> _serviceRegistrationV1;
+	private ServiceRegistration<ServletData> _serviceRegistrationV2;
+	private TestDTOV1 _testDTOV1;
+	private TestDTOV2 _testDTOV2;
 
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/GraphQLServletTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/GraphQLServletTest.java
@@ -69,22 +69,19 @@ public class GraphQLServletTest {
 
 		BundleContext bundleContext = bundle.getBundleContext();
 
-		_testDTOV1 = new TestDTO();
+		_v1TestDTO = new TestDTO();
 
-		TestServletData servletDataV1 = new TestServletData(_testDTOV1);
-
-		_testDTOV2 =
+		_v2TestDTO =
 			new com.liferay.portal.vulcan.internal.graphql.servlet.test.v2_0.
 				TestDTO();
 
-		ServletData servletDataV2 =
-			new com.liferay.portal.vulcan.internal.graphql.servlet.test.v2_0.
-				TestServletData(_testDTOV2);
-
 		_serviceRegistration1 = bundleContext.registerService(
-			ServletData.class, servletDataV1, null);
+			ServletData.class, new TestServletData(_v1TestDTO), null);
 		_serviceRegistration2 = bundleContext.registerService(
-			ServletData.class, servletDataV2, null);
+			ServletData.class,
+			new com.liferay.portal.vulcan.internal.graphql.servlet.test.v2_0.
+				TestServletData(_v2TestDTO),
+			null);
 	}
 
 	@After
@@ -99,7 +96,7 @@ public class GraphQLServletTest {
 		// With namespace v1
 
 		_assertEqualsV1(
-			false, _testDTOV1,
+			false, _v1TestDTO,
 			JSONUtil.getValueAsJSONObject(
 				_invoke(
 					new GraphQLField(
@@ -107,7 +104,7 @@ public class GraphQLServletTest {
 						new GraphQLField(
 							"createTestDTO",
 							Collections.singletonMap(
-								"testDTO", _toGraphQLString(_testDTOV1)),
+								"testDTO", _toGraphQLString(_v1TestDTO)),
 							new GraphQLField("id"), new GraphQLField("map"),
 							new GraphQLField("string"),
 							new GraphQLField("version"))),
@@ -118,7 +115,7 @@ public class GraphQLServletTest {
 		// With namespace v2
 
 		_assertEqualsV2(
-			false, _testDTOV2,
+			false, _v2TestDTO,
 			JSONUtil.getValueAsJSONObject(
 				_invoke(
 					new GraphQLField(
@@ -126,7 +123,7 @@ public class GraphQLServletTest {
 						new GraphQLField(
 							"createTestDTO",
 							Collections.singletonMap(
-								"testDTO", _toGraphQLString(_testDTOV2)),
+								"testDTO", _toGraphQLString(_v2TestDTO)),
 							new GraphQLField("id"), new GraphQLField("map"),
 							new GraphQLField("string"),
 							new GraphQLField("version"))),
@@ -137,13 +134,13 @@ public class GraphQLServletTest {
 		// Without namespace (backwards compatibility)
 
 		_assertEqualsV2(
-			false, _testDTOV2,
+			false, _v2TestDTO,
 			JSONUtil.getValueAsJSONObject(
 				_invoke(
 					new GraphQLField(
 						"createTestDTO",
 						Collections.singletonMap(
-							"testDTO", _toGraphQLString(_testDTOV2)),
+							"testDTO", _toGraphQLString(_v2TestDTO)),
 						new GraphQLField("id"), new GraphQLField("map"),
 						new GraphQLField("string"),
 						new GraphQLField("version")),
@@ -151,13 +148,13 @@ public class GraphQLServletTest {
 				"JSONObject/data", "JSONObject/createTestDTO"));
 
 		_assertEqualsV1(
-			false, _testDTOV1,
+			false, _v1TestDTO,
 			JSONUtil.getValueAsJSONObject(
 				_invoke(
 					new GraphQLField(
 						"createTestDTOV1",
 						Collections.singletonMap(
-							"testDTO", _toGraphQLString(_testDTOV1)),
+							"testDTO", _toGraphQLString(_v1TestDTO)),
 						new GraphQLField("id"), new GraphQLField("map"),
 						new GraphQLField("string"),
 						new GraphQLField("version")),
@@ -165,13 +162,13 @@ public class GraphQLServletTest {
 				"JSONObject/data", "JSONObject/createTestDTOV1"));
 
 		_assertEqualsV2(
-			false, _testDTOV2,
+			false, _v2TestDTO,
 			JSONUtil.getValueAsJSONObject(
 				_invoke(
 					new GraphQLField(
 						"createTestDTOV2",
 						Collections.singletonMap(
-							"testDTO", _toGraphQLString(_testDTOV2)),
+							"testDTO", _toGraphQLString(_v2TestDTO)),
 						new GraphQLField("id"), new GraphQLField("map"),
 						new GraphQLField("string"),
 						new GraphQLField("version")),
@@ -185,7 +182,7 @@ public class GraphQLServletTest {
 		// With namespace v1
 
 		_assertEqualsV1(
-			true, _testDTOV1,
+			true, _v1TestDTO,
 			JSONUtil.getValueAsJSONObject(
 				_invoke(
 					new GraphQLField(
@@ -226,7 +223,7 @@ public class GraphQLServletTest {
 		// With namespace v2
 
 		_assertEqualsV2(
-			true, _testDTOV2,
+			true, _v2TestDTO,
 			JSONUtil.getValueAsJSONObject(
 				_invoke(
 					new GraphQLField(
@@ -267,7 +264,7 @@ public class GraphQLServletTest {
 		// Without namespace (backwards compatibility)
 
 		_assertEqualsV2(
-			true, _testDTOV2,
+			true, _v2TestDTO,
 			JSONUtil.getValueAsJSONObject(
 				_invoke(
 					new GraphQLField(
@@ -279,7 +276,7 @@ public class GraphQLServletTest {
 				"JSONObject/data", "JSONObject/testDTO"));
 
 		_assertEqualsV1(
-			true, _testDTOV1,
+			true, _v1TestDTO,
 			JSONUtil.getValueAsJSONObject(
 				_invoke(
 					new GraphQLField(
@@ -291,7 +288,7 @@ public class GraphQLServletTest {
 				"JSONObject/data", "JSONObject/testDTOV1"));
 
 		_assertEqualsV2(
-			true, _testDTOV2,
+			true, _v2TestDTO,
 			JSONUtil.getValueAsJSONObject(
 				_invoke(
 					new GraphQLField(
@@ -376,7 +373,7 @@ public class GraphQLServletTest {
 				).build());
 
 			_assertEqualsV2(
-				true, _testDTOV2,
+				true, _v2TestDTO,
 				JSONUtil.getValueAsJSONObject(
 					_invoke(
 						new GraphQLField(
@@ -834,8 +831,8 @@ public class GraphQLServletTest {
 
 	private ServiceRegistration<ServletData> _serviceRegistration1;
 	private ServiceRegistration<ServletData> _serviceRegistration2;
-	private TestDTO _testDTOV1;
+	private TestDTO _v1TestDTO;
 	private com.liferay.portal.vulcan.internal.graphql.servlet.test.v2_0.TestDTO
-		_testDTOV2;
+		_v2TestDTO;
 
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/GraphQLServletTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/GraphQLServletTest.java
@@ -107,7 +107,7 @@ public class GraphQLServletTest {
 						new GraphQLField(
 							"createTestDTO",
 							Collections.singletonMap(
-								"testDTO", _toGraphQLStringV1(_testDTOV1)),
+								"testDTO", _toGraphQLString(_testDTOV1)),
 							new GraphQLField("id"), new GraphQLField("map"),
 							new GraphQLField("string"),
 							new GraphQLField("version"))),
@@ -126,7 +126,7 @@ public class GraphQLServletTest {
 						new GraphQLField(
 							"createTestDTO",
 							Collections.singletonMap(
-								"testDTO", _toGraphQLStringV2(_testDTOV2)),
+								"testDTO", _toGraphQLString(_testDTOV2)),
 							new GraphQLField("id"), new GraphQLField("map"),
 							new GraphQLField("string"),
 							new GraphQLField("version"))),
@@ -145,7 +145,7 @@ public class GraphQLServletTest {
 						new GraphQLField(
 							"createTestDTO",
 							Collections.singletonMap(
-								"testDTO", _toGraphQLStringV2(_testDTOV2)),
+								"testDTO", _toGraphQLString(_testDTOV2)),
 							new GraphQLField("id"), new GraphQLField("map"),
 							new GraphQLField("string"),
 							new GraphQLField("version"))),
@@ -162,7 +162,7 @@ public class GraphQLServletTest {
 					new GraphQLField(
 						"createTestDTO",
 						Collections.singletonMap(
-							"testDTO", _toGraphQLStringV2(_testDTOV2)),
+							"testDTO", _toGraphQLString(_testDTOV2)),
 						new GraphQLField("id"), new GraphQLField("map"),
 						new GraphQLField("string"),
 						new GraphQLField("version")),
@@ -1162,18 +1162,14 @@ public class GraphQLServletTest {
 		Assert.assertEquals(expectedPageSize, jsonObject.getInt("pageSize"));
 	}
 
-	private String _toGraphQLStringV1(TestDTOV1 testDTO) throws Exception {
+	private String _toGraphQLString(Object objectDTO) throws Exception {
 		StringBuilder sb = new StringBuilder("{");
 
-		for (Field field : ReflectionUtil.getDeclaredFields(TestDTOV1.class)) {
+		for (Field field : ReflectionUtil.getDeclaredFields(objectDTO.getClass())) {
 			if (ArrayUtil.isEmpty(
 					field.getAnnotationsByType(
 						com.liferay.portal.vulcan.graphql.annotation.
-							GraphQLField.class)) &&
-				!field.getName(
-				).endsWith(
-					"VersionOnly"
-				)) {
+							GraphQLField.class))) {
 
 				continue;
 			}
@@ -1185,38 +1181,7 @@ public class GraphQLServletTest {
 			sb.append(field.getName());
 			sb.append(": ");
 
-			_appendGraphQLFieldValue(sb, field.get(testDTO));
-		}
-
-		sb.append("}");
-
-		return sb.toString();
-	}
-
-	private String _toGraphQLStringV2(TestDTOV2 testDTO) throws Exception {
-		StringBuilder sb = new StringBuilder("{");
-
-		for (Field field : ReflectionUtil.getDeclaredFields(TestDTOV2.class)) {
-			if (ArrayUtil.isEmpty(
-					field.getAnnotationsByType(
-						com.liferay.portal.vulcan.graphql.annotation.
-							GraphQLField.class)) &&
-				field.getName(
-				).endsWith(
-					"versionOnly"
-				)) {
-
-				continue;
-			}
-
-			if (sb.length() > 1) {
-				sb.append(", ");
-			}
-
-			sb.append(field.getName());
-			sb.append(": ");
-
-			_appendGraphQLFieldValue(sb, field.get(testDTO));
+			_appendGraphQLFieldValue(sb, field.get(objectDTO));
 		}
 
 		sb.append("}");

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/GraphQLServletTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/GraphQLServletTest.java
@@ -633,7 +633,7 @@ public class GraphQLServletTest {
 		}
 
 		public String getExtendedString() {
-			return _extendedString + " " + version + " version";
+			return _extendedString;
 		}
 
 		public long getId() {
@@ -698,7 +698,7 @@ public class GraphQLServletTest {
 		}
 
 		public String getExtendedString() {
-			return _extendedString + " " + version +" version";
+			return _extendedString;
 		}
 
 		public long getId() {

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/GraphQLServletTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/GraphQLServletTest.java
@@ -153,6 +153,40 @@ public class GraphQLServletTest {
 				"JSONObject/data", "JSONObject/testPath",
 				"JSONObject/createTestDTO"));
 
+		_assertEqualsV1(
+			false, _testDTOV1,
+			JSONUtil.getValueAsJSONObject(
+				_invoke(
+					new GraphQLField(
+						"testPath",
+						new GraphQLField(
+							"createTestDTOV1",
+							Collections.singletonMap(
+								"testDTO", _toGraphQLString(_testDTOV1)),
+							new GraphQLField("id"), new GraphQLField("map"),
+							new GraphQLField("string"),
+							new GraphQLField("version"))),
+					"mutation"),
+				"JSONObject/data", "JSONObject/testPath",
+				"JSONObject/createTestDTOV1"));
+
+		_assertEqualsV2(
+			false, _testDTOV2,
+			JSONUtil.getValueAsJSONObject(
+				_invoke(
+					new GraphQLField(
+						"testPath",
+						new GraphQLField(
+							"createTestDTOV2",
+							Collections.singletonMap(
+								"testDTO", _toGraphQLString(_testDTOV2)),
+							new GraphQLField("id"), new GraphQLField("map"),
+							new GraphQLField("string"),
+							new GraphQLField("version"))),
+					"mutation"),
+				"JSONObject/data", "JSONObject/testPath",
+				"JSONObject/createTestDTOV2"));
+
 		// Without namespace (backwards compatibility)
 
 		_assertEqualsV2(
@@ -168,6 +202,34 @@ public class GraphQLServletTest {
 						new GraphQLField("version")),
 					"mutation"),
 				"JSONObject/data", "JSONObject/createTestDTO"));
+
+		_assertEqualsV1(
+			false, _testDTOV1,
+			JSONUtil.getValueAsJSONObject(
+				_invoke(
+					new GraphQLField(
+						"createTestDTOV1",
+						Collections.singletonMap(
+							"testDTO", _toGraphQLString(_testDTOV1)),
+						new GraphQLField("id"), new GraphQLField("map"),
+						new GraphQLField("string"),
+						new GraphQLField("version")),
+					"mutation"),
+				"JSONObject/data", "JSONObject/createTestDTOV1"));
+
+		_assertEqualsV2(
+			false, _testDTOV2,
+			JSONUtil.getValueAsJSONObject(
+				_invoke(
+					new GraphQLField(
+						"createTestDTOV2",
+						Collections.singletonMap(
+							"testDTO", _toGraphQLString(_testDTOV2)),
+						new GraphQLField("id"), new GraphQLField("map"),
+						new GraphQLField("string"),
+						new GraphQLField("version")),
+					"mutation"),
+				"JSONObject/data", "JSONObject/createTestDTOV2"));
 	}
 
 	@Test
@@ -269,7 +331,8 @@ public class GraphQLServletTest {
 							new GraphQLField("string"),
 							new GraphQLField("version"))),
 					"query"),
-				"JSONObject/data", "JSONObject/testPath", "JSONObject/testDTO"));
+				"JSONObject/data", "JSONObject/testPath",
+				"JSONObject/testDTO"));
 
 		_assertEqualsV1(
 			true, _testDTOV1,
@@ -283,7 +346,8 @@ public class GraphQLServletTest {
 							new GraphQLField("string"),
 							new GraphQLField("version"))),
 					"query"),
-				"JSONObject/data", "JSONObject/testPath",  "JSONObject/testDTOV1"));
+				"JSONObject/data", "JSONObject/testPath",
+				"JSONObject/testDTOV1"));
 
 		_assertEqualsV2(
 			true, _testDTOV2,
@@ -297,7 +361,8 @@ public class GraphQLServletTest {
 							new GraphQLField("string"),
 							new GraphQLField("version"))),
 					"query"),
-				"JSONObject/data", "JSONObject/testPath", "JSONObject/testDTOV2"));
+				"JSONObject/data", "JSONObject/testPath",
+				"JSONObject/testDTOV2"));
 
 		Assert.assertEquals(
 			"Not Found",

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/v1_0/TestDTO.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/v1_0/TestDTO.java
@@ -1,0 +1,77 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.vulcan.internal.graphql.servlet.test.v1_0;
+
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+
+import java.util.Map;
+
+/**
+ * @author Carlos Correa
+ */
+public class TestDTO {
+
+	public TestDTO() {
+		this(
+			RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
+			HashMapBuilder.put(
+				"a" + RandomTestUtil.randomString(),
+				RandomTestUtil.randomString()
+			).put(
+				"a" + RandomTestUtil.randomString(),
+				RandomTestUtil.randomString()
+			).build(),
+			RandomTestUtil.randomString());
+	}
+
+	public TestDTO(
+		String extendedString, long id, Map<String, String> map,
+		String string) {
+
+		_extendedString = extendedString;
+
+		this.id = id;
+		this.map = map;
+		this.string = string;
+	}
+
+	public String getExtendedString() {
+		return _extendedString;
+	}
+
+	public long getId() {
+		return id;
+	}
+
+	public Map<String, String> getMap() {
+		return map;
+	}
+
+	public String getString() {
+		return string;
+	}
+
+	public double getVersion() {
+		return version;
+	}
+
+	@GraphQLField
+	protected long id;
+
+	@GraphQLField
+	protected Map<String, String> map;
+
+	@GraphQLField
+	protected String string;
+
+	@GraphQLField
+	protected int version = 1;
+
+	private String _extendedString;
+
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/v1_0/TestDTO.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/v1_0/TestDTO.java
@@ -16,32 +16,8 @@ import java.util.Map;
  */
 public class TestDTO {
 
-	public TestDTO() {
-		this(
-			RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
-			HashMapBuilder.put(
-				"a" + RandomTestUtil.randomString(),
-				RandomTestUtil.randomString()
-			).put(
-				"a" + RandomTestUtil.randomString(),
-				RandomTestUtil.randomString()
-			).build(),
-			RandomTestUtil.randomString());
-	}
-
-	public TestDTO(
-		String extendedString, long id, Map<String, String> map,
-		String string) {
-
-		_extendedString = extendedString;
-
-		this.id = id;
-		this.map = map;
-		this.string = string;
-	}
-
 	public String getExtendedString() {
-		return _extendedString;
+		return _EXTENDED_STRING;
 	}
 
 	public long getId() {
@@ -61,17 +37,22 @@ public class TestDTO {
 	}
 
 	@GraphQLField
-	protected long id;
+	protected long id = RandomTestUtil.randomLong();
 
 	@GraphQLField
-	protected Map<String, String> map;
+	protected Map<String, String> map = HashMapBuilder.put(
+		"a" + RandomTestUtil.randomString(), RandomTestUtil.randomString()
+	).put(
+		"a" + RandomTestUtil.randomString(), RandomTestUtil.randomString()
+	).build();
 
 	@GraphQLField
-	protected String string;
+	protected String string = RandomTestUtil.randomString();
 
 	@GraphQLField
 	protected int version = 1;
 
-	private String _extendedString;
+	private static final String _EXTENDED_STRING =
+		RandomTestUtil.randomString();
 
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/v1_0/TestDTOPage.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/v1_0/TestDTOPage.java
@@ -1,0 +1,34 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.vulcan.internal.graphql.servlet.test.v1_0;
+
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+
+/**
+ * @author Carlos Correa
+ */
+public class TestDTOPage {
+
+	public TestDTOPage(int page, int pageSize) {
+		this.page = page;
+		this.pageSize = pageSize;
+	}
+
+	public int getPage() {
+		return page;
+	}
+
+	public int getPageSize() {
+		return pageSize;
+	}
+
+	@GraphQLField
+	protected int page;
+
+	@GraphQLField
+	protected int pageSize;
+
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/v1_0/TestDTOPage.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/v1_0/TestDTOPage.java
@@ -17,14 +17,6 @@ public class TestDTOPage {
 		this.pageSize = pageSize;
 	}
 
-	public int getPage() {
-		return page;
-	}
-
-	public int getPageSize() {
-		return pageSize;
-	}
-
 	@GraphQLField
 	protected int page;
 

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/v1_0/TestMutation.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/v1_0/TestMutation.java
@@ -18,4 +18,9 @@ public class TestMutation {
 		return testDTO;
 	}
 
+	@GraphQLField
+	public TestDTO createTestDTOV1(@GraphQLName("testDTO") TestDTO testDTO) {
+		return testDTO;
+	}
+
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/v1_0/TestMutation.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/v1_0/TestMutation.java
@@ -1,0 +1,21 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.vulcan.internal.graphql.servlet.test.v1_0;
+
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+
+/**
+ * @author Carlos Correa
+ */
+public class TestMutation {
+
+	@GraphQLField
+	public TestDTO createTestDTO(@GraphQLName("testDTO") TestDTO testDTO) {
+		return testDTO;
+	}
+
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/v1_0/TestQuery.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/v1_0/TestQuery.java
@@ -38,6 +38,11 @@ public class TestQuery {
 	}
 
 	@GraphQLField
+	public TestDTO testDTOV1() {
+		return _testDTO;
+	}
+
+	@GraphQLField
 	public TestDTO testNoPermissionOverDTO()
 		throws PrincipalException.MustHavePermission {
 

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/v1_0/TestQuery.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/v1_0/TestQuery.java
@@ -1,0 +1,71 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.vulcan.internal.graphql.servlet.test.v1_0;
+
+import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLTypeExtension;
+
+import javax.ws.rs.NotFoundException;
+
+/**
+ * @author Carlos Correa
+ */
+public class TestQuery {
+
+	public TestQuery() {
+	}
+
+	public TestQuery(TestDTO testDTO) {
+		_testDTO = testDTO;
+	}
+
+	@GraphQLField
+	public TestDTO testDTO() {
+		return _testDTO;
+	}
+
+	@GraphQLField
+	public TestDTOPage testDTOPage(
+		@GraphQLName("page") int page, @GraphQLName("pageSize") int pageSize) {
+
+		return new TestDTOPage(page, pageSize);
+	}
+
+	@GraphQLField
+	public TestDTO testNoPermissionOverDTO()
+		throws PrincipalException.MustHavePermission {
+
+		throw new PrincipalException.MustHavePermission(
+			0L, StringUtil.randomString());
+	}
+
+	@GraphQLField
+	public TestDTO testNotFoundDTO() {
+		throw new NotFoundException();
+	}
+
+	@GraphQLTypeExtension(TestDTO.class)
+	public class TestGraphQLTypeExtension {
+
+		public TestGraphQLTypeExtension(TestDTO testDTO) {
+			_testDTO = testDTO;
+		}
+
+		@GraphQLField
+		public String extendedString() {
+			return _testDTO.getExtendedString();
+		}
+
+		private final TestDTO _testDTO;
+
+	}
+
+	private static TestDTO _testDTO;
+
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/v1_0/TestServletData.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/v1_0/TestServletData.java
@@ -1,0 +1,47 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.vulcan.internal.graphql.servlet.test.v1_0;
+
+import com.liferay.portal.vulcan.graphql.servlet.ServletData;
+
+/**
+ * @author Carlos Correa
+ */
+public class TestServletData implements ServletData {
+
+	public TestServletData(TestDTO testDTO) {
+		_testQuery = new TestQuery(testDTO);
+	}
+
+	@Override
+	public String getApplicationName() {
+		return "test";
+	}
+
+	@Override
+	public Object getMutation() {
+		return _testMutationV1;
+	}
+
+	@Override
+	public String getPath() {
+		return "/test-path-graphql/v1_0";
+	}
+
+	@Override
+	public TestQuery getQuery() {
+		return _testQuery;
+	}
+
+	@Override
+	public boolean isJaxRsResourceInvocation() {
+		return false;
+	}
+
+	private final TestMutation _testMutationV1 = new TestMutation();
+	private final TestQuery _testQuery;
+
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/v1_0/TestServletData.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/v1_0/TestServletData.java
@@ -23,7 +23,7 @@ public class TestServletData implements ServletData {
 
 	@Override
 	public Object getMutation() {
-		return _testMutationV1;
+		return _testMutation;
 	}
 
 	@Override
@@ -41,7 +41,7 @@ public class TestServletData implements ServletData {
 		return false;
 	}
 
-	private final TestMutation _testMutationV1 = new TestMutation();
+	private final TestMutation _testMutation = new TestMutation();
 	private final TestQuery _testQuery;
 
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/v2_0/TestDTO.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/v2_0/TestDTO.java
@@ -1,0 +1,77 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.vulcan.internal.graphql.servlet.test.v2_0;
+
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+
+import java.util.Map;
+
+/**
+ * @author Carlos Correa
+ */
+public class TestDTO {
+
+	public TestDTO() {
+		this(
+			RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
+			HashMapBuilder.put(
+				"a" + RandomTestUtil.randomString(),
+				RandomTestUtil.randomString()
+			).put(
+				"a" + RandomTestUtil.randomString(),
+				RandomTestUtil.randomString()
+			).build(),
+			RandomTestUtil.randomString());
+	}
+
+	public TestDTO(
+		String extendedString, long id, Map<String, String> map,
+		String string) {
+
+		_extendedString = extendedString;
+
+		this.id = id;
+		this.map = map;
+		this.string = string;
+	}
+
+	public String getExtendedString() {
+		return _extendedString;
+	}
+
+	public long getId() {
+		return id;
+	}
+
+	public Map<String, String> getMap() {
+		return map;
+	}
+
+	public String getString() {
+		return string;
+	}
+
+	public double getVersion() {
+		return version;
+	}
+
+	@GraphQLField
+	protected long id;
+
+	@GraphQLField
+	protected Map<String, String> map;
+
+	@GraphQLField
+	protected String string;
+
+	@GraphQLField
+	protected int version = 2;
+
+	private String _extendedString;
+
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/v2_0/TestDTO.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/v2_0/TestDTO.java
@@ -16,32 +16,8 @@ import java.util.Map;
  */
 public class TestDTO {
 
-	public TestDTO() {
-		this(
-			RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
-			HashMapBuilder.put(
-				"a" + RandomTestUtil.randomString(),
-				RandomTestUtil.randomString()
-			).put(
-				"a" + RandomTestUtil.randomString(),
-				RandomTestUtil.randomString()
-			).build(),
-			RandomTestUtil.randomString());
-	}
-
-	public TestDTO(
-		String extendedString, long id, Map<String, String> map,
-		String string) {
-
-		_extendedString = extendedString;
-
-		this.id = id;
-		this.map = map;
-		this.string = string;
-	}
-
 	public String getExtendedString() {
-		return _extendedString;
+		return _EXTENDED_STRING;
 	}
 
 	public long getId() {
@@ -61,17 +37,22 @@ public class TestDTO {
 	}
 
 	@GraphQLField
-	protected long id;
+	protected long id = RandomTestUtil.randomLong();
 
 	@GraphQLField
-	protected Map<String, String> map;
+	protected Map<String, String> map = HashMapBuilder.put(
+		"a" + RandomTestUtil.randomString(), RandomTestUtil.randomString()
+	).put(
+		"a" + RandomTestUtil.randomString(), RandomTestUtil.randomString()
+	).build();
 
 	@GraphQLField
-	protected String string;
+	protected String string = RandomTestUtil.randomString();
 
 	@GraphQLField
 	protected int version = 2;
 
-	private String _extendedString;
+	private static final String _EXTENDED_STRING =
+		RandomTestUtil.randomString();
 
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/v2_0/TestDTOPage.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/v2_0/TestDTOPage.java
@@ -17,14 +17,6 @@ public class TestDTOPage {
 		this.pageSize = pageSize;
 	}
 
-	public int getPage() {
-		return page;
-	}
-
-	public int getPageSize() {
-		return pageSize;
-	}
-
 	@GraphQLField
 	protected int page;
 

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/v2_0/TestDTOPage.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/v2_0/TestDTOPage.java
@@ -1,0 +1,34 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.vulcan.internal.graphql.servlet.test.v2_0;
+
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+
+/**
+ * @author Carlos Correa
+ */
+public class TestDTOPage {
+
+	public TestDTOPage(int page, int pageSize) {
+		this.page = page;
+		this.pageSize = pageSize;
+	}
+
+	public int getPage() {
+		return page;
+	}
+
+	public int getPageSize() {
+		return pageSize;
+	}
+
+	@GraphQLField
+	protected int page;
+
+	@GraphQLField
+	protected int pageSize;
+
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/v2_0/TestMutation.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/v2_0/TestMutation.java
@@ -18,4 +18,9 @@ public class TestMutation {
 		return testDTO;
 	}
 
+	@GraphQLField
+	public TestDTO createTestDTOV2(@GraphQLName("testDTO") TestDTO testDTO) {
+		return testDTO;
+	}
+
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/v2_0/TestMutation.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/v2_0/TestMutation.java
@@ -1,0 +1,21 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.vulcan.internal.graphql.servlet.test.v2_0;
+
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+
+/**
+ * @author Carlos Correa
+ */
+public class TestMutation {
+
+	@GraphQLField
+	public TestDTO createTestDTO(@GraphQLName("testDTO") TestDTO testDTO) {
+		return testDTO;
+	}
+
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/v2_0/TestQuery.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/v2_0/TestQuery.java
@@ -38,6 +38,11 @@ public class TestQuery {
 	}
 
 	@GraphQLField
+	public TestDTO testDTOV2() {
+		return _testDTO;
+	}
+
+	@GraphQLField
 	public TestDTO testNoPermissionOverDTO()
 		throws PrincipalException.MustHavePermission {
 

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/v2_0/TestQuery.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/v2_0/TestQuery.java
@@ -1,0 +1,71 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.vulcan.internal.graphql.servlet.test.v2_0;
+
+import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLTypeExtension;
+
+import javax.ws.rs.NotFoundException;
+
+/**
+ * @author Carlos Correa
+ */
+public class TestQuery {
+
+	public TestQuery() {
+	}
+
+	public TestQuery(TestDTO testDTO) {
+		_testDTO = testDTO;
+	}
+
+	@GraphQLField
+	public TestDTO testDTO() {
+		return _testDTO;
+	}
+
+	@GraphQLField
+	public TestDTOPage testDTOPage(
+		@GraphQLName("page") int page, @GraphQLName("pageSize") int pageSize) {
+
+		return new TestDTOPage(page, pageSize);
+	}
+
+	@GraphQLField
+	public TestDTO testNoPermissionOverDTO()
+		throws PrincipalException.MustHavePermission {
+
+		throw new PrincipalException.MustHavePermission(
+			0L, StringUtil.randomString());
+	}
+
+	@GraphQLField
+	public TestDTO testNotFoundDTO() {
+		throw new NotFoundException();
+	}
+
+	@GraphQLTypeExtension(TestDTO.class)
+	public class TestGraphQLTypeExtension {
+
+		public TestGraphQLTypeExtension(TestDTO testDTO) {
+			_testDTO = testDTO;
+		}
+
+		@GraphQLField
+		public String extendedString() {
+			return _testDTO.getExtendedString();
+		}
+
+		private final TestDTO _testDTO;
+
+	}
+
+	private static TestDTO _testDTO;
+
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/v2_0/TestServletData.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/v2_0/TestServletData.java
@@ -1,0 +1,47 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.vulcan.internal.graphql.servlet.test.v2_0;
+
+import com.liferay.portal.vulcan.graphql.servlet.ServletData;
+
+/**
+ * @author Carlos Correa
+ */
+public class TestServletData implements ServletData {
+
+	public TestServletData(TestDTO testDTO) {
+		_testQuery = new TestQuery(testDTO);
+	}
+
+	@Override
+	public String getApplicationName() {
+		return "test";
+	}
+
+	@Override
+	public Object getMutation() {
+		return _testMutationV1;
+	}
+
+	@Override
+	public String getPath() {
+		return "/test-path-graphql/v2_0";
+	}
+
+	@Override
+	public TestQuery getQuery() {
+		return _testQuery;
+	}
+
+	@Override
+	public boolean isJaxRsResourceInvocation() {
+		return false;
+	}
+
+	private final TestMutation _testMutationV1 = new TestMutation();
+	private final TestQuery _testQuery;
+
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/v2_0/TestServletData.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/v2_0/TestServletData.java
@@ -23,7 +23,7 @@ public class TestServletData implements ServletData {
 
 	@Override
 	public Object getMutation() {
-		return _testMutationV1;
+		return _testMutationV2;
 	}
 
 	@Override
@@ -41,7 +41,7 @@ public class TestServletData implements ServletData {
 		return false;
 	}
 
-	private final TestMutation _testMutationV1 = new TestMutation();
+	private final TestMutation _testMutationV2 = new TestMutation();
 	private final TestQuery _testQuery;
 
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/v2_0/TestServletData.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/v2_0/TestServletData.java
@@ -23,7 +23,7 @@ public class TestServletData implements ServletData {
 
 	@Override
 	public Object getMutation() {
-		return _testMutationV2;
+		return _testMutation;
 	}
 
 	@Override
@@ -41,7 +41,7 @@ public class TestServletData implements ServletData {
 		return false;
 	}
 
-	private final TestMutation _testMutationV2 = new TestMutation();
+	private final TestMutation _testMutation = new TestMutation();
 	private final TestQuery _testQuery;
 
 }


### PR DESCRIPTION
Related ticket: https://liferay.atlassian.net/browse/LPD-26304

See https://github.com/liferay-headless/liferay-portal/pull/2023

---

The purpose of this ticket is to improve the already existing GraphQL by including several ServletData considering different versions to test:

- We always select the latest version of the query/mutation when there is no namespace set
- We always provide the query/mutation available, given a autogenerated namespace with the REST API version

---

This refactor was included as part of the story https://liferay.atlassian.net/browse/LPD-16317, but as we are not working on it anymore (at least in short term), we want to send to master all the improvements and tests we develop as part of that story. That is why we created the task and this pull request

cc/ @ZakiMiklos 