### PR TITLE
LPD-23654 Keep FeatureFlag.macro and FeatureFlag.path that are used by other tests.

### DIFF
--- a/modules/apps/feature-flag/feature-flag-test/src/testFunctional/macros/FeatureFlag.macro
+++ b/modules/apps/feature-flag/feature-flag-test/src/testFunctional/macros/FeatureFlag.macro
@@ -1,0 +1,43 @@
+definition {
+
+	@summary = "Default summary"
+	macro disableFeatureFlag(featureFlag = null, scope = null) {
+		FeatureFlag.toggleFeatureFlag(
+			featureFlag = ${featureFlag},
+			scope = ${scope},
+			toggleState = "Disabled");
+	}
+
+	@summary = "Default summary"
+	macro enableFeatureFlag(featureFlag = null, scope = null) {
+		FeatureFlag.toggleFeatureFlag(
+			featureFlag = ${featureFlag},
+			scope = ${scope},
+			toggleState = "Enabled");
+	}
+
+	@summary = "Default summary"
+	macro toggleFeatureFlag(toggleState = null, featureFlag = null, scope = null) {
+		if (isSet(scope)) {
+			Click(
+				key_configurationName = ${scope},
+				key_configurationScope = "Virtual Instance Scope",
+				locator1 = "SystemSettings#SCOPED_CONFIGURATION_NAME");
+		}
+
+		if (IsElementNotPresent(locator1 = "FeatureFlag#TOGGLE_ROW", title_row = ${featureFlag}, toggle_state = "")) {
+			Search.searchCP(searchTerm = ${featureFlag});
+		}
+
+		Check.checkToggleSwitch(
+			locator1 = "FeatureFlag#TOGGLE_ROW",
+			title_row = ${featureFlag},
+			toggle_state = "");
+
+		WaitForElementPresent(
+			locator1 = "FeatureFlag#TOGGLE_ROW",
+			title_row = ${featureFlag},
+			toggle_state = ${toggleState});
+	}
+
+}

--- a/modules/apps/feature-flag/feature-flag-test/src/testFunctional/paths/FeatureFlag.path
+++ b/modules/apps/feature-flag/feature-flag-test/src/testFunctional/paths/FeatureFlag.path
@@ -1,0 +1,21 @@
+<html>
+<head>
+<title>FeatureFlag</title>
+</head>
+
+<body>
+<table border="1" cellpadding="1" cellspacing="1">
+<thead>
+<tr><td rowspan="1" colspan="3">FeatureFlag</td></tr>
+</thead>
+
+<tbody>
+	<tr>
+		<td>TOGGLE_ROW</td>
+		<td>//*[@class="list-group-title"][contains(text(),'${title_row}')]//ancestor::li//label//span[contains(@class,'toggle-switch-label')][contains(text(),'${toggle_state}')]</td>
+		<td></td>
+	</tr>
+</tbody>
+</table>
+</body>
+</html>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-23654

Fix failing tests that used featureflag path and macro.