### PR TITLE
LRDOCS-13726 Changed Chat Providers URLs to follow the new documentation in Learn

### DIFF
--- a/learn-resources/data/click-to-chat-web.json
+++ b/learn-resources/data/click-to-chat-web.json
@@ -2,67 +2,67 @@
 	"chat-provider-account-id-chatwoot": {
 		"en_US": {
 			"message": "Get my account token for Chatwoot.",
-			"url": "https://learn.liferay.com/w/dxp/site-building/personalizing-site-experience/enabling-automated-live-chat-systems/getting-a-chat-provider-account-id/chatwoot"
+			"url": "https://learn.liferay.com/w/dxp/site-building/personalizing-site-experience/enabling-automated-live-chat-systems#getting-the-chat-provider-account-id-or-token"
 		}
 	},
 	"chat-provider-account-id-crisp": {
 		"en_US": {
 			"message": "Get my account token for Crisp.",
-			"url": "https://learn.liferay.com/w/dxp/site-building/personalizing-site-experience/enabling-automated-live-chat-systems/getting-a-chat-provider-account-id/crisp"
+			"url": "https://learn.liferay.com/w/dxp/site-building/personalizing-site-experience/enabling-automated-live-chat-systems#getting-the-chat-provider-account-id-or-token"
 		}
 	},
 	"chat-provider-account-id-hubspot": {
 		"en_US": {
 			"message": "Get my account token for Hubspot.",
-			"url": "https://learn.liferay.com/w/dxp/site-building/personalizing-site-experience/enabling-automated-live-chat-systems/getting-a-chat-provider-account-id/hubspot"
+			"url": "https://learn.liferay.com/w/dxp/site-building/personalizing-site-experience/enabling-automated-live-chat-systems#getting-the-chat-provider-account-id-or-token"
 		}
 	},
 	"chat-provider-account-id-jivochat": {
 		"en_US": {
 			"message": "Get my account token for JivoChat.",
-			"url": "https://learn.liferay.com/w/dxp/site-building/personalizing-site-experience/enabling-automated-live-chat-systems/getting-a-chat-provider-account-id/jivochat"
+			"url": "https://learn.liferay.com/w/dxp/site-building/personalizing-site-experience/enabling-automated-live-chat-systems#getting-the-chat-provider-account-id-or-token"
 		}
 	},
 	"chat-provider-account-id-livechat": {
 		"en_US": {
 			"message": "Get my account token for LiveChat.",
-			"url": "https://learn.liferay.com/w/dxp/site-building/personalizing-site-experience/enabling-automated-live-chat-systems/getting-a-chat-provider-account-id/livechat"
+			"url": "https://learn.liferay.com/w/dxp/site-building/personalizing-site-experience/enabling-automated-live-chat-systems#getting-the-chat-provider-account-id-or-token"
 		}
 	},
 	"chat-provider-account-id-liveperson": {
 		"en_US": {
 			"message": "Get my account token for LivePerson.",
-			"url": "https://learn.liferay.com/w/dxp/site-building/personalizing-site-experience/enabling-automated-live-chat-systems/getting-a-chat-provider-account-id/liveperson"
+			"url": "https://learn.liferay.com/w/dxp/site-building/personalizing-site-experience/enabling-automated-live-chat-systems#getting-the-chat-provider-account-id-or-token"
 		}
 	},
 	"chat-provider-account-id-smartsupp": {
 		"en_US": {
 			"message": "Get my account token for Smartsupp.",
-			"url": "https://learn.liferay.com/w/dxp/site-building/personalizing-site-experience/enabling-automated-live-chat-systems/getting-a-chat-provider-account-id/smartsupp"
+			"url": "https://learn.liferay.com/w/dxp/site-building/personalizing-site-experience/enabling-automated-live-chat-systems#getting-the-chat-provider-account-id-or-token"
 		}
 	},
 	"chat-provider-account-id-tawkto": {
 		"en_US": {
 			"message": "Get my account token for tawk.to.",
-			"url": "https://learn.liferay.com/w/dxp/site-building/personalizing-site-experience/enabling-automated-live-chat-systems/getting-a-chat-provider-account-id/tawk-to"
+			"url": "https://learn.liferay.com/w/dxp/site-building/personalizing-site-experience/enabling-automated-live-chat-systems#getting-the-chat-provider-account-id-or-token"
 		}
 	},
 	"chat-provider-account-id-tidio": {
 		"en_US": {
 			"message": "Get my account token for Tidio.",
-			"url": "https://learn.liferay.com/w/dxp/site-building/personalizing-site-experience/enabling-automated-live-chat-systems/getting-a-chat-provider-account-id/tidio"
+			"url": "https://learn.liferay.com/w/dxp/site-building/personalizing-site-experience/enabling-automated-live-chat-systems#getting-the-chat-provider-account-id-or-token"
 		}
 	},
 	"chat-provider-account-id-zendesk_web_widget": {
 		"en_US": {
 			"message": "Get my account token for Zendesk.",
-			"url": "https://learn.liferay.com/w/dxp/site-building/personalizing-site-experience/enabling-automated-live-chat-systems/getting-a-chat-provider-account-id/zendesk"
+			"url": "https://learn.liferay.com/w/dxp/site-building/personalizing-site-experience/enabling-automated-live-chat-systems#getting-the-chat-provider-account-id-or-token"
 		}
 	},
 	"chat-provider-account-id-zendesk_web_widget_classic": {
 		"en_US": {
 			"message": "Get my account token for Zendesk.",
-			"url": "https://learn.liferay.com/w/dxp/site-building/personalizing-site-experience/enabling-automated-live-chat-systems/getting-a-chat-provider-account-id/zendesk"
+			"url": "https://learn.liferay.com/w/dxp/site-building/personalizing-site-experience/enabling-automated-live-chat-systems#getting-the-chat-provider-account-id-or-token"
 		}
 	}
 }


### PR DESCRIPTION
Following https://github.com/sez11a/liferay-learn/pull/1263
After investigating the ticket, I’ve noticed that all the chat providers articles were deprecated. Talking to the team, we decided that It was not the best strategy to update and teach a workflow from an external software that is not Liferay, so these articles were consolidated in `enabling-automated-live-chat-systems.md`, linking to their own respective help pages.
This PR changes the URL from the account provider messages and link to the updated section in `enabling-automated-live-chat-systems.md`.
