### PR TITLE
LPD-21348 Checking default user existence, if removed upgrade won't finish

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/v9_2_1/ObjectDefinitionUpgradeProcess.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/v9_2_1/ObjectDefinitionUpgradeProcess.java
@@ -39,10 +39,16 @@ public class ObjectDefinitionUpgradeProcess extends UpgradeProcess {
 								"userId is null and ObjectDefinition.",
 								"companyId = ?"))) {
 
-					User user = _userLocalService.getUserByScreenName(
-						company.getCompanyId(), "default-service-account");
+					User defaultServiceAccountUser =
+						_userLocalService.fetchUserByScreenName(
+							user.getCompanyId(), "default-service-account");
 
-					preparedStatement1.setLong(1, user.getUserId());
+					if (defaultServiceAccountUser == null) {
+						continue;
+					}
+
+					preparedStatement1.setLong(
+						1, defaultServiceAccountUser.getUserId());
 
 					preparedStatement1.setLong(2, company.getCompanyId());
 


### PR DESCRIPTION
Hi Brian, after testing the alternative you suggested to check if the user is the defaultuser, the instances continued to not be deleted. I recorded a video of the scene, if you want to see it.

[Screencast from 2024-05-23 08-05-33.webm](https://github.com/brianchandotcom/liferay-portal/assets/41641596/d5edf3aa-4a83-4c61-9f9d-2c7138c5f4a7)

Still, I received a build failure notification and I'm sending this pr as an additional change to the fix, to handle upgrade cases as well. 

https://liferay.slack.com/archives/CLCD3DQLF/p1716415974262799?thread_ts=1716407799.275019&cid=CLCD3DQLF

Please, let me know what do you think, because I know it's something you wanted to avoid.

