### PR TITLE
LPD 30342

### DIFF
--- a/modules/apps/portal-language/portal-language-override-api/bnd.bnd
+++ b/modules/apps/portal-language/portal-language-override-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Language Override API
 Bundle-SymbolicName: com.liferay.portal.language.override.api
-Bundle-Version: 3.0.1
+Bundle-Version: 3.1.0
 Export-Package:\
 	com.liferay.portal.language.override.constants,\
 	com.liferay.portal.language.override.exception,\

--- a/modules/apps/portal-language/portal-language-override-api/build.gradle
+++ b/modules/apps/portal-language/portal-language-override-api/build.gradle
@@ -1,5 +1,7 @@
 dependencies {
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "org.osgi", name: "org.osgi.annotation.versioning", version: "1.1.0"
 	compileOnly project(":core:petra:petra-sql-dsl-api")
+	compileOnly project(":core:petra:petra-string")
 }

--- a/modules/apps/portal-language/portal-language-override-api/src/main/java/com/liferay/portal/language/override/exception/PLOEntryLanguageIdException.java
+++ b/modules/apps/portal-language/portal-language-override-api/src/main/java/com/liferay/portal/language/override/exception/PLOEntryLanguageIdException.java
@@ -2,28 +2,38 @@
  * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
+
 package com.liferay.portal.language.override.exception;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.util.PropsValues;
