### PR TITLE
LPD-1901 Set Alias type based on the output object field setting to keep the decimals in arithmetric operations

### DIFF
--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -42,6 +42,7 @@ import com.liferay.object.field.builder.AttachmentObjectFieldBuilder;
 import com.liferay.object.field.builder.DateObjectFieldBuilder;
 import com.liferay.object.field.builder.DateTimeObjectFieldBuilder;
 import com.liferay.object.field.builder.DecimalObjectFieldBuilder;
+import com.liferay.object.field.builder.FormulaObjectFieldBuilder;
 import com.liferay.object.field.builder.IntegerObjectFieldBuilder;
 import com.liferay.object.field.builder.LongIntegerObjectFieldBuilder;
 import com.liferay.object.field.builder.LongTextObjectFieldBuilder;
@@ -348,6 +349,20 @@ public class DefaultObjectEntryManagerImplTest
 						RandomTestUtil.randomString())
 				).name(
 					"decimalObjectFieldName"
+				).build(),
+				new FormulaObjectFieldBuilder(
+				).labelMap(
+					LocalizedMapUtil.getLocalizedMap(
+						RandomTestUtil.randomString())
+				).name(
+					"formulaObjectFieldName"
+				).objectFieldSettings(
+					Arrays.asList(
+						_createObjectFieldSetting("output", "Decimal"),
+						_createObjectFieldSetting(
+							"script",
+							"integerObjectFieldName / " +
+								"longIntegerObjectFieldName"))
 				).build(),
 				new IntegerObjectFieldBuilder(
 				).labelMap(
@@ -1056,6 +1071,29 @@ public class DefaultObjectEntryManagerImplTest
 					"dateTimeUTCObjectFieldName eq null",
 				dateTimeString1),
 			_objectDefinition2, 2);
+
+		// Formula field
+
+		assertEquals(
+			_defaultObjectEntryManager.addObjectEntry(
+				dtoConverterContext, _objectDefinition2,
+				new ObjectEntry() {
+					{
+						properties = HashMapBuilder.<String, Object>put(
+							"integerObjectFieldName", 3
+						).put(
+							"longIntegerObjectFieldName", 2
+						).build();
+					}
+				},
+				ObjectDefinitionConstants.SCOPE_COMPANY),
+			new ObjectEntry() {
+				{
+					properties = HashMapBuilder.<String, Object>put(
+						"formulaObjectFieldName", 1.5
+					).build();
+				}
+			});
 
 		// Picklist by list entry
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -3295,10 +3295,20 @@ public class ObjectEntryLocalServiceImpl
 
 				ddmExpression.setVariables(columns);
 
+				String output = GetterUtil.getString(
+					objectFieldSettingsValues.get("output"));
+
+				Class<?> javaType = Double.class;
+
+				if (Objects.equals(output, "Integer")) {
+					javaType = Integer.class;
+				}
+
 				try {
 					Expression<?> expression = ddmExpression.getDSLExpression();
 
-					selectExpressions.add(expression.as(objectField.getName()));
+					selectExpressions.add(
+						expression.as(objectField.getName(), javaType));
 				}
 				catch (Exception exception) {
 					_log.error(exception);


### PR DESCRIPTION
## Related tickets

- https://liferay.atlassian.net/browse/LPD-1901

## Motivation

A decimal number is expected in the following use case but it always set the output type as the expression1 [here](https://github.com/liferay/liferay-portal/blob/bb9d7a1d3cecde95457c46f7c75c2d7d4090ecf6/portal-kernel/src/com/liferay/portal/kernel/service/persistence/impl/BasePersistenceImpl.java#L1148),

**Given:** a division DSLFunction expression like this `expression1 / expression2` where the expression1 is a non-decimal column.

**When:** this expression is evaluated as an alias with the following operands 3 and 2 (e.g.: `3 / 2 as foo`)

**Then:** the result is 1 instead of 1.5 that is the expected due to [this](https://github.com/liferay/liferay-portal/blob/bb9d7a1d3cecde95457c46f7c75c2d7d4090ecf6/portal-kernel/src/com/liferay/portal/kernel/service/persistence/impl/BasePersistenceImpl.java#L1148)

## Proposed Solution

See https://github.com/liferay-core-infra/liferay-portal/pull/7300