### PR TITLE
LPD-27995

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -69,6 +69,18 @@
 		"to": ""
 	},
 	{
+		"classNames": [
+			"Http",
+			"HttpUtil"
+		],
+		"from": "regex:(http|_http|HttpUtil)\\.(addParameter|decodePath|decodeURL|encodeParameters|encodePath|fixPath|getCompleteURL|getDomain|getIpAddress|getParameter|getParameterMap|getPath|getProtocol|getQueryString|getRequestURL|getURI|hasDomain|hasProtocol|isForwarded|isSecure|normalizePath|parameterMapFromString|protocolize|removeDomain|removeParameter|removePathParameters|removeProtocol|sanitizeHeader|setParameter|shortenURL)",
+		"issueKey": "LPD-8040",
+		"newImports": [
+			"com.liferay.portal.kernel.util.HttpComponentsUtil"
+		],
+		"to": "HttpComponentsUtil.$2"
+	},
+	{
 		"from": "new AssetListEntryCreateDateComparator()",
 		"issueKey": "LPD-26157",
 		"skipParametersValidation": true,
@@ -648,7 +660,7 @@
 		"to": "fetchByExternalReferenceCode(param#1#, param#0#)"
 	},
 	{
-		"from": "AssetCategory::getLeftCategoryId",
+		"from": "regex:AssetCategory::getLeftCategoryId",
 		"issueKey": "LPS-196624",
 		"to": "AssetCategory::getCategoryId"
 	},

--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -73,12 +73,12 @@
 			"Http",
 			"HttpUtil"
 		],
-		"from": "regex:(http|_http|HttpUtil)\\.(addParameter|decodePath|decodeURL|encodeParameters|encodePath|fixPath|getCompleteURL|getDomain|getIpAddress|getParameter|getParameterMap|getPath|getProtocol|getQueryString|getRequestURL|getURI|hasDomain|hasProtocol|isForwarded|isSecure|normalizePath|parameterMapFromString|protocolize|removeDomain|removeParameter|removePathParameters|removeProtocol|sanitizeHeader|setParameter|shortenURL)",
+		"from": "regex:(http|_http|HttpUtil)\\.(?<methodName>addParameter|decodePath|decodeURL|encodeParameters|encodePath|fixPath|getCompleteURL|getDomain|getIpAddress|getParameter|getParameterMap|getPath|getProtocol|getQueryString|getRequestURL|getURI|hasDomain|hasProtocol|isForwarded|isSecure|normalizePath|parameterMapFromString|protocolize|removeDomain|removeParameter|removePathParameters|removeProtocol|sanitizeHeader|setParameter|shortenURL)",
 		"issueKey": "LPD-8040",
 		"newImports": [
 			"com.liferay.portal.kernel.util.HttpComponentsUtil"
 		],
-		"to": "HttpComponentsUtil.$2"
+		"to": "HttpComponentsUtil.${methodName}"
 	},
 	{
 		"from": "new AssetListEntryCreateDateComparator()",

--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -660,7 +660,7 @@
 		"to": "fetchByExternalReferenceCode(param#1#, param#0#)"
 	},
 	{
-		"from": "regex:AssetCategory::getLeftCategoryId",
+		"from": "AssetCategory::getLeftCategoryId",
 		"issueKey": "LPS-196624",
 		"to": "AssetCategory::getCategoryId"
 	},

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/UpgradeCatchAllCheck.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/UpgradeCatchAllCheck.testjava
@@ -15,6 +15,7 @@ import com.liferay.portal.kernel.cookies.constants.CookiesConstants;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.util.HtmlParser;
+import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 
 import java.util.ArrayList;
@@ -58,6 +59,68 @@ public class UpgradeCatchAllCheck implements ConfigurationBeanDeclaration {
 		}
 
 		_htmlParser.extractText(null);