+
+import java.util.Arrays;
 
 /**
  * @author Drew Brokke
  */
 public class PLOEntryLanguageIdException extends PortalException {
 
-	public PLOEntryLanguageIdException() {
+	public static class MustBeAvailable extends PLOEntryLanguageIdException {
+
+		public MustBeAvailable(String languageId) {
+			super(
+				StringBundler.concat(
+					"Unable to find language with id \"", languageId,
+					"\". The available options are: ",
+					Arrays.toString(PropsValues.LOCALES), "."));
+
+			this.languageId = languageId;
+		}
+
+		public final String languageId;
+
 	}
 
-	public PLOEntryLanguageIdException(String msg) {
+	private PLOEntryLanguageIdException(String msg) {
 		super(msg);
-	}
-
-	public PLOEntryLanguageIdException(String msg, Throwable throwable) {
-		super(msg, throwable);
-	}
-
-	public PLOEntryLanguageIdException(Throwable throwable) {
-		super(throwable);
 	}
 
 }

--- a/modules/apps/portal-language/portal-language-override-api/src/main/java/com/liferay/portal/language/override/exception/PLOEntryLanguageIdException.java
+++ b/modules/apps/portal-language/portal-language-override-api/src/main/java/com/liferay/portal/language/override/exception/PLOEntryLanguageIdException.java
@@ -1,0 +1,29 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+package com.liferay.portal.language.override.exception;
+
+import com.liferay.portal.kernel.exception.PortalException;
+
+/**
+ * @author Drew Brokke
+ */
+public class PLOEntryLanguageIdException extends PortalException {
+
+	public PLOEntryLanguageIdException() {
+	}
+
+	public PLOEntryLanguageIdException(String msg) {
+		super(msg);
+	}
+
+	public PLOEntryLanguageIdException(String msg, Throwable throwable) {
+		super(msg, throwable);
+	}
+
+	public PLOEntryLanguageIdException(Throwable throwable) {
+		super(throwable);
+	}
+
+}

--- a/modules/apps/portal-language/portal-language-override-api/src/main/resources/com/liferay/portal/language/override/exception/packageinfo
+++ b/modules/apps/portal-language/portal-language-override-api/src/main/resources/com/liferay/portal/language/override/exception/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 1.2.0

--- a/modules/apps/portal-language/portal-language-override-service/service.xml
+++ b/modules/apps/portal-language/portal-language-override-service/service.xml
@@ -50,6 +50,7 @@
 	</entity>
 	<exceptions>
 		<exception>PLOEntryKey</exception>
+		<exception>PLOEntryLanguageId</exception>
 		<exception>PLOEntryValue</exception>
 	</exceptions>
 </service-builder>

--- a/modules/apps/portal-language/portal-language-override-service/src/main/java/com/liferay/portal/language/override/service/impl/PLOEntryLocalServiceImpl.java
+++ b/modules/apps/portal-language/portal-language-override-service/src/main/java/com/liferay/portal/language/override/service/impl/PLOEntryLocalServiceImpl.java
@@ -5,6 +5,7 @@
 
 package com.liferay.portal.language.override.service.impl;
 
+import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -12,12 +13,15 @@ import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.ModelHintsUtil;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.language.override.exception.PLOEntryKeyException;
+import com.liferay.portal.language.override.exception.PLOEntryLanguageIdException;
 import com.liferay.portal.language.override.exception.PLOEntryValueException;
 import com.liferay.portal.language.override.model.PLOEntry;
 import com.liferay.portal.language.override.service.base.PLOEntryLocalServiceBaseImpl;
+import com.liferay.portal.util.PropsValues;
 
 import java.util.List;
 import java.util.Locale;
@@ -43,7 +47,9 @@ public class PLOEntryLocalServiceImpl extends PLOEntryLocalServiceBaseImpl {
 			String value)
 		throws PortalException {
 
-		_validate(key, value);
+		languageId = _getStandardizedLanguageId(languageId);
+
+		_validate(key, languageId, value);
 
 		PLOEntry ploEntry = fetchPLOEntry(companyId, key, languageId);
 
@@ -131,7 +137,30 @@ public class PLOEntryLocalServiceImpl extends PLOEntryLocalServiceBaseImpl {
 		}
 	}
 
-	private void _validate(String key, String value) throws PortalException {
+	private String _getStandardizedLanguageId(String languageId) {
+		languageId = StringUtil.replace(
+			languageId, CharPool.DASH, CharPool.UNDERLINE);
+
+		String[] languageParts = languageId.split(StringPool.UNDERLINE);
+
+		if (languageParts.length < 2) {
+			return languageId;
+		}
+
+		languageId =
+			StringUtil.lowerCase(languageParts[0]) + StringPool.UNDERLINE +
+				StringUtil.upperCase(languageParts[1]);
+
+		if (languageParts.length == 3) {
+			return languageId + StringPool.UNDERLINE + languageParts[2];
+		}
+
+		return languageId;
+	}
+
+	private void _validate(String key, String languageId, String value)
+		throws PortalException {
+
 		if (Validator.isBlank(key)) {
 			throw new PLOEntryKeyException.MustNotBeNull();
 		}
@@ -141,6 +170,10 @@ public class PLOEntryLocalServiceImpl extends PLOEntryLocalServiceBaseImpl {
 
 		if (key.length() > keyMaxLength) {
 			throw new PLOEntryKeyException.MustBeShorter(keyMaxLength);
+		}
+
+		if (!ArrayUtil.contains(PropsValues.LOCALES, languageId)) {
+			throw new PLOEntryLanguageIdException.MustBeAvailable(languageId);
 		}
 
 		if (Validator.isBlank(value)) {

--- a/modules/apps/portal-language/portal-language-override-test/src/testIntegration/java/com/liferay/portal/language/override/internal/portlet/action/test/ImportTranslationsMVCActionCommandTest.java
+++ b/modules/apps/portal-language/portal-language-override-test/src/testIntegration/java/com/liferay/portal/language/override/internal/portlet/action/test/ImportTranslationsMVCActionCommandTest.java
@@ -8,7 +8,6 @@ package com.liferay.portal.language.override.internal.portlet.action.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
@@ -18,7 +17,6 @@ import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.FileUtil;
-import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.language.override.model.PLOEntry;
 import com.liferay.portal.language.override.service.PLOEntryLocalService;
 import com.liferay.portal.test.rule.Inject;
@@ -72,19 +70,16 @@ public class ImportTranslationsMVCActionCommandTest {
 
 		Assert.assertNull(
 			_ploEntryLocalService.fetchPLOEntry(
-				TestPropsValues.getCompanyId(), key1,
-				LanguageUtil.getLanguageId(LocaleUtil.ENGLISH)));
+				TestPropsValues.getCompanyId(), key1, _LANGUAGE_ID));
 
 		Assert.assertNull(
 			_ploEntryLocalService.fetchPLOEntry(
-				TestPropsValues.getCompanyId(), key2,
-				LanguageUtil.getLanguageId(LocaleUtil.ENGLISH)));
+				TestPropsValues.getCompanyId(), key2, _LANGUAGE_ID));
 
 		ReflectionTestUtil.invoke(
 			_mvcActionCommand, "_importTranslations",
 			new Class<?>[] {ActionRequest.class, File.class, String.class},
-			new MockLiferayPortletActionRequest(), file,
-			LanguageUtil.getLanguageId(LocaleUtil.ENGLISH));
+			new MockLiferayPortletActionRequest(), file, _LANGUAGE_ID);
 
 		_assertLanguageKey(value1, key1);
 		_assertLanguageKey(value2, key2);
@@ -102,8 +97,7 @@ public class ImportTranslationsMVCActionCommandTest {
 		ReflectionTestUtil.invoke(
 			_mvcActionCommand, "_importTranslations",
 			new Class<?>[] {ActionRequest.class, File.class, String.class},
-			mockLiferayPortletActionRequest, file,
-			LanguageUtil.getLanguageId(LocaleUtil.ENGLISH));
+			mockLiferayPortletActionRequest, file, _LANGUAGE_ID);
 
 		Assert.assertTrue(
 			SessionErrors.contains(
@@ -124,8 +118,7 @@ public class ImportTranslationsMVCActionCommandTest {
 		ReflectionTestUtil.invoke(
 			_mvcActionCommand, "_importTranslations",
 			new Class<?>[] {ActionRequest.class, File.class, String.class},
-			mockLiferayPortletActionRequest, file,
-			LanguageUtil.getLanguageId(LocaleUtil.ENGLISH));
+			mockLiferayPortletActionRequest, file, _LANGUAGE_ID);
 
 		Assert.assertTrue(
 			SessionErrors.contains(
@@ -136,12 +129,13 @@ public class ImportTranslationsMVCActionCommandTest {
 		throws Exception {
 
 		PLOEntry ploEntry = _ploEntryLocalService.fetchPLOEntry(
-			TestPropsValues.getCompanyId(), key,
-			LanguageUtil.getLanguageId(LocaleUtil.ENGLISH));
+			TestPropsValues.getCompanyId(), key, _LANGUAGE_ID);
 
 		Assert.assertNotNull(ploEntry);
 		Assert.assertEquals(expectedValue, ploEntry.getValue());
 	}
+
+	private static final String _LANGUAGE_ID = "en_US";
 
 	@Inject(
 		filter = "mvc.command.name=/portal_language_override/import_translations"

--- a/modules/apps/portal-language/portal-language-override-test/src/testIntegration/java/com/liferay/portal/language/override/service/test/PLOEntryLocalServiceTest.java
+++ b/modules/apps/portal-language/portal-language-override-test/src/testIntegration/java/com/liferay/portal/language/override/service/test/PLOEntryLocalServiceTest.java
@@ -17,6 +17,7 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.language.LanguageResources;
 import com.liferay.portal.language.override.exception.PLOEntryKeyException;
+import com.liferay.portal.language.override.exception.PLOEntryLanguageIdException;
 import com.liferay.portal.language.override.exception.PLOEntryValueException;
 import com.liferay.portal.language.override.model.PLOEntry;
 import com.liferay.portal.language.override.service.PLOEntryLocalService;
@@ -46,8 +47,10 @@ public class PLOEntryLocalServiceTest {
 
 		_assertTranslationValue(newKey, null);
 
+		String languageId = LanguageUtil.getLanguageId(LocaleUtil.getDefault());
+
 		PLOEntry ploEntry = _addOrUpdatePLOEntry(
-			newKey, RandomTestUtil.randomString());
+			newKey, languageId, RandomTestUtil.randomString());
 
 		_assertTranslationValue(newKey, ploEntry.getValue());
 
@@ -57,7 +60,7 @@ public class PLOEntryLocalServiceTest {
 			LanguageResources.getMessage(LocaleUtil.getDefault(), existingKey));
 
 		ploEntry = _addOrUpdatePLOEntry(
-			existingKey, RandomTestUtil.randomString());
+			existingKey, languageId, RandomTestUtil.randomString());
 
 		_assertTranslationValue(existingKey, ploEntry.getValue());
 
@@ -68,25 +71,31 @@ public class PLOEntryLocalServiceTest {
 					PLOEntry.class.getName(), "key");
 
 				_addOrUpdatePLOEntry(
-					RandomTestUtil.randomString(keyMaxLength + 1),
+					RandomTestUtil.randomString(keyMaxLength + 1), languageId,
 					RandomTestUtil.randomString());
 			});
 		_assertException(
 			PLOEntryKeyException.MustNotBeNull.class,
 			() -> _addOrUpdatePLOEntry(
-				StringPool.BLANK, RandomTestUtil.randomString()));
+				StringPool.BLANK, languageId, RandomTestUtil.randomString()));
+		_assertException(
+			PLOEntryLanguageIdException.MustBeAvailable.class,
+			() -> _addOrUpdatePLOEntry(
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				StringPool.BLANK));
 		_assertException(
 			PLOEntryValueException.MustNotBeNull.class,
 			() -> _addOrUpdatePLOEntry(
-				RandomTestUtil.randomString(), StringPool.BLANK));
+				RandomTestUtil.randomString(), languageId, StringPool.BLANK));
 	}
 
