### PR TITLE
LPD-25633 Add log to measure import time.

### DIFF
--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineImportTaskExecutorImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineImportTaskExecutorImpl.java
@@ -34,6 +34,7 @@ import com.liferay.batch.engine.strategy.BatchEngineImportStrategy;
 import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerList;
 import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerListFactory;
 import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
 import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.log.Log;
@@ -83,6 +84,16 @@ public class BatchEngineImportTaskExecutorImpl
 		BatchEngineTaskItemDelegate<?> batchEngineTaskItemDelegate,
 		boolean checkPermissions) {
 
+		long startTime = 0;
+
+		if (_log.isInfoEnabled()) {
+			_log.info(
+				"Started batch engine import task with id : " +
+					batchEngineImportTask.getBatchEngineImportTaskId());
+
+			startTime = System.currentTimeMillis();
+		}
+
 		SafeCloseable safeCloseable = CompanyThreadLocal.setWithSafeCloseable(
 			batchEngineImportTask.getCompanyId(),
 			CTCollectionThreadLocal.getCTCollectionId());
@@ -131,6 +142,14 @@ public class BatchEngineImportTaskExecutorImpl
 			// catching a Throwable
 
 			safeCloseable.close();
+		}
+
+		if (_log.isInfoEnabled()) {
+			_log.info(
+				StringBundler.concat(
+					"Finished batch engine import task with id : ",
+					batchEngineImportTask.getBatchEngineImportTaskId(), " in ",
+					System.currentTimeMillis() - startTime, "ms"));
 		}
 	}
 


### PR DESCRIPTION
@victorhcunha please find a stable test machine to run some time measurement for https://liferay.atlassian.net/browse/LPD-25633.
This pull only adds a logging to measure the time for import, it is only meant to setup a baseline to track the improvements we are going to make for this ticket.

Headless team is going to make the initial optimization, and then we will take it over to continue.

1) Use a stable test machine, don't run anything to interrupt the workload during import.
2) Use mysql, not hsql.
3) Set logger "com.liferay.batch.engine.internal.BatchEngineImportTaskExecutorImpl" to INFO level to output the measurement.
4) Use the ticket steps 3 and 4 to run this test. The other glowroot steps 1/2/5 are useless, don't do them.

The import is quite slow, you should see the start message right after the curl command returns, but the finish message will take a long time to show. For me it takes about 7mins.
`2024-05-23 23:04:34.024 INFO  [default-13][BatchEngineImportTaskExecutorImpl:90] Started batch engine import task with id : 1`
`2024-05-23 23:11:17.249 INFO  [default-13][BatchEngineImportTaskExecutorImpl:148] Finished batch engine import task with id : 1 in 403224ms
`
Run this a few times to take average and STD. Every run should start from a clean env (you need to rebuild db, drop osgi/state, drop search index folder, etc), don't rerun the test on the same tomcat.

Post the results on the ticket.

Whenever there are commits merged for this ticket, redo the same measure to track updates.

CC @vicnate5 