### PR TITLE
LPD-28282 Disable CacheFilter by default. LanguageFilter is overlappi…

### DIFF
--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -9603,7 +9603,7 @@
     #
     # Env: LIFERAY_COM_PERIOD_LIFERAY_PERIOD_PORTAL_PERIOD_SERVLET_PERIOD_FILTERS_PERIOD_CACHE_PERIOD__UPPERCASEC_ACHE_UPPERCASEF_ILTER
     #
-    com.liferay.portal.servlet.filters.cache.CacheFilter=true
+    com.liferay.portal.servlet.filters.cache.CacheFilter=false
 
     #
     # The dynamic CSS filter is used to parse Sass CSS.


### PR DESCRIPTION
…ng most its filter target with CacheFilter, and LanguageFilter on purposely disabled pacge caching, which is making CacheFilter really useless.

@tinatian @vicnate5 please backport for LXC, thanks!

@victorhcunha please run a check for login, thanks!