+
+		HttpComponentsUtil.addParameter(null, null, null);
+		HttpComponentsUtil.decodePath(null);
+		HttpComponentsUtil.decodeURL(null);
+		HttpComponentsUtil.encodeParameters(null);
+		HttpComponentsUtil.encodePath(null);
+		HttpComponentsUtil.fixPath(null);
+		HttpComponentsUtil.getCompleteURL(null, null, null);
+		HttpComponentsUtil.getDomain(null);
+		HttpComponentsUtil.getIpAddress(null);
+		HttpComponentsUtil.getParameter(null, null);
+		HttpComponentsUtil.getParameterMap(null);
+		HttpComponentsUtil.getPath(null);
+		HttpComponentsUtil.getProtocol(null);
+		HttpComponentsUtil.getQueryString(null);
+		HttpComponentsUtil.getRequestURL(null);
+		HttpComponentsUtil.getURI(null);
+		HttpComponentsUtil.hasDomain(null);
+		HttpComponentsUtil.hasProtocol(null);
+		HttpComponentsUtil.isForwarded(null);
+		HttpComponentsUtil.isSecure(null);
+		HttpComponentsUtil.normalizePath(null);
+		HttpComponentsUtil.parameterMapFromString(null);
+		HttpComponentsUtil.protocolize(null, null);
+		HttpComponentsUtil.removeDomain(null);
+		HttpComponentsUtil.removeParameter(null);
+		HttpComponentsUtil.removePathParameters(null);
+		HttpComponentsUtil.removeProtocol(null);
+		HttpComponentsUtil.sanitizeHeader(null);
+		HttpComponentsUtil.setParameter(null, null, null);
+		HttpComponentsUtil.shortenURL(null);
+
+		HttpComponentsUtil.addParameter(null, null, null);
+		HttpComponentsUtil.decodePath(null);
+		HttpComponentsUtil.decodeURL(null);
+		HttpComponentsUtil.encodeParameters(null);
+		HttpComponentsUtil.encodePath(null);
+		HttpComponentsUtil.fixPath(null);
+		HttpComponentsUtil.getCompleteURL(null, null, null);
+		HttpComponentsUtil.getDomain(null);
+		HttpComponentsUtil.getIpAddress(null);
+		HttpComponentsUtil.getParameter(null, null);
+		HttpComponentsUtil.getParameterMap(null);
+		HttpComponentsUtil.getPath(null);
+		HttpComponentsUtil.getProtocol(null);
+		HttpComponentsUtil.getQueryString(null);
+		HttpComponentsUtil.getRequestURL(null);
+		HttpComponentsUtil.getURI(null);
+		HttpComponentsUtil.hasDomain(null);
+		HttpComponentsUtil.hasProtocol(null);
+		HttpComponentsUtil.isForwarded(null);
+		HttpComponentsUtil.isSecure(null);
+		HttpComponentsUtil.normalizePath(null);
+		HttpComponentsUtil.parameterMapFromString(null);
+		HttpComponentsUtil.protocolize(null, null);
+		HttpComponentsUtil.removeDomain(null);
+		HttpComponentsUtil.removeParameter(null);
+		HttpComponentsUtil.removePathParameters(null);
+		HttpComponentsUtil.removeProtocol(null);
+		HttpComponentsUtil.sanitizeHeader(null);
+		HttpComponentsUtil.setParameter(null, null, null);
+		HttpComponentsUtil.shortenURL(null);
 
 		new ArrayList<>(LanguageUtil.getAvailableLocales());
 
