### PR TITLE
LPD-30611 Improving performance when updating a data definition

### DIFF
--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/DataDefinitionResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/DataDefinitionResourceImpl.java
@@ -464,67 +464,26 @@ public class DataDefinitionResourceImpl extends BaseDataDefinitionResourceImpl {
 		DDMStructure ddmStructure = _ddmStructureLocalService.getDDMStructure(
 			dataDefinitionId);
 
-		DataDefinitionContentType dataDefinitionContentType =
-			DataDefinitionContentTypeRegistryUtil.getDataDefinitionContentType(
-				ddmStructure.getClassNameId());
-
-		_normalizeDataDefinitionFields(
-			dataDefinitionContentType.getContentType(),
-			dataDefinition.getDataDefinitionFields(), ddmStructure.getGroupId(),
-			_journalArticleLocalService.getStructureArticlesCount(
-				ddmStructure.getGroupId(), ddmStructure.getStructureId()));
-
-		DataLayout dataLayout = dataDefinition.getDefaultDataLayout();
-
-		if (dataLayout != null) {
-			DataLayoutResource dataLayoutResource = _getDataLayoutResource(
-				false);
-
-			DataLayout putDataLayout = dataLayoutResource.putDataLayout(
-				_getDefaultDataLayoutId(dataDefinitionId, dataLayout),
-				dataLayout);
-
-			dataDefinition.setDefaultDataLayout(() -> putDataLayout);
-		}
-
-		JSONObject definitionJSONObject = _jsonFactory.createJSONObject(
-			ddmStructure.getDefinition());
-
-		DDMForm ddmForm = DataDefinitionDDMFormUtil.toDDMForm(
-			dataDefinition, _ddmFormFieldTypeServicesRegistry);
-
-		ddmForm.setAllowInvalidAvailableLocalesForProperty(
-			dataDefinitionContentType.
-				allowInvalidAvailableLocalesForProperty());
-
-		ddmForm.setDefinitionSchemaVersion(
-			definitionJSONObject.getString("definitionSchemaVersion"));
-
-		_validate(dataDefinition, dataDefinitionContentType, ddmForm);
-
-		_removeFieldsFromDataLayoutsAndDataListViews(
-			dataDefinitionId,
-			_getRemovedFieldNames(dataDefinition, dataDefinitionId));
-
-		_sortNestedDDMFormFields(ddmForm.getDDMFormFields());
-
-		dataDefinition = _updateDataDefinition(
-			dataDefinition, dataDefinitionId, ddmForm);
+		dataDefinition = _putDataDefinition(
+			dataDefinitionId, dataDefinition, ddmStructure);
 
 		for (long classPK :
 				_deDataDefinitionFieldLinkLocalService.getClassPKS(
 					_portal.getClassNameId(DDMStructure.class),
 					dataDefinitionId)) {
 
+			DDMStructure existingDDMStructure =
+				_ddmStructureLocalService.getDDMStructure(classPK);
+
 			DataDefinition existingDataDefinition =
 				DataDefinitionUtil.toDataDefinition(
-					_ddmFormFieldTypeServicesRegistry,
-					_ddmStructureLocalService.getStructure(classPK),
+					_ddmFormFieldTypeServicesRegistry, existingDDMStructure,
 					_ddmStructureLayoutLocalService, _ddmStructureLocalService,
 					contextHttpServletRequest, _spiDDMFormRuleConverter);
 
-			putDataDefinition(
-				existingDataDefinition.getId(), existingDataDefinition);
+			_putDataDefinition(
+				existingDataDefinition.getId(), existingDataDefinition,
+				existingDDMStructure);
 		}
 
 		_deDataDefinitionFieldLinkLocalService.deleteDEDataDefinitionFieldLinks(
@@ -535,6 +494,13 @@ public class DataDefinitionResourceImpl extends BaseDataDefinitionResourceImpl {
 		if (id == null) {
 			id = getPermissionCheckerGroupId(dataDefinitionId);
 		}
+
+		DataDefinitionContentType dataDefinitionContentType =
+			DataDefinitionContentTypeRegistryUtil.getDataDefinitionContentType(
+				ddmStructure.getClassNameId());
+
+		DDMForm ddmForm = DataDefinitionDDMFormUtil.toDDMForm(
+			dataDefinition, _ddmFormFieldTypeServicesRegistry);
 
 		_addDataDefinitionFieldLinks(
 			dataDefinitionContentType.getContentType(), dataDefinitionId,
@@ -1251,6 +1217,58 @@ public class DataDefinitionResourceImpl extends BaseDataDefinitionResourceImpl {
 			});
 
 		return dataDefinition;
+	}
+
+	private DataDefinition _putDataDefinition(
+			Long dataDefinitionId, DataDefinition dataDefinition,
+			DDMStructure ddmStructure)
+		throws Exception {
+
+		DataDefinitionContentType dataDefinitionContentType =
+			DataDefinitionContentTypeRegistryUtil.getDataDefinitionContentType(
+				ddmStructure.getClassNameId());
+
+		_normalizeDataDefinitionFields(
+			dataDefinitionContentType.getContentType(),
+			dataDefinition.getDataDefinitionFields(), ddmStructure.getGroupId(),
+			_journalArticleLocalService.getStructureArticlesCount(
+				ddmStructure.getGroupId(), ddmStructure.getStructureId()));
+
+		DataLayout dataLayout = dataDefinition.getDefaultDataLayout();
+
+		if (dataLayout != null) {
+			DataLayoutResource dataLayoutResource = _getDataLayoutResource(
+				false);
+
+			DataLayout putDataLayout = dataLayoutResource.putDataLayout(
+				_getDefaultDataLayoutId(dataDefinitionId, dataLayout),
+				dataLayout);
+
+			dataDefinition.setDefaultDataLayout(() -> putDataLayout);
+		}
+
+		JSONObject definitionJSONObject = _jsonFactory.createJSONObject(
+			ddmStructure.getDefinition());
+
+		DDMForm ddmForm = DataDefinitionDDMFormUtil.toDDMForm(
+			dataDefinition, _ddmFormFieldTypeServicesRegistry);
+
+		ddmForm.setAllowInvalidAvailableLocalesForProperty(
+			dataDefinitionContentType.
+				allowInvalidAvailableLocalesForProperty());
+
+		ddmForm.setDefinitionSchemaVersion(
+			definitionJSONObject.getString("definitionSchemaVersion"));
+
+		_validate(dataDefinition, dataDefinitionContentType, ddmForm);
+
+		_removeFieldsFromDataLayoutsAndDataListViews(
+			dataDefinitionId,
+			_getRemovedFieldNames(dataDefinition, dataDefinitionId));
+
+		_sortNestedDDMFormFields(ddmForm.getDDMFormFields());
+
+		return _updateDataDefinition(dataDefinition, dataDefinitionId, ddmForm);
 	}
 
 	private void _removeFieldsFromDataLayout(

--- a/modules/apps/data-engine/data-engine-rest-impl/src/test/java/com/liferay/data/engine/rest/internal/resource/v2_0/DataDefinitionResourceTest.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/test/java/com/liferay/data/engine/rest/internal/resource/v2_0/DataDefinitionResourceTest.java
@@ -1,0 +1,42 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.data.engine.rest.internal.resource.v2_0;
+
+import com.liferay.data.engine.rest.dto.v2_0.DataDefinition;
+import com.liferay.data.engine.rest.resource.v2_0.DataDefinitionResource;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Nathaly Gomes
+ */
+public class DataDefinitionResourceTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testPutDataDefinition() throws Exception {
+		DataDefinitionResource dataDefinitionResource = Mockito.mock(
+			DataDefinitionResource.class);
+
+		dataDefinitionResource.putDataDefinition(1L, new DataDefinition());
+
+		Mockito.verify(
+			dataDefinitionResource, Mockito.times(1)
+		).putDataDefinition(
+			Mockito.anyLong(), Mockito.any(DataDefinition.class)
+		);
+	}
+
+}


### PR DESCRIPTION
Previous PR: https://github.com/brianchandotcom/liferay-portal/pull/152290

Hi Brian,
We are resending this PR because we would like to explain that @vngoliveira implemented a unit test, which is why the test is in the `data-engine-rest-impl` module.

Actual code: There is a recursion when updating a data definition, and it can create a performance issue when this entity is used as a fieldset in other data definitions.

Propose - This PR: we simplified the code and created a private method to update only what is necessary and avoid calling the update method many times. The test is simple (to verify if we resolved the recursion issue) because there are integration tests covering the update logic itself.

Thank you!

Related issue: https://liferay.atlassian.net/browse/LPD-30611

cc: @vngoliveira