### PR TITLE
 LPD-25361 - Trigger on after create|update actions after transaction commit

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/model/listener/ObjectEntryModelListener.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/model/listener/ObjectEntryModelListener.java
@@ -101,9 +101,48 @@ public class ObjectEntryModelListener extends BaseModelListener<ObjectEntry> {
 			throw new ModelListenerException(portalException);
 		}
 
-		_executeObjectActions(
-			ObjectActionTriggerConstants.KEY_ON_AFTER_DELETE, objectEntry,
-			objectEntry);
+		try {
+			long userId = PrincipalThreadLocal.getUserId();
+
+			if (userId == 0) {
+				userId = objectEntry.getUserId();
+			}
+
+			User user = _userLocalService.getUser(userId);
+
+			_executeObjectActions(
+				ObjectActionTriggerConstants.KEY_ON_AFTER_DELETE, objectEntry,
+				objectEntry, user);
+
+			if (!FeatureFlagManagerUtil.isEnabled("LPS-187142")) {
+				return;
+			}
+
+			ObjectDefinition objectDefinition =
+				_objectDefinitionLocalService.getObjectDefinition(
+					objectEntry.getObjectDefinitionId());
+
+			if (!objectDefinition.isRootDescendantNode() ||
+				!objectDefinition.isRootNode()) {
+
+				return;
+			}
+
+			ObjectEntry rootObjectEntry =
+				_objectEntryLocalService.fetchObjectEntry(
+					objectEntry.getRootObjectEntryId());
+
+			if (rootObjectEntry == null) {
+				return;
+			}
+
+			_executeObjectActions(
+				ObjectActionTriggerConstants.KEY_ON_AFTER_ROOT_UPDATE, null,
+				rootObjectEntry, user);
+		}
+		catch (PortalException portalException) {
+			throw new ModelListenerException(portalException);
+		}
 
 		_runRelevantObjectEntryModelListeners(
 			objectEntry,
@@ -180,56 +219,6 @@ public class ObjectEntryModelListener extends BaseModelListener<ObjectEntry> {
 	protected void activate(BundleContext bundleContext) {
 		_relevantObjectEntryModelListeners = ServiceTrackerListFactory.open(
 			bundleContext, RelevantObjectEntryModelListener.class);
-	}
-
-	private void _executeObjectActions(
-			String objectActionTriggerKey, ObjectEntry originalObjectEntry,
-			ObjectEntry objectEntry)
-		throws ModelListenerException {
-
-		try {
-			long userId = PrincipalThreadLocal.getUserId();
-
-			if (userId == 0) {
-				userId = objectEntry.getUserId();
-			}
-
-			User user = _userLocalService.getUser(userId);
-
-			_executeObjectActions(
-				objectActionTriggerKey, originalObjectEntry, objectEntry, user);
-
-			if (!FeatureFlagManagerUtil.isEnabled("LPS-187142")) {
-				return;
-			}
-
-			ObjectDefinition objectDefinition =
-				_objectDefinitionLocalService.getObjectDefinition(
-					objectEntry.getObjectDefinitionId());
-
-			if (!objectDefinition.isRootDescendantNode() &&
-				(!objectDefinition.isRootNode() ||
-				 StringUtil.equals(
-					 objectActionTriggerKey,
-					 ObjectActionTriggerConstants.KEY_ON_AFTER_ADD))) {
-
-				return;
-			}
-
-			objectEntry = _objectEntryLocalService.fetchObjectEntry(
-				objectEntry.getRootObjectEntryId());
-
-			if (objectEntry == null) {
-				return;
-			}
-
-			_executeObjectActions(
-				ObjectActionTriggerConstants.KEY_ON_AFTER_ROOT_UPDATE, null,
-				objectEntry, user);
-		}
-		catch (PortalException portalException) {
-			throw new ModelListenerException(portalException);
-		}
 	}
 
 	private void _executeObjectActions(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/model/listener/ObjectEntryModelListener.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/model/listener/ObjectEntryModelListener.java
@@ -118,10 +118,6 @@ public class ObjectEntryModelListener extends BaseModelListener<ObjectEntry> {
 
 		_route(EventTypes.UPDATE, originalObjectEntry, objectEntry);
 
-		_executeObjectActions(
-			ObjectActionTriggerConstants.KEY_ON_AFTER_UPDATE,
-			originalObjectEntry, objectEntry);
-
 		_runRelevantObjectEntryModelListeners(
 			objectEntry,
 			relevantObjectEntryModelListener ->

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/model/listener/ObjectEntryModelListener.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/model/listener/ObjectEntryModelListener.java
@@ -82,9 +82,6 @@ public class ObjectEntryModelListener extends BaseModelListener<ObjectEntry> {
 
 		_route(EventTypes.ADD, null, objectEntry);
 
-		_executeObjectActions(
-			ObjectActionTriggerConstants.KEY_ON_AFTER_ADD, null, objectEntry);
-
 		_runRelevantObjectEntryModelListeners(
 			objectEntry,
 			relevantObjectEntryModelListener ->

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -38,6 +38,7 @@ import com.liferay.object.entry.ObjectEntryContext;
 import com.liferay.object.entry.contributor.ObjectEntryValuesContributor;
 import com.liferay.object.entry.util.ObjectEntryThreadLocal;
 import com.liferay.object.exception.DuplicateObjectEntryExternalReferenceCodeException;
+import com.liferay.object.exception.NoSuchObjectDefinitionException;
 import com.liferay.object.exception.NoSuchObjectFieldException;
 import com.liferay.object.exception.ObjectDefinitionScopeException;
 import com.liferay.object.exception.ObjectEntryStatusException;
@@ -124,6 +125,7 @@ import com.liferay.portal.kernel.dao.orm.FinderCacheUtil;
 import com.liferay.portal.kernel.encryptor.Encryptor;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -1579,6 +1581,11 @@ public class ObjectEntryLocalServiceImpl
 
 		_reindex(objectEntry);
 
+		_executeObjectActions(
+			objectEntry.getCompanyId(),
+			ObjectActionTriggerConstants.KEY_ON_AFTER_UPDATE, objectDefinition,
+			objectEntry, user);
+
 		return objectEntry;
 	}
 
@@ -2008,8 +2015,10 @@ public class ObjectEntryLocalServiceImpl
 	}
 
 	private void _executeObjectActions(
-		long companyId, String objectActionTrigger,
-		ObjectDefinition objectDefinition, ObjectEntry objectEntry, User user) {
+			long companyId, String objectActionTrigger,
+			ObjectDefinition objectDefinition, ObjectEntry objectEntry,
+			User user)
+		throws NoSuchObjectDefinitionException {
 
 		ObjectActionEngine objectActionEngine =
 			_objectActionEngineSnapshot.get();
@@ -2019,6 +2028,34 @@ public class ObjectEntryLocalServiceImpl
 			() -> ObjectEntryUtil.getPayloadJSONObject(
 				_dtoConverterRegistry, _jsonFactory, objectActionTrigger,
 				objectDefinition, objectEntry, null, user),
+			user.getUserId());
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPS-187142") ||
+			(!objectDefinition.isRootDescendantNode() &&
+			 (!objectDefinition.isRootNode() ||
+			  StringUtil.equals(
+				  objectActionTrigger,
+				  ObjectActionTriggerConstants.KEY_ON_AFTER_ADD)))) {
+
+			return;
+		}
+
+		ObjectEntry rootObjectEntry = fetchObjectEntry(
+			objectEntry.getRootObjectEntryId());
+
+		if (rootObjectEntry == null) {
+			return;
+		}
+
+		objectActionEngine.executeObjectActions(
+			rootObjectEntry.getModelClassName(), companyId,
+			ObjectActionTriggerConstants.KEY_ON_AFTER_ROOT_UPDATE,
+			() -> ObjectEntryUtil.getPayloadJSONObject(
+				_dtoConverterRegistry, _jsonFactory,
+				ObjectActionTriggerConstants.KEY_ON_AFTER_ROOT_UPDATE,
+				_objectDefinitionPersistence.findByPrimaryKey(
+					rootObjectEntry.getObjectDefinitionId()),
+				rootObjectEntry, null, user),
 			user.getUserId());
 	}
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -24,8 +24,10 @@ import com.liferay.dynamic.data.mapping.expression.DDMExpressionFactory;
 import com.liferay.dynamic.data.mapping.util.NumberUtil;
 import com.liferay.list.type.model.ListTypeEntry;
 import com.liferay.list.type.service.ListTypeEntryLocalService;
+import com.liferay.object.action.engine.ObjectActionEngine;
 import com.liferay.object.action.util.ObjectActionThreadLocal;
 import com.liferay.object.configuration.ObjectConfiguration;
+import com.liferay.object.constants.ObjectActionTriggerConstants;
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.constants.ObjectFieldSettingConstants;
@@ -47,6 +49,7 @@ import com.liferay.object.field.business.type.ObjectFieldBusinessTypeRegistry;
 import com.liferay.object.field.setting.util.ObjectFieldSettingUtil;
 import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.internal.entry.util.ObjectEntrySearchUtil;
+import com.liferay.object.internal.entry.util.ObjectEntryUtil;
 import com.liferay.object.internal.filter.parser.CurrentUserObjectFilterParser;
 import com.liferay.object.internal.filter.parser.DateRangeObjectFilterParser;
 import com.liferay.object.internal.filter.parser.EqualityOperatorsObjectFilterParser;
@@ -187,6 +190,7 @@ import com.liferay.portal.search.sort.SortOrder;
 import com.liferay.portal.search.sort.Sorts;
 import com.liferay.portal.service.PersistedModelLocalServiceRegistryUtil;
 import com.liferay.portal.util.PropsValues;
+import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -305,16 +309,7 @@ public class ObjectEntryLocalServiceImpl
 			objectEntry.getUserId(), objectDefinition.getClassName(),
 			objectEntry.getPrimaryKey(), false, false, false);
 
-		boolean clearObjectEntryIdsMap =
-			ObjectActionThreadLocal.isClearObjectEntryIdsMap();
-
 		try {
-			if (clearObjectEntryIdsMap) {
-				ObjectActionThreadLocal.clearObjectEntryIdsMap();
-			}
-
-			ObjectActionThreadLocal.setClearObjectEntryIdsMap(false);
-
 			if (workflowAction == WorkflowConstants.ACTION_SAVE_DRAFT) {
 				ObjectEntryThreadLocal.setSkipObjectValidationRules(true);
 			}
@@ -322,9 +317,6 @@ public class ObjectEntryLocalServiceImpl
 			objectEntry = objectEntryPersistence.update(objectEntry);
 		}
 		finally {
-			ObjectActionThreadLocal.setClearObjectEntryIdsMap(
-				clearObjectEntryIdsMap);
-
 			ObjectEntryThreadLocal.setSkipObjectValidationRules(false);
 		}
 
@@ -338,6 +330,26 @@ public class ObjectEntryLocalServiceImpl
 		_startWorkflowInstance(userId, objectEntry, serviceContext);
 
 		_reindex(objectEntry);
+
+		boolean clearObjectEntryIdsMap =
+			ObjectActionThreadLocal.isClearObjectEntryIdsMap();
+
+		try {
+			if (clearObjectEntryIdsMap) {
+				ObjectActionThreadLocal.clearObjectEntryIdsMap();
+			}
+
+			ObjectActionThreadLocal.setClearObjectEntryIdsMap(false);
+
+			_executeObjectActions(
+				objectEntry.getCompanyId(),
+				ObjectActionTriggerConstants.KEY_ON_AFTER_ADD, objectDefinition,
+				objectEntry, user);
+		}
+		finally {
+			ObjectActionThreadLocal.setClearObjectEntryIdsMap(
+				clearObjectEntryIdsMap);
+		}
 
 		return objectEntry;
 	}
@@ -1993,6 +2005,21 @@ public class ObjectEntryLocalServiceImpl
 				pkObjectFieldDBColumnName, " = ", primaryKey));
 
 		FinderCacheUtil.clearDSLQueryCache(dbTableName);
