### PR TITLE
[Test Fix] LPD-26575 Fix UnsyncStringWriterTest because StringBundler's default init capacity is changed from 16 to 0

### DIFF
--- a/modules/core/petra/petra-io/src/test/java/com/liferay/petra/io/unsync/UnsyncStringWriterTest.java
+++ b/modules/core/petra/petra-io/src/test/java/com/liferay/petra/io/unsync/UnsyncStringWriterTest.java
@@ -195,7 +195,7 @@ public class UnsyncStringWriterTest extends BaseWriterTestCase {
 		Assert.assertNull(_stringBuilderField.get(unsyncStringWriter));
 
 		Assert.assertNotNull(stringBundler);
-		Assert.assertEquals(16, stringBundler.capacity());
+		Assert.assertEquals(0, stringBundler.capacity());
 
 		unsyncStringWriter = new UnsyncStringWriter(32);
 


### PR DESCRIPTION
@tinatian
forwarded from: https://github.com/liferay-core-infra/liferay-portal/pull/7036

Ticket: https://liferay.atlassian.net/browse/LPD-26575

StringBundler default is changed from 16 to 0 in this commit: https://github.com/liferay/liferay-portal/commit/f5a40b8ed653bcc017337b210ed9bc28da55ec1a#diff-ecf0644c7aed0cf7fb42dcd1065d063ccb259ecabdb9f800547bd5c043727f06R48

Changed unit test accordingly