### PR TITLE
LPD-32552 Avoid fetch data from a recycled request in a asynchronous context by fetching it before and passing via service context

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/internal/portlet/action/CompleteTaskMVCActionCommand.java
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/internal/portlet/action/CompleteTaskMVCActionCommand.java
@@ -36,6 +36,7 @@ import javax.portlet.ActionResponse;
 import javax.portlet.PortletResponse;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -84,10 +85,21 @@ public class CompleteTaskMVCActionCommand
 				themeDisplay.getCompanyId(), workflowTaskId);
 
 			ServiceContext serviceContext = (ServiceContext)workflowContext.get(
-				"serviceContext");
+				WorkflowConstants.CONTEXT_SERVICE_CONTEXT);
 
-			serviceContext.setRequest(
-				_getHttpServletRequest(actionRequest, actionResponse));
+			HttpServletRequest httpServletRequest = _getHttpServletRequest(
+				actionRequest, actionResponse);
+
+			serviceContext.setRequest(httpServletRequest);
+
+			serviceContext.setAttribute(
+				"serverName", httpServletRequest.getServerName());
+			serviceContext.setAttribute(
+				"serverPort", httpServletRequest.getServerPort());
+
+			HttpSession httpSession = httpServletRequest.getSession();
+
+			serviceContext.setAttribute("sessionId", httpSession.getId());
 
 			workflowContext.put(
 				WorkflowConstants.CONTEXT_USER_ID,

--- a/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/workflow/UserWorkflowHandler.java
+++ b/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/workflow/UserWorkflowHandler.java
@@ -12,7 +12,6 @@ import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.workflow.BaseWorkflowHandler;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.kernel.workflow.WorkflowHandler;
@@ -21,9 +20,6 @@ import java.io.Serializable;
 
 import java.util.Locale;
 import java.util.Map;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpSession;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -97,29 +93,24 @@ public class UserWorkflowHandler extends BaseWorkflowHandler<User> {
 			auditRequestThreadLocal.setRealUserId(userId);
 		}
 
-		HttpServletRequest httpServletRequest =
-			_portal.getOriginalServletRequest(serviceContext.getRequest());
+		Serializable serverName = serviceContext.getAttribute("serverName");
 
-		if (httpServletRequest == null) {
+		if (serverName == null) {
 			return;
 		}
 
-		auditRequestThreadLocal.setServerName(
-			httpServletRequest.getServerName());
+		auditRequestThreadLocal.setServerName((String)serverName);
 		auditRequestThreadLocal.setServerPort(
-			httpServletRequest.getServerPort());
+			(int)serviceContext.getAttribute("serverPort"));
 
-		HttpSession httpSession = httpServletRequest.getSession();
+		Serializable sessionId = serviceContext.getAttribute("sessionId");
 
-		if (httpSession == null) {
+		if (sessionId == null) {
 			return;
 		}
 
-		auditRequestThreadLocal.setSessionID(httpSession.getId());
+		auditRequestThreadLocal.setSessionID((String)sessionId);
 	}
-
-	@Reference
-	private Portal _portal;
 
 	@Reference
 	private UserLocalService _userLocalService;


### PR DESCRIPTION
## Related tickets

- https://liferay.atlassian.net/browse/LPD-32552

## Motivation

_"java.lang.IllegalStateException: The request object has been recycled and is no longer associated with this facade"_ is being thrown at [UserWorkflowHandler._updateAuditRequestThreadLocal](https://github.com/liferay/liferay-portal/blob/master/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/workflow/UserWorkflowHandler.java#L75), at this moment the request is already recycled and information like server name cannot be fetched due to the asynchronicity of workflow graph walker.

## Proposed Solution

Fetch the data before the request is recycled instead of forcing this operation to be synchronous by passing the `waitForCompletion` as true.

## Test

`WorkflowUser#CreateNewUserAccount` is already covering this use case