-	private PLOEntry _addOrUpdatePLOEntry(String key, String value)
+	private PLOEntry _addOrUpdatePLOEntry(
+			String key, String languageId, String value)
 		throws PortalException {
 
 		return _ploEntryLocalService.addOrUpdatePLOEntry(
 			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(), key,
-			LanguageUtil.getLanguageId(LocaleUtil.getDefault()), value);
+			languageId, value);
 	}
 
 	private void _assertException(

--- a/modules/apps/portal-language/portal-language-rest-api/src/main/java/com/liferay/portal/language/rest/resource/v1_0/MessageResource.java
+++ b/modules/apps/portal-language/portal-language-rest-api/src/main/java/com/liferay/portal/language/rest/resource/v1_0/MessageResource.java
@@ -38,7 +38,7 @@ import org.osgi.annotation.versioning.ProviderType;
 /**
  * To access this resource, run:
  *
- *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/portal-language/v1.0
+ *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/language/v1.0
  *
  * @author Thiago Buarque
  * @generated

--- a/modules/apps/portal-language/portal-language-rest-client/src/main/java/com/liferay/portal/language/rest/client/resource/v1_0/MessageResource.java
+++ b/modules/apps/portal-language/portal-language-rest-client/src/main/java/com/liferay/portal/language/rest/client/resource/v1_0/MessageResource.java
@@ -297,7 +297,7 @@ public interface MessageResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/portal-language/v1.0/messages");
+						"/o/language/v1.0/messages");
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);
@@ -406,7 +406,7 @@ public interface MessageResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/portal-language/v1.0/messages/batch");
+						"/o/language/v1.0/messages/batch");
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);
@@ -515,7 +515,7 @@ public interface MessageResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/portal-language/v1.0/messages");
+						"/o/language/v1.0/messages");
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);
@@ -615,7 +615,7 @@ public interface MessageResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/portal-language/v1.0/messages");
+						"/o/language/v1.0/messages");
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);
@@ -712,7 +712,7 @@ public interface MessageResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/portal-language/v1.0/messages/batch");
+						"/o/language/v1.0/messages/batch");
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);
@@ -812,7 +812,7 @@ public interface MessageResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/portal-language/v1.0/messages");
+						"/o/language/v1.0/messages");
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);
@@ -909,7 +909,7 @@ public interface MessageResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/portal-language/v1.0/messages/batch");
+						"/o/language/v1.0/messages/batch");
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);
@@ -1026,7 +1026,7 @@ public interface MessageResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/portal-language/v1.0/messages/import");
+						"/o/language/v1.0/messages/import");
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);

--- a/modules/apps/portal-language/portal-language-rest-impl/rest-config.yaml
+++ b/modules/apps/portal-language/portal-language-rest-impl/rest-config.yaml
@@ -1,7 +1,7 @@
 apiDir: "../portal-language-rest-api/src/main/java"
 apiPackagePath: "com.liferay.portal.language.rest"
 application:
-    baseURI: "/portal-language"
+    baseURI: "/language"
     className: "PortalLanguageRESTApplication"
     name: "Liferay.Portal.Language.REST"
 author: "Thiago Buarque"

--- a/modules/apps/portal-language/portal-language-rest-impl/rest-openapi.yaml
+++ b/modules/apps/portal-language/portal-language-rest-impl/rest-openapi.yaml
@@ -16,7 +16,7 @@ info:
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"
-    title: "Portal Language"
+    title: "Language"
     version: v1.0
 openapi: 3.0.1
 paths:

--- a/modules/apps/portal-language/portal-language-rest-impl/src/main/java/com/liferay/portal/language/rest/internal/jaxrs/application/PortalLanguageRESTApplication.java
+++ b/modules/apps/portal-language/portal-language-rest-impl/src/main/java/com/liferay/portal/language/rest/internal/jaxrs/application/PortalLanguageRESTApplication.java
@@ -17,7 +17,7 @@ import org.osgi.service.component.annotations.Component;
  */
 @Component(
 	property = {
-		"liferay.jackson=false", "osgi.jaxrs.application.base=/portal-language",
+		"liferay.jackson=false", "osgi.jaxrs.application.base=/language",
 		"osgi.jaxrs.extension.select=(osgi.jaxrs.name=Liferay.Vulcan)",
 		"osgi.jaxrs.name=Liferay.Portal.Language.REST"
 	},

--- a/modules/apps/portal-language/portal-language-rest-impl/src/main/java/com/liferay/portal/language/rest/internal/resource/v1_0/BaseMessageResourceImpl.java
+++ b/modules/apps/portal-language/portal-language-rest-impl/src/main/java/com/liferay/portal/language/rest/internal/resource/v1_0/BaseMessageResourceImpl.java
@@ -73,7 +73,7 @@ public abstract class BaseMessageResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'DELETE' 'http://localhost:8080/o/portal-language/v1.0/messages'  -u 'test@liferay.com:test'
+	 * curl -X 'DELETE' 'http://localhost:8080/o/language/v1.0/messages'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -107,7 +107,7 @@ public abstract class BaseMessageResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'DELETE' 'http://localhost:8080/o/portal-language/v1.0/messages/batch'  -u 'test@liferay.com:test'
+	 * curl -X 'DELETE' 'http://localhost:8080/o/language/v1.0/messages/batch'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -165,7 +165,7 @@ public abstract class BaseMessageResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/portal-language/v1.0/messages'  -u 'test@liferay.com:test'
+	 * curl -X 'GET' 'http://localhost:8080/o/language/v1.0/messages'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -202,7 +202,7 @@ public abstract class BaseMessageResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/portal-language/v1.0/messages' -d $'{"key": ___, "languageId": ___, "value": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/language/v1.0/messages' -d $'{"key": ___, "languageId": ___, "value": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.tags.Tags(
 		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Message")}
@@ -219,7 +219,7 @@ public abstract class BaseMessageResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/portal-language/v1.0/messages/batch'  -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/language/v1.0/messages/batch'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -263,7 +263,7 @@ public abstract class BaseMessageResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/portal-language/v1.0/messages' -d $'{"key": ___, "languageId": ___, "value": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/language/v1.0/messages' -d $'{"key": ___, "languageId": ___, "value": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.tags.Tags(
 		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Message")}
@@ -280,7 +280,7 @@ public abstract class BaseMessageResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/portal-language/v1.0/messages/batch'  -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/language/v1.0/messages/batch'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -324,7 +324,7 @@ public abstract class BaseMessageResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/portal-language/v1.0/messages/import'  -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/language/v1.0/messages/import'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(content = @io.swagger.v3.oas.annotations.media.Content(mediaType = "multipart/form-data", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = PostMessageImportRequestBody.class)))

--- a/modules/apps/portal-language/portal-language-rest-impl/src/main/java/com/liferay/portal/language/rest/internal/resource/v1_0/MessageResourceImpl.java
+++ b/modules/apps/portal-language/portal-language-rest-impl/src/main/java/com/liferay/portal/language/rest/internal/resource/v1_0/MessageResourceImpl.java
@@ -10,8 +10,11 @@ import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.language.LanguageResources;
 import com.liferay.portal.language.override.model.PLOEntry;
 import com.liferay.portal.language.override.service.PLOEntryLocalService;
 import com.liferay.portal.language.rest.dto.v1_0.Message;
@@ -26,11 +29,15 @@ import java.io.Serializable;
 
 import java.nio.charset.StandardCharsets;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.ResourceBundle;
+import java.util.Set;
 
 import javax.ws.rs.BadRequestException;
 
@@ -137,7 +144,41 @@ public class MessageResourceImpl extends BaseMessageResourceImpl {
 		Filter filter, Pagination pagination, Sort[] sorts,
 		Map<String, Serializable> parameters, String search) {
 
-		return Page.of(Collections.emptyList());
+		String languageId = GetterUtil.getString(parameters.get("languageId"));
+
+		ResourceBundle resourceBundle = LanguageResources.getResourceBundle(
+			LocaleUtil.fromLanguageId(languageId, true, true));
+
+		Set<String> keySet = resourceBundle.keySet();
+
+		keySet.addAll(_getCompanyPLOEntryKeys(contextCompany.getCompanyId()));
+
+		List<String> keys = new ArrayList<>(keySet);
+
+		Collections.sort(keys);
+
+		List<Message> messages = new ArrayList<>();
+
+		for (int i = pagination.getStartPosition();
+			 (i < keys.size()) && (i < pagination.getEndPosition()); i++) {
+
+			String key = keys.get(i);
+
+			Message message = new Message();
+
+			message.setKey(() -> key);
+			message.setLanguageId(() -> languageId);
+			message.setValue(
+				() -> ResourceBundleUtil.getString(resourceBundle, key));
+
+			messages.add(message);
+
+			if (i >= pagination.getEndPosition()) {
+				break;
+			}
+		}
+
+		return Page.of(messages, pagination, keys.size());
 	}
 
 	private Message _addOrUpdatePLOEntry(Message message)
@@ -152,6 +193,18 @@ public class MessageResourceImpl extends BaseMessageResourceImpl {
 		message.setValue(ploEntry::getValue);
 
 		return message;
+	}
+
+	private List<String> _getCompanyPLOEntryKeys(long companyId) {
+		List<String> keys = new ArrayList<>();
+
+		for (PLOEntry ploEntry :
+				_ploEntryLocalService.getPLOEntries(companyId)) {
+
+			keys.add(ploEntry.getKey());
+		}
+
+		return keys;
 	}
 
 	@Reference

--- a/modules/apps/portal-language/portal-language-rest-impl/src/main/java/com/liferay/portal/language/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/portal-language/portal-language-rest-impl/src/main/java/com/liferay/portal/language/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -42,7 +42,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.portal.language.rest.client', and version '1.0.0'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Portal Language", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.portal.language.rest.client', and version '1.0.0'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Language", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/portal-language/portal-language-rest-impl/src/main/java/com/liferay/portal/language/rest/internal/resource/v1_0/factory/MessageResourceFactoryImpl.java
+++ b/modules/apps/portal-language/portal-language-rest-impl/src/main/java/com/liferay/portal/language/rest/internal/resource/v1_0/factory/MessageResourceFactoryImpl.java
@@ -55,7 +55,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	property = "resource.locator.key=/portal-language/v1.0/Message",
+	property = "resource.locator.key=/language/v1.0/Message",
 	service = MessageResource.Factory.class
 )
 @Generated("")

--- a/modules/apps/portal-language/portal-language-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/openapi.properties
+++ b/modules/apps/portal-language/portal-language-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/openapi.properties
@@ -4,6 +4,6 @@
 
 api.version=v1.0
 openapi.resource=true
-openapi.resource.path=/portal-language
+openapi.resource.path=/language
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Portal.Language.REST)
 osgi.jaxrs.resource=true


### PR DESCRIPTION
# Functionalities
### Added the code for exporting via Batch API
Both import and export are performed via the available formats in the batch API (i.e. JSON, JSONL, CSV)

**For exporting**
```
curl --location --request POST \
'http://localhost:8080/o/headless-batch-engine/v1.0/export-task/com.liferay.portal.language.rest.dto.v1_0.Message/JSON?fieldNames=key%2ClanguageId%2Cvalue&languageId=en_US' \
-u "test@liferay.com:test"
```

Retrieve the content with
```
curl -L 'http://localhost:8080/o/headless-batch-engine/v1.0/export-task/by-external-reference-code/a98ae3f4-ac29-e69c-6929-2d48f640468f/content' \
-u "test@liferay.com:test" \
-o export.zip
```
### Added validation for the languageId field for the PLOEntry

There were no validation for the languageId in PLOEntry. Meaning the dev could add a PLOEntry for the language "abcd" and it would never be used

Let me know if something is missing, otherwise I'll consider as done and ask for review from my TL and proceed with the closing phase.

cc: @ethib137