### PR TITLE
LPD-30582 Fix failing CSS

### DIFF
--- a/modules/apps/headless/headless-discovery/headless-discovery-impl/src/main/java/com/liferay/headless/discovery/internal/jaxrs/application/HeadlessDiscoveryAPIApplication.java
+++ b/modules/apps/headless/headless-discovery/headless-discovery-impl/src/main/java/com/liferay/headless/discovery/internal/jaxrs/application/HeadlessDiscoveryAPIApplication.java
@@ -110,6 +110,10 @@ public class HeadlessDiscoveryAPIApplication extends Application {
 					html, "href=\"main.css\"",
 					"href=\"" + _portal.getPathContext() + "/o/api/main.css\"");
 				html = StringUtil.replace(
+					html, "href=\"headless-discovery-web-min.css\"",
+					"href=\"" + _portal.getPathContext() +
+						"/o/api/headless-discovery-web-min.css\"");
+				html = StringUtil.replace(
 					html, "src=\"headless-discovery-web-min.js\"",
 					"src=\"" + _portal.getPathContext() +
 						"/o/api/headless-discovery-web-min.js\"");
@@ -185,7 +189,7 @@ public class HeadlessDiscoveryAPIApplication extends Application {
 				}
 			});
 
-		if (parameter.contains("main.css")) {
+		if (parameter.endsWith(".css")) {
 			responseBuilder.type("text/css");
 		}
 		else {


### PR DESCRIPTION
I tested the previous pull from `/o/headless-discovery-web` context path and everything worked OK. However it turns out that we are using that application through `/o/api` instead, so I've had to tune the code to honor the new CSS file.

CC: @4lejandrito

This is a followup to https://github.com/brianchandotcom/liferay-portal/pull/152365