### PR TITLE
LPD-26381 Regen after SF

### DIFF
--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/ERCVersionedEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/ERCVersionedEntryPersistenceTest.java
@@ -168,16 +168,11 @@ public class ERCVersionedEntryPersistenceTest {
 
 		draftERCVersionedEntry.setMvccVersion(
 			ercVersionedEntry.getMvccVersion());
-
 		draftERCVersionedEntry.setUuid(ercVersionedEntry.getUuid());
-
 		draftERCVersionedEntry.setExternalReferenceCode(
 			ercVersionedEntry.getExternalReferenceCode());
-
 		draftERCVersionedEntry.setHeadId(-ercVersionedEntry.getHeadId());
-
 		draftERCVersionedEntry.setGroupId(ercVersionedEntry.getGroupId());
-
 		draftERCVersionedEntry.setCompanyId(ercVersionedEntry.getCompanyId());
 
 		_ercVersionedEntries.add(_persistence.update(draftERCVersionedEntry));


### PR DESCRIPTION
There's a Build Service missing after a SF over a template. This PR purpose is to execute this error.