### PR TITLE
LPD-28836 | getConfiguration method of the Product class was removed, now you must use getProductConfiguration

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -1,6 +1,14 @@
 [
 	{
 		"classNames": [
+			"Product"
+		],
+		"from": "getConfiguration",
+		"issueKey": "LPD-7749",
+		"to": "getProductConfiguration"
+	},
+	{
+		"classNames": [
 			"CommerceCatalogLocalService",
 			"CommerceCatalogLocalServiceUtil"
 		],

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/UpgradeCatchAllCheck.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/UpgradeCatchAllCheck.testjava
@@ -520,6 +520,10 @@ public class UpgradeCatchAllCheck implements ConfigurationBeanDeclaration {
 		portletDisplay.getPortletInstanceConfiguration(null);
 	}
 
+	public void method(Product product) {
+		product.getProductConfiguration();
+	}
+
 	public void method(
 		ResourceRequest resourceRequest, ResourceResponse resourceResponse) {
 

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/UpgradeCatchAllCheck.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/UpgradeCatchAllCheck.testjava
@@ -509,6 +509,10 @@ public class UpgradeCatchAllCheck implements ConfigurationBeanDeclaration {
 		portletDisplay.getPortletInstanceConfiguration(null);
 	}
 
+	public void method(Product product) {
+		product.getConfiguration();
+	}
+
 	public void method(
 		ResourceRequest resourceRequest, ResourceResponse resourceResponse) {
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-28836
cc: @drewbrokke @nicolas-sss
https://github.com/liferay-devtools/liferay-portal/pull/110