+	}
+
+	private void _executeObjectActions(
+		long companyId, String objectActionTrigger,
+		ObjectDefinition objectDefinition, ObjectEntry objectEntry, User user) {
+
+		ObjectActionEngine objectActionEngine =
+			_objectActionEngineSnapshot.get();
+
+		objectActionEngine.executeObjectActions(
+			objectDefinition.getClassName(), companyId, objectActionTrigger,
+			() -> ObjectEntryUtil.getPayloadJSONObject(
+				_dtoConverterRegistry, _jsonFactory, objectActionTrigger,
+				objectDefinition, objectEntry, null, user),
+			user.getUserId());
 	}
 
 	private void _fillDefaultValue(
@@ -4853,6 +4880,9 @@ public class ObjectEntryLocalServiceImpl
 	private static final Log _log = LogFactoryUtil.getLog(
 		ObjectEntryLocalServiceImpl.class);
 
+	private static final Snapshot<ObjectActionEngine>
+		_objectActionEngineSnapshot = new Snapshot<>(
+			ObjectEntryLocalServiceImpl.class, ObjectActionEngine.class, null);
 	private static final Snapshot<ObjectRelationshipLocalService>
 		_objectRelationshipLocalServiceSnapshot = new Snapshot<>(
 			ObjectEntryLocalServiceImpl.class,
@@ -4885,6 +4915,9 @@ public class ObjectEntryLocalServiceImpl
 
 	@Reference
 	private DLFileEntryLocalService _dlFileEntryLocalService;
+
+	@Reference
+	private DTOConverterRegistry _dtoConverterRegistry;
 
 	@Reference
 	private Encryptor _encryptor;

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectActionLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectActionLocalServiceTest.java
@@ -502,7 +502,8 @@ public class ObjectActionLocalServiceTest {
 
 			_assertWebhookObjectAction(
 				"John", "Smith", ObjectActionTriggerConstants.KEY_ON_AFTER_ADD,
-				_objectDefinition, null, null, WorkflowConstants.STATUS_DRAFT);
+				_objectDefinition, null, null,
+				WorkflowConstants.STATUS_APPROVED);
 
 			// Execute standalone action to run a Groovy script
 
@@ -668,7 +669,7 @@ public class ObjectActionLocalServiceTest {
 			_assertWebhookObjectAction(
 				"Peter", null, ObjectActionTriggerConstants.KEY_ON_AFTER_UPDATE,
 				_objectDefinition, "John", null,
-				WorkflowConstants.STATUS_DRAFT);
+				WorkflowConstants.STATUS_APPROVED);
 
 			// Hierarchy, root object entry
 
@@ -1033,7 +1034,7 @@ public class ObjectActionLocalServiceTest {
 
 		_assertWebhookObjectAction(
 			"John", "Smith", ObjectActionTriggerConstants.KEY_ON_AFTER_ADD,
-			_objectDefinition, null, null, WorkflowConstants.STATUS_DRAFT);
+			_objectDefinition, null, null, WorkflowConstants.STATUS_APPROVED);
 
 		ObjectEntry objectEntry2 = _objectEntryLocalService.addObjectEntry(
 			TestPropsValues.getUserId(), 0,
@@ -1047,7 +1048,7 @@ public class ObjectActionLocalServiceTest {
 
 		_assertWebhookObjectAction(
 			"Peter", "White", ObjectActionTriggerConstants.KEY_ON_AFTER_ADD,
-			_objectDefinition, null, null, WorkflowConstants.STATUS_DRAFT);
+			_objectDefinition, null, null, WorkflowConstants.STATUS_APPROVED);
 
 		_objectEntryLocalService.deleteObjectEntry(objectEntry1);
 		_objectEntryLocalService.deleteObjectEntry(objectEntry2);
@@ -2280,10 +2281,7 @@ public class ObjectActionLocalServiceTest {
 
 		if (StringUtil.equals(
 				objectActionTriggerKey,
-				ObjectActionTriggerConstants.KEY_ON_AFTER_DELETE) ||
-			StringUtil.equals(
-				objectActionTriggerKey,
-				ObjectActionTriggerConstants.KEY_ON_AFTER_UPDATE)) {
+				ObjectActionTriggerConstants.KEY_ON_AFTER_DELETE)) {
 
 			Assert.assertEquals(
 				originalFirstName,


### PR DESCRIPTION
Resent from #150626. 
We have to use a snapshot instead of a regular reference because using a regular reference causes a circular dependence between the modules