@@ -708,6 +771,9 @@ public class UpgradeCatchAllCheck implements ConfigurationBeanDeclaration {
 
 	@Reference
 	private HtmlParser _htmlParser;
+
+	@Reference
+	private Http _http;
 
 	@Reference
 	private JournalFolderLocalService _journalFolderLocalService;

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/UpgradeCatchAllCheck.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/UpgradeCatchAllCheck.testjava
@@ -60,6 +60,7 @@ public class UpgradeCatchAllCheck implements ConfigurationBeanDeclaration {
 
 		_htmlParser.extractText(null);
 
+		_http.hasProxyConfig();
 		HttpComponentsUtil.addParameter(null, null, null);
 		HttpComponentsUtil.decodePath(null);
 		HttpComponentsUtil.decodeURL(null);
@@ -91,6 +92,7 @@ public class UpgradeCatchAllCheck implements ConfigurationBeanDeclaration {
 		HttpComponentsUtil.setParameter(null, null, null);
 		HttpComponentsUtil.shortenURL(null);
 
+		HttpUtil.hasProxyConfig();
 		HttpComponentsUtil.addParameter(null, null, null);
 		HttpComponentsUtil.decodePath(null);
 		HttpComponentsUtil.decodeURL(null);

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/UpgradeCatchAllCheck.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/UpgradeCatchAllCheck.testjava
@@ -45,6 +45,68 @@ public class UpgradeCatchAllCheck implements ConfigurationBeanDeclaration {
 
 		HtmlUtil.extractText(null);
 
+		_http.addParameter(null, null, null);
+		_http.decodePath(null);
+		_http.decodeURL(null);
+		_http.encodeParameters(null);
+		_http.encodePath(null);
+		_http.fixPath(null);
+		_http.getCompleteURL(null, null, null);
+		_http.getDomain(null);
+		_http.getIpAddress(null);
+		_http.getParameter(null, null);
+		_http.getParameterMap(null);
+		_http.getPath(null);
+		_http.getProtocol(null);
+		_http.getQueryString(null);
+		_http.getRequestURL(null);
+		_http.getURI(null);
+		_http.hasDomain(null);
+		_http.hasProtocol(null);
+		_http.isForwarded(null);
+		_http.isSecure(null);
+		_http.normalizePath(null);
+		_http.parameterMapFromString(null);
+		_http.protocolize(null, null);
+		_http.removeDomain(null);
+		_http.removeParameter(null);
+		_http.removePathParameters(null);
+		_http.removeProtocol(null);
+		_http.sanitizeHeader(null);
+		_http.setParameter(null, null, null);
+		_http.shortenURL(null);
+
+		HttpUtil.addParameter(null, null, null);
+		HttpUtil.decodePath(null);
+		HttpUtil.decodeURL(null);
+		HttpUtil.encodeParameters(null);
+		HttpUtil.encodePath(null);
+		HttpUtil.fixPath(null);
+		HttpUtil.getCompleteURL(null, null, null);
+		HttpUtil.getDomain(null);
+		HttpUtil.getIpAddress(null);
+		HttpUtil.getParameter(null, null);
+		HttpUtil.getParameterMap(null);
+		HttpUtil.getPath(null);
+		HttpUtil.getProtocol(null);
+		HttpUtil.getQueryString(null);
+		HttpUtil.getRequestURL(null);
+		HttpUtil.getURI(null);
+		HttpUtil.hasDomain(null);
+		HttpUtil.hasProtocol(null);
+		HttpUtil.isForwarded(null);
+		HttpUtil.isSecure(null);
+		HttpUtil.normalizePath(null);
+		HttpUtil.parameterMapFromString(null);
+		HttpUtil.protocolize(null, null);
+		HttpUtil.removeDomain(null);
+		HttpUtil.removeParameter(null);
+		HttpUtil.removePathParameters(null);
+		HttpUtil.removeProtocol(null);
+		HttpUtil.sanitizeHeader(null);
+		HttpUtil.setParameter(null, null, null);
+		HttpUtil.shortenURL(null);
+
 		ListUtil.fromArray(LanguageUtil.getAvailableLocales());
 
 		new AssetListEntryCreateDateComparator();
@@ -695,6 +757,9 @@ public class UpgradeCatchAllCheck implements ConfigurationBeanDeclaration {
 
 	@Reference
 	private FDSTableSchemaBuilderFactory _fDSTableSchemaBuilderFactory;
+
+	@Reference
+	private Http _http;
 
 	@Reference
 	private JournalFolderLocalService _journalFolderLocalService;

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/UpgradeCatchAllCheck.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/UpgradeCatchAllCheck.testjava
@@ -45,6 +45,7 @@ public class UpgradeCatchAllCheck implements ConfigurationBeanDeclaration {
 
 		HtmlUtil.extractText(null);
 
+		_http.hasProxyConfig();
 		_http.addParameter(null, null, null);
 		_http.decodePath(null);
 		_http.decodeURL(null);
@@ -76,6 +77,7 @@ public class UpgradeCatchAllCheck implements ConfigurationBeanDeclaration {
 		_http.setParameter(null, null, null);
 		_http.shortenURL(null);
 
+		HttpUtil.hasProxyConfig();
 		HttpUtil.addParameter(null, null, null);
 		HttpUtil.decodePath(null);
 		HttpUtil.decodeURL(null);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-27995

Manually forwarded from: https://github.com/liferay-devtools/liferay-portal/pull/104
Passed automation testing and Peer Review.
FYI, the regex was needed to help compress the amount of cases, we decided that this way makes the most sense instead of having around 70 cases in the replacements.json.

We have to check a specific set of subcases since not every single method got moved from Http to HttpUtil, only a subset of the available methods. I added a negative case method such as the hasProxyConfig to confirm it does not upgrade