### PR TITLE
LPD-28555 add a predicatable ERC to all system sites

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
@@ -156,6 +156,7 @@ import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.TextFormatter;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.kernel.util.Validator;
@@ -894,6 +895,11 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 					getLocalizationMap(groupKey), null, type, true,
 					GroupConstants.DEFAULT_MEMBERSHIP_RESTRICTION, friendlyURL,
 					site, true, null);
+
+				group.setExternalReferenceCode(
+					_groupKeyToExternalReferenceCode(groupKey));
+
+				group = groupPersistence.update(group);
 
 				if (groupKey.equals(GroupConstants.USER_PERSONAL_SITE)) {
 					initUserPersonalSitePermissions(group);
@@ -5456,6 +5462,19 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 		finally {
 			groupPersistence.closeSession(session);
 		}
+	}
+
+	private String _groupKeyToExternalReferenceCode(String groupKey) {
+
+		// Web Search --> webSearch
+
+		groupKey = TextFormatter.format(groupKey, TextFormatter.F);
+
+		// webSearch --> web-search
+
+		groupKey = TextFormatter.format(groupKey, TextFormatter.K);
+
+		return "system-site-" + groupKey;
 	}
 
 	private Map<Locale, String> _normalizeNameMap(Map<Locale, String> nameMap) {


### PR DESCRIPTION
### Problem

There are several sites (groups in fact) called system sites (groups) that are created by Liferay for every Portal/Virtual Instance.

These are:

- CMS
- Control Panel
- Forms
- Guest
- User Personal Site
- plus an arbitrary number of system sites which are defined by the portal property `system.groups`

Currently, none of these are addressable such that they could be targeted by the endpoints at  `/o/headless-site/v1.0/sites/*` because their `externalReferenceCode` is auto-generated. Furthermore they are not discoverable because no single endpoint in Liferay provides either a list of groups or sites. There are endpoints that return a given group/site by id but the `externalReferenceCode` is not emitted in any of these resources.

This greatly inhibits client extensions such as the site initializer client extension from proving useful.

### Proposed Solution

This change adds predictable `externalReferenceCode` to every system site by modifying the `groupKey` value (which also happens to be the value provided by the `system.groups` system property) using the following algorithm:

1. convert the provided groupKey using the conversion; space delimited to camel case
  e.g. `Web Search --> webSearch` (`TextFormatter.F`)

1. convert the result of 1. using the conversion; camel case to kebob case
  e.g. `webSearch --> web-search` (`TextFormatter.K`)

1. prefix the result with `system-site-` so as to prevent collision with customer created sites
  e.g. `system-site-web-search`



As a result of this change, a developer who wishes to target a site intializer client extension at the default site (Guest) they would simply write:

```yaml
siteExternalReferenceCode: system-site-guest
```

in their client-extension.yaml definition.