### PR TITLE
LRSD-5058 Remove DTDs from bundle

### DIFF
--- a/portal-web/build.xml
+++ b/portal-web/build.xml
@@ -30,16 +30,6 @@
 		<pathelement location="${project.dir}/lib/portal/portlet.jar" />
 	</path>
 
-	<target name="build-dtd">
-		<copy
-			todir="docroot/dtd"
-		>
-			<fileset
-				dir="${project.dir}/definitions"
-			/>
-		</copy>
-	</target>
-
 	<target depends="build-common-web.clean,clean-tlds" name="clean">
 		<delete dir="classes" />
 		<delete dir="docroot/dtd" />
@@ -228,7 +218,7 @@ ${oversize.files.jsp}</fail>
 		</antcall>
 	</target>
 
-	<target depends="build-dtd" name="deploy">
+	<target name="deploy">
 		<manifest-macro />
 
 		<antcall target="build-common-web.deploy" />
@@ -262,7 +252,7 @@ ${oversize.files.jsp}</fail>
 		</gradle-execute>
 	</target>
 
-	<target depends="build-dtd" name="war">
+	<target name="war">
 		<manifest-macro />
 
 		<if>


### PR DESCRIPTION
Hey @brianchandotcom this was reported by a customer saying having the DTDs in the bundle is failing a security scan.  I'm thinking removing it from the build process might be the best approach.