### PR TITLE
LPD-31320 Revert "LPD-31320 as used"

### DIFF
--- a/modules/apps/template/template-test-util/src/main/java/com/liferay/template/test/util/TemplateTestUtil.java
+++ b/modules/apps/template/template-test-util/src/main/java/com/liferay/template/test/util/TemplateTestUtil.java
@@ -127,6 +127,11 @@ public class TemplateTestUtil {
 			ServiceContext serviceContext)
 		throws Exception {
 
+		TemplateEntry templateEntry = addTemplateEntry(
+			infoItemClassName, infoItemFormVariationKey,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			getSampleScriptFTL(fieldName), serviceContext);
+
 		InfoItemFormProvider<?> infoItemFormProvider =
 			(InfoItemFormProvider<?>)
 				infoItemServiceRegistry.getFirstInfoItemService(
@@ -134,11 +139,6 @@ public class TemplateTestUtil {
 
 		InfoForm infoForm = infoItemFormProvider.getInfoForm(
 			infoItemFormVariationKey, serviceContext.getScopeGroupId());
-
-		TemplateEntry templateEntry = addTemplateEntry(
-			infoItemClassName, infoItemFormVariationKey,
-			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			getSampleScriptFTL(fieldName), serviceContext);
 
 		return infoForm.getInfoField(
 			PortletDisplayTemplate.DISPLAY_STYLE_PREFIX +


### PR DESCRIPTION
This reverts commit 2a9376115f58a3cf563772c949317a0e10d5f0e7.

I'm sending this revert because we can't do this. This leads to returning null, as it's required that the TemplateEntry exists when calculating the InfoForm, so that it contains the field of the TemplateEntry.

Thank you!