### PR TITLE
[JDK Release Tester] LPD-32260 Fix functional-bundle-tomcat-mysql57-jdk17_open and remove leftover jdk11 test batches in portal-release

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -4422,26 +4422,6 @@ information. Make sure to commit in all format-javadoc results.
 		/>
 	</target>
 
-	<target name="functional-bundle-tomcat-mysql57-jdk11_oracle">
-		<set-tomcat-version-number liferay.portal.bundle="${test.portal.bundle.version}" />
-
-		<run-functional-test
-			app.server.type="tomcat"
-			database.type="mysql"
-			database.version="5.7"
-			setup.proxy="false"
-			test.build.fix.pack.zip.url="${test.build.fix.pack.zip.url}"
-			test.fix.pack.base.url="${test.fix.pack.base.url}"
-			test.license.xml.url="${test.license.xml.url}"
-			test.plugin.zip.url="${test.plugin.zip.url}"
-			test.plugins.war.zip.url="${test.plugins.war.zip.url}"
-			test.portal.bundle.version="${test.portal.bundle.version}"
-			test.portal.bundle.zip.url="${test.portal.bundle.zip.url}"
-			test.portal.lpkg.name="${test.portal.lpkg.name}"
-			test.sql.zip.url="${test.sql.zip.url}"
-		/>
-	</target>
-
 	<target name="functional-bundle-tomcat-mysql57-jdk11_zulu">
 		<set-tomcat-version-number liferay.portal.bundle="${test.portal.bundle.version}" />
 

--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -4422,26 +4422,6 @@ information. Make sure to commit in all format-javadoc results.
 		/>
 	</target>
 
-	<target name="functional-bundle-tomcat-mysql57-jdk11_zulu">
-		<set-tomcat-version-number liferay.portal.bundle="${test.portal.bundle.version}" />
-
-		<run-functional-test
-			app.server.type="tomcat"
-			database.type="mysql"
-			database.version="5.7"
-			setup.proxy="false"
-			test.build.fix.pack.zip.url="${test.build.fix.pack.zip.url}"
-			test.fix.pack.base.url="${test.fix.pack.base.url}"
-			test.license.xml.url="${test.license.xml.url}"
-			test.plugin.zip.url="${test.plugin.zip.url}"
-			test.plugins.war.zip.url="${test.plugins.war.zip.url}"
-			test.portal.bundle.version="${test.portal.bundle.version}"
-			test.portal.bundle.zip.url="${test.portal.bundle.zip.url}"
-			test.portal.lpkg.name="${test.portal.lpkg.name}"
-			test.sql.zip.url="${test.sql.zip.url}"
-		/>
-	</target>
-
 	<target name="functional-bundle-tomcat-mysql57-jdk17_open">
 		<set-tomcat-version-number liferay.portal.bundle="${test.portal.bundle.version}" />
 

--- a/test.properties
+++ b/test.properties
@@ -7657,7 +7657,6 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
         functional-bundle-tomcat-db2115-jdk8,\
         functional-bundle-tomcat-mariadb104-jdk8,\
         functional-bundle-tomcat-mariadb106-jdk8,\
-        functional-bundle-tomcat-mysql57-jdk11_open,\
         functional-bundle-tomcat-oracle193-jdk8,\
         functional-bundle-tomcat-postgresql134-jdk8,\
         functional-bundle-tomcat-postgresql144-jdk8,\
@@ -7868,7 +7867,7 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
             (portal.smoke.upgrades == true)\
         )
 
-    test.batch.run.property.query[functional-bundle-tomcat-mysql57-jdk11_open][portal-release]=\
+    test.batch.run.property.query[functional-bundle-tomcat-mysql57-jdk17_open][portal-release]=\
         (\
             (environment.acceptance == true) AND \
             (portal.release == true)\
@@ -7882,11 +7881,7 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
             (portal.acceptance != quarantine) AND \
             (portal.release == true) AND \
             (portal.upstream != quarantine)\
-        ) OR \
-        (portal.release ~ openjdk11)
-
-    test.batch.run.property.query[functional-bundle-tomcat-mysql57-jdk17_open][portal-release]=\
-        (environment.acceptance == true)
+        )
 
     test.batch.run.property.query[functional-bundle-tomcat-mysql80-jdk8][portal-release][dxp]=\
         (\

--- a/test.properties
+++ b/test.properties
@@ -7685,7 +7685,6 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
         empty-osgi-core-dir-mysql57-jdk8,\
         functional-bundle-tomcat-hypersonic20-jdk8,\
         functional-bundle-tomcat-mariadb102-jdk8,\
-        functional-bundle-tomcat-mysql57-jdk11_zulu,\
         functional-bundle-tomcat-mysql57-jdk17_open,\
         functional-bundle-tomcat-mysql57-jdk21_zulu,\
         functional-bundle-tomcat-mysql80-jdk8,\
@@ -7885,9 +7884,6 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
             (portal.upstream != quarantine)\
         ) OR \
         (portal.release ~ openjdk11)
-
-    test.batch.run.property.query[functional-bundle-tomcat-mysql57-jdk11_zulu][portal-release]=\
-        (portal.smoke == true)
 
     test.batch.run.property.query[functional-bundle-tomcat-mysql57-jdk17_open][portal-release]=\
         (environment.acceptance == true)

--- a/test.properties
+++ b/test.properties
@@ -7658,7 +7658,6 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
         functional-bundle-tomcat-mariadb104-jdk8,\
         functional-bundle-tomcat-mariadb106-jdk8,\
         functional-bundle-tomcat-mysql57-jdk11_open,\
-        functional-bundle-tomcat-mysql57-jdk11_oracle,\
         functional-bundle-tomcat-oracle193-jdk8,\
         functional-bundle-tomcat-postgresql134-jdk8,\
         functional-bundle-tomcat-postgresql144-jdk8,\
@@ -7886,9 +7885,6 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
             (portal.upstream != quarantine)\
         ) OR \
         (portal.release ~ openjdk11)
-
-    test.batch.run.property.query[functional-bundle-tomcat-mysql57-jdk11_oracle][portal-release]=\
-        (portal.smoke == true)
 
     test.batch.run.property.query[functional-bundle-tomcat-mysql57-jdk11_zulu][portal-release]=\
         (portal.smoke == true)


### PR DESCRIPTION
@vicnate5 @tinatian 
Forwarded.

Message from last submitted https://github.com/liferay-core-infra/liferay-portal/pull/7318 below:

These changes should be ok since they did change in job summary here: https://test-5-1.liferay.com/userContent/jobs/test-portal-release/builds/889/job-summary/index.html

I would like these to merge in soon so that release team can give me feedback on the the changes ive made so far.